### PR TITLE
fix(native): resolve build.bat by absolute path (system-color, media-control)

### DIFF
--- a/media-control/build.gradle.kts
+++ b/media-control/build.gradle.kts
@@ -88,7 +88,7 @@ val buildNativeWindows by tasks.registering(Exec::class) {
     inputs.dir(nativeDir)
     outputs.dir(nativeResourceDir)
     workingDir(nativeDir)
-    commandLine("cmd", "/c", "build.bat")
+    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
 }
 
 tasks.processResources {

--- a/system-color/build.gradle.kts
+++ b/system-color/build.gradle.kts
@@ -84,7 +84,7 @@ val buildNativeWindows by tasks.registering(Exec::class) {
     inputs.dir(nativeDir)
     outputs.dir(nativeResourceDir)
     workingDir(nativeDir)
-    commandLine("cmd.exe", "/c", "build.bat")
+    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
 }
 
 tasks.processResources {


### PR DESCRIPTION
## Problem

`packageDistributionForCurrentOS` (and any task depending on the native builds) failed locally on Windows with:

```
Execution failed for task ':system-color:buildNativeWindows'.
> Process 'command 'cmd.exe'' finished with non-zero exit value 1
  'build.bat' n'est pas reconnu en tant que commande interne ou externe
```

The build aborted before ever reaching `packageNsis`, so no NSIS installer was produced.

## Cause

`system-color` and `media-control` invoked the Windows native build as `cmd /c build.bat` — a **bare** script name, relying on cmd.exe searching the process working directory. In some environments cmd.exe does not resolve a bare `build.bat` against the working dir and reports it as an unknown command. Every other native module already passes an absolute path (`nativeDir.file("build.bat").asFile.absolutePath`) or the `.\build.bat` form; these two were the only stragglers.

## Fix

Pass the absolute path to `build.bat`, matching the other modules.

## Verified

- `:system-color:buildNativeWindows` → **BUILD SUCCESSFUL**, DLLs produced.
- `:examples:system-info-demo:packageNsis` → **BUILD SUCCESSFUL**, installer produced at `build/compose/binaries/main/nsis/systeminfo-1.0.0-win-x64-nsis.exe`.

## Test plan

- [ ] `./gradlew :system-color:buildNativeWindows` on Windows.
- [ ] `./gradlew :media-control:buildNativeWindows` on Windows.
- [ ] `./gradlew :examples:system-info-demo:packageDistributionForCurrentOS` produces the NSIS installer.