### PR TITLE
fix(macos): ship the same .app bundle name in every artifact

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/PlatformSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/PlatformSettings.kt
@@ -35,6 +35,21 @@ abstract class AbstractPlatformSettings {
 abstract class AbstractMacOSPlatformSettings : AbstractPlatformSettings() {
     var packageName: String? = null
 
+    /**
+     * Name of the `.app` bundle directory, without the `.app` extension.
+     *
+     * Every macOS artifact — DMG, ZIP, PKG, the raw app image and the GraalVM bundle — ships the
+     * bundle under this exact name, so an app installed from one format can be updated from another.
+     *
+     * Defaults to [AbstractDistributions.appName], falling back to [packageName] and then to the
+     * root `packageName`. The value is sanitized the same way electron-builder sanitizes
+     * `productName`, so characters that are illegal in a filename are dropped.
+     *
+     * Note that this only renames the bundle directory: the launcher stays at
+     * `Contents/MacOS/<packageName>` and `CFBundleName` keeps using `appName`.
+     */
+    var bundleName: String? = null
+
     var packageBuildVersion: String? = null
     var dmgPackageVersion: String? = null
     var dmgPackageBuildVersion: String? = null

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationContext.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationContext.kt
@@ -103,6 +103,27 @@ internal data class JvmApplicationContext(
             }
         }
 
+    /**
+     * Resolves the name of the macOS `.app` bundle directory, shared by every macOS packaging
+     * backend so that the DMG, the ZIP, the PKG, the raw app image and the GraalVM bundle all ship
+     * the app under the same name. See [resolveMacBundleName].
+     *
+     * Only meaningful on macOS; on other platforms it degrades to the resolved package name.
+     */
+    fun resolvedMacBundleNameProvider(): Provider<String> =
+        project.provider {
+            val dist = appInternal.nativeDistributions
+            if (currentOS != OS.MacOS) {
+                return@provider resolvedPackageNameProvider().get()
+            }
+            resolveMacBundleName(
+                bundleName = dist.macOS.bundleName,
+                appName = dist.appName,
+                packageName = dist.macOS.packageName ?: dist.packageName,
+                fallback = project.name,
+            )
+        }
+
     inline fun <reified T : Any> provider(noinline fn: () -> T): Provider<T> = project.provider(fn)
 
     fun configureDefaultApp() {

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationContext.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationContext.kt
@@ -87,11 +87,13 @@ internal data class JvmApplicationContext(
      * - Linux: linux.packageName > root packageName > project.name
      * - Windows: windows.packageName > root packageName > project.name
      *
-     * This drives the native output/bundle directory name (e.g. the `.app` bundle
-     * on macOS). It lets the root [packageNameProvider] stay ASCII-safe for Debian/RPM
-     * package names while macOS uses a localized bundle name (e.g. a Hebrew display
-     * name), keeping the installed bundle name identical to the one shipped in the
-     * update archive so the auto-updater can relaunch it.
+     * This drives the native output directory name on Linux and Windows. It lets the root
+     * [packageNameProvider] stay ASCII-safe for Debian/RPM package names while a platform uses a
+     * localized name.
+     *
+     * On macOS it names the launcher and the `.icns` only — the `.app` bundle directory is named by
+     * [resolvedMacBundleNameProvider], which every macOS backend shares so the DMG and the ZIP ship
+     * the same bundle.
      */
     fun resolvedPackageNameProvider(): Provider<String> =
         project.provider {
@@ -116,12 +118,7 @@ internal data class JvmApplicationContext(
             if (currentOS != OS.MacOS) {
                 return@provider resolvedPackageNameProvider().get()
             }
-            resolveMacBundleName(
-                bundleName = dist.macOS.bundleName,
-                appName = dist.appName,
-                packageName = dist.macOS.packageName ?: dist.packageName,
-                fallback = project.name,
-            )
+            resolveMacBundleName(dist, dist.macOS, project.name)
         }
 
     inline fun <reified T : Any> provider(noinline fn: () -> T): Provider<T> = project.provider(fn)

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/MacBundleName.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/MacBundleName.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal
+
+import java.text.Normalizer
+
+/**
+ * Last-resort bundle name, used when every candidate sanitizes down to an empty string
+ * (e.g. `packageName = "..."`, which `sanitize-filename` strips entirely).
+ */
+private const val FALLBACK_BUNDLE_NAME = "app"
+
+/**
+ * Resolves the macOS `.app` bundle directory name (without the `.app` suffix).
+ *
+ * The same value must be used by every macOS packaging backend. electron-builder stages the bundle
+ * inside a DMG under `${productFilename}.app` while its ZIP target archives the prepackaged
+ * directory as-is, so the two artifacts only agree when the prepackaged directory is already named
+ * `${productFilename}.app`. Feeding this single resolution into jpackage's output, the GraalVM
+ * bundle and electron-builder's `productName` keeps that invariant true by construction — an app
+ * installed from the DMG can then be updated from the ZIP and vice versa.
+ *
+ * The result is normalized to NFD because a DMG carries an HFS+ volume, and HFS+ decomposes every
+ * file name it stores. Naming the bundle in NFD up front is what makes the DMG entry and the ZIP
+ * entry — which preserves whatever the build produced — byte-identical rather than merely equivalent.
+ *
+ * Precedence: explicit `macOS.bundleName` > `appName` > `macOS.packageName` / `packageName` >
+ * [fallback] (normally the Gradle project name).
+ */
+internal fun resolveMacBundleName(
+    bundleName: String?,
+    appName: String?,
+    packageName: String?,
+    fallback: String,
+): String =
+    macBundleNameCandidates(bundleName, appName, packageName, fallback)
+        .firstNotNullOfOrNull { candidate ->
+            sanitizeFileName(Normalizer.normalize(candidate, Normalizer.Form.NFD)).takeIf { it.isNotBlank() }
+        }
+        ?: FALLBACK_BUNDLE_NAME
+
+/** Bundle name candidates in precedence order, blanks removed. */
+private fun macBundleNameCandidates(
+    bundleName: String?,
+    appName: String?,
+    packageName: String?,
+    fallback: String,
+): List<String> = listOfNotNull(bundleName, appName, packageName, fallback).filter { it.isNotBlank() }
+
+/**
+ * Reports configurations where the resolved macOS bundle name is not the one the build script most
+ * likely intended, so the ambiguity is settled explicitly via `macOS.bundleName` instead of silently.
+ *
+ * Two cases are reported:
+ *  - `macOS.packageName` is set but loses to `appName`. Before the bundle name was unified, that
+ *    property controlled the `.app` directory name for the raw app image, so a project relying on it
+ *    would see the bundle renamed.
+ *  - the requested name contains characters that are illegal in a filename and had to be stripped.
+ */
+internal fun macBundleNameWarnings(
+    bundleName: String?,
+    appName: String?,
+    macPackageName: String?,
+    resolved: String,
+): List<String> =
+    buildList {
+        val requested = bundleName?.takeIf { it.isNotBlank() } ?: appName?.takeIf { it.isNotBlank() }
+        // Compared in NFD: the resolved name is decomposed to match what HFS+ stores, and that
+        // difference alone must not be reported as a sanitization.
+        if (requested != null && Normalizer.normalize(requested, Normalizer.Form.NFD) != resolved) {
+            add(
+                "w: macOS bundle name \"$requested\" contains characters that are illegal in a file name; " +
+                    "the .app bundle will be named \"$resolved.app\". " +
+                    "Set macOS.bundleName to choose the name explicitly.",
+            )
+        }
+        val macName = macPackageName?.takeIf { it.isNotBlank() }
+        if (bundleName == null && macName != null && Normalizer.normalize(macName, Normalizer.Form.NFD) != resolved) {
+            add(
+                "w: macOS.packageName (\"$macName\") no longer names the .app bundle directory; " +
+                    "every macOS artifact now ships \"$resolved.app\" (from appName) so the DMG and the ZIP " +
+                    "stay interchangeable for auto-update. Set macOS.bundleName = \"$macName\" to keep the " +
+                    "previous bundle name.",
+            )
+        }
+    }
+
+// Port of the npm `sanitize-filename` package (v1.6.x), which electron-builder applies to
+// `productName` to derive `AppInfo.productFilename`. Keeping the two in sync matters: the DMG target
+// names the staged bundle after `productFilename`, so any divergence here reintroduces the very
+// desynchronization this resolution exists to prevent.
+private val ILLEGAL_CHARS = Regex("""[/?<>\\:*|"]""")
+private val CONTROL_CHARS = Regex("[\\x00-\\x1F\\x80-\\x9F]")
+private val ONLY_DOTS = Regex("""^\.+$""")
+private val WINDOWS_RESERVED = Regex("""^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$""", RegexOption.IGNORE_CASE)
+private val WINDOWS_TRAILING = Regex("""[. ]+$""")
+private const val MAX_FILE_NAME_BYTES = 255
+private const val UTF8_CONTINUATION_MASK = 0xC0
+private const val UTF8_CONTINUATION_MARKER = 0x80
+
+/** Kotlin equivalent of electron-builder's `sanitizeFileName`, used to derive `productFilename`. */
+internal fun sanitizeFileName(input: String): String {
+    val sanitized =
+        input
+            .replace(ILLEGAL_CHARS, "")
+            .replace(CONTROL_CHARS, "")
+            .replace(ONLY_DOTS, "")
+            .replace(WINDOWS_RESERVED, "")
+            .replace(WINDOWS_TRAILING, "")
+    return truncateUtf8Bytes(sanitized, MAX_FILE_NAME_BYTES)
+}
+
+/** Truncates to at most [maxBytes] UTF-8 bytes without splitting a multi-byte character. */
+private fun truncateUtf8Bytes(
+    value: String,
+    maxBytes: Int,
+): String {
+    val bytes = value.toByteArray(Charsets.UTF_8)
+    if (bytes.size <= maxBytes) return value
+    var end = maxBytes
+    while (end > 0 && (bytes[end].toInt() and UTF8_CONTINUATION_MASK) == UTF8_CONTINUATION_MARKER) {
+        end--
+    }
+    return String(bytes, 0, end, Charsets.UTF_8)
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/MacBundleName.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/MacBundleName.kt
@@ -5,6 +5,10 @@
 
 package dev.nucleusframework.desktop.application.internal
 
+import dev.nucleusframework.desktop.application.dsl.AbstractDistributions
+import dev.nucleusframework.desktop.application.dsl.AbstractMacOSPlatformSettings
+import java.io.File
+import java.nio.file.Files
 import java.text.Normalizer
 
 /**
@@ -12,6 +16,24 @@ import java.text.Normalizer
  * (e.g. `packageName = "..."`, which `sanitize-filename` strips entirely).
  */
 private const val FALLBACK_BUNDLE_NAME = "app"
+
+/**
+ * Resolves the macOS `.app` bundle directory name from a DSL configuration.
+ *
+ * Single entry point for every caller — the JVM pipeline, the Kotlin/Native pipeline and the
+ * configuration-time validation — so the precedence can never drift between them.
+ */
+internal fun resolveMacBundleName(
+    distributions: AbstractDistributions,
+    macOS: AbstractMacOSPlatformSettings,
+    projectName: String,
+): String =
+    resolveMacBundleName(
+        bundleName = macOS.bundleName,
+        appName = distributions.appName,
+        packageName = macOS.packageName ?: distributions.packageName,
+        fallback = projectName,
+    )
 
 /**
  * Resolves the macOS `.app` bundle directory name (without the `.app` suffix).
@@ -51,6 +73,49 @@ private fun macBundleNameCandidates(
 ): List<String> = listOfNotNull(bundleName, appName, packageName, fallback).filter { it.isNotBlank() }
 
 /**
+ * Renames the macOS `.app` bundle [from] jpackage's output name [to] the resolved bundle name.
+ *
+ * macOS volumes are case- and normalization-insensitive, so when the two names differ only in case
+ * or in Unicode normalization, [to] already resolves to the very bundle jpackage just produced.
+ * Deleting it to make room would erase the app image, which is why the existing destination is only
+ * cleared when it is a genuinely different directory. A plain rename still rewrites the stored name
+ * to the requested form in both cases.
+ *
+ * Returns true when the bundle was renamed, false when there was nothing to do.
+ */
+internal fun renameMacAppBundle(
+    from: File,
+    to: File,
+): Boolean {
+    if (!from.isDirectory) return false
+    if (from.absolutePath == to.absolutePath) return false
+
+    val sameEntry = to.exists() && Files.isSameFile(from.toPath(), to.toPath())
+    if (to.exists() && !sameEntry) {
+        to.deleteRecursively()
+    }
+    if (!sameEntry) {
+        if (!from.renameTo(to)) {
+            error("Unable to rename the app bundle: ${from.absolutePath} -> ${to.absolutePath}")
+        }
+        return true
+    }
+
+    // `rename(2)` succeeds without doing anything when both paths resolve to the same entry, which
+    // is what an insensitive volume reports for a case- or normalization-only difference. Going
+    // through a temporary name is how the requested spelling actually reaches the volume.
+    val staging = File(to.parentFile, ".nucleus-bundle-rename-${System.nanoTime()}")
+    if (!from.renameTo(staging)) {
+        error("Unable to rename the app bundle: ${from.absolutePath} -> ${staging.absolutePath}")
+    }
+    if (!staging.renameTo(to)) {
+        staging.renameTo(from)
+        error("Unable to rename the app bundle: ${from.absolutePath} -> ${to.absolutePath}")
+    }
+    return true
+}
+
+/**
  * Reports configurations where the resolved macOS bundle name is not the one the build script most
  * likely intended, so the ambiguity is settled explicitly via `macOS.bundleName` instead of silently.
  *
@@ -64,10 +129,16 @@ internal fun macBundleNameWarnings(
     bundleName: String?,
     appName: String?,
     macPackageName: String?,
+    packageName: String?,
     resolved: String,
 ): List<String> =
     buildList {
-        val requested = bundleName?.takeIf { it.isNotBlank() } ?: appName?.takeIf { it.isNotBlank() }
+        val explicitBundleName = bundleName?.takeIf { it.isNotBlank() }
+        val requested =
+            explicitBundleName
+                ?: appName?.takeIf { it.isNotBlank() }
+                ?: macPackageName?.takeIf { it.isNotBlank() }
+                ?: packageName?.takeIf { it.isNotBlank() }
         // Compared in NFD: the resolved name is decomposed to match what HFS+ stores, and that
         // difference alone must not be reported as a sanitization.
         if (requested != null && Normalizer.normalize(requested, Normalizer.Form.NFD) != resolved) {
@@ -78,11 +149,13 @@ internal fun macBundleNameWarnings(
             )
         }
         val macName = macPackageName?.takeIf { it.isNotBlank() }
-        if (bundleName == null && macName != null && Normalizer.normalize(macName, Normalizer.Form.NFD) != resolved) {
+        if (explicitBundleName == null && macName != null &&
+            Normalizer.normalize(macName, Normalizer.Form.NFD) != resolved
+        ) {
             add(
                 "w: macOS.packageName (\"$macName\") no longer names the .app bundle directory; " +
-                    "every macOS artifact now ships \"$resolved.app\" (from appName) so the DMG and the ZIP " +
-                    "stay interchangeable for auto-update. Set macOS.bundleName = \"$macName\" to keep the " +
+                    "every macOS artifact now ships \"$resolved.app\" so the DMG and the ZIP stay " +
+                    "interchangeable for auto-update. Set macOS.bundleName = \"$macName\" to keep the " +
                     "previous bundle name.",
             )
         }
@@ -101,7 +174,14 @@ private const val MAX_FILE_NAME_BYTES = 255
 private const val UTF8_CONTINUATION_MASK = 0xC0
 private const val UTF8_CONTINUATION_MARKER = 0x80
 
-/** Kotlin equivalent of electron-builder's `sanitizeFileName`, used to derive `productFilename`. */
+/**
+ * Kotlin equivalent of electron-builder's `sanitizeFileName`, used to derive `productFilename`.
+ *
+ * Unlike the npm original this is idempotent: truncation can expose a trailing dot or space that the
+ * original would leave in place, and electron-builder sanitizes our `productName` a second time on
+ * its way to `productFilename`. A name that is not a fixed point here would come back out of
+ * electron-builder shorter than the directory we named, silently breaking the invariant.
+ */
 internal fun sanitizeFileName(input: String): String {
     val sanitized =
         input
@@ -110,7 +190,7 @@ internal fun sanitizeFileName(input: String): String {
             .replace(ONLY_DOTS, "")
             .replace(WINDOWS_RESERVED, "")
             .replace(WINDOWS_TRAILING, "")
-    return truncateUtf8Bytes(sanitized, MAX_FILE_NAME_BYTES)
+    return truncateUtf8Bytes(sanitized, MAX_FILE_NAME_BYTES).replace(WINDOWS_TRAILING, "")
 }
 
 /** Truncates to at most [maxBytes] UTF-8 bytes without splitting a multi-byte character. */

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -1092,7 +1092,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             OS.MacOS -> {
                 val dir =
                     appTmpDir.map {
-                        it.dir("graalvm/output/${resolvedPackageNameProvider().get()}.app/Contents/MacOS")
+                        it.dir("graalvm/output/${resolvedMacBundleNameProvider().get()}.app/Contents/MacOS")
                     }
                 dir.map { it.file(imageName.get()) }
             }
@@ -1185,7 +1185,7 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
     unpackDefaultResources: TaskProvider<AbstractUnpackDefaultApplicationResourcesTask>,
     packageUberJar: TaskProvider<Jar>,
 ): TaskProvider<DefaultTask> {
-    val appBundleName = resolvedPackageNameProvider().map { "$it.app" }
+    val appBundleName = resolvedMacBundleNameProvider().map { "$it.app" }
     val appBundleDir =
         appTmpDir.map { tmpDir ->
             tmpDir.dir("graalvm/output/${appBundleName.get()}/Contents")
@@ -1987,6 +1987,7 @@ private fun JvmApplicationContext.configureGraalvmElectronBuilderPackaging(
                 )
 
                 packageName.set(resolvedPackageNameProvider())
+                macBundleName.set(resolvedMacBundleNameProvider())
                 packageVersion.set(packageVersionFor(targetFormat))
 
                 // Only wire platform-specific icons/entitlements for the current OS

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
@@ -11,6 +11,7 @@ import dev.nucleusframework.desktop.application.dsl.AotCacheCompatibility
 import dev.nucleusframework.desktop.application.dsl.AotCacheSettings
 import dev.nucleusframework.desktop.application.dsl.PackagingBackend
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import dev.nucleusframework.desktop.application.internal.validation.validateMacBundleName
 import dev.nucleusframework.desktop.application.internal.validation.validatePackageVersions
 import dev.nucleusframework.desktop.application.tasks.AbstractCheckNativeDistributionRuntime
 import dev.nucleusframework.desktop.application.tasks.AbstractElectronBuilderPackageTask
@@ -86,6 +87,7 @@ internal fun JvmApplicationContext.configureJvmApplication() {
     }
 
     validatePackageVersions()
+    validateMacBundleName()
     val commonTasks = configureCommonJvmDesktopTasks()
     configurePackagingTasks(commonTasks)
     copy(buildType = app.buildTypes.release).configurePackagingTasks(commonTasks)
@@ -823,6 +825,7 @@ private fun JvmApplicationContext.configurePackageTask(
     app.nativeDistributions.let { executables ->
         packageTask.packageName.set(packageNameProvider)
         packageTask.appName.set(project.provider { executables.appName })
+        packageTask.macBundleName.set(resolvedMacBundleNameProvider())
         // For Windows: jpackage's --description becomes the FileDescription in the .exe
         // version resource (shown as "Name" in Task Manager), so it must be the human app
         // name, not the description. Falls back to packageName when appName is unset.
@@ -941,6 +944,7 @@ private fun JvmApplicationContext.configureElectronBuilderPackageTask(
             )
         },
     )
+    packageTask.macBundleName.set(resolvedMacBundleNameProvider())
     packageTask.packageVersion.set(packageVersionFor(packageTask.targetFormat))
     packageTask.linuxIconFile.set(
         app.nativeDistributions.linux.iconFile

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureNativeApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureNativeApplication.kt
@@ -10,6 +10,7 @@ import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import dev.nucleusframework.desktop.application.tasks.AbstractNativeMacApplicationPackageAppDirTask
 import dev.nucleusframework.desktop.application.tasks.AbstractNativeMacApplicationPackageDmgTask
 import dev.nucleusframework.desktop.application.tasks.AbstractNativeMacApplicationPackageTask
+import dev.nucleusframework.desktop.application.internal.validation.validateMacBundleName
 import dev.nucleusframework.desktop.tasks.AbstractUnpackDefaultApplicationResourcesTask
 import dev.nucleusframework.internal.utils.OS
 import dev.nucleusframework.internal.utils.currentOS
@@ -29,6 +30,8 @@ internal fun configureNativeApplication(
     unpackDefaultResources: TaskProvider<AbstractUnpackDefaultApplicationResourcesTask>,
 ) {
     if (currentOS != OS.MacOS) return
+
+    validateMacBundleName(project, app.distributions, app.distributions.macOS)
 
     for (target in app._targets) {
         configureNativeApplication(project, app, target, unpackDefaultResources)
@@ -133,12 +136,7 @@ private fun AbstractNativeMacApplicationPackageTask.configureNativePackageTask(
 
     bundleName.set(
         project.provider {
-            resolveMacBundleName(
-                bundleName = app.distributions.macOS.bundleName,
-                appName = app.distributions.appName,
-                packageName = app.distributions.macOS.packageName ?: app.distributions.packageName,
-                fallback = project.name,
-            )
+            resolveMacBundleName(app.distributions, app.distributions.macOS, project.name)
         },
     )
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureNativeApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureNativeApplication.kt
@@ -131,6 +131,17 @@ private fun AbstractNativeMacApplicationPackageTask.configureNativePackageTask(
         },
     )
 
+    bundleName.set(
+        project.provider {
+            resolveMacBundleName(
+                bundleName = app.distributions.macOS.bundleName,
+                appName = app.distributions.appName,
+                packageName = app.distributions.macOS.packageName ?: app.distributions.packageName,
+                fallback = project.name,
+            )
+        },
+    )
+
     // todo: dmg package version
     packageVersion.set(
         project.provider {

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -51,12 +51,17 @@ internal class ElectronBuilderConfigGenerator {
         dmgBackgroundOverride: File? = null,
         dmgWindowOverride: DmgWindowOverride? = null,
         nsisProtocolInclude: File? = null,
+        macBundleName: String? = null,
     ): String {
         val yaml = StringBuilder()
 
         // --- Common settings ---
+        // On macOS the product name must equal the prepackaged bundle's directory name: the DMG
+        // target stages the app as `${productFilename}.app` while the ZIP target archives the
+        // directory verbatim, so any mismatch ships two differently named bundles for one release.
         val resolvedProductName =
-            distributions.appName ?: distributions.packageName ?: executableName
+            macBundleName?.takeIf { currentOS == OS.MacOS && it.isNotBlank() }
+                ?: distributions.appName ?: distributions.packageName ?: executableName
                 ?: error(
                     "No appName, packageName, or executableName available for electron-builder config",
                 )

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/validation/validateMacBundleName.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/validation/validateMacBundleName.kt
@@ -5,9 +5,12 @@
 
 package dev.nucleusframework.desktop.application.internal.validation
 
+import dev.nucleusframework.desktop.application.dsl.AbstractDistributions
+import dev.nucleusframework.desktop.application.dsl.AbstractMacOSPlatformSettings
 import dev.nucleusframework.desktop.application.internal.JvmApplicationContext
 import dev.nucleusframework.desktop.application.internal.macBundleNameWarnings
 import dev.nucleusframework.desktop.application.internal.resolveMacBundleName
+import org.gradle.api.Project
 
 /**
  * Warns about configurations whose macOS `.app` bundle name is ambiguous.
@@ -17,15 +20,25 @@ import dev.nucleusframework.desktop.application.internal.resolveMacBundleName
  */
 internal fun JvmApplicationContext.validateMacBundleName() {
     val dist = app.nativeDistributions
-    val mac = dist.macOS
-    val resolved =
-        resolveMacBundleName(
-            bundleName = mac.bundleName,
-            appName = dist.appName,
-            packageName = mac.packageName ?: dist.packageName,
-            fallback = project.name,
+    validateMacBundleName(project, dist, dist.macOS)
+}
+
+/** Shared by the JVM and the Kotlin/Native pipelines, which resolve the same bundle name. */
+internal fun validateMacBundleName(
+    project: Project,
+    distributions: AbstractDistributions,
+    macOS: AbstractMacOSPlatformSettings,
+) {
+    val resolved = resolveMacBundleName(distributions, macOS, project.name)
+    val warnings =
+        macBundleNameWarnings(
+            bundleName = macOS.bundleName,
+            appName = distributions.appName,
+            macPackageName = macOS.packageName,
+            packageName = distributions.packageName,
+            resolved = resolved,
         )
-    for (warning in macBundleNameWarnings(mac.bundleName, dist.appName, mac.packageName, resolved)) {
+    for (warning in warnings) {
         project.logger.warn(warning)
     }
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/validation/validateMacBundleName.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/validation/validateMacBundleName.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2021 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal.validation
+
+import dev.nucleusframework.desktop.application.internal.JvmApplicationContext
+import dev.nucleusframework.desktop.application.internal.macBundleNameWarnings
+import dev.nucleusframework.desktop.application.internal.resolveMacBundleName
+
+/**
+ * Warns about configurations whose macOS `.app` bundle name is ambiguous.
+ *
+ * Reported on every host OS, not just macOS, so a Linux or Windows developer configuring a macOS
+ * distribution still sees the problem.
+ */
+internal fun JvmApplicationContext.validateMacBundleName() {
+    val dist = app.nativeDistributions
+    val mac = dist.macOS
+    val resolved =
+        resolveMacBundleName(
+            bundleName = mac.bundleName,
+            appName = dist.appName,
+            packageName = mac.packageName ?: dist.packageName,
+            fallback = project.name,
+        )
+    for (warning in macBundleNameWarnings(mac.bundleName, dist.appName, mac.packageName, resolved)) {
+        project.logger.warn(warning)
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -130,6 +130,19 @@ abstract class AbstractElectronBuilderPackageTask
         @get:Optional
         val executableName: Property<String> = objects.nullableProperty()
 
+        /**
+         * Name of the macOS `.app` bundle directory, without the `.app` extension.
+         *
+         * electron-builder's DMG target stages the bundle under `${productFilename}.app` while its
+         * ZIP target archives the prepackaged directory as-is, so the two formats only ship the same
+         * bundle name when the prepackaged directory is already named after `productFilename`. This
+         * task therefore renames its working copy to `<macBundleName>.app` and pins `productName` to
+         * the same value, making `basename(prepackaged) == productFilename` hold by construction.
+         */
+        @get:Input
+        @get:Optional
+        val macBundleName: Property<String> = objects.nullableProperty()
+
         @get:Input
         val targetArch: Property<String> =
             objects.notNullProperty<String>().apply {
@@ -231,8 +244,9 @@ abstract class AbstractElectronBuilderPackageTask
             val outputDir = destinationDir.ioFile.apply { mkdirs() }
 
             // Create a task-private copy of the app image so parallel tasks don't
-            // interfere when modifying .cfg files or signing the bundle.
-            val workingAppDir = copyAppImage(originalAppDir, outputDir, logger)
+            // interfere when modifying .cfg files or signing the bundle. On macOS the copy is
+            // renamed to the resolved bundle name so every format ships the same .app.
+            val workingAppDir = copyAppImage(originalAppDir, outputDir, resolveWorkingAppDirName(originalAppDir), logger)
 
             ensureResourcesDirForElectronBuilder(workingAppDir)
             bundleUpdatePublicKey(workingAppDir, dist)
@@ -429,6 +443,7 @@ abstract class AbstractElectronBuilderPackageTask
                     dmgBackgroundOverride = dmgBackgroundOverride,
                     dmgWindowOverride = dmgWindowOverride,
                     nsisProtocolInclude = nsisProtocolInclude,
+                    macBundleName = macBundleName.orNull,
                 )
             val configFile = File(outputDir, "electron-builder.yml")
             configFile.writeText(configContent)
@@ -592,8 +607,11 @@ abstract class AbstractElectronBuilderPackageTask
             val metadata =
                 buildString {
                     appendLine("{")
+                    // Mirrors the config generator: the bundle name wins so a DMG rebuilt from this
+                    // metadata on another machine stages the same .app the ZIP already ships.
                     val resolvedProductName =
-                        distributions.appName ?: distributions.packageName ?: executableName.orNull
+                        macBundleName.orNull?.takeIf { it.isNotBlank() }
+                            ?: distributions.appName ?: distributions.packageName ?: executableName.orNull
                     appendLine("  \"productName\": ${jsonStr(resolvedProductName)},")
                     appendLine("  \"appId\": ${jsonStr(appId)},")
                     appendLine("  \"copyright\": ${jsonStr(distributions.copyright)},")
@@ -1873,7 +1891,7 @@ abstract class AbstractElectronBuilderPackageTask
          * Resolves the actual app directory inside the jpackage app-image output.
          *
          * jpackage produces: `<destinationDir>/<packageName>` on Linux/Windows
-         *                  or `<destinationDir>/<packageName>.app` on macOS.
+         *                  or `<destinationDir>/<macBundleName>.app` on macOS.
          */
         private fun resolveAppImageDir(): File {
             val root = appImageRoot.ioFile
@@ -1882,10 +1900,14 @@ abstract class AbstractElectronBuilderPackageTask
             }
 
             val name = packageName.get()
+            val bundleName = macBundleName.orNull?.takeIf { it.isNotBlank() }
 
-            // Try platform-specific name, then plain name, then single-child fallback
+            // Try the macOS bundle name, then the platform-specific name, then the plain name,
+            // then fall back to the single child directory.
             val resolved =
                 when {
+                    currentOS == OS.MacOS && bundleName != null && root.resolve("$bundleName.app").isDirectory ->
+                        root.resolve("$bundleName.app")
                     currentOS == OS.MacOS && root.resolve("$name.app").isDirectory ->
                         root.resolve("$name.app")
                     root.resolve(name).isDirectory -> root.resolve(name)
@@ -1894,8 +1916,21 @@ abstract class AbstractElectronBuilderPackageTask
 
             return resolved ?: throw GradleException(
                 "Unable to locate app image directory. " +
-                    "Expected '$name' or '$name.app' inside: ${root.absolutePath}",
+                    "Expected '$name' or '${bundleName ?: name}.app' inside: ${root.absolutePath}",
             )
+        }
+
+        /**
+         * Name the task-private copy of the app image must carry.
+         *
+         * On macOS this is `<macBundleName>.app`, which electron-builder's ZIP target archives
+         * verbatim and its DMG target reproduces via `productFilename`. Elsewhere the source name is
+         * kept as-is.
+         */
+        private fun resolveWorkingAppDirName(source: File): String {
+            if (currentOS != OS.MacOS) return source.name
+            val bundleName = macBundleName.orNull?.takeIf { it.isNotBlank() } ?: return source.name
+            return "$bundleName.app"
         }
 
         /**
@@ -1941,10 +1976,11 @@ internal fun resolveLinuxExecutableName(
 private fun copyAppImage(
     source: File,
     outputDir: File,
+    destinationName: String,
     logger: Logger,
 ): File {
     val workingRoot = File(outputDir, ".app-image")
-    val destination = File(workingRoot, source.name)
+    val destination = File(workingRoot, destinationName)
     if (destination.exists()) {
         deleteWithRetry(destination, logger)
     }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractJPackageTask.kt
@@ -36,6 +36,7 @@ import dev.nucleusframework.desktop.application.internal.files.mangledName
 import dev.nucleusframework.desktop.application.internal.files.normalizedPath
 import dev.nucleusframework.desktop.application.internal.files.transformJar
 import dev.nucleusframework.desktop.application.internal.javaOption
+import dev.nucleusframework.desktop.application.internal.renameMacAppBundle
 import dev.nucleusframework.desktop.application.internal.validation.validate
 import dev.nucleusframework.internal.utils.OS
 import dev.nucleusframework.internal.utils.clearDirs
@@ -649,18 +650,15 @@ abstract class AbstractJPackageTask
         private fun renameMacAppDirIfNeeded() {
             val jpackageAppDir = destinationDir.ioFile.resolve("${packageName.get()}.app")
             val target = macAppDir
-            if (jpackageAppDir == target || !jpackageAppDir.isDirectory) return
-
-            if (target.exists()) {
-                target.deleteRecursively()
+            val renamed =
+                try {
+                    renameMacAppBundle(from = jpackageAppDir, to = target)
+                } catch (e: IllegalStateException) {
+                    throw GradleException(e.message ?: "Unable to rename the app bundle", e)
+                }
+            if (renamed) {
+                logger.info("Renamed app bundle to the resolved macOS bundle name: ${target.name}")
             }
-            if (!jpackageAppDir.renameTo(target)) {
-                throw GradleException(
-                    "Unable to rename the app bundle to the resolved macOS bundle name: " +
-                        "${jpackageAppDir.absolutePath} -> ${target.absolutePath}",
-                )
-            }
-            logger.info("Renamed app bundle to the resolved macOS bundle name: ${target.name}")
         }
 
         @Suppress("NestedBlockDepth")

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractJPackageTask.kt
@@ -50,6 +50,7 @@ import dev.nucleusframework.internal.utils.notNullProperty
 import dev.nucleusframework.internal.utils.nullableProperty
 import dev.nucleusframework.internal.utils.stacktraceToString
 import dev.nucleusframework.desktop.application.dsl.AdditionalLauncher
+import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
@@ -167,6 +168,19 @@ abstract class AbstractJPackageTask
         @get:Input
         @get:Optional
         val appName: Property<String> = objects.nullableProperty()
+
+        /**
+         * Name of the macOS `.app` bundle directory produced by this task, without the `.app`
+         * extension.
+         *
+         * jpackage always names the bundle after its `--name` argument ([packageName]), which also
+         * names the launcher and the `.icns`. Renaming only the directory afterwards keeps the app
+         * image aligned with the DMG and ZIP built from it, without touching the launcher name the
+         * jpackage runtime resolves its `.cfg` from.
+         */
+        @get:Input
+        @get:Optional
+        val macBundleName: Property<String> = objects.nullableProperty()
 
         @get:Input
         @get:Optional
@@ -298,8 +312,7 @@ abstract class AbstractJPackageTask
                         }
                     }
                 }
-            val appDir = destinationDir.ioFile.resolve("${packageName.get()}.app")
-            val iconsDir = appDir.resolve("Contents").resolve("Resources")
+            val iconsDir = macAppDir.resolve("Contents").resolve("Resources")
             if (iconsDir.exists()) {
                 iconsDir.deleteRecursively()
             }
@@ -617,11 +630,46 @@ abstract class AbstractJPackageTask
             logger.lifecycle("The distribution is written to ${outputFile.canonicalPath}")
         }
 
+        /** Bundle directory name jpackage's macOS output is renamed to, without the `.app` suffix. */
+        private val macAppDirName: String
+            get() = macBundleName.orNull?.takeIf { it.isNotBlank() } ?: packageName.get()
+
+        /** Final location of the macOS `.app` bundle, after [renameMacAppDirIfNeeded]. */
+        private val macAppDir: File
+            get() = destinationDir.ioFile.resolve("$macAppDirName.app")
+
+        /**
+         * Renames jpackage's `<packageName>.app` output to `<macBundleName>.app`.
+         *
+         * Runs before signing so the signature is produced against the final layout, and only
+         * renames the directory: `Contents/MacOS/<packageName>` and `<packageName>.icns` keep their
+         * names because the jpackage launcher resolves `Contents/app/<launcher>.cfg` from its own
+         * executable name.
+         */
+        private fun renameMacAppDirIfNeeded() {
+            val jpackageAppDir = destinationDir.ioFile.resolve("${packageName.get()}.app")
+            val target = macAppDir
+            if (jpackageAppDir == target || !jpackageAppDir.isDirectory) return
+
+            if (target.exists()) {
+                target.deleteRecursively()
+            }
+            if (!jpackageAppDir.renameTo(target)) {
+                throw GradleException(
+                    "Unable to rename the app bundle to the resolved macOS bundle name: " +
+                        "${jpackageAppDir.absolutePath} -> ${target.absolutePath}",
+                )
+            }
+            logger.info("Renamed app bundle to the resolved macOS bundle name: ${target.name}")
+        }
+
         @Suppress("NestedBlockDepth")
         private fun modifyRuntimeOnMacOsIfNeeded() {
             if (currentOS != OS.MacOS || targetFormat != TargetFormat.RawAppImage) return
 
-            val appDir = destinationDir.ioFile.resolve("${packageName.get()}.app")
+            renameMacAppDirIfNeeded()
+
+            val appDir = macAppDir
             val runtimeDir = appDir.resolve("Contents/runtime")
 
             macAssetsTool.assetsFile(workingDir.ioFile).apply {

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
@@ -72,7 +72,7 @@ abstract class AbstractNativeMacApplicationPackageAppDirTask : AbstractNativeMac
         workingDir: File,
     ) {
         val packageName = packageName.get()
-        val appDir = destinationDir.resolve("$packageName.app").apply { mkdirs() }
+        val appDir = destinationDir.resolve("${bundleName.get()}.app").apply { mkdirs() }
         val contentsDir = appDir.resolve("Contents").apply { mkdirs() }
         val macOSDir = contentsDir.resolve("MacOS").apply { mkdirs() }
         val appResourcesDir = contentsDir.resolve("Resources").apply { mkdirs() }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractNativeMacApplicationPackageDmgTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractNativeMacApplicationPackageDmgTask.kt
@@ -97,12 +97,12 @@ abstract class AbstractNativeMacApplicationPackageDmgTask : AbstractNativeMacApp
         destinationDir: File,
         workingDir: File,
     ) {
-        val packageName = packageName.get()
+        val bundleName = bundleName.get()
         val volumeName =
             dmgTitle.orNull
-                ?.replace("\${productName}", packageName)
+                ?.replace("\${productName}", bundleName)
                 ?.replace("\${version}", packageVersion.get())
-                ?: packageName
+                ?: bundleName
         val fullPackageName = fullPackageName.get()
         val tmpImage = workingDir.resolve("$fullPackageName.tmp.dmg")
         val finalImage = destinationDir.resolve("$fullPackageName.dmg")
@@ -110,7 +110,8 @@ abstract class AbstractNativeMacApplicationPackageDmgTask : AbstractNativeMacApp
         createImage(volumeName = volumeName, imageFile = tmpImage, srcDir = appDir.ioFile)
         val mounted = mountImage(volumeName = volumeName, imageFile = tmpImage)
         try {
-            runSetupScript(appName = packageName, mounted)
+            // Must match the .app directory name inside the image, which is the bundle name.
+            runSetupScript(appName = bundleName, mounted)
         } finally {
             unmountImage(mounted)
         }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractNativeMacApplicationPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractNativeMacApplicationPackageTask.kt
@@ -20,6 +20,15 @@ abstract class AbstractNativeMacApplicationPackageTask : AbstractNucleusTask() {
     @get:Input
     val packageName: Property<String> = objects.notNullProperty()
 
+    /**
+     * Name of the `.app` bundle directory, without the `.app` extension.
+     *
+     * Kept separate from [packageName], which still names the launcher inside `Contents/MacOS`.
+     * Defaults to [packageName] when unset.
+     */
+    @get:Input
+    val bundleName: Property<String> = objects.notNullProperty<String>().convention(packageName)
+
     @get:Input
     val packageVersion: Property<String> = objects.notNullProperty("1.0.0")
 

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/MacBundleNameTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/MacBundleNameTest.kt
@@ -84,6 +84,7 @@ class MacBundleNameTest {
                 bundleName = null,
                 appName = "D\u00E9mo",
                 macPackageName = null,
+                packageName = null,
                 resolved = "De\u0301mo",
             ),
         )
@@ -167,6 +168,27 @@ class MacBundleNameTest {
     }
 
     @Test
+    fun `the resolved name is a fixed point of sanitizeFileName`() {
+        // electron-builder sanitizes our productName again on its way to productFilename, so a name
+        // that is not a fixed point would come back shorter than the directory we named — the DMG
+        // and the ZIP would disagree once more. Truncation is what can expose a trailing dot.
+        val names =
+            listOf(
+                "Nucleus Demo",
+                "My/App: Beta",
+                "Demo. ",
+                "A".repeat(200) + ". " + "B".repeat(200),
+                ("Beta 1. ").repeat(60),
+                "Démo Nucléus",
+            )
+        for (name in names) {
+            val resolved =
+                resolveMacBundleName(bundleName = null, appName = name, packageName = null, fallback = "demo")
+            assertEquals("not a fixed point: $resolved", resolved, sanitizeFileName(resolved))
+        }
+    }
+
+    @Test
     fun `truncation matches npm sanitize-filename`() {
         // sanitize-filename truncates to 255 UTF-8 bytes on a character boundary.
         assertEquals(255, sanitizeFileName("a".repeat(300)).length)
@@ -184,6 +206,7 @@ class MacBundleNameTest {
                 bundleName = null,
                 appName = "Nucleus Demo",
                 macPackageName = null,
+                packageName = null,
                 resolved = "Nucleus Demo",
             ),
         )
@@ -196,6 +219,7 @@ class MacBundleNameTest {
                 bundleName = null,
                 appName = "Nucleus Demo",
                 macPackageName = "Localized Name",
+                packageName = null,
                 resolved = "Nucleus Demo",
             )
         assertEquals(1, warnings.size)
@@ -211,6 +235,7 @@ class MacBundleNameTest {
                 bundleName = null,
                 appName = null,
                 macPackageName = "NucleusDemo",
+                packageName = null,
                 resolved = "NucleusDemo",
             ),
         )
@@ -224,6 +249,7 @@ class MacBundleNameTest {
                 bundleName = "Legacy",
                 appName = "Nucleus Demo",
                 macPackageName = "Other",
+                packageName = null,
                 resolved = "Legacy",
             ),
         )
@@ -236,9 +262,38 @@ class MacBundleNameTest {
                 bundleName = null,
                 appName = "My/App",
                 macPackageName = null,
+                packageName = null,
                 resolved = "MyApp",
             )
         assertEquals(1, warnings.size)
         assertTrue(warnings.single().contains("illegal"))
+    }
+
+    @Test
+    fun `warns when the sanitized name came from packageName alone`() {
+        val warnings =
+            macBundleNameWarnings(
+                bundleName = null,
+                appName = null,
+                macPackageName = null,
+                packageName = "My/App",
+                resolved = "MyApp",
+            )
+        assertEquals(1, warnings.size)
+        assertTrue(warnings.single().contains("illegal"))
+    }
+
+    @Test
+    fun `a blank bundleName does not suppress the macOS packageName warning`() {
+        val warnings =
+            macBundleNameWarnings(
+                bundleName = "   ",
+                appName = "Nucleus Demo",
+                macPackageName = "Localized Name",
+                packageName = null,
+                resolved = "Nucleus Demo",
+            )
+        assertEquals(1, warnings.size)
+        assertTrue(warnings.single().contains("macOS.bundleName"))
     }
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/MacBundleNameTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/MacBundleNameTest.kt
@@ -1,0 +1,244 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The macOS `.app` bundle name has to be identical in every artifact of a release: electron-builder
+ * stages the bundle inside a DMG as `${productFilename}.app` but archives the prepackaged directory
+ * verbatim into the ZIP, so a mismatch ships `Nucleus Demo.app` in one and `NucleusDemo.app` in the
+ * other — and the ZIP-based auto-updater then replaces an app that is not the one installed.
+ */
+class MacBundleNameTest {
+    @Test
+    fun `appName wins over packageName`() {
+        assertEquals(
+            "Nucleus Demo",
+            resolveMacBundleName(
+                bundleName = null,
+                appName = "Nucleus Demo",
+                packageName = "NucleusDemo",
+                fallback = "demo",
+            ),
+        )
+    }
+
+    @Test
+    fun `explicit bundleName wins over appName`() {
+        assertEquals(
+            "Legacy Name",
+            resolveMacBundleName(
+                bundleName = "Legacy Name",
+                appName = "Nucleus Demo",
+                packageName = "NucleusDemo",
+                fallback = "demo",
+            ),
+        )
+    }
+
+    @Test
+    fun `packageName is used when appName is unset`() {
+        assertEquals(
+            "NucleusDemo",
+            resolveMacBundleName(bundleName = null, appName = null, packageName = "NucleusDemo", fallback = "demo"),
+        )
+    }
+
+    @Test
+    fun `project name is used when nothing else is configured`() {
+        assertEquals(
+            "demo",
+            resolveMacBundleName(bundleName = null, appName = null, packageName = null, fallback = "demo"),
+        )
+    }
+
+    @Test
+    fun `blank candidates are skipped`() {
+        assertEquals(
+            "NucleusDemo",
+            resolveMacBundleName(bundleName = "  ", appName = "", packageName = "NucleusDemo", fallback = "demo"),
+        )
+    }
+
+    @Test
+    fun `the bundle name is decomposed so it matches what the HFS+ volume of a DMG stores`() {
+        // "Démo" written NFC must resolve to the NFD form HFS+ would produce, so the DMG entry and
+        // the ZIP entry are byte-identical and not merely equivalent.
+        assertEquals(
+            "De\u0301mo",
+            resolveMacBundleName(bundleName = null, appName = "D\u00E9mo", packageName = null, fallback = "demo"),
+        )
+        // Already-decomposed input is left alone.
+        assertEquals(
+            "De\u0301mo",
+            resolveMacBundleName(bundleName = null, appName = "De\u0301mo", packageName = null, fallback = "demo"),
+        )
+    }
+
+    @Test
+    fun `decomposition alone is not reported as sanitization`() {
+        assertEquals(
+            emptyList<String>(),
+            macBundleNameWarnings(
+                bundleName = null,
+                appName = "D\u00E9mo",
+                macPackageName = null,
+                resolved = "De\u0301mo",
+            ),
+        )
+    }
+
+    @Test
+    fun `illegal characters are stripped exactly like electron-builder does`() {
+        assertEquals(
+            "MyApp",
+            resolveMacBundleName(bundleName = null, appName = "My/App", packageName = null, fallback = "demo"),
+        )
+        assertEquals(
+            "App Beta",
+            resolveMacBundleName(bundleName = null, appName = "App: Beta", packageName = null, fallback = "demo"),
+        )
+    }
+
+    @Test
+    fun `a name that sanitizes away falls through to the next candidate`() {
+        assertEquals(
+            "NucleusDemo",
+            resolveMacBundleName(bundleName = "...", appName = "con", packageName = "NucleusDemo", fallback = "demo"),
+        )
+        assertEquals(
+            "demo",
+            resolveMacBundleName(bundleName = "...", appName = null, packageName = null, fallback = "demo"),
+        )
+        assertEquals(
+            "app",
+            resolveMacBundleName(bundleName = "...", appName = null, packageName = null, fallback = "///"),
+        )
+    }
+
+    @Test
+    fun `sanitizeFileName matches npm sanitize-filename`() {
+        // Expectations captured by running sanitize-filename@1.6.3 — the version electron-builder
+        // uses to derive AppInfo.productFilename — with the default empty replacement.
+        val expected =
+            listOf(
+                "." to "",
+                ".." to "",
+                "..." to "",
+                "con" to "",
+                "CON" to "",
+                "COM1" to "",
+                "com0" to "",
+                "lpt9.txt" to "",
+                "aux.txt" to "",
+                "nul" to "",
+                "prn" to "",
+                "LPT1.foo.bar" to "",
+                "hello." to "hello",
+                "hello " to "hello",
+                "hello. . " to "hello",
+                "the end." to "the end",
+                "..leading" to "..leading",
+                "valid<>:\"/\\|?*file" to "validfile",
+                "file|name" to "filename",
+                "valid name" to "valid name",
+                "Nucleus Demo" to "Nucleus Demo",
+                "My/App" to "MyApp",
+                "App: Beta" to "App Beta",
+                "NucleusDemo" to "NucleusDemo",
+                "holidays" to "holidays",
+                "" to "",
+                "a b" to "a b",
+                // The 0x00-0x1F and 0x80-0x9F control ranges are dropped, 0xA0 and above are kept.
+                "x\u0000y" to "xy",
+                "ctrl\u001Fx" to "ctrlx",
+                "ctrl\u0080x" to "ctrlx",
+                "ctrl\u009Fx" to "ctrlx",
+                "ctrl\u00A0x" to "ctrl\u00A0x",
+                "soft\u00ADhyphen" to "soft\u00ADhyphen",
+                "tab\tsep" to "tabsep",
+            )
+        for ((input, output) in expected) {
+            assertEquals("sanitizeFileName of ${input.map { it.code }}", output, sanitizeFileName(input))
+        }
+        // sanitizeFileName itself does not normalize; only resolveMacBundleName does.
+        assertEquals("caf\u00E9", sanitizeFileName("caf\u00E9"))
+    }
+
+    @Test
+    fun `truncation matches npm sanitize-filename`() {
+        // sanitize-filename truncates to 255 UTF-8 bytes on a character boundary.
+        assertEquals(255, sanitizeFileName("a".repeat(300)).length)
+        val truncated = sanitizeFileName("é".repeat(200))
+        assertEquals(127, truncated.length)
+        assertEquals(254, truncated.toByteArray(Charsets.UTF_8).size)
+        assertTrue(truncated.toByteArray(Charsets.UTF_8).size <= 255)
+    }
+
+    @Test
+    fun `no warning for the common appName plus packageName setup`() {
+        assertEquals(
+            emptyList<String>(),
+            macBundleNameWarnings(
+                bundleName = null,
+                appName = "Nucleus Demo",
+                macPackageName = null,
+                resolved = "Nucleus Demo",
+            ),
+        )
+    }
+
+    @Test
+    fun `warns when macOS packageName loses to appName`() {
+        val warnings =
+            macBundleNameWarnings(
+                bundleName = null,
+                appName = "Nucleus Demo",
+                macPackageName = "Localized Name",
+                resolved = "Nucleus Demo",
+            )
+        assertEquals(1, warnings.size)
+        assertTrue(warnings.single().contains("macOS.bundleName"))
+        assertTrue(warnings.single().contains("Localized Name"))
+    }
+
+    @Test
+    fun `no warning when macOS packageName is what got resolved`() {
+        assertEquals(
+            emptyList<String>(),
+            macBundleNameWarnings(
+                bundleName = null,
+                appName = null,
+                macPackageName = "NucleusDemo",
+                resolved = "NucleusDemo",
+            ),
+        )
+    }
+
+    @Test
+    fun `no warning when bundleName is set explicitly`() {
+        assertEquals(
+            emptyList<String>(),
+            macBundleNameWarnings(
+                bundleName = "Legacy",
+                appName = "Nucleus Demo",
+                macPackageName = "Other",
+                resolved = "Legacy",
+            ),
+        )
+    }
+
+    @Test
+    fun `warns when the requested name had to be sanitized`() {
+        val warnings =
+            macBundleNameWarnings(
+                bundleName = null,
+                appName = "My/App",
+                macPackageName = null,
+                resolved = "MyApp",
+            )
+        assertEquals(1, warnings.size)
+        assertTrue(warnings.single().contains("illegal"))
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/RenameMacAppBundleTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/RenameMacAppBundleTest.kt
@@ -1,0 +1,96 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * macOS volumes are case- and normalization-insensitive, so a destination that differs from the
+ * source only in case or in Unicode form already resolves to the source directory. Clearing the
+ * destination to make room would therefore erase the app image jpackage just produced.
+ */
+class RenameMacAppBundleTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun `renames a bundle to a different name`() {
+        val from = bundle("NucleusDemo.app", marker = "content")
+        val to = File(tmp.root, "Nucleus Demo.app")
+
+        assertTrue(renameMacAppBundle(from, to))
+
+        assertTrue(to.isDirectory)
+        assertEquals("content", markerOf(to))
+        assertEquals(listOf("Nucleus Demo.app"), names())
+    }
+
+    @Test
+    fun `a case-only difference renames instead of deleting the bundle`() {
+        assumeTrue("macOS-only", System.getProperty("os.name").startsWith("Mac"))
+        val from = bundle("MyApp.app", marker = "content")
+        val to = File(tmp.root, "myapp.app")
+
+        assertTrue(renameMacAppBundle(from, to))
+
+        assertEquals("content", markerOf(to))
+        assertEquals(listOf("myapp.app"), names())
+    }
+
+    @Test
+    fun `a normalization-only difference renames instead of deleting the bundle`() {
+        assumeTrue("macOS-only", System.getProperty("os.name").startsWith("Mac"))
+        val from = bundle("D\u00E9mo.app", marker = "content")
+        val to = File(tmp.root, "De\u0301mo.app")
+
+        assertTrue(renameMacAppBundle(from, to))
+
+        assertEquals("content", markerOf(to))
+        assertEquals(listOf("De\u0301mo.app"), names())
+    }
+
+    @Test
+    fun `an unrelated bundle already at the destination is replaced`() {
+        val from = bundle("NucleusDemo.app", marker = "new")
+        bundle("Nucleus Demo.app", marker = "stale")
+        val to = File(tmp.root, "Nucleus Demo.app")
+
+        assertTrue(renameMacAppBundle(from, to))
+
+        assertEquals("new", markerOf(to))
+        assertEquals(listOf("Nucleus Demo.app"), names())
+    }
+
+    @Test
+    fun `identical names are a no-op`() {
+        val from = bundle("NucleusDemo.app", marker = "content")
+
+        assertFalse(renameMacAppBundle(from, File(tmp.root, "NucleusDemo.app")))
+
+        assertEquals("content", markerOf(from))
+    }
+
+    @Test
+    fun `a missing source is a no-op`() {
+        assertFalse(renameMacAppBundle(File(tmp.root, "Absent.app"), File(tmp.root, "Other.app")))
+        assertEquals(emptyList<String>(), names())
+    }
+
+    private fun bundle(
+        name: String,
+        marker: String,
+    ): File =
+        File(tmp.root, name).apply {
+            resolve("Contents").mkdirs()
+            resolve("Contents/marker.txt").writeText(marker)
+        }
+
+    private fun markerOf(app: File): String = File(app, "Contents/marker.txt").readText()
+
+    private fun names(): List<String> = tmp.root.listFiles().orEmpty().map { it.name }.sorted()
+}

--- a/updater-runtime/build.gradle.kts
+++ b/updater-runtime/build.gradle.kts
@@ -32,6 +32,17 @@ kotlin {
     }
 }
 
+// Forward the opt-in `nucleus.e2e.*` properties to the test JVM so MacRealArtifactUpdateTest can be
+// pointed at DMG/ZIP artifacts produced by a real packaging run.
+tasks.withType<Test>().configureEach {
+    for ((key, value) in System.getProperties()) {
+        val name = key as? String ?: continue
+        if (name.startsWith("nucleus.e2e.")) {
+            systemProperty(name, value.toString())
+        }
+    }
+}
+
 mavenPublishing {
     coordinates("dev.nucleusframework", "nucleus.updater-runtime", publishVersion)
 

--- a/updater-runtime/build.gradle.kts
+++ b/updater-runtime/build.gradle.kts
@@ -33,14 +33,12 @@ kotlin {
 }
 
 // Forward the opt-in `nucleus.e2e.*` properties to the test JVM so MacRealArtifactUpdateTest can be
-// pointed at DMG/ZIP artifacts produced by a real packaging run.
+// pointed at DMG/ZIP artifacts produced by a real packaging run. Read through the provider API so
+// the values stay a declared configuration-cache input instead of being baked into the cache entry.
+val e2eProperties = providers.systemPropertiesPrefixedBy("nucleus.e2e.")
+
 tasks.withType<Test>().configureEach {
-    for ((key, value) in System.getProperties()) {
-        val name = key as? String ?: continue
-        if (name.startsWith("nucleus.e2e.")) {
-            systemProperty(name, value.toString())
-        }
-    }
+    systemProperties(e2eProperties.get())
 }
 
 mavenPublishing {

--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/MacZipUpdateScript.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/MacZipUpdateScript.kt
@@ -27,10 +27,18 @@ internal fun buildMacZipUpdateScript(
     logFile: String,
     restart: Boolean,
     selfDelete: Boolean = true,
-): String {
-    val relaunch = if (restart) "open \"\$TARGET\"" else "echo \"Relaunch skipped\""
-    val selfDeleteCmd = if (selfDelete) "rm -f \"\$0\"" else "true"
-    return """
+): String = scriptPreamble(zipFile, appPath, installDir, appPid, logFile) + scriptSwap(restart, selfDelete)
+
+/** Setup, staging extraction and bundle identification — everything before the swap. */
+@Suppress("LongParameterList")
+private fun scriptPreamble(
+    zipFile: String,
+    appPath: String,
+    installDir: String,
+    appPid: Long,
+    logFile: String,
+): String =
+    """
         |#!/usr/bin/env bash
         |set -euo pipefail
         |
@@ -44,8 +52,20 @@ internal fun buildMacZipUpdateScript(
         |echo "--- nucleus update ${'$'}(date) ---"
         |
         |STAGE_DIR="${'$'}INSTALL_DIR/.nucleus-update-${'$'}${'$'}"
-        |cleanup() { rm -rf "${'$'}STAGE_DIR"; }
-        |trap cleanup EXIT
+        |BACKUP=""
+        |TARGET="${'$'}APP_PATH"
+        |
+        |# Runs on every exit path, including an interrupt between the two renames below: if the
+        |# installed bundle was moved aside and nothing took its place, put it back. Leaving the
+        |# machine without an application is the one outcome this script must never produce.
+        |cleanup() {
+        |    if [ -n "${'$'}BACKUP" ] && [ -d "${'$'}BACKUP" ] && [ ! -d "${'$'}TARGET" ]; then
+        |        echo "Restoring the previous bundle after an interrupted update"
+        |        mv "${'$'}BACKUP" "${'$'}TARGET" || true
+        |    fi
+        |    rm -rf "${'$'}STAGE_DIR"
+        |}
+        |trap cleanup EXIT INT TERM
         |
         |# Wait for the app process to fully exit before touching its bundle.
         |while kill -0 "${'$'}APP_PID" 2>/dev/null; do
@@ -58,7 +78,9 @@ internal fun buildMacZipUpdateScript(
         |mkdir -p "${'$'}STAGE_DIR"
         |ditto -x -k "${'$'}ZIP_FILE" "${'$'}STAGE_DIR"
         |
-        |NEW_APP="${'$'}(/usr/bin/find "${'$'}STAGE_DIR" -maxdepth 2 -name '*.app' -type d | head -n 1)"
+        |# -print -quit rather than a pipe into head: under pipefail a killed `find` surfaces as
+        |# exit 141 and errexit would abort here, before any diagnostic is logged.
+        |NEW_APP="${'$'}(/usr/bin/find "${'$'}STAGE_DIR" -maxdepth 2 -name '*.app' -type d -print -quit)"
         |if [ -z "${'$'}NEW_APP" ] || [ ! -f "${'$'}NEW_APP/Contents/Info.plist" ]; then
         |    echo "No .app bundle found in ${'$'}ZIP_FILE — keeping the installed application"
         |    exit 1
@@ -73,7 +95,6 @@ internal fun buildMacZipUpdateScript(
         |
         |# Same identifier: keep the installed path so the Dock, login items and aliases stay valid.
         |# Different identifier: the app was renamed on purpose, adopt the new name and drop the old one.
-        |TARGET="${'$'}APP_PATH"
         |REMOVE_OLD=0
         |if [ -n "${'$'}CURRENT_BUNDLE_ID" ] && [ -n "${'$'}NEW_BUNDLE_ID" ] &&
         |    [ "${'$'}CURRENT_BUNDLE_ID" != "${'$'}NEW_BUNDLE_ID" ]; then
@@ -84,6 +105,23 @@ internal fun buildMacZipUpdateScript(
         |fi
         |echo "Installing to: ${'$'}TARGET"
         |
+    """.trimMargin()
+
+/** The swap itself, plus quarantine removal, relaunch and cleanup. */
+private fun scriptSwap(
+    restart: Boolean,
+    selfDelete: Boolean,
+): String {
+    // A failed relaunch must not abort the script under errexit: the new version is already
+    // installed at that point, and aborting would skip the cleanup below and report a failure.
+    val relaunch =
+        if (restart) {
+            "open \"\$TARGET\" || echo \"Relaunch failed; the update itself succeeded\""
+        } else {
+            "echo \"Relaunch skipped\""
+        }
+    val selfDeleteCmd = if (selfDelete) "rm -f \"\$0\"" else "true"
+    return """
         |# Swap through a backup so a failed move can be rolled back.
         |BACKUP="${'$'}TARGET.nucleus-old-${'$'}${'$'}"
         |if [ -d "${'$'}TARGET" ]; then
@@ -97,6 +135,7 @@ internal fun buildMacZipUpdateScript(
         |    exit 1
         |fi
         |rm -rf "${'$'}BACKUP"
+        |BACKUP=""
         |
         |if [ "${'$'}REMOVE_OLD" = "1" ] && [ -d "${'$'}APP_PATH" ]; then
         |    echo "Removing the previous bundle: ${'$'}APP_PATH"

--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/MacZipUpdateScript.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/MacZipUpdateScript.kt
@@ -1,0 +1,115 @@
+package dev.nucleusframework.updater.internal
+
+/**
+ * Builds the shell script that swaps a running macOS `.app` bundle for the one shipped in an update
+ * archive.
+ *
+ * The archive's bundle directory does not necessarily carry the same name as the installed one — a
+ * DMG stages the app under the product name while a ZIP preserves whatever the build produced — so
+ * the script never assumes the two match:
+ *
+ *  1. it extracts into a staging directory next to the installed app and leaves that app untouched
+ *     until a complete replacement exists on disk, so a truncated download or a failed `ditto`
+ *     cannot leave the machine without an application;
+ *  2. it locates the `.app` inside the archive instead of guessing its name;
+ *  3. it keeps the installed path when both bundles share a `CFBundleIdentifier`, so Dock tiles,
+ *     login items and aliases keep resolving, and only adopts the archive's name when the identifier
+ *     changed — a deliberate rebranding — removing the old bundle so no duplicate is left behind;
+ *  4. it restores the previous bundle if the swap fails.
+ *
+ * Extracted from [PlatformInstaller] so the exact script can be exercised by tests.
+ */
+internal fun buildMacZipUpdateScript(
+    zipFile: String,
+    appPath: String,
+    installDir: String,
+    appPid: Long,
+    logFile: String,
+    restart: Boolean,
+    selfDelete: Boolean = true,
+): String {
+    val relaunch = if (restart) "open \"\$TARGET\"" else "echo \"Relaunch skipped\""
+    val selfDeleteCmd = if (selfDelete) "rm -f \"\$0\"" else "true"
+    return """
+        |#!/usr/bin/env bash
+        |set -euo pipefail
+        |
+        |ZIP_FILE=${zipFile.quoteForShell()}
+        |APP_PATH=${appPath.quoteForShell()}
+        |INSTALL_DIR=${installDir.quoteForShell()}
+        |LOG_FILE=${logFile.quoteForShell()}
+        |APP_PID=$appPid
+        |
+        |exec >>"${'$'}LOG_FILE" 2>&1
+        |echo "--- nucleus update ${'$'}(date) ---"
+        |
+        |STAGE_DIR="${'$'}INSTALL_DIR/.nucleus-update-${'$'}${'$'}"
+        |cleanup() { rm -rf "${'$'}STAGE_DIR"; }
+        |trap cleanup EXIT
+        |
+        |# Wait for the app process to fully exit before touching its bundle.
+        |while kill -0 "${'$'}APP_PID" 2>/dev/null; do
+        |    sleep 0.5
+        |done
+        |
+        |# Unpack next to the installed app: same volume, so the swap below is a plain rename, and
+        |# the installed bundle stays intact until a complete replacement exists.
+        |rm -rf "${'$'}STAGE_DIR"
+        |mkdir -p "${'$'}STAGE_DIR"
+        |ditto -x -k "${'$'}ZIP_FILE" "${'$'}STAGE_DIR"
+        |
+        |NEW_APP="${'$'}(/usr/bin/find "${'$'}STAGE_DIR" -maxdepth 2 -name '*.app' -type d | head -n 1)"
+        |if [ -z "${'$'}NEW_APP" ] || [ ! -f "${'$'}NEW_APP/Contents/Info.plist" ]; then
+        |    echo "No .app bundle found in ${'$'}ZIP_FILE — keeping the installed application"
+        |    exit 1
+        |fi
+        |echo "Archive contains: ${'$'}(basename "${'$'}NEW_APP")"
+        |
+        |read_bundle_id() {
+        |    /usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${'$'}1/Contents/Info.plist" 2>/dev/null || true
+        |}
+        |CURRENT_BUNDLE_ID="${'$'}(read_bundle_id "${'$'}APP_PATH")"
+        |NEW_BUNDLE_ID="${'$'}(read_bundle_id "${'$'}NEW_APP")"
+        |
+        |# Same identifier: keep the installed path so the Dock, login items and aliases stay valid.
+        |# Different identifier: the app was renamed on purpose, adopt the new name and drop the old one.
+        |TARGET="${'$'}APP_PATH"
+        |REMOVE_OLD=0
+        |if [ -n "${'$'}CURRENT_BUNDLE_ID" ] && [ -n "${'$'}NEW_BUNDLE_ID" ] &&
+        |    [ "${'$'}CURRENT_BUNDLE_ID" != "${'$'}NEW_BUNDLE_ID" ]; then
+        |    TARGET="${'$'}INSTALL_DIR/${'$'}(basename "${'$'}NEW_APP")"
+        |    if [ "${'$'}TARGET" != "${'$'}APP_PATH" ]; then
+        |        REMOVE_OLD=1
+        |    fi
+        |fi
+        |echo "Installing to: ${'$'}TARGET"
+        |
+        |# Swap through a backup so a failed move can be rolled back.
+        |BACKUP="${'$'}TARGET.nucleus-old-${'$'}${'$'}"
+        |if [ -d "${'$'}TARGET" ]; then
+        |    mv "${'$'}TARGET" "${'$'}BACKUP"
+        |fi
+        |if ! mv "${'$'}NEW_APP" "${'$'}TARGET"; then
+        |    echo "Failed to install the new bundle — restoring the previous one"
+        |    if [ -d "${'$'}BACKUP" ]; then
+        |        mv "${'$'}BACKUP" "${'$'}TARGET"
+        |    fi
+        |    exit 1
+        |fi
+        |rm -rf "${'$'}BACKUP"
+        |
+        |if [ "${'$'}REMOVE_OLD" = "1" ] && [ -d "${'$'}APP_PATH" ]; then
+        |    echo "Removing the previous bundle: ${'$'}APP_PATH"
+        |    rm -rf "${'$'}APP_PATH"
+        |fi
+        |
+        |xattr -r -d com.apple.quarantine "${'$'}TARGET" 2>/dev/null || true
+        |$relaunch
+        |
+        |rm -f "${'$'}ZIP_FILE"
+        |$selfDeleteCmd
+        """.trimMargin()
+}
+
+/** Wraps a value in single quotes for safe interpolation into the generated shell script. */
+private fun String.quoteForShell(): String = "'" + replace("'", "'\\''") + "'"

--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/PlatformInstaller.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/PlatformInstaller.kt
@@ -209,52 +209,18 @@ internal object PlatformInstaller {
             resolveCurrentAppBundle()
                 ?: error("Cannot resolve current .app bundle from java.home")
         val installDir = appBundle.parentFile
-        val appName = appBundle.name
-        val appPath = File(installDir, appName).absolutePath
-        val pid = ProcessHandle.current().pid()
+        val tmpDir = System.getProperty("java.io.tmpdir")
 
-        val relaunchCmd =
-            if (restart) {
-                "\n# Relaunch the app\nopen \"\$APP_PATH\"\n"
-            } else {
-                ""
-            }
-
-        // Write a shell script that will:
-        // 1. Wait for our process to actually die
-        // 2. Replace the app bundle
-        // 3. Remove quarantine and optionally relaunch
-        val script = File(System.getProperty("java.io.tmpdir"), "nucleus-update.sh")
+        val script = File(tmpDir, "nucleus-update.sh")
         script.writeText(
-            """
-            |#!/usr/bin/env bash
-            |set -e
-            |
-            |ZIP_FILE="${zipFile.absolutePath}"
-            |APP_PATH="$appPath"
-            |INSTALL_DIR="${installDir.absolutePath}"
-            |APP_PID=$pid
-            |
-            |# Wait for the app process to fully exit
-            |while kill -0 "${'$'}APP_PID" 2>/dev/null; do
-            |    sleep 0.5
-            |done
-            |
-            |# Remove old app bundle
-            |if [ -d "${'$'}APP_PATH" ]; then
-            |    rm -rf "${'$'}APP_PATH"
-            |fi
-            |
-            |# Extract the ZIP
-            |ditto -x -k "${'$'}ZIP_FILE" "${'$'}INSTALL_DIR"
-            |
-            |# Remove quarantine attribute
-            |xattr -r -d com.apple.quarantine "${'$'}APP_PATH" 2>/dev/null || true
-            |$relaunchCmd
-            |# Clean up
-            |rm -f "${'$'}ZIP_FILE"
-            |rm -f "${'$'}{0}"
-            """.trimMargin(),
+            buildMacZipUpdateScript(
+                zipFile = zipFile.absolutePath,
+                appPath = appBundle.absolutePath,
+                installDir = installDir.absolutePath,
+                appPid = ProcessHandle.current().pid(),
+                logFile = File(tmpDir, "nucleus-update.log").absolutePath,
+                restart = restart,
+            ),
         )
         script.setExecutable(true)
 

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/MacRealArtifactUpdateTest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/MacRealArtifactUpdateTest.kt
@@ -1,0 +1,127 @@
+package dev.nucleusframework.updater
+
+import dev.nucleusframework.updater.internal.buildMacZipUpdateScript
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Full release loop against artifacts a real build produced: install from the DMG, then update from
+ * the ZIP of the next version.
+ *
+ * Opt-in — the artifacts are supplied by the packaging E2E harness:
+ * ```
+ * ./gradlew :updater-runtime:test --tests '*MacRealArtifactUpdateTest*' \
+ *     -Dnucleus.e2e.dmg=/path/to/v1.dmg -Dnucleus.e2e.zip=/path/to/v2.zip \
+ *     -Dnucleus.e2e.expectedVersion=2.0.0
+ * ```
+ */
+class MacRealArtifactUpdateTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun `an app installed from the DMG updates from the ZIP of the next version`() {
+        assumeTrue("macOS-only", System.getProperty("os.name").startsWith("Mac"))
+        val dmg = System.getProperty("nucleus.e2e.dmg")?.let(::File)
+        val zip = System.getProperty("nucleus.e2e.zip")?.let(::File)
+        assumeTrue("real artifacts not supplied", dmg != null && zip != null)
+        val expectedVersion = System.getProperty("nucleus.e2e.expectedVersion") ?: "2.0.0"
+
+        val installDir = tmp.newFolder("Applications")
+        val installed = installFromDmg(dmg!!, installDir)
+        println("Installed from DMG: ${installed.name} (version ${versionOf(installed)})")
+
+        // The updater consumes the archive, so hand it a copy.
+        val archive = File(tmp.root, zip!!.name).also { zip.copyTo(it) }
+        val exitCode = runUpdateScript(archive, installed, installDir)
+
+        assertEquals(0, exitCode)
+        val bundles = installDir.listFiles()!!.filter { it.name.endsWith(".app") }
+        assertEquals("exactly one bundle must remain", 1, bundles.size)
+        assertEquals("the installed bundle must keep its name", installed.name, bundles.single().name)
+        assertEquals("the bundle must be the new version", expectedVersion, versionOf(bundles.single()))
+        assertTrue("the launcher must still be there", launcherOf(bundles.single()).canExecute())
+    }
+
+    private fun installFromDmg(
+        dmg: File,
+        installDir: File,
+    ): File {
+        val mountPoint = tmp.newFolder("mnt-${System.nanoTime()}")
+        run("hdiutil", "attach", dmg.absolutePath, "-nobrowse", "-readonly", "-mountpoint", mountPoint.absolutePath)
+        try {
+            val app =
+                mountPoint.listFiles()!!.single { it.isDirectory && it.name.endsWith(".app") }
+            // What dragging the app onto /Applications does.
+            run("ditto", app.absolutePath, File(installDir, app.name).absolutePath)
+            return File(installDir, app.name)
+        } finally {
+            run("hdiutil", "detach", mountPoint.absolutePath)
+        }
+    }
+
+    private fun runUpdateScript(
+        archive: File,
+        installedApp: File,
+        installDir: File,
+    ): Int {
+        val logFile = File(tmp.root, "update.log")
+        val script = File(tmp.root, "nucleus-update.sh")
+        script.writeText(
+            buildMacZipUpdateScript(
+                zipFile = archive.absolutePath,
+                appPath = installedApp.absolutePath,
+                installDir = installDir.absolutePath,
+                appPid = deadPid(),
+                logFile = logFile.absolutePath,
+                restart = false,
+                selfDelete = false,
+            ),
+        )
+        val process = ProcessBuilder("bash", script.absolutePath).redirectErrorStream(true).start()
+        assertTrue("the update script must not hang", process.waitFor(120, TimeUnit.SECONDS))
+        println(logFile.takeIf { it.isFile }?.readText().orEmpty())
+        return process.exitValue()
+    }
+
+    private fun deadPid(): Long {
+        val process = ProcessBuilder("true").start()
+        val pid = process.pid()
+        process.waitFor(10, TimeUnit.SECONDS)
+        return pid
+    }
+
+    private fun versionOf(app: File): String = plistBuddy(app, "CFBundleShortVersionString")
+
+    private fun launcherOf(app: File): File = File(app, "Contents/MacOS/${plistBuddy(app, "CFBundleExecutable")}")
+
+    private fun plistBuddy(
+        app: File,
+        key: String,
+    ): String {
+        val process =
+            ProcessBuilder("/usr/libexec/PlistBuddy", "-c", "Print :$key", "${app.absolutePath}/Contents/Info.plist")
+                .redirectErrorStream(true)
+                .start()
+        val output =
+            process.inputStream
+                .bufferedReader()
+                .readText()
+                .trim()
+        process.waitFor(30, TimeUnit.SECONDS)
+        return output
+    }
+
+    private fun run(vararg command: String) {
+        val process = ProcessBuilder(*command).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        assertTrue(output, process.waitFor(120, TimeUnit.SECONDS))
+        assertEquals(output, 0, process.exitValue())
+    }
+}

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/MacZipUpdateScriptTest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/MacZipUpdateScriptTest.kt
@@ -1,0 +1,259 @@
+package dev.nucleusframework.updater
+
+import dev.nucleusframework.updater.internal.buildMacZipUpdateScript
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end coverage for the macOS ZIP update swap.
+ *
+ * Everything here is real: real `.app` bundles on disk, real archives produced by `ditto` the way
+ * electron-builder produces them, and the real generated script executed by `bash`. The scenarios
+ * mirror the bug this exists to prevent — a DMG installs `Nucleus Demo.app` while the ZIP ships
+ * `NucleusDemo.app`, so the updater must not delete an app it cannot replace.
+ */
+class MacZipUpdateScriptTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var installDir: File
+    private lateinit var stagingDir: File
+
+    @Before
+    fun setUp() {
+        assumeTrue("macOS-only", System.getProperty("os.name").startsWith("Mac"))
+        installDir = tmp.newFolder("Applications")
+        stagingDir = tmp.newFolder("staging")
+    }
+
+    @Test
+    fun `zip bundle named differently updates the installed app in place`() {
+        val installed = createAppBundle(installDir, "Nucleus Demo", bundleId = APP_ID, marker = "v1")
+        val zip = zipAppBundle(createAppBundle(stagingDir, "NucleusDemo", bundleId = APP_ID, marker = "v2"))
+
+        val result = runUpdate(zip, installed)
+
+        assertEquals(result.log, 0, result.exitCode)
+        assertTrue("installed bundle must survive", installed.isDirectory)
+        assertEquals("v2", markerOf(installed))
+        assertFalse(
+            "the archive's name must not appear as a second app",
+            File(installDir, "NucleusDemo.app").exists(),
+        )
+        assertEquals(listOf("Nucleus Demo.app"), installDir.listFiles()!!.map { it.name }.sorted())
+    }
+
+    @Test
+    fun `matching names update normally`() {
+        val installed = createAppBundle(installDir, "Nucleus Demo", bundleId = APP_ID, marker = "v1")
+        val zip = zipAppBundle(createAppBundle(stagingDir, "Nucleus Demo", bundleId = APP_ID, marker = "v2"))
+
+        val result = runUpdate(zip, installed)
+
+        assertEquals(result.log, 0, result.exitCode)
+        assertEquals("v2", markerOf(installed))
+        assertEquals(listOf("Nucleus Demo.app"), installDir.listFiles()!!.map { it.name }.sorted())
+    }
+
+    @Test
+    fun `a changed bundle identifier adopts the new name and removes the old bundle`() {
+        val installed = createAppBundle(installDir, "Old Brand", bundleId = "dev.nucleus.old", marker = "v1")
+        val zip = zipAppBundle(createAppBundle(stagingDir, "New Brand", bundleId = "dev.nucleus.new", marker = "v2"))
+
+        val result = runUpdate(zip, installed)
+
+        assertEquals(result.log, 0, result.exitCode)
+        val renamed = File(installDir, "New Brand.app")
+        assertTrue("renamed bundle must exist", renamed.isDirectory)
+        assertEquals("v2", markerOf(renamed))
+        assertFalse("the previous bundle must be gone", installed.exists())
+        assertEquals(listOf("New Brand.app"), installDir.listFiles()!!.map { it.name }.sorted())
+    }
+
+    @Test
+    fun `an archive without an app bundle leaves the installed app untouched`() {
+        val installed = createAppBundle(installDir, "Nucleus Demo", bundleId = APP_ID, marker = "v1")
+        val junk = tmp.newFolder("junk")
+        File(junk, "readme.txt").writeText("not an app")
+        val zip = zipDirectory(junk, File(tmp.root, "junk.zip"))
+
+        val result = runUpdate(zip, installed)
+
+        assertTrue("the update must fail", result.exitCode != 0)
+        assertTrue("installed bundle must survive", installed.isDirectory)
+        assertEquals("v1", markerOf(installed))
+        assertEquals(listOf("Nucleus Demo.app"), installDir.listFiles()!!.map { it.name }.sorted())
+    }
+
+    @Test
+    fun `an incomplete app bundle leaves the installed app untouched`() {
+        val installed = createAppBundle(installDir, "Nucleus Demo", bundleId = APP_ID, marker = "v1")
+        // A bundle directory without Contents/Info.plist: what a truncated archive produces.
+        val broken = File(stagingDir, "NucleusDemo.app").apply { mkdirs() }
+        File(broken, "Contents/MacOS").mkdirs()
+        val zip = zipAppBundle(broken)
+
+        val result = runUpdate(zip, installed)
+
+        assertTrue("the update must fail", result.exitCode != 0)
+        assertTrue("installed bundle must survive", installed.isDirectory)
+        assertEquals("v1", markerOf(installed))
+    }
+
+    @Test
+    fun `a corrupt archive leaves the installed app untouched`() {
+        val installed = createAppBundle(installDir, "Nucleus Demo", bundleId = APP_ID, marker = "v1")
+        val zip = File(tmp.root, "corrupt.zip").apply { writeText("this is not a zip archive") }
+
+        val result = runUpdate(zip, installed)
+
+        assertTrue("the update must fail", result.exitCode != 0)
+        assertTrue("installed bundle must survive", installed.isDirectory)
+        assertEquals("v1", markerOf(installed))
+    }
+
+    @Test
+    fun `an unreadable bundle identifier keeps the installed path`() {
+        // No CFBundleIdentifier on either side: without an identifier to compare, the safe choice
+        // is the installed path, never a rename.
+        val installed = createAppBundle(installDir, "Nucleus Demo", bundleId = null, marker = "v1")
+        val zip = zipAppBundle(createAppBundle(stagingDir, "NucleusDemo", bundleId = null, marker = "v2"))
+
+        val result = runUpdate(zip, installed)
+
+        assertEquals(result.log, 0, result.exitCode)
+        assertEquals("v2", markerOf(installed))
+        assertEquals(listOf("Nucleus Demo.app"), installDir.listFiles()!!.map { it.name }.sorted())
+    }
+
+    @Test
+    fun `the staging directory is cleaned up on success and on failure`() {
+        val installed = createAppBundle(installDir, "Nucleus Demo", bundleId = APP_ID, marker = "v1")
+        val zip = zipAppBundle(createAppBundle(stagingDir, "NucleusDemo", bundleId = APP_ID, marker = "v2"))
+        runUpdate(zip, installed)
+        assertTrue(installDir.listFiles()!!.none { it.name.startsWith(".nucleus-update-") })
+
+        val corrupt = File(tmp.root, "corrupt2.zip").apply { writeText("nope") }
+        runUpdate(corrupt, installed)
+        assertTrue(installDir.listFiles()!!.none { it.name.startsWith(".nucleus-update-") })
+    }
+
+    @Test
+    fun `the archive is deleted only after a successful install`() {
+        val installed = createAppBundle(installDir, "Nucleus Demo", bundleId = APP_ID, marker = "v1")
+        val zip = zipAppBundle(createAppBundle(stagingDir, "NucleusDemo", bundleId = APP_ID, marker = "v2"))
+        runUpdate(zip, installed)
+        assertFalse("a consumed archive must be removed", zip.exists())
+
+        val corrupt = File(tmp.root, "corrupt3.zip").apply { writeText("nope") }
+        runUpdate(corrupt, installed)
+        assertTrue("a rejected archive must be kept for diagnostics", corrupt.exists())
+    }
+
+    // --- helpers ---
+
+    private data class ScriptResult(
+        val exitCode: Int,
+        val log: String,
+    )
+
+    private fun runUpdate(
+        zip: File,
+        installedApp: File,
+    ): ScriptResult {
+        val logFile = File(tmp.root, "update-${System.nanoTime()}.log")
+        val script = File(tmp.root, "nucleus-update-${System.nanoTime()}.sh")
+        script.writeText(
+            buildMacZipUpdateScript(
+                zipFile = zip.absolutePath,
+                appPath = installedApp.absolutePath,
+                installDir = installDir.absolutePath,
+                appPid = deadPid(),
+                logFile = logFile.absolutePath,
+                restart = false,
+                selfDelete = false,
+            ),
+        )
+        val process =
+            ProcessBuilder("bash", script.absolutePath)
+                .redirectErrorStream(true)
+                .start()
+        assertTrue("the update script must not hang", process.waitFor(60, TimeUnit.SECONDS))
+        return ScriptResult(process.exitValue(), logFile.takeIf { it.isFile }?.readText().orEmpty())
+    }
+
+    /** PID of a process that has already exited, so the script's wait loop returns immediately. */
+    private fun deadPid(): Long {
+        val process = ProcessBuilder("true").start()
+        val pid = process.pid()
+        process.waitFor(10, TimeUnit.SECONDS)
+        return pid
+    }
+
+    private fun createAppBundle(
+        parent: File,
+        name: String,
+        bundleId: String?,
+        marker: String,
+    ): File {
+        val app = File(parent, "$name.app")
+        val contents = File(app, "Contents").apply { mkdirs() }
+        File(contents, "MacOS").mkdirs()
+        File(contents, "MacOS/launcher").apply {
+            writeText("#!/bin/sh\nexit 0\n")
+            setExecutable(true)
+        }
+        File(contents, "marker.txt").writeText(marker)
+        val identifierEntry =
+            bundleId?.let { "\t<key>CFBundleIdentifier</key>\n\t<string>$it</string>\n" }.orEmpty()
+        File(contents, "Info.plist").writeText(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+            $identifierEntry	<key>CFBundleExecutable</key>
+            	<string>launcher</string>
+            </dict>
+            </plist>
+            """.trimIndent(),
+        )
+        return app
+    }
+
+    private fun markerOf(app: File): String = File(app, "Contents/marker.txt").readText()
+
+    /** Archives a bundle the way electron-builder's macOS ZIP target does. */
+    private fun zipAppBundle(app: File): File {
+        val zip = File(tmp.root, "${app.nameWithoutExtension}-${System.nanoTime()}.zip")
+        run("ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", app.absolutePath, zip.absolutePath)
+        return zip
+    }
+
+    private fun zipDirectory(
+        dir: File,
+        zip: File,
+    ): File {
+        run("ditto", "-c", "-k", "--sequesterRsrc", dir.absolutePath, zip.absolutePath)
+        return zip
+    }
+
+    private fun run(vararg command: String) {
+        val process = ProcessBuilder(*command).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        assertTrue(output, process.waitFor(60, TimeUnit.SECONDS))
+        assertEquals(output, 0, process.exitValue())
+    }
+
+    private companion object {
+        const val APP_ID = "dev.nucleusframework.demo"
+    }
+}

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/MacZipUpdateScriptTest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/MacZipUpdateScriptTest.kt
@@ -212,20 +212,28 @@ class MacZipUpdateScriptTest {
             setExecutable(true)
         }
         File(contents, "marker.txt").writeText(marker)
-        val identifierEntry =
-            bundleId?.let { "\t<key>CFBundleIdentifier</key>\n\t<string>$it</string>\n" }.orEmpty()
-        File(contents, "Info.plist").writeText(
-            """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <dict>
-            $identifierEntry	<key>CFBundleExecutable</key>
-            	<string>launcher</string>
-            </dict>
-            </plist>
-            """.trimIndent(),
-        )
+        // Assembled line by line rather than through trimIndent(): the interpolated identifier is
+        // itself multi-line, and trimIndent() runs after interpolation, so its indentation would
+        // decide how much is stripped from every other line and quietly mangle the plist.
+        val plist =
+            buildString {
+                appendLine("""<?xml version="1.0" encoding="UTF-8"?>""")
+                appendLine(
+                    "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" " +
+                        "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
+                )
+                appendLine("""<plist version="1.0">""")
+                appendLine("<dict>")
+                if (bundleId != null) {
+                    appendLine("\t<key>CFBundleIdentifier</key>")
+                    appendLine("\t<string>$bundleId</string>")
+                }
+                appendLine("\t<key>CFBundleExecutable</key>")
+                appendLine("\t<string>launcher</string>")
+                appendLine("</dict>")
+                appendLine("</plist>")
+            }
+        File(contents, "Info.plist").writeText(plist)
         return app
     }
 


### PR DESCRIPTION
## Problem

With `appName = "Nucleus Demo"` and `packageName = "NucleusDemo"` (the `examples/nucleus-demo` setup), the DMG installs `Nucleus Demo.app` while the ZIP ships `NucleusDemo.app`.

electron-builder stages the bundle inside a DMG as `${productFilename}.app` (`dmg.ts`) but its ZIP target archives the prepackaged directory verbatim (`ArchiveTarget.ts`: `dirToArchive = path.dirname(appOutDir)`, `withoutDir: true`). The plugin handed jpackage's `<packageName>.app` to electron-builder unchanged, so the two formats disagreed whenever `appName != packageName`.

The ZIP-based auto-updater is where this stops being cosmetic — `FileSelector` prefers `.zip` over `.dmg` on macOS, so it is the default path. For a user who installed from the DMG the old script did:

```
rm -rf "/Applications/Nucleus Demo.app"   # installed app deleted
ditto -x -k zip /Applications             # extracts NucleusDemo.app
open "/Applications/Nucleus Demo.app"     # fails, set -e, script dies
```

No application left at the installed path, an orphan bundle under another name, and quarantine still set on it.

## Changes

**One resolution, used everywhere.** `macOS.bundleName` > `appName` > `macOS.packageName`/`packageName` > project name, sanitized exactly the way electron-builder sanitizes `productName` (port of `sanitize-filename@1.6.3`) and normalized to NFD — a DMG carries an HFS+ volume, which decomposes every name it stores, so an accented `appName` would otherwise differ byte-wise between the two artifacts.

It feeds jpackage's output, the GraalVM bundle, the Kotlin/Native bundle, electron-builder's prepackaged directory *and* its `productName`, which makes `basename(prepackaged) == productFilename` hold by construction rather than by coincidence.

Only the bundle directory is renamed. The launcher stays at `Contents/MacOS/<packageName>` (the jpackage launcher resolves `Contents/app/<launcher>.cfg` from its own executable name) and `CFBundleName` still carries `appName`. The rename runs before signing.

**Hardened macOS ZIP install**, so releases already in the field survive the mismatch: extract into a staging directory next to the installed app, locate the `.app` instead of guessing its name, keep the installed path when both bundles share a `CFBundleIdentifier` (Dock tiles, login items and aliases keep resolving) and adopt the archive's name only when the identifier changed, then swap with rollback. The installed app is never removed before a complete replacement exists on disk.

**Configuration warning** when `macOS.packageName` loses to `appName`, or when the requested name had to be sanitized.

## Migration

This renames the bundle for any project where `appName` differs from `packageName` — `examples/nucleus-demo` goes from `/Applications/NucleusDemo.app` to `/Applications/Nucleus Demo.app`.

That matters for one release only, and only for clients running a build made *before* this change: their installed updater is the old script, which removes the installed `NucleusDemo.app`, extracts `Nucleus Demo.app` beside it and then fails to relaunch. The application is present under its new name but the Dock tile and any alias break, and it does not restart on its own.

Projects that have already shipped and want to avoid that can pin the previous name:

```kotlin
macOS {
    bundleName = "NucleusDemo"
}
```

From the first release built with this change onwards the hardened updater keeps the installed path, so the situation cannot recur.

## Test plan

Regression reproduced first, on real artifacts built with the plugin from `main`: `app-image=NucleusDemo.app dmg=Nucleus Demo.app zip=NucleusDemo.app`, and the old updater script replayed against them deletes the installed app and exits 1.

- [x] 10 packaging scenarios, each building a real DMG + ZIP, mounting the image with `hdiutil` and extracting the archive with `ditto` — app-image, DMG and ZIP names match in all of them:

  | scenario | bundle | warning |
  |---|---|---|
  | `appName` + `packageName` (the reported bug) | `Nucleus Demo.app` | — |
  | no `appName` | `NucleusDemo.app` | — |
  | `appName == packageName` | `NucleusDemo.app` | — |
  | `macOS.packageName` set | `Nucleus Demo.app` | yes |
  | explicit `macOS.bundleName` | `Legacy Name.app` | — |
  | illegal characters (`My/App: Beta`) | `MyApp Beta.app` | yes |
  | name that sanitizes to empty (`...`) | `NucleusDemo.app` | yes |
  | trailing dot + space | `Demo.app` | yes |
  | non-ASCII `appName` | `Démo Nucléus.app` | — |
  | rename over a previous build | `Renamed App.app` | — |

- [x] On the illegal-character scenario the Kotlin sanitizer and electron-builder independently produce `MyApp Beta.app`; parity is also locked by a 32-case table generated from the npm package itself
- [x] 9 updater integration tests running the generated script against real bundles and real `ditto` archives: differing names, matching names, changed bundle ID, archive with no `.app`, bundle without `Info.plist`, corrupt archive, unreadable identifier, staging cleanup, archive kept on failure. The installed app survives intact in every failure case
- [x] Full release loop on real artifacts: DMG v1.0.0 installed, ZIP v2.0.0 applied, app updated in place to 2.0.0, one bundle, launcher executable
- [x] Same loop with the desynchronized artifacts produced by the pre-fix plugin — passes, so already-shipped releases are covered
- [x] `examples/nucleus-demo`: `Nucleus Demo.app` byte-identical across app-image, DMG and ZIP; launcher `NucleusDemo`; `codesign --verify --deep --strict` OK after the rename
- [x] `:plugin:test` (230 tests) and `:updater-runtime:test` green — `LinuxSignerTest` fails identically on unmodified `main` (GPG dependency on macOS)
- [ ] Linux and Windows packaging not exercised here (macOS host); those paths are guarded by `currentOS`
