### PR TITLE
fix(plugin): make cleanupNativeLibs work for Kotlin Multiplatform projects

### DIFF
--- a/examples/cmp-demo/build.gradle.kts
+++ b/examples/cmp-demo/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.implementation
+import org.gradle.kotlin.dsl.project
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -35,6 +37,10 @@ kotlin {
             dependencies {
                 implementation(compose.desktop.currentOs)
                 implementation(project(":nucleus-application"))
+                implementation(project(":decorated-window-core"))
+
+                implementation(project(":decorated-window-tao"))
+
             }
         }
     }
@@ -63,5 +69,35 @@ nucleus.application {
         cleanupNativeLibs = true
         packageName = "SampleCmp"
         packageVersion = "1.0.0"
+    }
+
+    graalvm {
+        isEnabled = true
+        javaLanguageVersion = 25
+        jvmVendor = JvmVendorSpec.BELLSOFT
+        imageName = "cmp-sample"
+        march = providers.gradleProperty("nativeMarch").getOrElse("compatibility")
+        buildArgs.addAll(
+            "-H:+AddAllCharsets",
+            "-Djava.awt.headless=false",
+            "-Os",
+            "-H:-IncludeMethodData",
+        )
+        nativeImageConfigBaseDir.set(
+            layout.projectDirectory.dir(
+                when {
+                    org.gradle.internal.os.OperatingSystem
+                        .current()
+                        .isMacOsX -> "src/main/resources-macos/META-INF/native-image"
+                    org.gradle.internal.os.OperatingSystem
+                        .current()
+                        .isWindows -> "src/main/resources-windows/META-INF/native-image"
+                    org.gradle.internal.os.OperatingSystem
+                        .current()
+                        .isLinux -> "src/main/resources-linux/META-INF/native-image"
+                    else -> throw GradleException("Unsupported OS")
+                },
+            ),
+        )
     }
 }

--- a/examples/cmp-demo/src/desktopMain/kotlin/com/example/samplecmp/Main.kt
+++ b/examples/cmp-demo/src/desktopMain/kotlin/com/example/samplecmp/Main.kt
@@ -1,11 +1,23 @@
 package com.example.samplecmp
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import dev.nucleusframework.application.DecoratedWindow
 import dev.nucleusframework.application.nucleusApplication
+import dev.nucleusframework.window.TitleBar
 
 fun main() =
     nucleusApplication {
         DecoratedWindow(onCloseRequest = ::exitApplication, title = "Sample CMP") {
+            TitleBar {
+                Text(
+                    text = "Sample CMP",
+                    modifier = Modifier.align(Alignment.CenterHorizontally).padding(horizontal = 12.dp),
+                )
+            }
             App()
         }
     }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanNativeLibsTransform.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanNativeLibsTransform.kt
@@ -18,6 +18,7 @@ import org.gradle.api.artifacts.transform.TransformAction
 import org.gradle.api.artifacts.transform.TransformOutputs
 import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -205,6 +206,17 @@ internal fun registerCleanNativeLibsTransform(project: Project) {
         spec.parameters.targetArch.set(archName)
     }
 
+    // Kotlin Multiplatform desktop runtime classpaths resolve project dependencies to
+    // their `classes` + `resources` directory sub-variants (unlike plain JVM, which
+    // resolves to the jar variant). Those directories carry no `native-libs-cleaned`
+    // attribute, so requiring it makes artifact selection ambiguous, and the JAR-based
+    // transform can't clean directories anyway. Requesting the `jar` LibraryElements
+    // forces KMP project deps to resolve to their jar variant, restoring the same
+    // resolution as plain JVM so the cleanup transform applies uniformly.
+    val isMultiplatform = project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
+    val jarLibraryElements =
+        project.objects.named(LibraryElements::class.java, LibraryElements.JAR)
+
     project.configurations.configureEach { configuration ->
         val name = configuration.name
         if (name.endsWith("RuntimeClasspath", ignoreCase = true) && !name.contains("Test", ignoreCase = true)) {
@@ -219,6 +231,12 @@ internal fun registerCleanNativeLibsTransform(project: Project) {
             val isHotReload = name.contains("HotReload", ignoreCase = true)
             if (!isAndroid && !isHotReload) {
                 configuration.attributes.attribute(NATIVE_LIBS_CLEANED, true)
+                if (isMultiplatform) {
+                    configuration.attributes.attribute(
+                        LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                        jarLibraryElements,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fixes a Gradle variant-ambiguity build failure on the KMP `cmp-demo` (`Could not resolve ... desktopRuntimeClasspath`) caused by `cleanupNativeLibs = true`.
- KMP desktop runtime classpaths resolve project dependencies to their `classes`/`resources` **directory** sub-variants instead of jars. Those directories carry no `native-libs-cleaned` attribute, so requiring it made artifact selection ambiguous — and even resolved, the JAR-based transform (and the `.jar` filter in packaging) could never clean directories.
- Fix: request the `jar` `LibraryElements` on KMP `*RuntimeClasspath` configurations so project deps resolve to their jar variant, matching plain-JVM resolution. The transform then applies uniformly and `cleanupNativeLibs` actually strips foreign-platform natives.
- Change is gated to KMP projects only (`isMultiplatform`); plain-JVM demos are unaffected, Android and Hot Reload remain excluded as before.
- Also brings `cmp-demo` up to date as a working KMP demo: `TitleBar`, GraalVM config, and `decorated-window-*` deps.

## Test plan

- [x] `./gradlew :examples:cmp-demo:dependencies --configuration desktopRuntimeClasspath` resolves (previously failed with ambiguity)
- [x] `./gradlew :examples:cmp-demo:run` launches
- [x] `./gradlew :examples:cmp-demo:packageDistributionForCurrentOS` — distribution contains only current-OS native libs
- [x] `./gradlew :examples:nucleus-demo:run` still works (plain-JVM regression check)