### PR TITLE
feat(packaging): gate post-processing recompression behind new Ultra level

### DIFF
--- a/examples/cmp-demo/build.gradle.kts
+++ b/examples/cmp-demo/build.gradle.kts
@@ -73,7 +73,7 @@ nucleus.application {
         cleanupNativeLibs = true
         packageName = "SampleCmp"
         packageVersion = "1.0.0"
-        compressionLevel = CompressionLevel.Maximum
+        compressionLevel = CompressionLevel.Ultra
         homepage = "https://github.com/KdroidFilter/NucleusDemo"
 
         linux {

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/CompressionLevel.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/CompressionLevel.kt
@@ -12,4 +12,12 @@ enum class CompressionLevel(
     Store("store"),
     Normal("normal"),
     Maximum("maximum"),
+
+    /**
+     * Like [Maximum] for every format electron-builder handles natively (its `id` maps to
+     * `"maximum"`), but additionally enables the plugin's post-processing recompression steps that
+     * electron-builder's own `maximum` leaves on the table: LZMA (ULMO) for DMG and `xz -9e` for DEB.
+     * These steps are slower and are therefore opt-in via this level rather than [Maximum].
+     */
+    Ultra("maximum"),
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -404,7 +404,8 @@ abstract class AbstractElectronBuilderPackageTask
                 null to null
             }
 
-            if (targetFormat == TargetFormat.AppImage && distributions.compressionLevel == CompressionLevel.Maximum) {
+            // Both Maximum and Ultra map to electron-builder's "maximum"; warn for either.
+            if (targetFormat == TargetFormat.AppImage && distributions.compressionLevel?.id == "maximum") {
                 logger.warn(
                     "AppImage with 'maximum' compression can cause extremely slow startup times (60s+) " +
                         "due to squashfs/FUSE decompression overhead. Consider 'normal' or 'store' instead. " +
@@ -886,10 +887,10 @@ abstract class AbstractElectronBuilderPackageTask
          * with `hdiutil convert -format ULMO` — LZMA, ~20% smaller — then re-sign (reconversion drops
          * the signature) and refresh the auto-update blockmap/manifest checksums.
          *
-         * Runs only when the user opted into maximum compression, left the DMG format unpinned, and
-         * targets macOS 10.15+ (ULMO images do not mount on older systems). It is also skipped when
-         * electron-builder is publishing inline, since the pre-recompression artifact would already
-         * have been uploaded.
+         * Runs only when the user opted into [CompressionLevel.Ultra], left the DMG format unpinned,
+         * and targets macOS 10.15+ (ULMO images do not mount on older systems). It is also skipped
+         * when electron-builder is publishing inline, since the pre-recompression artifact would
+         * already have been uploaded.
          */
         private fun recompressDmgWithLzma(
             outputDir: File,
@@ -897,7 +898,7 @@ abstract class AbstractElectronBuilderPackageTask
         ) {
             if (currentOS != OS.MacOS) return
             if (targetFormat != TargetFormat.Dmg) return
-            if (dist.compressionLevel != CompressionLevel.Maximum) return
+            if (dist.compressionLevel != CompressionLevel.Ultra) return
 
             dist.macOS.dmg.format?.let {
                 logger.info("Skipping LZMA DMG recompression: an explicit dmg.format=$it is set")
@@ -1099,7 +1100,7 @@ abstract class AbstractElectronBuilderPackageTask
          * internal xz level — the payload stays at fpm's default preset. Re-building the deb with
          * `dpkg-deb` at the highest xz effort typically shrinks it ~25%. Mirrors [recompressDmgWithLzma].
          *
-         * Runs only when the user opted into maximum compression and electron-builder is not
+         * Runs only when the user opted into [CompressionLevel.Ultra] and electron-builder is not
          * publishing inline (mirroring the DMG path). RPM payload recompression would require
          * rebuilding via rpmbuild/rpmrebuild and is out of scope.
          */
@@ -1109,7 +1110,7 @@ abstract class AbstractElectronBuilderPackageTask
         ) {
             if (currentOS != OS.Linux) return
             if (targetFormat != TargetFormat.Deb) return
-            if (dist.compressionLevel != CompressionLevel.Maximum) return
+            if (dist.compressionLevel != CompressionLevel.Ultra) return
             if (resolvePublishFlag() != "never") {
                 logger.warn(
                     "Skipping xz deb recompression: electron-builder is publishing inline " +


### PR DESCRIPTION
## Summary

- Adds a new `CompressionLevel.Ultra`. The DMG LZMA (ULMO) and DEB `xz -9e` post-processing steps — which are slower than electron-builder's own packaging — now run **only** on `Ultra` instead of `Maximum`.
- `Ultra`'s `id` maps to `"maximum"`, so electron-builder and config generation treat it exactly like `Maximum` for every natively-handled format (NSIS, AppImage, etc.). It just additionally enables the plugin's post-processing.
- `Maximum` now yields a faster build with no extra recompression; the post-processing is opt-in.
- The AppImage slow-startup warning fires for both `Maximum` and `Ultra` (both send `"maximum"` to electron-builder).
- `cmp-demo` moves to `Ultra` to keep benefiting from the smaller deb.

### Resulting behavior

| Level | electron-builder | Plugin DMG/deb post-processing |
|---|---|---|
| `Store` / `Normal` / `Maximum` | unchanged | ❌ (faster build) |
| `Ultra` | same as `Maximum` | ✅ LZMA DMG + `xz -9e` deb |

Other examples intentionally stay on `Maximum` (faster builds, no recompression).

## Test plan

- [x] Plugin compiles (`:plugin:compileKotlin`) and passes `ktlintMainSourceSetCheck`
- [x] E2E `Ultra`: `:examples:cmp-demo:packageGraalvmDeb` → `xz recompression: … −28.3%` (48 MB → 35 MB)
- [x] E2E `Maximum`: same task → 0 recompression log lines, deb stays 48 MB
- [x] `id` collision safe — no reverse `id → enum` lookup exists in the codebase