### PR TITLE
fix(notification): stop Tao UI freeze when showing Windows toasts

### DIFF
--- a/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/NativeWindowsNotificationBridge.kt
+++ b/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/NativeWindowsNotificationBridge.kt
@@ -4,6 +4,7 @@ package dev.nucleusframework.notification.windows
 
 import dev.nucleusframework.core.runtime.NativeLibraryLoader
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 import javax.swing.SwingUtilities
 
@@ -16,6 +17,93 @@ internal object NativeWindowsNotificationBridge {
     private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeWindowsNotificationBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
+
+    /**
+     * All WinRT calls run on this single dedicated thread so that COM is initialized as MTA
+     * (a fresh thread with no prior apartment). This is essential under the Tao backend, where
+     * Compose event handlers run on the event-loop thread that winit has already initialized as
+     * STA via `OleInitialize`. Showing a toast on that STA thread binds the `ClassicCom` event
+     * handlers to it, so delivering the activation/dismissal events requires the thread to pump
+     * messages — which it cannot while blocked inside the click handler, freezing the whole UI
+     * until the user interacts with the toast. On a dedicated MTA thread the handlers are invoked
+     * on COM RPC pool threads, so no message pump is needed and the UI thread is never blocked.
+     */
+    private val comExecutor =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "nucleus-winrt-notification").apply { isDaemon = true }
+        }
+
+    // -- Public API routed onto the COM (MTA) thread --
+
+    fun initialize(
+        aumid: String,
+        isAppx: Boolean,
+        appName: String,
+        shortcutPolicy: Int,
+    ): Boolean = comExecutor.submit<Boolean> { nativeInitialize(aumid, isAppx, appName, shortcutPolicy) }.get()
+
+    @Suppress("LongParameterList")
+    fun showToast(
+        xml: String,
+        tag: String,
+        group: String,
+        expiresOnReboot: Boolean,
+        expirationTimeMs: Long,
+        suppressPopup: Boolean,
+        dataKeys: Array<String>,
+        dataValues: Array<String>,
+        dataSequenceNumber: Int,
+        callbackId: Long,
+    ) {
+        comExecutor.execute {
+            nativeShowToast(
+                xml,
+                tag,
+                group,
+                expiresOnReboot,
+                expirationTimeMs,
+                suppressPopup,
+                dataKeys,
+                dataValues,
+                dataSequenceNumber,
+                callbackId,
+            )
+        }
+    }
+
+    fun updateToast(
+        tag: String,
+        group: String,
+        sequenceNumber: Int,
+        keys: Array<String>,
+        values: Array<String>,
+        callbackId: Long,
+    ) {
+        comExecutor.execute { nativeUpdateToast(tag, group, sequenceNumber, keys, values, callbackId) }
+    }
+
+    fun removeToast(
+        tag: String,
+        group: String,
+    ) {
+        comExecutor.execute { nativeRemoveToast(tag, group) }
+    }
+
+    fun removeGroupToasts(group: String) {
+        comExecutor.execute { nativeRemoveGroupToasts(group) }
+    }
+
+    fun clearAllToasts() {
+        comExecutor.execute { nativeClearAllToasts() }
+    }
+
+    fun getHistory(callbackId: Long) {
+        comExecutor.execute { nativeGetHistory(callbackId) }
+    }
+
+    fun uninitialize() {
+        comExecutor.submit { nativeUninitialize() }.get()
+    }
 
     // Listeners for toast events
     private val listeners = ConcurrentHashMap.newKeySet<ToastNotificationListener>()
@@ -49,7 +137,7 @@ internal object NativeWindowsNotificationBridge {
      * For packaged apps (MSIX), pass an empty string and isAppx=true.
      */
     @JvmStatic
-    external fun nativeInitialize(
+    private external fun nativeInitialize(
         aumid: String,
         isAppx: Boolean,
         appName: String,
@@ -69,7 +157,7 @@ internal object NativeWindowsNotificationBridge {
      */
     @JvmStatic
     @Suppress("LongParameterList")
-    external fun nativeShowToast(
+    private external fun nativeShowToast(
         xml: String,
         tag: String,
         group: String,
@@ -93,7 +181,7 @@ internal object NativeWindowsNotificationBridge {
      * @param callbackId Callback ID for result notification.
      */
     @JvmStatic
-    external fun nativeUpdateToast(
+    private external fun nativeUpdateToast(
         tag: String,
         group: String,
         sequenceNumber: Int,
@@ -109,7 +197,7 @@ internal object NativeWindowsNotificationBridge {
      * @param group Notification group.
      */
     @JvmStatic
-    external fun nativeRemoveToast(
+    private external fun nativeRemoveToast(
         tag: String,
         group: String,
     )
@@ -118,26 +206,26 @@ internal object NativeWindowsNotificationBridge {
      * Remove all toasts in a specific group from Action Center.
      */
     @JvmStatic
-    external fun nativeRemoveGroupToasts(group: String)
+    private external fun nativeRemoveGroupToasts(group: String)
 
     /**
      * Remove all toasts from Action Center for this app.
      */
     @JvmStatic
-    external fun nativeClearAllToasts()
+    private external fun nativeClearAllToasts()
 
     /**
      * Get the history of notifications in Action Center.
      * Results are delivered via [onHistoryResult] callback.
      */
     @JvmStatic
-    external fun nativeGetHistory(callbackId: Long)
+    private external fun nativeGetHistory(callbackId: Long)
 
     /**
      * Clean up native resources. Call on app shutdown.
      */
     @JvmStatic
-    external fun nativeUninitialize()
+    private external fun nativeUninitialize()
 
     // =========================================================================
     // Callbacks from native code

--- a/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/WindowsNotificationCenter.kt
+++ b/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/WindowsNotificationCenter.kt
@@ -94,7 +94,7 @@ object WindowsNotificationCenter {
         }
 
         initialized =
-            NativeWindowsNotificationBridge.nativeInitialize(
+            NativeWindowsNotificationBridge.initialize(
                 resolvedAumid,
                 isAppx,
                 resolvedAppName,
@@ -141,7 +141,7 @@ object WindowsNotificationCenter {
         val xml = ToastXmlBuilder.buildXml(content)
         val noOpCallback: (String?) -> Unit = {}
         val id = NativeWindowsNotificationBridge.registerCallback(callback ?: noOpCallback)
-        NativeWindowsNotificationBridge.nativeShowToast(
+        NativeWindowsNotificationBridge.showToast(
             xml = xml,
             tag = tag,
             group = group,
@@ -174,7 +174,7 @@ object WindowsNotificationCenter {
 
         val noOpCallback: (String?) -> Unit = {}
         val id = NativeWindowsNotificationBridge.registerCallback(callback ?: noOpCallback)
-        NativeWindowsNotificationBridge.nativeShowToast(
+        NativeWindowsNotificationBridge.showToast(
             xml = xml,
             tag = tag,
             group = group,
@@ -243,7 +243,7 @@ object WindowsNotificationCenter {
 
         val noOpCallback: (String?) -> Unit = {}
         val id = NativeWindowsNotificationBridge.registerCallback(callback ?: noOpCallback)
-        NativeWindowsNotificationBridge.nativeUpdateToast(
+        NativeWindowsNotificationBridge.updateToast(
             tag = tag,
             group = group,
             sequenceNumber = data.sequenceNumber,
@@ -261,19 +261,19 @@ object WindowsNotificationCenter {
         group: String = "",
     ) {
         if (!ensureReady(null)) return
-        NativeWindowsNotificationBridge.nativeRemoveToast(tag, group)
+        NativeWindowsNotificationBridge.removeToast(tag, group)
     }
 
     /** Remove all toasts in a group from Action Center. */
     fun removeGroup(group: String) {
         if (!ensureReady(null)) return
-        NativeWindowsNotificationBridge.nativeRemoveGroupToasts(group)
+        NativeWindowsNotificationBridge.removeGroupToasts(group)
     }
 
     /** Remove all toasts from Action Center for this app. */
     fun clearAll() {
         if (!ensureReady(null)) return
-        NativeWindowsNotificationBridge.nativeClearAllToasts()
+        NativeWindowsNotificationBridge.clearAllToasts()
     }
 
     // -- History --
@@ -289,7 +289,7 @@ object WindowsNotificationCenter {
             return
         }
         val id = NativeWindowsNotificationBridge.registerCallback(callback)
-        NativeWindowsNotificationBridge.nativeGetHistory(id)
+        NativeWindowsNotificationBridge.getHistory(id)
     }
 
     // -- Listeners --
@@ -312,7 +312,7 @@ object WindowsNotificationCenter {
      */
     fun uninitialize() {
         if (!isAvailable || !initialized) return
-        NativeWindowsNotificationBridge.nativeUninitialize()
+        NativeWindowsNotificationBridge.uninitialize()
         initialized = false
     }
 


### PR DESCRIPTION
## Summary

- Under the **Tao backend**, `WindowsNotificationCenter.show()` was called from the Compose `onClick`, which runs on the Tao event-loop thread. winit initializes that thread as a COM **STA** (`OleInitialize`).
- `CoInitializeEx(MULTITHREADED)` in the native init therefore failed silently with `RPC_E_CHANGED_MODE`, leaving the thread STA and binding the `ClassicCom` toast event handlers to it.
- Delivering the activation/dismissal events is an **incoming COM call** to that STA, which requires the thread to pump messages — impossible while it's blocked inside the click handler. Result: the entire app froze until the user interacted with the toast.

## Fix

- Route **all** WinRT calls through a dedicated single-thread executor (`nucleus-winrt-notification`) in `NativeWindowsNotificationBridge`. This fresh thread becomes a real **MTA**, so `ClassicCom` handlers are invoked on COM RPC pool threads with no message pump, and the UI thread is never blocked.
- `initialize`/`uninitialize` block (`.get()`) since they return a value / must finalize cleanly; `showToast`/`updateToast`/`removeToast`/etc. are fire-and-forget (results already arrive via JNI callbacks).
- Raw `nativeXxx` externals made `private` to guarantee everything goes through the MTA thread.
- **No C change** — the existing DLL works as-is, no native rebuild required.

## Test plan

- [x] `./gradlew :examples:nucleus-demo:run` on the Tao backend
- [x] Show a toast with buttons — UI stays responsive while the toast is displayed
- [x] Click a button — activation event is received and UI remains interactive
- [x] Verify dismiss / update-progress / clear-all still work