### PR TITLE
feat(packaging): shrink macOS DMG with LZMA (ULMO) post-processing

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/MacDmgLzma.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/MacDmgLzma.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.internal.utils.Arch
+import java.io.File
+
+/**
+ * Pure helpers for post-processing a macOS DMG with LZMA (ULMO) compression.
+ *
+ * electron-builder's bundled `dmgbuild` caps DMG compression at bzip2 (UDBZ) — its format
+ * allow-list has no `ULMO` entry — even though `hdiutil` has supported LZMA-compressed images
+ * since macOS 10.15. Recompressing the finished image with `hdiutil convert -format ULMO`
+ * typically shaves ~20% off a bzip2 DMG, matching the LZMA that NSIS uses on Windows.
+ */
+internal object MacDmgLzma {
+    private const val CATALINA_MAJOR = 10
+    private const val CATALINA_MINOR = 15
+
+    /**
+     * ULMO (LZMA) disk images only mount on macOS 10.15 (Catalina) and later. Returns whether a
+     * DMG targeting [minimumSystemVersion] may safely use ULMO. A null/blank value carries no
+     * constraint and is treated as a modern target.
+     */
+    fun isUlmoCompatible(minimumSystemVersion: String?): Boolean {
+        if (minimumSystemVersion.isNullOrBlank()) return true
+        val parts = minimumSystemVersion.trim().split(".")
+        val major = parts.getOrNull(0)?.toIntOrNull() ?: return true
+        val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
+        return when {
+            major > CATALINA_MAJOR -> true
+            major < CATALINA_MAJOR -> false
+            else -> minor >= CATALINA_MINOR
+        }
+    }
+
+    private const val APP_BUILDER_SEARCH_DEPTH = 8
+
+    /**
+     * Locates electron-builder's bundled `app-builder` binary, used to regenerate the
+     * differential-update blockmap after recompression. It is a transitive dependency
+     * (`app-builder-bin`) of the electron-builder install created by npx.
+     *
+     * Searches the task-isolated npm cache (`<outputDir>/.npm-cache`, where the plugin points
+     * `NPM_CONFIG_CACHE`) first, then falls back to npm's default per-user npx cache. Returns null
+     * when it cannot be found — the caller then drops the now-stale blockmap instead.
+     */
+    fun locateAppBuilder(
+        outputDir: File,
+        arch: Arch,
+        userHome: File = File(System.getProperty("user.home")),
+    ): File? {
+        val binaryName = if (arch == Arch.Arm64) "app-builder_arm64" else "app-builder_amd64"
+        val roots = listOf(File(outputDir, ".npm-cache"), File(userHome, ".npm/_npx"))
+        for (root in roots) {
+            findAppBuilder(root, binaryName)?.let { return it }
+        }
+        return null
+    }
+
+    private fun findAppBuilder(
+        root: File,
+        binaryName: String,
+    ): File? {
+        if (!root.isDirectory) return null
+        return root
+            .walkTopDown()
+            .maxDepth(APP_BUILDER_SEARCH_DEPTH)
+            .firstOrNull { it.isFile && it.name == binaryName && it.parentFile?.name == "mac" }
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlChecksums.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlChecksums.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal
+
+import java.io.File
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Recomputes and rewrites the checksums that electron-builder auto-update manifests
+ * (`latest*.yml`) record for a packaged artifact.
+ *
+ * Any post-processing that mutates an artifact after electron-builder has already fingerprinted
+ * it — notarization stapling, DMG LZMA recompression — invalidates the `sha512`/`size`
+ * (and, when the blockmap changes, `blockMapSize`) stored in the manifest. These helpers bring
+ * the manifest back in sync so the in-app updater accepts the new artifact.
+ */
+internal object UpdateYmlChecksums {
+    private const val BUFFER_SIZE = 8192
+
+    /** Base64-encoded SHA-512 of [file], matching electron-builder's manifest `sha512` field. */
+    fun sha512Base64(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-512")
+        file.inputStream().buffered().use { input ->
+            val buffer = ByteArray(BUFFER_SIZE)
+            var read = input.read(buffer)
+            while (read != -1) {
+                digest.update(buffer, 0, read)
+                read = input.read(buffer)
+            }
+        }
+        return Base64.getEncoder().encodeToString(digest.digest())
+    }
+
+    /**
+     * Returns [yaml] with the `sha512`/`size` (and top-level `sha512`) of the entry for [fileName]
+     * replaced by [newHash]/[newSize].
+     *
+     * When [newBlockMapSize] is non-null, an existing `blockMapSize` line in the entry is updated;
+     * when it is null, any `blockMapSize` line is removed so the updater falls back to a full
+     * download instead of chasing a stale/absent blockmap.
+     */
+    fun updateYamlEntry(
+        yaml: String,
+        fileName: String,
+        newHash: String,
+        newSize: Long,
+        newBlockMapSize: Long? = null,
+    ): String {
+        val lines = yaml.lines().toMutableList()
+        var i = 0
+        var topLevelPath: String? = null
+
+        while (i < lines.size) {
+            val line = lines[i]
+            val trimmed = line.trimStart()
+
+            if (isUrlEntry(trimmed) && extractUrl(trimmed) == fileName) {
+                i = updateFileEntryFields(lines, i + 1, newHash, newSize, newBlockMapSize)
+                continue
+            }
+
+            val isTopLevel = !line.startsWith(" ") && !line.startsWith("\t")
+            if (isTopLevel && trimmed.startsWith("path:")) {
+                topLevelPath = trimmed.removePrefix("path:").trim()
+            }
+            if (isTopLevel && trimmed.startsWith("sha512:") && topLevelPath == fileName) {
+                lines[i] = "sha512: $newHash"
+            }
+
+            i++
+        }
+
+        return lines.joinToString("\n")
+    }
+
+    private fun isUrlEntry(trimmed: String): Boolean = trimmed.startsWith("- url:") || trimmed.startsWith("-url:")
+
+    private fun extractUrl(trimmed: String): String =
+        trimmed
+            .removePrefix("-")
+            .trimStart()
+            .removePrefix("url:")
+            .trim()
+
+    private fun isEndOfFileEntry(entryLine: String): Boolean {
+        if (isUrlEntry(entryLine)) return true
+        if (entryLine.startsWith("blockMapSize:")) return false
+        return !entryLine.startsWith(" ") && entryLine.contains(":")
+    }
+
+    private fun updateFileEntryFields(
+        lines: MutableList<String>,
+        startIndex: Int,
+        newHash: String,
+        newSize: Long,
+        newBlockMapSize: Long?,
+    ): Int {
+        var i = startIndex
+        while (i < lines.size) {
+            val entryLine = lines[i].trimStart()
+            val indent = lines[i].length - lines[i].trimStart().length
+            when {
+                entryLine.startsWith("sha512:") -> lines[i] = " ".repeat(indent) + "sha512: $newHash"
+                entryLine.startsWith("size:") -> lines[i] = " ".repeat(indent) + "size: $newSize"
+                entryLine.startsWith("blockMapSize:") -> {
+                    if (newBlockMapSize != null) {
+                        lines[i] = " ".repeat(indent) + "blockMapSize: $newBlockMapSize"
+                    } else {
+                        // Blockmap no longer valid: drop the reference so the updater does a full download.
+                        lines.removeAt(i)
+                        continue
+                    }
+                }
+                isEndOfFileEntry(entryLine) -> break
+            }
+            i++
+        }
+        return i
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -10,10 +10,12 @@ import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
 import dev.nucleusframework.desktop.application.dsl.MacOSSigningSettings
 import dev.nucleusframework.desktop.application.dsl.ReleaseChannel
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import dev.nucleusframework.desktop.application.internal.UpdateYmlChecksums
 import dev.nucleusframework.desktop.application.internal.UpdateYmlPublish
 import dev.nucleusframework.desktop.application.internal.UpdateYmlGenerator
 import dev.nucleusframework.desktop.application.internal.LinuxSigner
 import dev.nucleusframework.desktop.application.internal.LinuxUpdateHelper
+import dev.nucleusframework.desktop.application.internal.MacDmgLzma
 import dev.nucleusframework.desktop.application.internal.MacSigner
 import dev.nucleusframework.desktop.application.internal.MacSignerImpl
 import dev.nucleusframework.desktop.application.internal.NoCertificateSigner
@@ -298,6 +300,10 @@ abstract class AbstractElectronBuilderPackageTask
                 signPkgInstaller(outputDir)
             }
             signLinuxPackage(outputDir, dist)
+
+            // Must run before cleanupBuildTemporaries(), which removes the isolated npm cache
+            // where the app-builder binary used to regenerate the blockmap lives.
+            recompressDmgWithLzma(outputDir, dist)
 
             cleanupParasiticFiles(outputDir)
             cleanupBuildTemporaries(outputDir)
@@ -866,6 +872,218 @@ abstract class AbstractElectronBuilderPackageTask
             pkgFile.delete()
             signedPkg.renameTo(pkgFile)
             logger.lifecycle("Signed PKG installer: ${pkgFile.name}")
+        }
+
+        /**
+         * Post-processes the DMG electron-builder just produced by recompressing it with LZMA (ULMO).
+         *
+         * electron-builder's bundled dmgbuild caps DMG compression at bzip2 (UDBZ), so we reconvert
+         * with `hdiutil convert -format ULMO` — LZMA, ~20% smaller — then re-sign (reconversion drops
+         * the signature) and refresh the auto-update blockmap/manifest checksums.
+         *
+         * Runs only when the user opted into maximum compression, left the DMG format unpinned, and
+         * targets macOS 10.15+ (ULMO images do not mount on older systems). It is also skipped when
+         * electron-builder is publishing inline, since the pre-recompression artifact would already
+         * have been uploaded.
+         */
+        private fun recompressDmgWithLzma(
+            outputDir: File,
+            dist: JvmApplicationDistributions,
+        ) {
+            if (currentOS != OS.MacOS) return
+            if (targetFormat != TargetFormat.Dmg) return
+            if (dist.compressionLevel != CompressionLevel.Maximum) return
+
+            dist.macOS.dmg.format?.let {
+                logger.info("Skipping LZMA DMG recompression: an explicit dmg.format=$it is set")
+                return
+            }
+            if (!MacDmgLzma.isUlmoCompatible(dist.macOS.minimumSystemVersion)) {
+                logger.lifecycle(
+                    "Skipping LZMA (ULMO) DMG recompression: minimumSystemVersion " +
+                        "'${dist.macOS.minimumSystemVersion}' predates macOS 10.15. Keeping bzip2 (UDBZ).",
+                )
+                return
+            }
+            if (resolvePublishFlag() != "never") {
+                logger.warn(
+                    "Skipping LZMA (ULMO) DMG recompression: electron-builder is publishing inline " +
+                        "(publish != never), so the DMG has already been uploaded. Use a separate upload " +
+                        "step (publish = never) to benefit from LZMA recompression.",
+                )
+                return
+            }
+
+            val dmgFiles =
+                outputDir
+                    .listFiles { f -> f.isFile && f.extension.equals("dmg", ignoreCase = true) }
+                    ?.toList()
+                    .orEmpty()
+            if (dmgFiles.isEmpty()) {
+                logger.info("No .dmg artifact found to recompress in ${outputDir.absolutePath}")
+                return
+            }
+
+            val resolvedArch = Arch.entries.first { it.id == targetArch.get() }
+            val appBuilder = MacDmgLzma.locateAppBuilder(outputDir, resolvedArch)
+            if (appBuilder == null) {
+                logger.info("app-builder not found in npm cache; blockmaps will be dropped after recompression")
+            }
+            for (dmg in dmgFiles) {
+                recompressSingleDmg(dmg, appBuilder)
+            }
+        }
+
+        private fun recompressSingleDmg(
+            dmg: File,
+            appBuilder: File?,
+        ) {
+            val sizeBefore = dmg.length()
+            val wasSigned = isDmgSigned(dmg)
+
+            val recompressed = File(dmg.parentFile, "${dmg.nameWithoutExtension}.ulmo.dmg")
+            if (recompressed.exists()) recompressed.delete()
+
+            logger.lifecycle("Recompressing ${dmg.name} with LZMA (ULMO)…")
+            execOperations.exec { spec ->
+                spec.executable = "hdiutil"
+                spec.args =
+                    listOf("convert", dmg.absolutePath, "-format", "ULMO", "-o", recompressed.absolutePath, "-quiet")
+                spec.isIgnoreExitValue = false
+            }
+            if (!recompressed.isFile) {
+                throw GradleException("LZMA recompression produced no output: ${recompressed.absolutePath}")
+            }
+
+            if (!dmg.delete()) throw GradleException("Could not replace original DMG: ${dmg.absolutePath}")
+            if (!recompressed.renameTo(dmg)) {
+                recompressed.copyTo(dmg, overwrite = true)
+                recompressed.delete()
+            }
+
+            // Reconversion drops the code signature, so re-sign when the source image was signed.
+            if (wasSigned) signDmg(dmg)
+
+            refreshDmgMetadata(dmg, appBuilder)
+            verifyDmg(dmg)
+
+            val sizeAfter = dmg.length()
+            val savedPct = if (sizeBefore > 0) (sizeBefore - sizeAfter) * 100.0 / sizeBefore else 0.0
+            logger.lifecycle(
+                String.format(
+                    Locale.ROOT,
+                    "LZMA recompression: %s  %,d → %,d bytes (−%.1f%%)",
+                    dmg.name,
+                    sizeBefore,
+                    sizeAfter,
+                    savedPct,
+                ),
+            )
+        }
+
+        /** Whether [dmg] currently carries a code signature (electron-builder signs it when dmg.sign = true). */
+        private fun isDmgSigned(dmg: File): Boolean {
+            val stdout = ByteArrayOutputStream()
+            val stderr = ByteArrayOutputStream()
+            return try {
+                val result =
+                    execOperations.exec { spec ->
+                        spec.executable = "codesign"
+                        spec.args = listOf("-v", "--verify", dmg.absolutePath)
+                        spec.isIgnoreExitValue = true
+                        spec.standardOutput = stdout
+                        spec.errorOutput = stderr
+                    }
+                result.exitValue == 0
+            } catch (_: Exception) {
+                false
+            }
+        }
+
+        /**
+         * Signs [dmg] with the configured Developer ID Application identity. Uses `--force` directly
+         * (no prior `--remove-signature`, which fails on the freshly-converted, unsigned image).
+         */
+        private fun signDmg(dmg: File) {
+            val settings = macSigner?.settings
+            if (settings == null) {
+                logger.warn(
+                    "${dmg.name} was signed before recompression but no Developer ID identity " +
+                        "is available to re-sign it.",
+                )
+                return
+            }
+            logger.info("Re-signing ${dmg.name} with '${settings.fullDeveloperID}' after recompression")
+            execOperations.exec { spec ->
+                spec.executable = "codesign"
+                spec.args =
+                    buildList {
+                        add("--force")
+                        add("--timestamp")
+                        add("--sign")
+                        add(settings.fullDeveloperID)
+                        settings.keychain?.let {
+                            add("--keychain")
+                            add(it.absolutePath)
+                        }
+                        add(dmg.absolutePath)
+                    }
+                spec.isIgnoreExitValue = false
+            }
+        }
+
+        /**
+         * Regenerates the differential-update blockmap for the recompressed [dmg] (via electron-builder's
+         * app-builder) and rewrites the sha512/size/blockMapSize any local manifest records for it.
+         * When app-builder is unavailable, the stale blockmap is dropped and updaters fall back to a
+         * full download.
+         */
+        private fun refreshDmgMetadata(
+            dmg: File,
+            appBuilder: File?,
+        ) {
+            val blockmap = File(dmg.parentFile, "${dmg.name}.blockmap")
+            var newBlockMapSize: Long? = null
+            if (appBuilder != null) {
+                try {
+                    execOperations.exec { spec ->
+                        spec.executable = appBuilder.absolutePath
+                        spec.args = listOf("blockmap", "--input", dmg.absolutePath, "--output", blockmap.absolutePath)
+                        spec.isIgnoreExitValue = false
+                    }
+                    if (blockmap.isFile) newBlockMapSize = blockmap.length()
+                } catch (e: Exception) {
+                    logger.warn("Failed to regenerate blockmap for ${dmg.name}: ${e.message}. Dropping stale blockmap.")
+                    blockmap.delete()
+                }
+            } else if (blockmap.exists()) {
+                blockmap.delete()
+            }
+
+            val newHash = UpdateYmlChecksums.sha512Base64(dmg)
+            val newSize = dmg.length()
+            val ymls =
+                dmg.parentFile.listFiles { f ->
+                    f.isFile && (f.extension == "yml" || f.extension == "yaml")
+                } ?: return
+            for (yml in ymls) {
+                val content = yml.readText()
+                if (!content.contains(dmg.name)) continue
+                val updated = UpdateYmlChecksums.updateYamlEntry(content, dmg.name, newHash, newSize, newBlockMapSize)
+                if (updated != content) {
+                    yml.writeText(updated)
+                    logger.lifecycle("Updated auto-update manifest ${yml.name} for ${dmg.name}")
+                }
+            }
+        }
+
+        /** Verifies the recompressed image mounts and its checksums are intact. */
+        private fun verifyDmg(dmg: File) {
+            execOperations.exec { spec ->
+                spec.executable = "hdiutil"
+                spec.args = listOf("verify", dmg.absolutePath)
+                spec.isIgnoreExitValue = false
+            }
         }
 
         /**

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractNotarizationTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractNotarizationTask.kt
@@ -9,6 +9,7 @@ import dev.nucleusframework.desktop.application.dsl.MacOSNotarizationSettings
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import dev.nucleusframework.desktop.application.internal.NOTARIZATION_REQUEST_INFO_FILE_NAME
 import dev.nucleusframework.desktop.application.internal.NotarizationRequestInfo
+import dev.nucleusframework.desktop.application.internal.UpdateYmlChecksums
 import dev.nucleusframework.desktop.application.internal.files.checkExistingFile
 import dev.nucleusframework.desktop.application.internal.files.findOutputFileOrDir
 import dev.nucleusframework.desktop.application.internal.validation.ValidatedMacOSNotarizationSettings
@@ -27,8 +28,6 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
-import java.security.MessageDigest
-import java.util.Base64
 import javax.inject.Inject
 
 @DisableCachingByDefault(because = "Depends on external Apple notarization service")
@@ -173,14 +172,14 @@ abstract class AbstractNotarizationTask
             val dir = packageFile.parentFile ?: return
             val fileName = packageFile.name
             val newSize = packageFile.length()
-            val newHash = sha512Base64(packageFile)
+            val newHash = UpdateYmlChecksums.sha512Base64(packageFile)
 
             val ymlFiles = dir.listFiles { f -> f.extension == "yml" || f.extension == "yaml" } ?: return
             for (ymlFile in ymlFiles) {
                 val content = ymlFile.readText()
                 if (!content.contains(fileName)) continue
 
-                val updated = updateYamlEntry(content, fileName, newHash, newSize)
+                val updated = UpdateYmlChecksums.updateYamlEntry(content, fileName, newHash, newSize)
                 if (updated != content) {
                     ymlFile.writeText(updated)
                     logger.lifecycle("Updated checksums in ${ymlFile.name} for $fileName")
@@ -188,92 +187,7 @@ abstract class AbstractNotarizationTask
             }
         }
 
-        private fun sha512Base64(file: File): String {
-            val digest = MessageDigest.getInstance("SHA-512")
-            file.inputStream().buffered().use { input ->
-                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                var read = input.read(buffer)
-                while (read != -1) {
-                    digest.update(buffer, 0, read)
-                    read = input.read(buffer)
-                }
-            }
-            return Base64.getEncoder().encodeToString(digest.digest())
-        }
-
         companion object {
-            private const val DEFAULT_BUFFER_SIZE = 8192
             private val SUBMISSION_ID_REGEX = Regex("""^\s*id:\s*([0-9a-fA-F-]+)\s*$""", RegexOption.MULTILINE)
-
-            internal fun updateYamlEntry(
-                yaml: String,
-                fileName: String,
-                newHash: String,
-                newSize: Long,
-            ): String {
-                val lines = yaml.lines().toMutableList()
-                var i = 0
-                var topLevelPath: String? = null
-
-                while (i < lines.size) {
-                    val line = lines[i]
-                    val trimmed = line.trimStart()
-
-                    if (isUrlEntry(trimmed) && extractUrl(trimmed) == fileName) {
-                        i = updateFileEntryFields(lines, i + 1, newHash, newSize)
-                        continue
-                    }
-
-                    val isTopLevel = !line.startsWith(" ") && !line.startsWith("\t")
-                    if (isTopLevel && trimmed.startsWith("path:")) {
-                        topLevelPath = trimmed.removePrefix("path:").trim()
-                    }
-                    if (isTopLevel && trimmed.startsWith("sha512:") && topLevelPath == fileName) {
-                        lines[i] = "sha512: $newHash"
-                    }
-
-                    i++
-                }
-
-                return lines.joinToString("\n")
-            }
-
-            private fun isUrlEntry(trimmed: String): Boolean = trimmed.startsWith("- url:") || trimmed.startsWith("-url:")
-
-            private fun extractUrl(trimmed: String): String =
-                trimmed
-                    .removePrefix("-")
-                    .trimStart()
-                    .removePrefix("url:")
-                    .trim()
-
-            private fun isEndOfFileEntry(entryLine: String): Boolean {
-                if (isUrlEntry(entryLine)) return true
-                if (entryLine.startsWith("blockMapSize:")) return false
-                return !entryLine.startsWith(" ") && entryLine.contains(":")
-            }
-
-            private fun updateFileEntryFields(
-                lines: MutableList<String>,
-                startIndex: Int,
-                newHash: String,
-                newSize: Long,
-            ): Int {
-                var i = startIndex
-                while (i < lines.size) {
-                    val entryLine = lines[i].trimStart()
-                    if (entryLine.startsWith("sha512:")) {
-                        val indent = lines[i].length - lines[i].trimStart().length
-                        lines[i] = " ".repeat(indent) + "sha512: $newHash"
-                    } else if (entryLine.startsWith("size:")) {
-                        val indent = lines[i].length - lines[i].trimStart().length
-                        lines[i] = " ".repeat(indent) + "size: $newSize"
-                    } else if (isEndOfFileEntry(entryLine)) {
-                        break
-                    }
-                    i++
-                }
-                return i
-            }
         }
     }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/MacDmgLzmaTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/MacDmgLzmaTest.kt
@@ -1,0 +1,35 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MacDmgLzmaTest {
+    @Test
+    fun `null or blank minimumSystemVersion is treated as modern`() {
+        assertTrue(MacDmgLzma.isUlmoCompatible(null))
+        assertTrue(MacDmgLzma.isUlmoCompatible(""))
+        assertTrue(MacDmgLzma.isUlmoCompatible("   "))
+    }
+
+    @Test
+    fun `macOS 10_15 and later support ULMO`() {
+        assertTrue(MacDmgLzma.isUlmoCompatible("10.15"))
+        assertTrue(MacDmgLzma.isUlmoCompatible("10.15.7"))
+        assertTrue(MacDmgLzma.isUlmoCompatible("11"))
+        assertTrue(MacDmgLzma.isUlmoCompatible("12.0"))
+        assertTrue(MacDmgLzma.isUlmoCompatible("26.0"))
+    }
+
+    @Test
+    fun `macOS before 10_15 does not support ULMO`() {
+        assertFalse(MacDmgLzma.isUlmoCompatible("10.14"))
+        assertFalse(MacDmgLzma.isUlmoCompatible("10.13.6"))
+        assertFalse(MacDmgLzma.isUlmoCompatible("10.9"))
+    }
+
+    @Test
+    fun `unparseable minimumSystemVersion is treated as modern rather than blocking`() {
+        assertTrue(MacDmgLzma.isUlmoCompatible("latest"))
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlChecksumsTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlChecksumsTest.kt
@@ -1,0 +1,70 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdateYmlChecksumsTest {
+    private val macYml =
+        """
+        version: 1.0.0
+        files:
+          - url: app-1.0.0-mac-arm64.dmg
+            sha512: OLDHASH==
+            size: 75030177
+            blockMapSize: 79282
+        path: app-1.0.0-mac-arm64.dmg
+        sha512: OLDHASH==
+        releaseDate: '2026-07-15T00:00:00.000Z'
+        """.trimIndent()
+
+    @Test
+    fun `updates per-file and top-level sha512, size and blockMapSize`() {
+        val updated =
+            UpdateYmlChecksums.updateYamlEntry(
+                yaml = macYml,
+                fileName = "app-1.0.0-mac-arm64.dmg",
+                newHash = "NEWHASH==",
+                newSize = 58607594,
+                newBlockMapSize = 61868,
+            )
+
+        assertFalse("old hash must be gone", updated.contains("OLDHASH=="))
+        assertTrue(updated.contains("sha512: NEWHASH=="))
+        assertTrue(updated.contains("size: 58607594"))
+        assertTrue(updated.contains("blockMapSize: 61868"))
+        // Top-level sha512 (paired with path:) is updated too.
+        assertTrue(updated.lines().any { it == "sha512: NEWHASH==" })
+    }
+
+    @Test
+    fun `null blockMapSize drops the blockMapSize line`() {
+        val updated =
+            UpdateYmlChecksums.updateYamlEntry(
+                yaml = macYml,
+                fileName = "app-1.0.0-mac-arm64.dmg",
+                newHash = "NEWHASH==",
+                newSize = 58607594,
+                newBlockMapSize = null,
+            )
+
+        assertFalse(updated.contains("blockMapSize"))
+        assertTrue(updated.contains("size: 58607594"))
+        assertTrue(updated.contains("sha512: NEWHASH=="))
+    }
+
+    @Test
+    fun `unrelated file names are left untouched`() {
+        val updated =
+            UpdateYmlChecksums.updateYamlEntry(
+                yaml = macYml,
+                fileName = "other.dmg",
+                newHash = "NEWHASH==",
+                newSize = 1,
+                newBlockMapSize = 2,
+            )
+
+        assertTrue(updated.contains("sha512: OLDHASH=="))
+        assertTrue(updated.contains("size: 75030177"))
+    }
+}


### PR DESCRIPTION
## Summary

electron-builder's bundled `dmgbuild` caps DMG compression at bzip2 (UDBZ) — its format allow-list has no `ULMO` entry — even though `hdiutil` has supported LZMA-compressed images since macOS 10.15. This PR recompresses the finished DMG with `hdiutil convert -format ULMO` (LZMA), typically shaving **~20%** off a bzip2 DMG, matching the LZMA that NSIS uses on Windows.

- **`MacDmgLzma`** — pure helpers: `isUlmoCompatible(minimumSystemVersion)` (ULMO only mounts on macOS 10.15+) and `locateAppBuilder(...)` (finds electron-builder's `app-builder` binary to regenerate the blockmap).
- **`recompressDmgWithLzma`** in `AbstractElectronBuilderPackageTask` — runs after packaging, only when: macOS + `TargetFormat.Dmg` + `compressionLevel = Maximum` + no explicit `dmg.format` + `minimumSystemVersion >= 10.15` + `publish = never` (an inline-published DMG has already been uploaded). Reconverts to ULMO, re-signs (reconversion drops the signature), regenerates the differential-update blockmap, and refreshes the `latest*.yml` auto-update checksums.
- **`UpdateYmlChecksums`** — extracted from `AbstractNotarizationTask` (shared sha512/size/blockMapSize rewriting of electron-builder manifests) and extended with `blockMapSize` handling. Notarization now reuses it.

## Test plan

- [x] `:plugin:compileKotlin` succeeds
- [x] Unit tests: `MacDmgLzmaTest`, `UpdateYmlChecksumsTest`
- [ ] macOS DMG build with `compressionLevel = Maximum`: verify DMG shrinks, mounts (`hdiutil verify`), and re-signs
- [ ] Verify the in-app updater accepts the recompressed DMG (blockmap/manifest checksums in sync)
- [ ] Verify interaction with notarization + stapling (stapling re-hashes after recompression)

## Notes

Split out of #345 (was bundled with the GraalVM binary-size reduction). This is the electron-builder/DMG side; #345 keeps the native-image `-Os` + strip changes.
