### PR TITLE
Make NucleusApplicationScope implement Compose's ApplicationScope

### DIFF
--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
@@ -1,3 +1,5 @@
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
 package dev.nucleusframework.window.jewel
 
 import androidx.compose.runtime.Composable
@@ -16,12 +18,16 @@ import dev.nucleusframework.window.DecoratedWindow
 import dev.nucleusframework.window.NucleusDecoratedWindowTheme
 import dev.nucleusframework.window.styling.TitleBarStyle
 import org.jetbrains.jewel.foundation.theme.JewelTheme
+import kotlin.internal.LowPriorityInOverloadResolution
 import dev.nucleusframework.application.DecoratedWindow as NucleusDecoratedWindowFn
 
 private const val LUMINANCE_THRESHOLD = 0.5f
 
 /** AWT-backed (JBR / JNI) Jewel-styled wrapper for [DecoratedWindow]. */
 @Suppress("FunctionNaming", "LongParameterList")
+// Low priority: NucleusApplicationScope implements ApplicationScope, so inside
+// nucleusApplication both overloads are applicable — the Nucleus one must win.
+@LowPriorityInOverloadResolution
 @Composable
 fun ApplicationScope.JewelDecoratedWindow(
     onCloseRequest: () -> Unit,

--- a/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedDialog.kt
+++ b/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedDialog.kt
@@ -1,3 +1,5 @@
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
 package dev.nucleusframework.window.material
 
 import androidx.compose.material3.MaterialTheme
@@ -12,10 +14,14 @@ import dev.nucleusframework.application.NucleusDecoratedDialogScope
 import dev.nucleusframework.window.AwtDecoratedDialogScope
 import dev.nucleusframework.window.DecoratedDialog
 import dev.nucleusframework.window.NucleusDecoratedWindowTheme
+import kotlin.internal.LowPriorityInOverloadResolution
 import dev.nucleusframework.application.DecoratedDialog as NucleusDecoratedDialog
 
 /** AWT-backed (JBR / JNI) Material 3 wrapper for [DecoratedDialog]. */
 @Suppress("FunctionNaming", "LongParameterList")
+// Low priority: NucleusApplicationScope implements ApplicationScope, so inside
+// nucleusApplication both overloads are applicable — the Nucleus one must win.
+@LowPriorityInOverloadResolution
 @Composable
 fun ApplicationScope.MaterialDecoratedDialog(
     onCloseRequest: () -> Unit,

--- a/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
+++ b/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
@@ -1,3 +1,5 @@
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
 package dev.nucleusframework.window.material
 
 import androidx.compose.material3.MaterialTheme
@@ -14,6 +16,7 @@ import dev.nucleusframework.window.AwtDecoratedWindowScope
 import dev.nucleusframework.window.DecoratedWindow
 import dev.nucleusframework.window.NucleusDecoratedWindowTheme
 import dev.nucleusframework.window.styling.TitleBarStyle
+import kotlin.internal.LowPriorityInOverloadResolution
 import dev.nucleusframework.application.DecoratedWindow as NucleusDecoratedWindow
 
 /**
@@ -26,6 +29,9 @@ import dev.nucleusframework.application.DecoratedWindow as NucleusDecoratedWindo
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+// Low priority: NucleusApplicationScope implements ApplicationScope, so inside
+// nucleusApplication both overloads are applicable — the Nucleus one must win.
+@LowPriorityInOverloadResolution
 fun ApplicationScope.MaterialDecoratedWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),

--- a/nucleus-application/build.gradle.kts
+++ b/nucleus-application/build.gradle.kts
@@ -20,7 +20,9 @@ dependencies {
     api(project(":aot-runtime"))
     implementation(project(":core-runtime"))
     implementation(project(":graalvm-runtime"))
-    implementation(libs.compose.desktop.common)
+    // api: NucleusApplicationScope extends Compose's ApplicationScope, so the
+    // supertype must be visible on consumers' compile classpath.
+    api(libs.compose.desktop.common)
 
     // An app ships exactly one backend at runtime — by construction (their
     // imports overlap, so coexistence is unsupported). We compile against

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplicationScope.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplicationScope.kt
@@ -17,6 +17,13 @@ import dev.nucleusframework.window.tao.ApplicationScope as TaoApplicationScope
  * Extends Compose's [AwtApplicationScope] so libraries scoped to the plain
  * Compose application scope (e.g. tray composables) work inside
  * [nucleusApplication] blocks without Nucleus-specific overloads.
+ *
+ * Composables that rely on AWT under the hood (Compose's `Tray`, `Window`, …)
+ * are only supported on the AWT backends (JNI / JBR). On the Tao backend the
+ * process runs without an AWT event loop and the native event loop owns the
+ * main thread, so calling them compiles but is unsupported — AWT would
+ * initialize off-thread (deadlock-prone on macOS). Use AWT-free alternatives
+ * (e.g. ComposeNativeTray) with Tao.
  */
 @Stable
 sealed interface NucleusApplicationScope : AwtApplicationScope {

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplicationScope.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplicationScope.kt
@@ -13,11 +13,15 @@ import dev.nucleusframework.window.tao.ApplicationScope as TaoApplicationScope
  * Backend-agnostic scope exposed by [nucleusApplication]. The two concrete
  * subtypes wrap the AWT / Tao application scopes so [DecoratedWindow] can
  * dispatch on `when (this)` without leaking backend types into user code.
+ *
+ * Extends Compose's [AwtApplicationScope] so libraries scoped to the plain
+ * Compose application scope (e.g. tray composables) work inside
+ * [nucleusApplication] blocks without Nucleus-specific overloads.
  */
 @Stable
-sealed interface NucleusApplicationScope {
+sealed interface NucleusApplicationScope : AwtApplicationScope {
     /** Posts an exit request to the underlying event loop. */
-    fun exitApplication()
+    override fun exitApplication()
 
     /** The backend currently driving this scope. Never [NucleusBackend.Auto]. */
     val backend: NucleusBackend


### PR DESCRIPTION
## Summary
`NucleusApplicationScope` now extends `androidx.compose.ui.window.ApplicationScope` (it already declared the interface's single member, `exitApplication()`).

## Motivation
Libraries whose composables are scoped to Compose's plain `ApplicationScope` — most immediately the `Tray` composables in ComposeNativeTray (NucleusFramework/ComposeNativeTray#418, NucleusFramework/ComposeNativeTray#419) — become callable inside `nucleusApplication { }` blocks with a single overload set. The tray core can then drop its `nucleus-application` dependency entirely and work in both vanilla Compose `application { }` apps and Nucleus apps.

## Changes
- `NucleusApplicationScope : ApplicationScope` (one-line supertype; `exitApplication` becomes an override).
- `compose.desktop.common` moves `implementation` → `api` in `nucleus-application` since the supertype is now public API.
- The parallel AWT variants of `MaterialDecoratedWindow`, `MaterialDecoratedDialog` and `JewelDecoratedWindow` (receiver `ApplicationScope`) are now also applicable inside `nucleusApplication`, and neither signature is more specific (the `content` lambdas differ). They are marked `@LowPriorityInOverloadResolution` so the Nucleus overloads keep winning; in plain `application { }` blocks they remain the only applicable candidates, so behaviour there is unchanged.

## Compatibility
- Source-compatible for normal call sites; binary-compatible (interfaces gain a supertype, JVM signatures unchanged).
- Third-party code that defines its own parallel `ApplicationScope` / `NucleusApplicationScope` overload pairs could hit the same ambiguity and would need the same annotation — considered unlikely.

## Verification
- `:nucleus-application`, `:decorated-window-material3`, `:decorated-window-jewel` build green.
- Validated end-to-end against ComposeNativeTray: with a locally published 2.1.4, the tray core compiles with `ApplicationScope`-scoped `Tray` overloads and no `nucleus-application` dependency; the demo (`nucleusApplication` + `MaterialDecoratedWindow` + `Tray` + `TrayApp`) compiles and its overloads resolve to the Nucleus variants.