### PR TITLE
fix(tao): make Dispatchers.Main work without a running Tao loop (#337)

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -41,6 +41,12 @@ object TaoApplication {
         // pump would race the very first `NavHost.setGraph` → `addObserver`
         // call on real apps.
         TaoMainDispatcher.taoMainThread = Thread.currentThread()
+        // Hand queue draining over to the native loop: from here `dispatch`
+        // wakes Tao and `pump()` drains `pending`, instead of the pre-loop
+        // fallback thread (see TaoMainDispatcher, issue #337). Done *before*
+        // Lifecycle priming so the fallback is fully quiesced and cannot
+        // re-poison `MainDispatcherChecker` after we prime it below.
+        TaoMainDispatcher.onNativeLoopStarting()
         // Pre-seed Lifecycle's MainDispatcherChecker so its lazy
         // `runBlocking(Dispatchers.Main.immediate)` probe never fires from
         // inside the pump — on Lifecycle 2.10.x that probe deadlocks the

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoMainDispatcher.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoMainDispatcher.kt
@@ -3,10 +3,15 @@ package dev.nucleusframework.window.tao
 import androidx.compose.runtime.snapshots.Snapshot
 import kotlinx.coroutines.CoroutineDispatcher
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
+
+private const val FALLBACK_QUIESCE_TIMEOUT_SECONDS = 2L
+private const val FALLBACK_THREAD_NAME = "Nucleus-Tao-Main-Fallback"
 
 /**
  * Coroutine dispatcher that posts blocks onto the Tao main thread.
@@ -25,7 +30,10 @@ internal object TaoMainDispatcher : CoroutineDispatcher() {
     /**
      * Thread reference for the Tao main thread. Captured eagerly from
      * [TaoApplication.run] before [NativeTaoBridge.nativeRunBlocking] takes the
-     * thread over, so it is non-null as soon as user composition runs.
+     * thread over, so it is non-null as soon as user composition runs. When
+     * `Dispatchers.Main` is used before any loop starts, the pre-loop fallback
+     * thread captures itself here instead; [TaoApplication.run] later overwrites
+     * it with the real main thread.
      *
      * Consumed by [TaoMainCoroutineDispatcher.isDispatchNeeded] and by
      * downstream `Dispatchers.Main` resolvers (most notably AndroidX
@@ -35,6 +43,89 @@ internal object TaoMainDispatcher : CoroutineDispatcher() {
     @Volatile
     @JvmField
     internal var taoMainThread: Thread? = null
+
+    /**
+     * `true` once [TaoApplication.run] is about to hand the main thread to the
+     * native Tao event loop (which drains [pending] via [pump] on every
+     * `MAIN_EVENTS_CLEARED` tick). Until then the loop is not running, so a
+     * fallback thread drains the queue instead — see [dispatch].
+     *
+     * Without this, adding `nucleus.decorated-window-tao` to the classpath makes
+     * [TaoMainDispatcherFactory] win the `Dispatchers.Main` ServiceLoader pick,
+     * but any `Dispatchers.Main` use *before* (or entirely without) a running
+     * loop would enqueue forever with nothing to drain it — e.g. a bare
+     * `runBlocking(Dispatchers.Main) { … }` hangs indefinitely (issue #337).
+     */
+    @Volatile
+    private var loopRunning = false
+
+    /**
+     * Coalesces fallback-drain submissions. Reset at the very start of the
+     * drain task (before draining) so any dispatch racing the drain re-arms a
+     * fresh task instead of being lost.
+     */
+    private val fallbackDrainPending = AtomicBoolean(false)
+
+    /**
+     * Single daemon thread that drains [pending] while the native Tao loop is
+     * not running. It becomes the [taoMainThread] for the loop-less case so
+     * that `Dispatchers.Main.immediate` re-entrancy (e.g. AndroidX Lifecycle's
+     * `runBlocking(Dispatchers.Main.immediate)` probe) runs inline instead of
+     * deadlocking on the single executor thread.
+     *
+     * Lazily created on first pre-loop dispatch and torn down again by
+     * [onNativeLoopStarting] once the native loop takes over, so it is not left
+     * parked for the whole app lifetime. Lifecycle transitions are guarded by
+     * [fallbackLock].
+     */
+    private val fallbackLock = Any()
+    private var fallbackExecutor: ExecutorService? = null
+
+    /**
+     * Marks the native Tao loop as the active drainer. Called by
+     * [TaoApplication.run] right before `nativeRunBlocking`, after the real main
+     * thread has been captured into [taoMainThread].
+     *
+     * From this point [dispatch] wakes the native loop and the fallback drain is
+     * retired. The fallback executor is shut down and **awaited** so no block
+     * runs on the fallback thread once the native loop owns the main thread —
+     * this both preserves main-thread affinity and, since it runs before
+     * `LifecycleMainDispatcherPriming`, prevents a late fallback block from
+     * re-poisoning AndroidX Lifecycle's `MainDispatcherChecker`. Any blocks the
+     * fallback left behind are handed to [pump] via [wakeNativeForLeftovers].
+     */
+    internal fun onNativeLoopStarting() {
+        loopRunning = true
+        val executor = synchronized(fallbackLock) { fallbackExecutor.also { fallbackExecutor = null } }
+        if (executor != null) {
+            executor.shutdown()
+            try {
+                if (!executor.awaitTermination(FALLBACK_QUIESCE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    executor.shutdownNow()
+                }
+            } catch (_: InterruptedException) {
+                executor.shutdownNow()
+                Thread.currentThread().interrupt()
+            }
+        }
+        wakeNativeForLeftovers()
+    }
+
+    /**
+     * Wakes the native loop when it is the active drainer and [pending] still
+     * holds blocks the fallback did not drain (or that arrived during the
+     * hand-off). Without this the leftover blocks would sit undrained until an
+     * unrelated OS event happened to fire `MAIN_EVENTS_CLEARED`.
+     */
+    private fun wakeNativeForLeftovers() {
+        if (loopRunning &&
+            !pending.isEmpty() &&
+            NativeTaoBridge.isLoaded &&
+            wakePending.compareAndSet(false, true)
+        ) {
+            NativeTaoBridge.nativeWake()
+        }
+    }
 
     /**
      * Coalesces native wake calls within a single pump cycle. Set on the
@@ -88,13 +179,85 @@ internal object TaoMainDispatcher : CoroutineDispatcher() {
         block: Runnable,
     ) {
         pending.offer(block)
-        // Wake the Tao event loop. Tao runs with `ControlFlow::Wait` and
-        // would otherwise sleep until an OS event arrives, leaving this
-        // block undrained whenever no window is currently driving the loop
-        // (e.g. before the first frame, or after the last window closes).
-        if (NativeTaoBridge.isLoaded && wakePending.compareAndSet(false, true)) {
-            NativeTaoBridge.nativeWake()
+        if (loopRunning) {
+            // Wake the Tao event loop. Tao runs with `ControlFlow::Wait` and
+            // would otherwise sleep until an OS event arrives, leaving this
+            // block undrained whenever no window is currently driving the loop
+            // (e.g. before the first frame, or after the last window closes).
+            if (NativeTaoBridge.isLoaded && wakePending.compareAndSet(false, true)) {
+                NativeTaoBridge.nativeWake()
+            }
+        } else {
+            // The native loop is not running yet (or never will — e.g. a bare
+            // `runBlocking(Dispatchers.Main) { … }` with no `nucleusApplication`).
+            // Drive the queue on a dedicated fallback thread so Dispatchers.Main
+            // works regardless. Handed off to `pump()` once the loop starts.
+            scheduleFallbackDrain()
         }
+    }
+
+    private fun scheduleFallbackDrain() {
+        if (!fallbackDrainPending.compareAndSet(false, true)) return
+        // Resolve (creating on demand) the executor under the lock so we never
+        // race onNativeLoopStarting's shutdown. If the loop has since taken
+        // over, there is nothing to schedule — hand the block to pump() instead.
+        val executor =
+            synchronized(fallbackLock) {
+                if (loopRunning) null else fallbackExecutor ?: newFallbackExecutor().also { fallbackExecutor = it }
+            }
+        if (executor == null) {
+            fallbackDrainPending.set(false)
+            wakeNativeForLeftovers()
+            return
+        }
+        try {
+            executor.execute {
+                // Reset before draining so a dispatch racing this task re-arms
+                // a fresh drain rather than being dropped.
+                fallbackDrainPending.set(false)
+                if (taoMainThread == null) {
+                    taoMainThread = Thread.currentThread()
+                }
+                drainFallback()
+            }
+        } catch (_: RejectedExecutionException) {
+            // onNativeLoopStarting shut the executor down between the lock and
+            // here; the loop now owns draining.
+            fallbackDrainPending.set(false)
+            wakeNativeForLeftovers()
+        }
+    }
+
+    private fun newFallbackExecutor(): ExecutorService =
+        Executors.newSingleThreadExecutor { r ->
+            Thread(r, FALLBACK_THREAD_NAME).apply { isDaemon = true }
+        }
+
+    /**
+     * Drains [pending] on the fallback thread until the queue empties or the
+     * native loop takes over ([loopRunning]). If the loop took over mid-drain,
+     * any blocks left behind are handed to the first [pump] via
+     * [wakeNativeForLeftovers] rather than relying on an incidental
+     * `MAIN_EVENTS_CLEARED` tick.
+     */
+    private fun drainFallback() {
+        var ranAnything = false
+        while (!loopRunning) {
+            val block = pending.poll() ?: break
+            ranAnything = true
+            @Suppress("TooGenericExceptionCaught", "PrintStackTrace")
+            try {
+                block.run()
+            } catch (t: Throwable) {
+                // Match pump(): dispatchers swallow synchronous throwables so a
+                // single failing block never kills the drain.
+                t.printStackTrace()
+            }
+        }
+        if (ranAnything) {
+            Snapshot.sendApplyNotifications()
+        }
+        wakeNativeForLeftovers()
     }
 
     /** Drains everything currently pending. New blocks dispatched while

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoMainDispatcherHandoffTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoMainDispatcherHandoffTest.kt
@@ -1,0 +1,147 @@
+package dev.nucleusframework.window.tao
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import java.util.Queue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Validates the hand-off between the pre-loop fallback drainer and the native
+ * Tao event loop — the review findings on the issue #337 fix.
+ *
+ * Each test asserts the *correct* post-fix behavior; run against the pre-fix
+ * code they fail, which is what confirms the findings are real.
+ */
+class TaoMainDispatcherHandoffTest {
+    @BeforeTest
+    fun setUp() = resetDispatcherState()
+
+    @AfterTest
+    fun tearDown() = resetDispatcherState()
+
+    /**
+     * Findings #2 / #3: [TaoMainDispatcher.onNativeLoopStarting] must quiesce any
+     * in-flight fallback drain before returning, so no block runs on the fallback
+     * thread once the native loop owns the main thread (and so Lifecycle priming,
+     * which runs after it, cannot be re-poisoned by a late fallback block).
+     */
+    @Test
+    fun `onNativeLoopStarting waits for the in-flight fallback block`() {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val finished = AtomicBoolean(false)
+
+        TaoMainDispatcher.dispatch(
+            EmptyCoroutineContext,
+            Runnable {
+                started.countDown()
+                release.await()
+                finished.set(true)
+            },
+        )
+        assertTrue(started.await(5, TimeUnit.SECONDS), "fallback block never started")
+
+        val handoffReturned = AtomicBoolean(false)
+        val handoff =
+            Thread {
+                TaoMainDispatcher.onNativeLoopStarting()
+                handoffReturned.set(true)
+            }
+        handoff.start()
+
+        // The block is still held by `release`, so a correct onNativeLoopStarting
+        // must still be blocked in awaitTermination and NOT have returned.
+        Thread.sleep(300)
+        assertFalse(finished.get(), "test bug: block finished early")
+        assertFalse(
+            handoffReturned.get(),
+            "onNativeLoopStarting returned before quiescing the in-flight fallback block (findings #2/#3)",
+        )
+
+        release.countDown()
+        handoff.join(5_000)
+        assertTrue(handoffReturned.get(), "onNativeLoopStarting never returned")
+        assertTrue(finished.get(), "fallback block never finished")
+    }
+
+    /**
+     * Finding #5: the fallback executor thread must be shut down once the native
+     * loop takes over, not left parked for the whole app lifetime.
+     */
+    @Test
+    fun `fallback thread is shut down after handoff`() {
+        val done = CountDownLatch(1)
+        TaoMainDispatcher.dispatch(EmptyCoroutineContext, Runnable { done.countDown() })
+        assertTrue(done.await(5, TimeUnit.SECONDS), "fallback block never ran")
+
+        TaoMainDispatcher.onNativeLoopStarting()
+
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (fallbackThreadAlive() && System.nanoTime() < deadline) {
+            Thread.sleep(20)
+        }
+        assertFalse(
+            fallbackThreadAlive(),
+            "fallback thread still alive after handoff (finding #5)",
+        )
+    }
+
+    /**
+     * Finding #4: a `runBlocking(Dispatchers.Main)` nested inside a block already
+     * running on the (fallback) main thread must run inline instead of dead-locking
+     * the single-thread executor.
+     */
+    @Test
+    fun `nested runBlocking on Main from a Main block does not deadlock`() {
+        val ok = AtomicBoolean(false)
+        val done = CountDownLatch(1)
+        TaoMainDispatcher.dispatch(
+            EmptyCoroutineContext,
+            Runnable {
+                runBlocking(Dispatchers.Main) { ok.set(true) }
+                done.countDown()
+            },
+        )
+        assertTrue(
+            done.await(5, TimeUnit.SECONDS),
+            "nested runBlocking(Dispatchers.Main) dead-locked the fallback (finding #4)",
+        )
+        assertTrue(ok.get(), "nested coroutine body never ran")
+    }
+
+    private fun fallbackThreadAlive(): Boolean =
+        Thread.getAllStackTraces().keys.any { it.name == FALLBACK_THREAD_NAME && it.isAlive }
+
+    private fun resetDispatcherState() {
+        val target = TaoMainDispatcher
+        val cls = target.javaClass
+
+        fun field(name: String) = runCatching { cls.getDeclaredField(name).apply { isAccessible = true } }.getOrNull()
+
+        field("loopRunning")?.set(target, false)
+        field("taoMainThread")?.set(target, null)
+        (field("fallbackDrainPending")?.get(target) as? AtomicBoolean)?.set(false)
+        (field("wakePending")?.get(target) as? AtomicBoolean)?.set(false)
+        (field("pending")?.get(target) as? Queue<*>)?.clear()
+        field("fallbackExecutor")?.let { f ->
+            (f.get(target) as? ExecutorService)?.let { exec ->
+                exec.shutdownNow()
+                exec.awaitTermination(2, TimeUnit.SECONDS)
+                f.set(target, null)
+            }
+        }
+    }
+
+    private companion object {
+        const val FALLBACK_THREAD_NAME = "Nucleus-Tao-Main-Fallback"
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoMainDispatcherReproTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoMainDispatcherReproTest.kt
@@ -1,0 +1,72 @@
+package dev.nucleusframework.window.tao
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Reproduces https://github.com/NucleusFramework/Nucleus/issues/337
+ *
+ * `TaoMainDispatcherFactory` wins the `MainDispatcherFactory` ServiceLoader pick
+ * (loadPriority = 100), so `Dispatchers.Main` routes to the Tao dispatcher even
+ * when the Tao event loop was never started. Before the fix, dispatched blocks
+ * were only drained by `pump()` on `MAIN_EVENTS_CLEARED` ticks, so any
+ * `Dispatchers.Main` use without a running loop hung forever.
+ */
+class TaoMainDispatcherReproTest {
+    @Test
+    fun `Dispatchers Main resolves to Tao dispatcher`() {
+        // Sanity: the ServiceLoader really did pick the Tao factory.
+        assertTrue(
+            Dispatchers.Main.toString().contains("Tao"),
+            "Expected Dispatchers.Main to be the Tao dispatcher, was ${Dispatchers.Main}",
+        )
+    }
+
+    @Test
+    fun `runBlocking on Dispatchers Main completes without a running Tao loop`() {
+        // Run on a separate thread so a hang fails the test via join timeout
+        // instead of blocking the JUnit runner forever.
+        var ran = false
+        val worker =
+            Thread {
+                runBlocking(Dispatchers.Main) {
+                    ran = true
+                }
+            }
+        worker.isDaemon = true
+        worker.start()
+        worker.join(5_000)
+        if (worker.isAlive) {
+            worker.interrupt()
+            fail("runBlocking(Dispatchers.Main) hung — issue #337 reproduced")
+        }
+        assertTrue(ran, "coroutine body never executed")
+    }
+
+    @Test
+    fun `delay on Dispatchers Main resumes without a running Tao loop`() {
+        var ran = false
+        val worker =
+            Thread {
+                runBlocking {
+                    withContext(Dispatchers.Main) {
+                        delay(50)
+                        ran = true
+                    }
+                }
+            }
+        worker.isDaemon = true
+        worker.start()
+        worker.join(5_000)
+        if (worker.isAlive) {
+            worker.interrupt()
+            fail("delay() on Dispatchers.Main hung — issue #337 reproduced")
+        }
+        assertTrue(ran, "coroutine after delay never resumed")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #337 — `Dispatchers.Main` hangs when `decorated-window-tao` is on the classpath.

`TaoMainDispatcherFactory` wins the `MainDispatcherFactory` ServiceLoader pick (`loadPriority = 100`), so `Dispatchers.Main` routes to the Tao dispatcher process-wide as soon as the module is present. But the dispatcher's queue was only drained by `pump()` on `MAIN_EVENTS_CLEARED` native ticks, which only fire while the Tao event loop is running. Any `Dispatchers.Main` use **before** or **without** `nucleusApplication { }` — e.g. a bare `runBlocking(Dispatchers.Main) { println("Hi") }` — enqueued forever with nothing to drain it and hung indefinitely.

### Fix
- **Pre-loop fallback drainer** — while the native loop is not running, a dedicated daemon thread (`Nucleus-Tao-Main-Fallback`) drains the queue, so `Dispatchers.Main` works regardless of whether the loop ever starts. It becomes `taoMainThread` for the loop-less case so `Dispatchers.Main.immediate` re-entrancy (e.g. AndroidX Lifecycle's probe) runs inline instead of dead-locking.
- **Clean hand-off** — `onNativeLoopStarting()` shuts down **and awaits** the fallback executor *before* Lifecycle priming, so no block runs off the real main thread once the loop owns it, and `MainDispatcherChecker` can't be re-poisoned by a late fallback block.
- **No stranded blocks** — the native pump is woken for any blocks left in the queue at hand-off, and the fallback thread is torn down rather than left parked for the app's lifetime.

### Note on review findings
A code review flagged a possible nested-`runBlocking` deadlock; e2e validation showed `isDispatchNeeded` is `false` on the fallback thread (nested `runBlocking(Dispatchers.Main)` runs inline), so that was a false positive and is covered by a regression test.

## Test plan
- [x] `TaoMainDispatcherReproTest` — reproduces #337: `runBlocking(Dispatchers.Main)` and `delay()` on `Dispatchers.Main` complete without a running loop
- [x] `TaoMainDispatcherHandoffTest` — `onNativeLoopStarting` quiesces the in-flight fallback block; fallback thread is shut down after hand-off; nested `runBlocking` does not dead-lock
- [x] Full `:decorated-window-tao:test` green (16/16, 0 skipped)
- [x] ktlint + detekt clean on all changed files (only pre-existing baseline issues remain in untouched files)