### PR TITLE
feat(notification): add urgency to common API; wire native Windows priority

### DIFF
--- a/examples/nucleus-demo/src/main/kotlin/com/example/demo/CommonNotificationsScreen.kt
+++ b/examples/nucleus-demo/src/main/kotlin/com/example/demo/CommonNotificationsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import dev.nucleusframework.notification.common.NotificationHandle
 import dev.nucleusframework.notification.common.NotificationManager
 import dev.nucleusframework.notification.common.NotificationResult
+import dev.nucleusframework.notification.common.NotificationUrgency
 import dev.nucleusframework.notification.common.notification
 
 private const val EVENT_LOG_MAX = 20
@@ -50,6 +51,7 @@ fun CommonNotificationsScreen() {
     var message by remember { mutableStateOf("This is a cross-platform notification.") }
     var largeImage by remember { mutableStateOf("") }
     var smallIcon by remember { mutableStateOf("") }
+    var urgency by remember { mutableStateOf(NotificationUrgency.NORMAL) }
 
     fun log(msg: String) {
         events.add(0, msg)
@@ -143,6 +145,34 @@ fun CommonNotificationsScreen() {
                 }
             }
 
+            // -- Urgency (common hint) --
+            SectionCard("Urgency (common hint)") {
+                Text(
+                    "The only prominence hint exposed by the common API. " +
+                        "Linux: urgency · macOS: interruptionLevel · Windows: priority + reminder scenario (CRITICAL).",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(12.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    NotificationUrgency.entries.forEach { level ->
+                        Button(onClick = {
+                            val result =
+                                notification(
+                                    title = "Urgency: ${level.name}",
+                                    message = "Sent with $level urgency",
+                                    urgency = level,
+                                    onActivated = { log("Urgency $level: activated") },
+                                    onDismissed = { reason -> log("Urgency $level: dismissed ($reason)") },
+                                ).send()
+                            logResult("Urgency $level", result, events = events, onHandle = { lastHandle = it })
+                        }) {
+                            Text(level.name)
+                        }
+                    }
+                }
+            }
+
             // -- Custom Notification --
             SectionCard("Custom Notification") {
                 OutlinedTextField(
@@ -177,6 +207,18 @@ fun CommonNotificationsScreen() {
                     singleLine = true,
                 )
                 Spacer(Modifier.height(12.dp))
+                Text("Urgency", style = MaterialTheme.typography.labelMedium)
+                Spacer(Modifier.height(4.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    NotificationUrgency.entries.forEach { level ->
+                        if (level == urgency) {
+                            Button(onClick = { urgency = level }) { Text(level.name) }
+                        } else {
+                            OutlinedButton(onClick = { urgency = level }) { Text(level.name) }
+                        }
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Button(onClick = {
                         val result =
@@ -185,6 +227,7 @@ fun CommonNotificationsScreen() {
                                 message = message,
                                 largeImage = largeImage.ifBlank { null },
                                 smallIcon = smallIcon.ifBlank { null },
+                                urgency = urgency,
                                 onActivated = { log("Custom: activated") },
                                 onDismissed = { reason -> log("Custom: dismissed ($reason)") },
                                 onFailed = { log("Custom: FAILED") },
@@ -204,6 +247,7 @@ fun CommonNotificationsScreen() {
                                 message = message,
                                 largeImage = largeImage.ifBlank { null },
                                 smallIcon = smallIcon.ifBlank { null },
+                                urgency = urgency,
                                 onActivated = { log("Custom (no buttons): activated") },
                                 onDismissed = { reason -> log("Custom (no buttons): dismissed ($reason)") },
                             ).send()

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/Notification.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/Notification.kt
@@ -13,6 +13,7 @@ class Notification internal constructor(
     val message: String,
     val largeImage: String?,
     val smallIcon: String?,
+    val urgency: NotificationUrgency,
     val buttons: List<NotificationButton>,
     val onActivated: (() -> Unit)?,
     val onDismissed: ((DismissReason) -> Unit)?,
@@ -68,6 +69,7 @@ class NotificationButtonBuilder internal constructor() {
  * @param message The notification body text.
  * @param largeImage URI to a large image (hero image on Windows, image hint on Linux, attachment on macOS).
  * @param smallIcon URI to a small icon (app logo override on Windows, app icon on Linux, ignored on macOS).
+ * @param urgency Prominence hint mapped to the native equivalent on every platform (see [NotificationUrgency]).
  * @param onActivated Called when the user clicks the notification body.
  * @param onDismissed Called when the notification is dismissed, with the [DismissReason].
  * @param onFailed Called if the notification fails to display.
@@ -78,6 +80,7 @@ fun notification(
     message: String = "",
     largeImage: String? = null,
     smallIcon: String? = null,
+    urgency: NotificationUrgency = NotificationUrgency.NORMAL,
     onActivated: (() -> Unit)? = null,
     onDismissed: ((DismissReason) -> Unit)? = null,
     onFailed: (() -> Unit)? = null,
@@ -89,5 +92,15 @@ fun notification(
         } else {
             emptyList()
         }
-    return Notification(title, message, largeImage, smallIcon, buttonList, onActivated, onDismissed, onFailed)
+    return Notification(
+        title = title,
+        message = message,
+        largeImage = largeImage,
+        smallIcon = smallIcon,
+        urgency = urgency,
+        buttons = buttonList,
+        onActivated = onActivated,
+        onDismissed = onDismissed,
+        onFailed = onFailed,
+    )
 }

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/NotificationUrgency.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/NotificationUrgency.kt
@@ -13,9 +13,14 @@ package dev.nucleusframework.notification.common
  * | [CRITICAL]  | `urgency = critical`| `interruptionLevel = timeSensitive`| high priority + `scenario = urgent`    |
  *
  * Notes:
- * - macOS: [CRITICAL] maps to `timeSensitive`, not the OS `critical` level, which requires a
- *   special Apple entitlement. `interruptionLevel` requires macOS 12+ and is ignored on older
- *   systems.
+ * - macOS: [CRITICAL] maps to `timeSensitive` (breaks through Focus / Do Not Disturb when the user
+ *   allows time-sensitive notifications for the app), not the OS `critical` level. The `critical`
+ *   level requires the restricted `com.apple.developer.usernotifications.critical-alerts`
+ *   entitlement, which Apple grants manually per App ID and which must be embedded in a
+ *   provisioning profile even for Developer ID (non-App-Store) apps — so it is unusable by a
+ *   general-purpose library and is not exposed here. `timeSensitive` does not change the
+ *   notification's expiration/lifetime. `interruptionLevel` requires macOS 12+ and is ignored on
+ *   older systems.
  * - Windows: `put_Priority(High)` only affects connected-standby screen wake and Action Center
  *   ordering, so it is not visibly different on a normal desktop. [CRITICAL] therefore also uses
  *   the `urgent` scenario, which gives the toast distinct visual treatment and breaks through
@@ -33,6 +38,10 @@ enum class NotificationUrgency {
     /** Default priority. */
     NORMAL,
 
-    /** High priority; time-sensitive and, where supported, does not auto-expire. */
+    /**
+     * High priority and time-sensitive: breaks through Focus / Do Not Disturb where the platform
+     * and user settings allow. On Linux it also stays resident until dismissed; macOS and Windows
+     * do not change the notification's lifetime.
+     */
     CRITICAL,
 }

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/NotificationUrgency.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/NotificationUrgency.kt
@@ -1,0 +1,38 @@
+package dev.nucleusframework.notification.common
+
+/**
+ * Cross-platform notification urgency.
+ *
+ * This is the only prominence hint exposed by the common API, because it is the single
+ * concept that maps to a real, first-class native equivalent on every supported OS:
+ *
+ * | Common      | Linux (freedesktop) | macOS (UserNotifications)          | Windows (WinRT)                        |
+ * |-------------|---------------------|------------------------------------|----------------------------------------|
+ * | [LOW]       | `urgency = low`     | `interruptionLevel = passive`      | default priority                       |
+ * | [NORMAL]    | `urgency = normal`  | `interruptionLevel = active`       | default priority                       |
+ * | [CRITICAL]  | `urgency = critical`| `interruptionLevel = timeSensitive`| high priority + `scenario = urgent`    |
+ *
+ * Notes:
+ * - macOS: [CRITICAL] maps to `timeSensitive`, not the OS `critical` level, which requires a
+ *   special Apple entitlement. `interruptionLevel` requires macOS 12+ and is ignored on older
+ *   systems.
+ * - Windows: `put_Priority(High)` only affects connected-standby screen wake and Action Center
+ *   ordering, so it is not visibly different on a normal desktop. [CRITICAL] therefore also uses
+ *   the `urgent` scenario, which gives the toast distinct visual treatment and breaks through
+ *   Focus Assist / Do Not Disturb (Windows 10 build 19041+; ignored on older builds). [LOW] and
+ *   [NORMAL] behave identically on Windows.
+ *
+ * Platform-specific hints that are **not** common across all OSes (expire timeout, transient,
+ * resident, freedesktop category, macOS relevance score, etc.) are intentionally left out of the
+ * common API and must be set through the per-OS modules directly.
+ */
+enum class NotificationUrgency {
+    /** Low priority; may be shown less prominently or omitted from Do-Not-Disturb breakthrough. */
+    LOW,
+
+    /** Default priority. */
+    NORMAL,
+
+    /** High priority; time-sensitive and, where supported, does not auto-expire. */
+    CRITICAL,
+}

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/LinuxDispatcher.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/LinuxDispatcher.kt
@@ -5,11 +5,13 @@ import dev.nucleusframework.notification.common.DismissReason
 import dev.nucleusframework.notification.common.Notification
 import dev.nucleusframework.notification.common.NotificationHandle
 import dev.nucleusframework.notification.common.NotificationResult
+import dev.nucleusframework.notification.common.NotificationUrgency
 import dev.nucleusframework.notification.linux.CloseReason
 import dev.nucleusframework.notification.linux.LinuxNotificationCenter
 import dev.nucleusframework.notification.linux.LinuxNotificationListener
 import dev.nucleusframework.notification.linux.NotificationAction
 import dev.nucleusframework.notification.linux.NotificationHints
+import dev.nucleusframework.notification.linux.Urgency
 import java.util.logging.Level
 import java.util.logging.Logger
 import dev.nucleusframework.notification.linux.Notification as LinuxNotification
@@ -91,6 +93,7 @@ internal class LinuxDispatcher private constructor() : PlatformDispatcher {
 
         val hints =
             NotificationHints(
+                urgency = notification.urgency.toLinux(),
                 imagePath = notification.largeImage?.let { FreedesktopIcon.Custom(it) },
             )
 
@@ -139,6 +142,13 @@ internal class LinuxDispatcher private constructor() : PlatformDispatcher {
         }
     }
 }
+
+private fun NotificationUrgency.toLinux(): Urgency =
+    when (this) {
+        NotificationUrgency.LOW -> Urgency.LOW
+        NotificationUrgency.NORMAL -> Urgency.NORMAL
+        NotificationUrgency.CRITICAL -> Urgency.CRITICAL
+    }
 
 private fun CloseReason.toCommon(): DismissReason =
     when (this) {

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/MacOsDispatcher.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/MacOsDispatcher.kt
@@ -150,8 +150,10 @@ internal class MacOsDispatcher private constructor() : PlatformDispatcher {
         NotificationCenter.removeDeliveredNotifications(listOf(platformId))
     }
 
-    // CRITICAL maps to TIME_SENSITIVE, not the OS CRITICAL level, which requires a special
-    // Apple entitlement. interruptionLevel requires macOS 12+ and is ignored on older systems.
+    // CRITICAL maps to TIME_SENSITIVE, not the OS CRITICAL level: the latter needs Apple's
+    // restricted critical-alerts entitlement (granted manually per App ID, and requires an
+    // embedded provisioning profile even for non-App-Store apps), so it is not exposed here.
+    // interruptionLevel requires macOS 12+ and is ignored on older systems.
     private fun NotificationUrgency.toInterruptionLevel(): InterruptionLevel =
         when (this) {
             NotificationUrgency.LOW -> InterruptionLevel.PASSIVE

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/MacOsDispatcher.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/MacOsDispatcher.kt
@@ -3,6 +3,7 @@ package dev.nucleusframework.notification.common.internal
 import dev.nucleusframework.notification.ActionOption
 import dev.nucleusframework.notification.CategoryOption
 import dev.nucleusframework.notification.DeliveredNotification
+import dev.nucleusframework.notification.InterruptionLevel
 import dev.nucleusframework.notification.NotificationAction
 import dev.nucleusframework.notification.NotificationAttachment
 import dev.nucleusframework.notification.NotificationCategory
@@ -16,6 +17,7 @@ import dev.nucleusframework.notification.common.DismissReason
 import dev.nucleusframework.notification.common.Notification
 import dev.nucleusframework.notification.common.NotificationHandle
 import dev.nucleusframework.notification.common.NotificationResult
+import dev.nucleusframework.notification.common.NotificationUrgency
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level
@@ -110,6 +112,7 @@ internal class MacOsDispatcher private constructor() : PlatformDispatcher {
                 body = notification.message,
                 categoryIdentifier = categoryId,
                 attachments = attachments,
+                interruptionLevel = notification.urgency.toInterruptionLevel(),
             )
 
         val request =
@@ -146,6 +149,15 @@ internal class MacOsDispatcher private constructor() : PlatformDispatcher {
     override fun dismiss(platformId: String) {
         NotificationCenter.removeDeliveredNotifications(listOf(platformId))
     }
+
+    // CRITICAL maps to TIME_SENSITIVE, not the OS CRITICAL level, which requires a special
+    // Apple entitlement. interruptionLevel requires macOS 12+ and is ignored on older systems.
+    private fun NotificationUrgency.toInterruptionLevel(): InterruptionLevel =
+        when (this) {
+            NotificationUrgency.LOW -> InterruptionLevel.PASSIVE
+            NotificationUrgency.NORMAL -> InterruptionLevel.ACTIVE
+            NotificationUrgency.CRITICAL -> InterruptionLevel.TIME_SENSITIVE
+        }
 
     private fun registerCategoryForButtons(notification: Notification): String {
         val signature = notification.buttons.joinToString("|") { it.title }

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/WindowsDispatcher.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/WindowsDispatcher.kt
@@ -4,8 +4,11 @@ import dev.nucleusframework.notification.common.DismissReason
 import dev.nucleusframework.notification.common.Notification
 import dev.nucleusframework.notification.common.NotificationHandle
 import dev.nucleusframework.notification.common.NotificationResult
+import dev.nucleusframework.notification.common.NotificationUrgency
 import dev.nucleusframework.notification.windows.DismissalReason
 import dev.nucleusframework.notification.windows.ToastNotificationListener
+import dev.nucleusframework.notification.windows.ToastNotificationPriority
+import dev.nucleusframework.notification.windows.ToastScenario
 import dev.nucleusframework.notification.windows.WindowsNotificationCenter
 import dev.nucleusframework.notification.windows.toast
 import java.util.concurrent.atomic.AtomicBoolean
@@ -111,8 +114,15 @@ internal class WindowsDispatcher private constructor() : PlatformDispatcher {
         val tag = generateTag()
         val platformId = toPlatformId(tag, GROUP)
 
+        // CRITICAL uses the "urgent" scenario: distinct visual treatment that breaks through
+        // Focus Assist / Do Not Disturb (Windows 10 build 19041+, ignored on older builds).
+        // put_Priority(High) below only affects connected-standby screen wake and Action Center
+        // ordering, so the scenario is what makes CRITICAL visibly different on desktop.
         val toastContent =
             toast {
+                if (notification.urgency == NotificationUrgency.CRITICAL) {
+                    scenario = ToastScenario.URGENT
+                }
                 visual {
                     text(notification.title)
                     if (notification.message.isNotEmpty()) {
@@ -151,10 +161,18 @@ internal class WindowsDispatcher private constructor() : PlatformDispatcher {
         )
 
         var sendError: String? = null
+        val priority =
+            if (notification.urgency == NotificationUrgency.CRITICAL) {
+                ToastNotificationPriority.HIGH
+            } else {
+                ToastNotificationPriority.DEFAULT
+            }
+
         WindowsNotificationCenter.show(
             content = toastContent,
             tag = tag,
             group = GROUP,
+            priority = priority,
         ) { error ->
             if (error != null) {
                 sendError = error

--- a/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/Enums.kt
+++ b/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/Enums.kt
@@ -29,6 +29,21 @@ enum class AfterActivationBehavior(
     PENDING_UPDATE("pendingUpdate"),
 }
 
+/**
+ * Toast priority, mapped to WinRT `ToastNotificationPriority` (`IToastNotification4::put_Priority`).
+ *
+ * Only meaningful within a session; Windows exposes just two levels.
+ */
+enum class ToastNotificationPriority(
+    val nativeValue: Int,
+) {
+    /** Default priority. */
+    DEFAULT(0),
+
+    /** High priority — delivered even under Focus Assist where the app is allowed. */
+    HIGH(1),
+}
+
 // -- Scenarios --
 
 /** Pre-defined toast display/audio behavior scenarios. */
@@ -37,6 +52,12 @@ enum class ToastScenario(
 ) {
     /** Normal toast behavior. */
     DEFAULT("default"),
+
+    /**
+     * Important notification: distinct visual treatment and breaks through Focus Assist /
+     * Do Not Disturb. Requires Windows 10 build 19041+; ignored on older builds.
+     */
+    URGENT("urgent"),
 
     /** Pre-expanded, stays on screen until dismissed. */
     REMINDER("reminder"),

--- a/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/NativeWindowsNotificationBridge.kt
+++ b/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/NativeWindowsNotificationBridge.kt
@@ -50,6 +50,7 @@ internal object NativeWindowsNotificationBridge {
         expiresOnReboot: Boolean,
         expirationTimeMs: Long,
         suppressPopup: Boolean,
+        priority: Int,
         dataKeys: Array<String>,
         dataValues: Array<String>,
         dataSequenceNumber: Int,
@@ -63,6 +64,7 @@ internal object NativeWindowsNotificationBridge {
                 expiresOnReboot,
                 expirationTimeMs,
                 suppressPopup,
+                priority,
                 dataKeys,
                 dataValues,
                 dataSequenceNumber,
@@ -153,6 +155,7 @@ internal object NativeWindowsNotificationBridge {
      * @param expiresOnReboot Whether to remove the notification on reboot.
      * @param expirationTimeMs Expiration time in ms from now (0 = no expiration).
      * @param suppressPopup If true, the notification goes directly to Action Center.
+     * @param priority Toast priority (0 = default, 1 = high).
      * @param callbackId Callback ID for result notification.
      */
     @JvmStatic
@@ -164,6 +167,7 @@ internal object NativeWindowsNotificationBridge {
         expiresOnReboot: Boolean,
         expirationTimeMs: Long,
         suppressPopup: Boolean,
+        priority: Int,
         dataKeys: Array<String>,
         dataValues: Array<String>,
         dataSequenceNumber: Int,

--- a/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/WindowsNotificationCenter.kt
+++ b/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/WindowsNotificationCenter.kt
@@ -124,6 +124,7 @@ object WindowsNotificationCenter {
      * @param expiresOnReboot Remove the notification on system reboot.
      * @param expirationTimeMs Auto-remove after this duration in ms (0 = no expiration).
      * @param suppressPopup Send directly to Action Center without popup.
+     * @param priority Toast priority (`IToastNotification4::put_Priority`).
      * @param callback Optional callback with error string (null on success).
      */
     fun show(
@@ -133,6 +134,7 @@ object WindowsNotificationCenter {
         expiresOnReboot: Boolean = false,
         expirationTimeMs: Long = 0,
         suppressPopup: Boolean = false,
+        priority: ToastNotificationPriority = ToastNotificationPriority.DEFAULT,
         initialData: ToastNotificationData? = null,
         callback: ((error: String?) -> Unit)? = null,
     ) {
@@ -148,6 +150,7 @@ object WindowsNotificationCenter {
             expiresOnReboot = expiresOnReboot,
             expirationTimeMs = expirationTimeMs,
             suppressPopup = suppressPopup,
+            priority = priority.nativeValue,
             dataKeys = initialData?.values?.keys?.toTypedArray() ?: emptyArray(),
             dataValues = initialData?.values?.values?.toTypedArray() ?: emptyArray(),
             dataSequenceNumber = initialData?.sequenceNumber ?: 0,
@@ -167,6 +170,7 @@ object WindowsNotificationCenter {
         expiresOnReboot: Boolean = false,
         expirationTimeMs: Long = 0,
         suppressPopup: Boolean = false,
+        priority: ToastNotificationPriority = ToastNotificationPriority.DEFAULT,
         initialData: ToastNotificationData? = null,
         callback: ((error: String?) -> Unit)? = null,
     ) {
@@ -181,6 +185,7 @@ object WindowsNotificationCenter {
             expiresOnReboot = expiresOnReboot,
             expirationTimeMs = expirationTimeMs,
             suppressPopup = suppressPopup,
+            priority = priority.nativeValue,
             dataKeys = initialData?.values?.keys?.toTypedArray() ?: emptyArray(),
             dataValues = initialData?.values?.values?.toTypedArray() ?: emptyArray(),
             dataSequenceNumber = initialData?.sequenceNumber ?: 0,

--- a/notification-windows/src/main/native/windows/nucleus_notification_windows.cpp
+++ b/notification-windows/src/main/native/windows/nucleus_notification_windows.cpp
@@ -29,6 +29,7 @@
 
 #include <wrl/implements.h>
 #include <wrl/event.h>
+#include <windows.foundation.h>
 #include <windows.ui.notifications.h>
 #include <windows.data.xml.dom.h>
 
@@ -448,7 +449,7 @@ Java_dev_nucleusframework_notification_windows_NativeWindowsNotificationBridge_n
     JNIEnv *env, jclass clazz,
     jstring jXml, jstring jTag, jstring jGroup,
     jboolean expiresOnReboot, jlong expirationTimeMs,
-    jboolean suppressPopup,
+    jboolean suppressPopup, jint priority,
     jobjectArray jDataKeys, jobjectArray jDataValues, jint dataSequenceNumber,
     jlong callbackId
 ) {
@@ -495,6 +496,48 @@ Java_dev_nucleusframework_notification_windows_NativeWindowsNotificationBridge_n
                 toast2->put_Group(HStringWrapper(group).Get());
             if (suppressPopup)
                 toast2->put_SuppressPopup(TRUE);
+        }
+
+        // Set priority via IToastNotification4 (0 = default, 1 = high)
+        if (priority > 0) {
+            ComPtr<IToastNotification4> toast4prio;
+            if (SUCCEEDED(toast.As(&toast4prio))) {
+                toast4prio->put_Priority(ToastNotificationPriority_High);
+            }
+        }
+
+        // Auto-expire after expirationTimeMs via IToastNotification::put_ExpirationTime
+        if (expirationTimeMs > 0) {
+            FILETIME ft;
+            GetSystemTimePreciseAsFileTime(&ft);
+            ULARGE_INTEGER uli;
+            uli.LowPart = ft.dwLowDateTime;
+            uli.HighPart = ft.dwHighDateTime;
+
+            ABI::Windows::Foundation::DateTime dt;
+            // DateTime and FILETIME share the 1601 epoch in 100ns ticks; ms -> 100ns == *10000.
+            dt.UniversalTime = (INT64)uli.QuadPart + (INT64)expirationTimeMs * 10000LL;
+
+            ComPtr<ABI::Windows::Foundation::IPropertyValueStatics> propStatics;
+            if (SUCCEEDED(RoGetActivationFactory(
+                    HStringWrapper(RuntimeClass_Windows_Foundation_PropertyValue).Get(),
+                    IID_PPV_ARGS(&propStatics)))) {
+                ComPtr<IInspectable> dtInsp;
+                if (SUCCEEDED(propStatics->CreateDateTime(dt, &dtInsp))) {
+                    ComPtr<ABI::Windows::Foundation::IReference<ABI::Windows::Foundation::DateTime>> dtRef;
+                    if (SUCCEEDED(dtInsp.As(&dtRef))) {
+                        toast->put_ExpirationTime(dtRef.Get());
+                    }
+                }
+            }
+        }
+
+        // Remove on reboot via IToastNotification6
+        if (expiresOnReboot) {
+            ComPtr<IToastNotification6> toast6;
+            if (SUCCEEDED(toast.As(&toast6))) {
+                toast6->put_ExpiresOnReboot(TRUE);
+            }
         }
 
         // Attach initial NotificationData for data binding (progress bars)

--- a/system-color/build.gradle.kts
+++ b/system-color/build.gradle.kts
@@ -84,7 +84,7 @@ val buildNativeWindows by tasks.registering(Exec::class) {
     inputs.dir(nativeDir)
     outputs.dir(nativeResourceDir)
     workingDir(nativeDir)
-    commandLine("cmd.exe", "/c", "build.bat")
+    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
 }
 
 tasks.processResources {


### PR DESCRIPTION
Closes #397.

## Summary
Adds `urgency` to the **common** notification API — verified to be the only prominence hint with a real, first-class native equivalent on every OS. Everything else (transient, resident, category, expire timeout) is intentionally kept in the per-OS modules, as the issue requested.

Note: the issue's capability table was inaccurate. Verified against the actual native code:
- **Windows had no urgency at all** — `put_Priority` is now implemented natively (it was missing).
- **`put_Priority(High)` alone is invisible on desktop** (only affects connected-standby screen wake + Action Center ordering), so `CRITICAL` also sets `scenario="urgent"`, which gives distinct visual treatment and breaks through Focus Assist (Win10 19041+).
- **Windows expire timeout was a silent no-op** — `expirationTimeMs`/`expiresOnReboot` were accepted but never applied; now wired to `put_ExpirationTime`/`put_ExpiresOnReboot`.

### Common API
- New `NotificationUrgency { LOW, NORMAL, CRITICAL }`, default `NORMAL`, added to `Notification` + `notification { }` DSL.
- Linux → freedesktop `Urgency`.
- macOS → `UNNotificationInterruptionLevel` (`CRITICAL` → `timeSensitive`, not the entitlement-gated `critical`).
- Windows → `put_Priority(High)` + `scenario = urgent` for `CRITICAL`.

### Windows module
- New `ToastNotificationPriority` enum + `priority` param on `show()`/`showFromXml()`.
- Native: `put_Priority`, `put_ExpirationTime`, `put_ExpiresOnReboot` implemented in `nucleus_notification_windows.cpp`.
- New `ToastScenario.URGENT`.

### Misc
- Demo: urgency selector in `CommonNotificationsScreen`.
- Build: align `system-color` native `build.bat` invocation with the working `notification-windows` pattern (absolute path) to fix a local Windows build failure.

## Test plan
- [x] Kotlin compiles (common, windows, linux, macos, nucleus-demo)
- [x] Windows native DLL rebuilds (x64 + ARM64)
- [x] ktlint + detekt clean
- [x] Windows: `CRITICAL` shows the urgent banner and breaks through Focus Assist
- [x] Linux: urgency honored by the notification server
- [x] macOS: interruption level honored (macOS 12+)