### PR TITLE
feat(tao): DecoratedWindow(transparent=true) for full-window transparency

### DIFF
--- a/decorated-window-tao/api/decorated-window-tao.api
+++ b/decorated-window-tao/api/decorated-window-tao.api
@@ -179,7 +179,7 @@ public final class dev/nucleusframework/window/tao/DecoratedDialogKt {
 }
 
 public final class dev/nucleusframework/window/tao/DecoratedWindowComposableKt {
-	public static final fun DecoratedWindow-dM2IDAM (Ldev/nucleusframework/window/tao/ApplicationScope;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;Ljava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/unit/DpSize;ZZZZZZZLdev/nucleusframework/window/tao/TaoWindow;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLdev/nucleusframework/window/tao/MacOSStyle;ZLandroidx/compose/runtime/CompositionLocalContext;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun DecoratedWindow-KMb5BrY (Ldev/nucleusframework/window/tao/ApplicationScope;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;Ljava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/unit/DpSize;ZZZZZZZZLdev/nucleusframework/window/tao/TaoWindow;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZLdev/nucleusframework/window/tao/MacOSStyle;ZLandroidx/compose/runtime/CompositionLocalContext;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;IIII)V
 }
 
 public final class dev/nucleusframework/window/tao/DecoratedWindowKt {
@@ -401,8 +401,8 @@ public final class dev/nucleusframework/window/tao/TaoApplication {
 	public static final field $stable I
 	public static final field INSTANCE Ldev/nucleusframework/window/tao/TaoApplication;
 	public final fun exit ()V
-	public final fun openWindow (Ljava/lang/String;DDZZZZLdev/nucleusframework/window/tao/TaoWindow;Z)Ldev/nucleusframework/window/tao/TaoWindow;
-	public static synthetic fun openWindow$default (Ldev/nucleusframework/window/tao/TaoApplication;Ljava/lang/String;DDZZZZLdev/nucleusframework/window/tao/TaoWindow;ZILjava/lang/Object;)Ldev/nucleusframework/window/tao/TaoWindow;
+	public final fun openWindow (Ljava/lang/String;DDZZZZLdev/nucleusframework/window/tao/TaoWindow;ZZ)Ldev/nucleusframework/window/tao/TaoWindow;
+	public static synthetic fun openWindow$default (Ldev/nucleusframework/window/tao/TaoApplication;Ljava/lang/String;DDZZZZLdev/nucleusframework/window/tao/TaoWindow;ZZILjava/lang/Object;)Ldev/nucleusframework/window/tao/TaoWindow;
 	public final fun run (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/decorated-window-tao/api/decorated-window-tao.api
+++ b/decorated-window-tao/api/decorated-window-tao.api
@@ -401,8 +401,8 @@ public final class dev/nucleusframework/window/tao/TaoApplication {
 	public static final field $stable I
 	public static final field INSTANCE Ldev/nucleusframework/window/tao/TaoApplication;
 	public final fun exit ()V
-	public final fun openWindow (Ljava/lang/String;DDZZZZLdev/nucleusframework/window/tao/TaoWindow;ZZ)Ldev/nucleusframework/window/tao/TaoWindow;
-	public static synthetic fun openWindow$default (Ldev/nucleusframework/window/tao/TaoApplication;Ljava/lang/String;DDZZZZLdev/nucleusframework/window/tao/TaoWindow;ZZILjava/lang/Object;)Ldev/nucleusframework/window/tao/TaoWindow;
+	public final fun openWindow (Ljava/lang/String;DDZZZZLdev/nucleusframework/window/tao/TaoWindow;ZZZ)Ldev/nucleusframework/window/tao/TaoWindow;
+	public static synthetic fun openWindow$default (Ldev/nucleusframework/window/tao/TaoApplication;Ljava/lang/String;DDZZZZLdev/nucleusframework/window/tao/TaoWindow;ZZZILjava/lang/Object;)Ldev/nucleusframework/window/tao/TaoWindow;
 	public final fun run (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -192,9 +192,9 @@ val smokeStandalonePanelMac by tasks.registering(JavaExec::class) {
 // Captures under build/reports/tao-transparent-smoke and pixel-checks that the
 // empty client composites the desktop. Not part of `check`.
 //
-// Windows: java.awt.Robot omits layered windows. Point
+// macOS/Linux: AWT Robot. Windows: Robot omits layered windows — point
 // `-Dnucleus.tao.transparent.smoke.captureTool=` at a CAPTUREBLT helper
-// (built into build/tmp-smoke/capture_region.exe by the smoke setup).
+// (build/tmp-smoke/capture_region.exe).
 val taoTransparentSmoke by tasks.registering(JavaExec::class) {
     description = "Manual smoke: DecoratedWindow(transparent=true) over the desktop (#416)"
     group = "verification"
@@ -205,26 +205,28 @@ val taoTransparentSmoke by tasks.registering(JavaExec::class) {
             .dir("reports/tao-transparent-smoke")
             .get()
             .asFile
-    val captureTool =
-        layout.buildDirectory
-            .file("tmp-smoke/capture_region.exe")
-            .get()
-            .asFile
     systemProperty("nucleus.tao.transparent.smoke.outdir", outDir.absolutePath)
-    systemProperty("nucleus.tao.transparent.smoke.captureTool", captureTool.absolutePath)
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        val captureTool =
+            layout.buildDirectory
+                .file("tmp-smoke/capture_region.exe")
+                .get()
+                .asFile
+        systemProperty("nucleus.tao.transparent.smoke.captureTool", captureTool.absolutePath)
+        doFirst {
+            if (!captureTool.isFile) {
+                error(
+                    "CAPTUREBLT helper missing at ${captureTool.absolutePath}. " +
+                        "Build it once with cl against capture_region.c " +
+                        "(see TransparentWindowSmokeMain).",
+                )
+            }
+        }
+    }
     // Forward hold duration so a manual look is possible, e.g.
     // -Dnucleus.tao.transparent.smoke.holdMs=10000
     System.getProperty("nucleus.tao.transparent.smoke.holdMs")?.let {
         systemProperty("nucleus.tao.transparent.smoke.holdMs", it)
-    }
-    // Fail fast with a clear message if the helper is missing on Windows.
-    doFirst {
-        if (Os.isFamily(Os.FAMILY_WINDOWS) && !captureTool.isFile) {
-            error(
-                "CAPTUREBLT helper missing at ${captureTool.absolutePath}. " +
-                    "Build it once with cl against capture_region.c (see TransparentWindowSmokeMain).",
-            )
-        }
     }
 }
 

--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -192,7 +192,7 @@ val smokeStandalonePanelMac by tasks.registering(JavaExec::class) {
 // Captures under build/reports/tao-transparent-smoke and pixel-checks that the
 // empty client composites the desktop. Not part of `check`.
 //
-// macOS/Linux: AWT Robot. Windows: Robot omits layered windows — point
+// macOS/X11: AWT Robot. Windows: Robot omits layered windows — point
 // `-Dnucleus.tao.transparent.smoke.captureTool=` at a CAPTUREBLT helper
 // (build/tmp-smoke/capture_region.exe).
 val taoTransparentSmoke by tasks.registering(JavaExec::class) {
@@ -200,6 +200,18 @@ val taoTransparentSmoke by tasks.registering(JavaExec::class) {
     group = "verification"
     classpath = sourceSets.test.get().runtimeClasspath
     mainClass.set("dev.nucleusframework.window.tao.headful.TransparentWindowSmokeMain")
+    // Linux: pin the window to XWayland. Robot goes through the X server, so on
+    // a native Wayland session it cannot see the Tao surface (both captures come
+    // back byte-identical) and xdg-shell drops setOuterPosition, leaving the
+    // capture rect pointing at wherever the compositor did *not* put the window.
+    // Under XWayland both work. Overridable — the smoke then refuses to emit a
+    // pixel verdict on Wayland (see TransparentWindowSmokeMain).
+    if (Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC)) {
+        environment(
+            "NUCLEUS_TAO_LINUX_RENDERER",
+            providers.environmentVariable("NUCLEUS_TAO_LINUX_RENDERER").getOrElse("x11"),
+        )
+    }
     val outDir =
         layout.buildDirectory
             .dir("reports/tao-transparent-smoke")

--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -188,6 +188,46 @@ val smokeStandalonePanelMac by tasks.registering(JavaExec::class) {
     jvmArgs("-XstartOnFirstThread")
 }
 
+// Manual smoke for #416: transparent DecoratedWindow + opaque marker over desktop.
+// Captures under build/reports/tao-transparent-smoke and pixel-checks that the
+// empty client composites the desktop. Not part of `check`.
+//
+// Windows: java.awt.Robot omits layered windows. Point
+// `-Dnucleus.tao.transparent.smoke.captureTool=` at a CAPTUREBLT helper
+// (built into build/tmp-smoke/capture_region.exe by the smoke setup).
+val taoTransparentSmoke by tasks.registering(JavaExec::class) {
+    description = "Manual smoke: DecoratedWindow(transparent=true) over the desktop (#416)"
+    group = "verification"
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass.set("dev.nucleusframework.window.tao.headful.TransparentWindowSmokeMain")
+    val outDir =
+        layout.buildDirectory
+            .dir("reports/tao-transparent-smoke")
+            .get()
+            .asFile
+    val captureTool =
+        layout.buildDirectory
+            .file("tmp-smoke/capture_region.exe")
+            .get()
+            .asFile
+    systemProperty("nucleus.tao.transparent.smoke.outdir", outDir.absolutePath)
+    systemProperty("nucleus.tao.transparent.smoke.captureTool", captureTool.absolutePath)
+    // Forward hold duration so a manual look is possible, e.g.
+    // -Dnucleus.tao.transparent.smoke.holdMs=10000
+    System.getProperty("nucleus.tao.transparent.smoke.holdMs")?.let {
+        systemProperty("nucleus.tao.transparent.smoke.holdMs", it)
+    }
+    // Fail fast with a clear message if the helper is missing on Windows.
+    doFirst {
+        if (Os.isFamily(Os.FAMILY_WINDOWS) && !captureTool.isFile) {
+            error(
+                "CAPTUREBLT helper missing at ${captureTool.absolutePath}. " +
+                    "Build it once with cl against capture_region.c (see TransparentWindowSmokeMain).",
+            )
+        }
+    }
+}
+
 // ── Maven publication ──────────────────────────────────────────────────────
 
 mavenPublishing {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
@@ -224,6 +224,9 @@ public fun DecoratedWindowScope.BasicTitleBar(
     // back to transparent after rendering, so the drop shadow is unaffected.
     // Keyed content stack: co-composed WindowBackground survives when this
     // TitleBar is removed (clearContent only drops this writer).
+    // Fully transparent windows (#416): WindowClearColorLayers coerces opaque
+    // chrome colours to alpha-0 for the clear only — the TitleBar still paints
+    // its own bar; empty client regions stay see-through.
     val titleBarBackground by style.colors.backgroundFor(currentState)
     val clearColorLayers = LocalWindowClearColorLayers.current
     val clearColorKey = remember { Any() }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -234,8 +234,8 @@ internal fun ApplicationScope.openDecoratedWindow(
     alwaysOnTop: Boolean = false,
     maximized: Boolean = false,
     isDialog: Boolean = false,
-    // Fully borderless window: no native chrome at all — on macOS this drops the
-    // traffic-light buttons too. For overlay/ghost windows (drag previews, HUDs).
+    // Fully borderless: macOS drops traffic lights; Win/Linux skip the Compose
+    // CSD outline (and Linux CSD shadow). For overlays/ghosts (drag previews, HUDs).
     undecorated: Boolean = false,
     // Full-window per-pixel transparency (#416). Creation-time only — see
     // DecoratedWindow(transparent = …).
@@ -310,6 +310,10 @@ internal fun ApplicationScope.openDecoratedWindow(
             // TaoComposeSceneHost.attach() instead.
             skipTaskbar = hiddenFromDock,
             transparent = transparent,
+            // Tao defaults undecorated windows to a DWM drop shadow (and
+            // grows the outer rect for its inset). Borderless overlays must
+            // opt out or the ghost still shows a soft contour.
+            undecoratedShadow = !undecorated,
         )
 
     // Compose Hot Reload: the agent only auto-wraps AWT `ComposeWindow`/
@@ -337,6 +341,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             alwaysOnTop,
             maximized,
             isDialog,
+            undecorated,
             icon,
             minimumSize,
             onCloseRequest,
@@ -359,6 +364,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             alwaysOnTop,
             maximized,
             isDialog,
+            undecorated,
             icon,
             minimumSize,
             onCloseRequest,
@@ -603,6 +609,7 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     alwaysOnTop: Boolean,
     maximized: Boolean,
     isDialog: Boolean,
+    undecorated: Boolean,
     icon: Painter?,
     minimumSize: DpSize?,
     onCloseRequest: () -> Unit,
@@ -621,7 +628,9 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     // default; the host gates it to Wayland non-popup windows (X11 stays flat)
     // and it degrades to no-op if the compositor lacks wl_shm / an RGBA visual.
     // Kill switch: NUCLEUS_TAO_LINUX_SHADOW=0. See docs/linux-csd-shadow-subsurface.md.
-    host.decorationShadowEnabled = System.getenv("NUCLEUS_TAO_LINUX_SHADOW") != "0"
+    // Fully borderless overlays (`undecorated`) drop the shadow too.
+    host.decorationShadowEnabled =
+        !undecorated && System.getenv("NUCLEUS_TAO_LINUX_SHADOW") != "0"
     host.setSceneCompositionLocalContext(initialCompositionLocalContext)
 
     // ── Linux accessibility (AT-SPI2 via AccessKit) ────────────────────────
@@ -690,14 +699,20 @@ private fun ApplicationScope.openDecoratedWindowLinux(
                 // loop). See [TaoLinuxUriHandler].
                 LocalUriHandler provides TaoLinuxUriHandler,
             ) {
+                // Default: CSD outline (vanilla-style frame for custom chrome).
+                // `undecorated` = fully borderless overlay — no Compose stroke.
                 val border =
-                    rememberUndecoratedWindowBorder(
-                        state = stateHolder.value,
-                        linuxDe = linuxDe,
-                        gnomeCornerArc = 24f,
-                        kdeCornerArc = 10f,
-                        isDialog = isDialog,
-                    )
+                    if (undecorated) {
+                        Modifier
+                    } else {
+                        rememberUndecoratedWindowBorder(
+                            state = stateHolder.value,
+                            linuxDe = linuxDe,
+                            gnomeCornerArc = 24f,
+                            kdeCornerArc = 10f,
+                            isDialog = isDialog,
+                        )
+                    }
                 val modalCount =
                     remember {
                         mutableStateOf(0)
@@ -983,6 +998,7 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     alwaysOnTop: Boolean,
     maximized: Boolean,
     isDialog: Boolean,
+    undecorated: Boolean,
     icon: Painter?,
     minimumSize: DpSize?,
     onCloseRequest: () -> Unit,
@@ -993,7 +1009,12 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     transparent: Boolean,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
-    val host = TaoComposeSceneHostWindows(window, fullyTransparent = transparent)
+    val host =
+        TaoComposeSceneHostWindows(
+            window,
+            fullyTransparent = transparent,
+            borderlessChrome = undecorated,
+        )
     host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
@@ -1024,7 +1045,9 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     host.semanticsOwnerListener = a11yObserver
 
     val stateHolder = mutableStateOf(DecoratedWindowState.of(active = true, maximized = maximized))
-    val titleBarHeightState = host.titleBarHeightDpState.also { it.value = 32f }
+    // Borderless overlays have no TitleBar chrome — keep the caption zone at 0.
+    val titleBarHeightState =
+        host.titleBarHeightDpState.also { it.value = if (undecorated) 0f else 32f }
     // Hoisted out of the composition so the initial native theme push below
     // (before the first blocking render and show()) can read it.
     val appearanceOverride = mutableStateOf(dev.nucleusframework.window.WindowAppearanceMode.System)
@@ -1101,14 +1124,21 @@ private fun ApplicationScope.openDecoratedWindowWindows(
                         }
                     }
                 }
+                // Default: CSD outline for custom chrome windows. `undecorated`
+                // means fully borderless (vanilla Compose Desktop semantics for
+                // overlays/ghosts) — do not stroke a frame.
                 val border =
-                    rememberUndecoratedWindowBorder(
-                        state = stateHolder.value,
-                        linuxDe = LinuxDesktopEnvironment.Unknown,
-                        gnomeCornerArc = 24f,
-                        kdeCornerArc = 10f,
-                        isDialog = isDialog,
-                    )
+                    if (undecorated) {
+                        Modifier
+                    } else {
+                        rememberUndecoratedWindowBorder(
+                            state = stateHolder.value,
+                            linuxDe = LinuxDesktopEnvironment.Unknown,
+                            gnomeCornerArc = 24f,
+                            kdeCornerArc = 10f,
+                            isDialog = isDialog,
+                        )
+                    }
                 val modalCount =
                     remember {
                         mutableStateOf(0)
@@ -1175,10 +1205,25 @@ private fun ApplicationScope.openDecoratedWindowWindows(
         // native side before the first paint — the snapshot flow above only
         // starts once the event loop resumes, which is after show().
         pushNativeTheme()
+        // Theme push re-runs applyCaptionColors; reassert borderless so a
+        // transparent clear (alpha-0 → RGB black) cannot restore a DWM border.
+        if (undecorated && NativeTaoWindowsDecoBridge.isLoaded) {
+            val hwnd = NativeTaoBridge.nativeHwndHandle(window.handle)
+            if (hwnd != 0L) {
+                NativeTaoWindowsDecoBridge.nativeSetBorderlessChrome(hwnd, true)
+            }
+        }
         // onResized renders synchronously, so this doubles as the guaranteed
         // first paint before the window is shown (no separate onRedrawRequested).
         host.onResized(initialW, initialH)
         if (visible) window.show()
+        // DWM finalises non-client chrome on show — reassert once more.
+        if (undecorated && NativeTaoWindowsDecoBridge.isLoaded) {
+            val hwnd = NativeTaoBridge.nativeHwndHandle(window.handle)
+            if (hwnd != 0L) {
+                NativeTaoWindowsDecoBridge.nativeSetBorderlessChrome(hwnd, true)
+            }
+        }
     }
 
     // Fullscreen toggle, two hooks (issue 413):

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -310,9 +310,9 @@ internal fun ApplicationScope.openDecoratedWindow(
             // TaoComposeSceneHost.attach() instead.
             skipTaskbar = hiddenFromDock,
             transparent = transparent,
-            // Tao defaults undecorated windows to a DWM drop shadow (and
-            // grows the outer rect for its inset). Borderless overlays must
-            // opt out or the ghost still shows a soft contour.
+            // Tao defaults borderless windows to a drop shadow (DWM on
+            // Windows, NSWindow.hasShadow on macOS). Overlays must opt out
+            // or the ghost still shows a soft contour.
             undecoratedShadow = !undecorated,
         )
 
@@ -417,7 +417,10 @@ internal fun ApplicationScope.openDecoratedWindow(
     // Single source of truth shared with the host (which feeds it as a top
     // inset to the PlatformContext) and the TitleBar composable (which
     // updates it via SideEffect from its requested height).
-    val titleBarHeightState = host.titleBarHeightDpState.also { it.value = 28f }
+    // Borderless overlays have no TitleBar chrome — keep the caption zone at 0
+    // (parity with the Windows path).
+    val titleBarHeightState =
+        host.titleBarHeightDpState.also { it.value = if (undecorated) 0f else 28f }
 
     val scopeFactory: ColumnScope.() -> TaoDecoratedWindowScope = {
         object : TaoDecoratedWindowScope, ColumnScope by this {
@@ -630,7 +633,8 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     // Kill switch: NUCLEUS_TAO_LINUX_SHADOW=0. See docs/linux-csd-shadow-subsurface.md.
     // Fully borderless overlays (`undecorated`) drop the shadow too.
     host.decorationShadowEnabled =
-        !undecorated && System.getenv("NUCLEUS_TAO_LINUX_SHADOW") != "0"
+        !undecorated &&
+        System.getenv("NUCLEUS_TAO_LINUX_SHADOW") != "0"
     host.setSceneCompositionLocalContext(initialCompositionLocalContext)
 
     // ── Linux accessibility (AT-SPI2 via AccessKit) ────────────────────────

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -142,8 +142,7 @@ internal class WindowClearColorLayers(
         if (contentWriters.remove(key) != null) push()
     }
 
-    private fun coerce(argb: Int): Int =
-        if (fullyTransparent && ((argb ushr 24) and 0xFF) == 0xFF) 0 else argb
+    private fun coerce(argb: Int): Int = if (fullyTransparent && ((argb ushr 24) and 0xFF) == 0xFF) 0 else argb
 
     private fun push() {
         hostClearColor.value = resolved

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -93,6 +93,12 @@ private const val DEFAULT_CLEAR_ARGB = 0xFFFFFFFF.toInt()
  * writer so a surviving `WindowBackground` is restored when `TitleBar`
  * leaves composition instead of wiping the slot to null.
  *
+ * When [fullyTransparent] is true (#416), fully opaque ARGB values are coerced
+ * to alpha-0 so a default white theme or TitleBar chrome colour cannot fill
+ * the empty client and hide the desktop. Semi-transparent colours still tint.
+ * Compose widgets keep painting their own backgrounds; this only affects the
+ * Skia / native clear under unpainted regions.
+ *
  * Every write re-resolves into the host state *synchronously, inside the
  * caller's SideEffect* — so the first composition has fully themed the host
  * before the window's first blocking render and `show()`.
@@ -101,8 +107,9 @@ private const val DEFAULT_CLEAR_ARGB = 0xFFFFFFFF.toInt()
  */
 internal class WindowClearColorLayers(
     private val hostClearColor: androidx.compose.runtime.MutableState<Int>,
+    private val fullyTransparent: Boolean = false,
 ) {
-    private var style: Int = DEFAULT_CLEAR_ARGB
+    private var style: Int = if (fullyTransparent) 0 else DEFAULT_CLEAR_ARGB
 
     /** Insertion-ordered content writers; last entry is the active content. */
     private val contentWriters = LinkedHashMap<Any, Int>()
@@ -113,7 +120,7 @@ internal class WindowClearColorLayers(
     val observableResolved: androidx.compose.runtime.State<Int> get() = hostClearColor
 
     fun setStyle(argb: Int) {
-        style = argb
+        style = coerce(argb)
         push()
     }
 
@@ -126,7 +133,7 @@ internal class WindowClearColorLayers(
         argb: Int,
     ) {
         contentWriters.remove(key)
-        contentWriters[key] = argb
+        contentWriters[key] = coerce(argb)
         push()
     }
 
@@ -134,6 +141,9 @@ internal class WindowClearColorLayers(
     fun clearContent(key: Any) {
         if (contentWriters.remove(key) != null) push()
     }
+
+    private fun coerce(argb: Int): Int =
+        if (fullyTransparent && ((argb ushr 24) and 0xFF) == 0xFF) 0 else argb
 
     private fun push() {
         hostClearColor.value = resolved
@@ -228,6 +238,9 @@ internal fun ApplicationScope.openDecoratedWindow(
     // Fully borderless window: no native chrome at all — on macOS this drops the
     // traffic-light buttons too. For overlay/ghost windows (drag previews, HUDs).
     undecorated: Boolean = false,
+    // Full-window per-pixel transparency (#416). Creation-time only — see
+    // DecoratedWindow(transparent = …).
+    transparent: Boolean = false,
     // Linux only: make this window a popup overlay of [popupFor]
     // (GTK_WINDOW_POPUP transient → wl_subsurface on Wayland, the only
     // client-positionable window kind under xdg-shell). Positions are
@@ -297,6 +310,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             // hiddenFromDock via the activation policy in
             // TaoComposeSceneHost.attach() instead.
             skipTaskbar = hiddenFromDock,
+            transparent = transparent,
         )
 
     // Compose Hot Reload: the agent only auto-wraps AWT `ComposeWindow`/
@@ -331,6 +345,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             onKeyEvent,
             initialCompositionLocalContext,
             nativePopupLayers,
+            transparent,
             hotReloadContent,
         )
     }
@@ -352,11 +367,18 @@ internal fun ApplicationScope.openDecoratedWindow(
             onKeyEvent,
             initialCompositionLocalContext,
             nativePopupLayers,
+            transparent,
             hotReloadContent,
         )
     }
 
-    val host = TaoComposeSceneHost(window, macOSStyle = macOSStyle, hiddenFromDock = hiddenFromDock)
+    val host =
+        TaoComposeSceneHost(
+            window,
+            macOSStyle = macOSStyle,
+            hiddenFromDock = hiddenFromDock,
+            fullyTransparent = transparent,
+        )
     host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
@@ -431,7 +453,13 @@ internal fun ApplicationScope.openDecoratedWindow(
             }
         }
         host.setContent {
-            val clearColorLayers = remember { WindowClearColorLayers(host.clearColorArgbState) }
+            val clearColorLayers =
+                remember {
+                    WindowClearColorLayers(
+                        host.clearColorArgbState,
+                        fullyTransparent = transparent,
+                    )
+                }
             CompositionLocalProvider(
                 LocalTitleBarInfo provides TitleBarInfo(title, icon),
                 LocalTaoWindow provides window,
@@ -583,9 +611,10 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     onKeyEvent: (KeyEvent) -> Boolean,
     initialCompositionLocalContext: CompositionLocalContext?,
     nativePopupLayers: Boolean,
+    transparent: Boolean,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
-    val host = TaoComposeSceneHostLinux(window)
+    val host = TaoComposeSceneHostLinux(window, fullyTransparent = transparent)
     host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
@@ -640,7 +669,13 @@ private fun ApplicationScope.openDecoratedWindowLinux(
         // the X11 XID via NativeTaoBridge.nativeLinuxHandles().
         a11yController.attach()
         host.setContent {
-            val clearColorLayers = remember { WindowClearColorLayers(host.clearColorArgbState) }
+            val clearColorLayers =
+                remember {
+                    WindowClearColorLayers(
+                        host.clearColorArgbState,
+                        fullyTransparent = transparent,
+                    )
+                }
             CompositionLocalProvider(
                 LocalTitleBarInfo provides TitleBarInfo(title, icon),
                 LocalTaoWindow provides window,
@@ -956,9 +991,10 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     onKeyEvent: (KeyEvent) -> Boolean,
     initialCompositionLocalContext: CompositionLocalContext?,
     nativePopupLayers: Boolean,
+    transparent: Boolean,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
-    val host = TaoComposeSceneHostWindows(window)
+    val host = TaoComposeSceneHostWindows(window, fullyTransparent = transparent)
     host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
@@ -1020,7 +1056,13 @@ private fun ApplicationScope.openDecoratedWindowWindows(
         host.attach()
         a11yController.attach()
         host.setContent {
-            val clearColorLayers = remember { WindowClearColorLayers(host.clearColorArgbState) }
+            val clearColorLayers =
+                remember {
+                    WindowClearColorLayers(
+                        host.clearColorArgbState,
+                        fullyTransparent = transparent,
+                    )
+                }
             CompositionLocalProvider(
                 LocalTitleBarInfo provides TitleBarInfo(title, icon),
                 LocalTaoWindow provides window,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -64,7 +64,17 @@ public fun ApplicationScope.DecoratedWindow(
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
     isDialog: Boolean = false,
-    /** Fully borderless window (no traffic lights on macOS) — for overlays/ghosts. */
+    /**
+     * Fully borderless window — for overlays/ghosts (drag previews, HUDs).
+     *
+     * - macOS: drops native traffic lights / title-bar chrome.
+     * - Windows / Linux: skips the Compose CSD outline
+     *   ([rememberUndecoratedWindowBorder]); on Linux also disables the
+     *   client-side drop-shadow subsurface. Default `false` keeps the usual
+     *   custom-chrome frame.
+     *
+     * Pair with [transparent] for a vanilla-Compose-like see-through overlay.
+     */
     undecorated: Boolean = false,
     /**
      * Full-window per-pixel transparency (#416). Creation-time only.
@@ -79,6 +89,8 @@ public fun ApplicationScope.DecoratedWindow(
      * Prefer custom chrome over stock [TitleBar] when you want a mostly
      * see-through window; TitleBar paints its own bar but no longer fills the
      * empty client via the clear path.
+     *
+     * For a fully borderless ghost (no CSD outline), also pass [undecorated].
      */
     transparent: Boolean = false,
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -67,6 +67,21 @@ public fun ApplicationScope.DecoratedWindow(
     /** Fully borderless window (no traffic lights on macOS) — for overlays/ghosts. */
     undecorated: Boolean = false,
     /**
+     * Full-window per-pixel transparency (#416). Creation-time only.
+     *
+     * When `true`, the Tao top-level is built with `with_transparent` so
+     * alpha-0 pixels composite the desktop (macOS `NSWindow.opaque = false`,
+     * Windows DWM blur-behind empty region, Linux ARGB visual). Fully opaque
+     * style / TitleBar / [WindowBackground] colours are coerced to alpha-0 for
+     * the **clear** only — widgets still paint themselves — so empty client
+     * regions show the desktop. Semi-transparent colours still tint.
+     *
+     * Prefer custom chrome over stock [TitleBar] when you want a mostly
+     * see-through window; TitleBar paints its own bar but no longer fills the
+     * empty client via the clear path.
+     */
+    transparent: Boolean = false,
+    /**
      * Linux only: popup overlay of another window (wl_subsurface on Wayland —
      * client-positionable; parent-relative coordinates). Ignored elsewhere.
      */
@@ -164,6 +179,7 @@ public fun ApplicationScope.DecoratedWindow(
                     maximized = state.placement == WindowPlacement.Maximized,
                     isDialog = isDialog,
                     undecorated = undecorated,
+                    transparent = transparent,
                     popupFor = popupFor,
                     onPreviewKeyEvent = { latestPreview(it) },
                     onKeyEvent = { latestKey(it) },
@@ -178,7 +194,9 @@ public fun ApplicationScope.DecoratedWindow(
                             // The hoisted style writes its own layer, never the
                             // resolved state: `WindowBackground` / `TitleBar`
                             // (the content layer) always outrank it, whatever
-                            // the recomposition order.
+                            // the recomposition order. Fully-transparent windows
+                            // coerce opaque style to alpha-0 inside
+                            // [WindowClearColorLayers] (#416).
                             clearColorLayers?.setStyle(backgroundArgb)
                         }
                         latestContent.invoke(this)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -87,6 +87,9 @@ public object TaoApplication {
         skipTaskbar: Boolean = false,
         // Full-window per-pixel transparency (#416). Creation-time only.
         transparent: Boolean = false,
+        // Windows: DWM drop shadow on undecorated windows (tao default true).
+        // Set false for borderless overlays (`DecoratedWindow(undecorated)`).
+        undecoratedShadow: Boolean = true,
     ): TaoWindow {
         val handle = handleSeq.getAndIncrement()
         val window = TaoWindow(handle, isResizable = resizable, isPopup = popupOf != null)
@@ -103,6 +106,7 @@ public object TaoApplication {
             popupOf?.handle ?: 0L,
             skipTaskbar,
             transparent,
+            undecoratedShadow,
         )
         return window
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -85,6 +85,8 @@ public object TaoApplication {
         // skip-taskbar hint (X11/XWayland only). Must be set at creation
         // (tao builder attribute); see NativeTaoBridge.
         skipTaskbar: Boolean = false,
+        // Full-window per-pixel transparency (#416). Creation-time only.
+        transparent: Boolean = false,
     ): TaoWindow {
         val handle = handleSeq.getAndIncrement()
         val window = TaoWindow(handle, isResizable = resizable, isPopup = popupOf != null)
@@ -100,6 +102,7 @@ public object TaoApplication {
             maximized,
             popupOf?.handle ?: 0L,
             skipTaskbar,
+            transparent,
         )
         return window
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -87,8 +87,8 @@ public object TaoApplication {
         skipTaskbar: Boolean = false,
         // Full-window per-pixel transparency (#416). Creation-time only.
         transparent: Boolean = false,
-        // Windows: DWM drop shadow on undecorated windows (tao default true).
-        // Set false for borderless overlays (`DecoratedWindow(undecorated)`).
+        // Drop shadow on borderless windows (Windows DWM / macOS hasShadow).
+        // Set false for overlays (`DecoratedWindow(undecorated)`).
         undecoratedShadow: Boolean = true,
     ): TaoWindow {
         val handle = handleSeq.getAndIncrement()

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/UndecoratedWindowBorder.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/UndecoratedWindowBorder.kt
@@ -22,10 +22,14 @@ import dev.nucleusframework.window.styling.LocalDecoratedWindowStyle
 private val DialogElevationStroke = Color(0x1F000000)
 
 /**
- * Returns the [Modifier.insideBorder] used by `DecoratedWindow` on
- * Linux + Windows when running undecorated (no native chrome) — same logic
- * as `decorated-window-jni`'s `DecoratedWindowBody`. macOS keeps its native
- * decorations and does not need a Compose-drawn border.
+ * Returns the [Modifier.insideBorder] used by Tao `DecoratedWindow` on
+ * Linux + Windows for the **default custom-chrome** look (no native frame —
+ * same role as `decorated-window-jni`'s `DecoratedWindowBody` border). macOS
+ * keeps native decorations and does not need this.
+ *
+ * Callers that pass `undecorated = true` (fully borderless overlays / ghosts)
+ * must **not** apply this modifier — that matches vanilla Compose Desktop
+ * `Window(undecorated = true)` (no framework-drawn contour).
  *
  * When [isDialog] is set, a faint shadow-toned stroke is layered on top so the
  * dialog reads as an elevated surface above its dimmed parent (Linux only —

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
@@ -203,6 +203,25 @@ internal object NativeMetalBridge {
     )
 
     /**
+     * Full-window per-pixel transparency (#416). Sets the single native
+     * transparency mode to FULL (`NSWindow.opaque = NO`, clear layers) so
+     * alpha-0 Compose pixels composite the desktop. Glass REGIONS requests
+     * cannot demote FULL. Creation-time only in practice; call after Metal attach.
+     */
+    @JvmStatic
+    external fun nativeSetFullyTransparent(
+        nsViewPtr: Long,
+        enabled: Boolean,
+    )
+
+    /**
+     * Current `NSWindow.isOpaque` for the window owning [nsViewPtr]. Used by
+     * the #416 headful probe. Returns `true` when the view has no window yet.
+     */
+    @JvmStatic
+    external fun nativeIsWindowOpaque(nsViewPtr: Long): Boolean
+
+    /**
      * Inserts a hosted `NSSplitViewController` pane region below the content
      * view — AppKit backs it with the wallpaper-tinted system material
      * (System Settings sidebar look). [kindOrdinal] is

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -139,6 +139,11 @@ internal object NativeTaoBridge {
         // (`WindowBackground(Color.Transparent)` or the transparent=true
         // default style path) so the desktop shows through empty regions.
         transparent: Boolean,
+        // Windows only: DWM drop shadow for undecorated (no-native-chrome)
+        // windows. Tao defaults this to true and expands the outer rect for
+        // the shadow inset. Ghost overlays pass false
+        // (`DecoratedWindow(undecorated = true)`). Ignored on macOS/Linux.
+        undecoratedShadow: Boolean,
     )
 
     @JvmStatic

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -139,10 +139,10 @@ internal object NativeTaoBridge {
         // (`WindowBackground(Color.Transparent)` or the transparent=true
         // default style path) so the desktop shows through empty regions.
         transparent: Boolean,
-        // Windows only: DWM drop shadow for undecorated (no-native-chrome)
-        // windows. Tao defaults this to true and expands the outer rect for
-        // the shadow inset. Ghost overlays pass false
-        // (`DecoratedWindow(undecorated = true)`). Ignored on macOS/Linux.
+        // Drop shadow for borderless windows. Windows: DWM undecorated shadow
+        // (outer-rect inset). macOS: NSWindow.hasShadow. Ghost overlays pass
+        // false (`DecoratedWindow(undecorated = true)`). Ignored on Linux
+        // (CSD shadow is gated in the host).
         undecoratedShadow: Boolean,
     )
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -134,6 +134,11 @@ internal object NativeTaoBridge {
         // XWayland, ignored on native Wayland (no taskbar opt-out protocol).
         // Ignored on macOS (Dock hiding uses the activation policy).
         skipTaskbar: Boolean,
+        // Full-window per-pixel transparency (#416). Creation-time only —
+        // maps to tao `with_transparent`. Pair with an alpha-0 clear
+        // (`WindowBackground(Color.Transparent)` or the transparent=true
+        // default style path) so the desktop shows through empty regions.
+        transparent: Boolean,
     )
 
     @JvmStatic

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
@@ -35,6 +35,18 @@ internal object NativeTaoWindowsDecoBridge {
     )
 
     /**
+     * Fully borderless DWM chrome for overlay/ghost windows
+     * (`DecoratedWindow(undecorated = true)`). Suppresses caption/border
+     * colours and the 1px shadow frame extension so a transparent client has
+     * no system contour.
+     */
+    @JvmStatic
+    external fun nativeSetBorderlessChrome(
+        hwnd: Long,
+        borderless: Boolean,
+    )
+
+    /**
      * Applies the whole window theme atomically: `WM_ERASEBKGND` fill, DWM
      * caption/border colors, `DWMWA_USE_IMMERSIVE_DARK_MODE`, and the
      * Windows 10 acrylic tint when that fallback is live. [isDark] arrives

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -94,6 +94,9 @@ internal class TaoComposeSceneHost(
     private val macOSStyle: MacOSStyle = MacOSStyle.Auto,
     // macOS-only: hide this app's Dock icon (app-wide activation policy).
     private val hiddenFromDock: Boolean = false,
+    // Full-window per-pixel transparency (#416). Creation-time; pairs with
+    // tao `with_transparent` so alpha-0 Skia clears show the desktop.
+    private val fullyTransparent: Boolean = false,
 ) : AbstractTaoComposeSceneHost() {
     val titleBarHeightDpState: androidx.compose.runtime.MutableState<Float> =
         androidx.compose.runtime.mutableStateOf(0f)
@@ -103,8 +106,12 @@ internal class TaoComposeSceneHost(
     // composables update it so any Compose region without an explicit
     // background — most visibly animation gaps around fullscreen/title-bar
     // transitions — matches the active chrome instead of flashing white.
+    // Fully transparent windows start at alpha 0 so empty client areas show
+    // the desktop before the first composition rewrites the style layer.
     val clearColorArgbState: androidx.compose.runtime.MutableState<Int> =
-        androidx.compose.runtime.mutableStateOf(0xFFFFFFFF.toInt())
+        androidx.compose.runtime.mutableStateOf(
+            if (fullyTransparent) 0 else 0xFFFFFFFF.toInt(),
+        )
 
     // Behind-window glass background (see NativeMetalBridge.nativeSetGlassBackground).
     // While active, the render loop clears the Skia surface to transparent so
@@ -273,6 +280,14 @@ internal class TaoComposeSceneHost(
         val handle = NativeMetalBridge.nativeAttach(nsView)
         require(handle != 0L) { "Failed to attach CAMetalLayer to NSView" }
         attachmentHandle = handle
+
+        // #416: keep NSWindow non-opaque and layers clear after attach.
+        // tao already set opaque=false at builder time; our background / glass
+        // paths must not force it back to YES.
+        if (fullyTransparent) {
+            NativeMetalBridge.nativeSetFullyTransparent(nsView, true)
+            NativeMetalBridge.nativeSetWindowBackgroundColor(nsView, clearColorArgbState.value)
+        }
 
         // Render loop, AWT/skiko MetalVSyncer pattern: a FrameDispatcher
         // (coalescing) drives one frame per `invalidate`; each frame renders then

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -100,6 +100,10 @@ import kotlin.coroutines.CoroutineContext as KCoroutineContext
 internal class TaoComposeSceneHostLinux(
     private val window: TaoWindow,
     private val coroutineContext: CoroutineContext = EmptyCoroutineContext,
+    // Full-window per-pixel transparency (#416). Creation-time; Linux always
+    // builds with an ARGB visual for EGL, and this flag starts the clear at
+    // alpha 0 so empty client areas show the desktop.
+    private val fullyTransparent: Boolean = false,
 ) : AbstractTaoComposeSceneHost() {
     val titleBarHeightDpState: androidx.compose.runtime.MutableState<Float> =
         androidx.compose.runtime.mutableStateOf(0f)
@@ -108,13 +112,15 @@ internal class TaoComposeSceneHostLinux(
      * ARGB color the render loop clears the surface to each frame, pushed in
      * via [LocalRequestedClearColor] by the themed window (window background)
      * and by `TitleBar` (resolved title-bar background). Defaults to opaque
-     * white until the first composition. The
-     * post-render carve ([applyFrameDecoration]) re-clears the CSD shadow
+     * white until the first composition (alpha 0 when [fullyTransparent]).
+     * The post-render carve ([applyFrameDecoration]) re-clears the CSD shadow
      * margins and rounded corners to transparent, so the drop shadow still
      * composites over clean transparency regardless of this clear color.
      */
     val clearColorArgbState: androidx.compose.runtime.MutableState<Int> =
-        androidx.compose.runtime.mutableStateOf(0xFFFFFFFF.toInt())
+        androidx.compose.runtime.mutableStateOf(
+            if (fullyTransparent) 0 else 0xFFFFFFFF.toInt(),
+        )
 
     /** App-level pre-dispatch hook. See [TaoComposeSceneHost.previewKeyHandler]. */
     var previewKeyHandler: ((KeyEvent) -> Boolean)? = null

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -1372,6 +1372,18 @@ internal class TaoComposeSceneHostWindows(
     }
 
     /**
+     * Clear colour for the next present: backdrop tint while a system material
+     * is armed, otherwise the resolved clear (alpha-0 for fully transparent
+     * windows, themed otherwise).
+     */
+    private fun resolveClientClearArgb(): Int =
+        if (transparentBackgroundState.value) {
+            backdropTintArgbState.value
+        } else {
+            clearColorArgbState.value
+        }
+
+    /**
      * Reverts an active backdrop and presents one last opaque themed frame,
      * synchronously. Called from [TaoWindow.onPrepareClose] / [TaoWindow.requestClose]
      * on the **confirmed destroy** path only — not from cancelable
@@ -1390,18 +1402,6 @@ internal class TaoComposeSceneHostWindows(
      *
      * Idempotent; a later detach() finds nothing to do.
      */
-    /**
-     * Clear colour for the next present: backdrop tint while a system material
-     * is armed, otherwise the resolved clear (alpha-0 for fully transparent
-     * windows, themed otherwise).
-     */
-    private fun resolveClientClearArgb(): Int =
-        if (transparentBackgroundState.value) {
-            backdropTintArgbState.value
-        } else {
-            clearColorArgbState.value
-        }
-
     fun prepareClose() {
         if (hwnd == 0L || !transparentBackgroundState.value) return
         NativeTaoWindowsDecoBridge.nativePrepareClose(hwnd)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -76,6 +76,9 @@ import kotlin.coroutines.CoroutineContext as KCoroutineContext
 internal class TaoComposeSceneHostWindows(
     private val window: TaoWindow,
     private val coroutineContext: CoroutineContext = EmptyCoroutineContext,
+    // Full-window per-pixel transparency (#416). Creation-time; pairs with
+    // tao `with_transparent` (DWM blur-behind empty region).
+    private val fullyTransparent: Boolean = false,
 ) : AbstractTaoComposeSceneHost() {
     val titleBarHeightDpState: androidx.compose.runtime.MutableState<Float> =
         androidx.compose.runtime.mutableStateOf(0f)
@@ -87,16 +90,22 @@ internal class TaoComposeSceneHostWindows(
      * white until the first composition. Aligns
      * the Windows host with macOS / Linux (and the AWT backends) so a Compose
      * region without an explicit background matches the chrome color instead
-     * of a hardcoded white.
+     * of a hardcoded white. Fully transparent windows start at alpha 0.
      */
     val clearColorArgbState: androidx.compose.runtime.MutableState<Int> =
-        androidx.compose.runtime.mutableStateOf(0xFFFFFFFF.toInt())
+        androidx.compose.runtime.mutableStateOf(
+            if (fullyTransparent) 0 else 0xFFFFFFFF.toInt(),
+        )
 
     /**
      * Whether the client area must stay transparent — set while a DWM system
      * backdrop is applied (see `WindowsBackdrop`). The render loop then clears
-     * to alpha 0 instead of [clearColorArgbState], so the backdrop shows
-     * wherever Compose paints nothing.
+     * to the backdrop tint instead of [clearColorArgbState], so the material
+     * shows wherever Compose paints nothing.
+     *
+     * Fully transparent windows (#416) do **not** arm this flag: they clear
+     * with [clearColorArgbState] (alpha-0 by default) on a top-level that
+     * already has tao's DWM blur-behind empty region.
      *
      * The Windows counterpart of the macOS host's `glassBackgroundState`;
      * unlike macOS the surface needs no native flag to carry alpha — the ANGLE
@@ -804,13 +813,7 @@ internal class TaoComposeSceneHostWindows(
                 // uninitialized black buffer (captured on the exit path).
                 // The sub-ms clear shrinks the gap and colours it.
                 NativeTaoGlBridge.nativeResize(attachmentHandle, widthPxNew, heightPxNew, scale)
-                val clearArgb =
-                    if (transparentBackgroundState.value) {
-                        backdropTintArgbState.value
-                    } else {
-                        clearColorArgbState.value
-                    }
-                NativeTaoGlBridge.nativeClearPresent(attachmentHandle, clearArgb)
+                NativeTaoGlBridge.nativeClearPresent(attachmentHandle, resolveClientClearArgb())
                 // Raw GL clear-color/scissor calls happened behind Skia's
                 // state cache; resync before the Skia render below.
                 directContext?.resetGLAll()
@@ -1032,13 +1035,11 @@ internal class TaoComposeSceneHostWindows(
             // While a system backdrop is active the clear is the app's tint
             // layer over the DWM material (0 = raw material); otherwise the
             // opaque themed background.
-            surface.canvas.clear(
-                if (transparentBackgroundState.value) {
-                    backdropTintArgbState.value
-                } else {
-                    clearColorArgbState.value
-                },
-            )
+            // Backdrop mode: tint over the DWM material (0 = raw material).
+            // Fully transparent without a backdrop: use the resolved clear
+            // colour (alpha-0 by default, or a semi-transparent WindowBackground).
+            // Opaque windows: themed clear as usual.
+            surface.canvas.clear(resolveClientClearArgb())
             sc.render(surface.canvas.asComposeCanvas(), now)
             // `flushAndSubmit` issues the glFlush that commits the frame to
             // the back buffer; the present happens below, after the overlay/
@@ -1389,6 +1390,18 @@ internal class TaoComposeSceneHostWindows(
      *
      * Idempotent; a later detach() finds nothing to do.
      */
+    /**
+     * Clear colour for the next present: backdrop tint while a system material
+     * is armed, otherwise the resolved clear (alpha-0 for fully transparent
+     * windows, themed otherwise).
+     */
+    private fun resolveClientClearArgb(): Int =
+        if (transparentBackgroundState.value) {
+            backdropTintArgbState.value
+        } else {
+            clearColorArgbState.value
+        }
+
     fun prepareClose() {
         if (hwnd == 0L || !transparentBackgroundState.value) return
         NativeTaoWindowsDecoBridge.nativePrepareClose(hwnd)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -79,6 +79,9 @@ internal class TaoComposeSceneHostWindows(
     // Full-window per-pixel transparency (#416). Creation-time; pairs with
     // tao `with_transparent` (DWM blur-behind empty region).
     private val fullyTransparent: Boolean = false,
+    // Fully borderless overlay (`DecoratedWindow(undecorated = true)`): no
+    // Compose CSD stroke and no DWM caption/border/shadow contour.
+    private val borderlessChrome: Boolean = false,
 ) : AbstractTaoComposeSceneHost() {
     val titleBarHeightDpState: androidx.compose.runtime.MutableState<Float> =
         androidx.compose.runtime.mutableStateOf(0f)
@@ -261,8 +264,20 @@ internal class TaoComposeSceneHostWindows(
         // Title-bar height is set later — the value the TitleBar composable publishes
         // via SideEffect arrives after first composition.
         scale = NativeTaoBridge.nativeScaleFactor(window.handle) / 1000f
-        val initialTitleBarPx = (titleBarHeightDpState.value * scale).toInt().coerceAtLeast(28)
+        // Borderless overlays have no caption chrome: keep the deco zone at 0
+        // so we don't reserve a phantom 28px title-bar hit band.
+        val initialTitleBarPx =
+            if (borderlessChrome) {
+                0
+            } else {
+                (titleBarHeightDpState.value * scale).toInt().coerceAtLeast(28)
+            }
         NativeTaoWindowsDecoBridge.nativeInstallDecoration(hwnd, initialTitleBarPx)
+        if (borderlessChrome) {
+            // Kill DWM 1px contour + shadow margin (Compose border is already
+            // skipped by the openDecoratedWindowWindows undecorated path).
+            NativeTaoWindowsDecoBridge.nativeSetBorderlessChrome(hwnd, true)
+        }
 
         // ANGLE/D3D11 (WARP-capable on RDP/VMs) is the only Windows backend.
         // Skia needs an EGL-assembled GL interface — the default makeGL()

--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -96,19 +96,19 @@ static const char kTaoPassthroughViewKey = 13;
 // Last themed fallback background ARGB. Applied to NSWindow and CAMetalLayer so
 // AppKit fullscreen/title-bar animations never reveal the default white window.
 static const char kTaoBackgroundArgbKey = 14;
-// NSNumber(int): window transparency mode (only OFF and REGIONS are shipped).
-//   0 = opaque (normal themed background)
-//   1 = regions — the WINDOW stays opaque (WindowServer then feeds
-//       behind-window materials the desktop-tinted wallpaper backdrop, like
-//       System Settings' sidebar — real windows behind never show through),
-//       but the CAMetalLayer goes transparent so the in-window material
-//       views show wherever Compose leaves alpha-0 pixels.
-// Full-window non-opaque glass was deliberately never exposed: Apple's
-// materials are for in-window panes (windowGlassRegion), not the whole window.
+// NSNumber(int): single window transparency mode.
+//   0 OFF     — opaque themed background
+//   1 REGIONS — window stays opaque (System Settings-style materials get a
+//               wallpaper-only backdrop); CAMetalLayer is non-opaque so
+//               in-window material panes show through alpha-0 Compose pixels
+//   2 FULL    — full-window per-pixel transparency (#416): window non-opaque,
+//               desktop composites through alpha-0 pixels
+// FULL is creation-time and is never demoted by glass REGIONS/OFF requests.
 static const char kTaoTransparentModeKey = 16;
 
 #define TAO_TRANSPARENCY_OFF     0
 #define TAO_TRANSPARENCY_REGIONS 1
+#define TAO_TRANSPARENCY_FULL    2
 
 // Same metrics as decorated-window-jni's applyConstraints — keeps the
 // traffic-lights at the same offsets Apple's own apps use.
@@ -392,6 +392,18 @@ static void applyStoredWindowBackground(NSWindow *window, NSView *view) {
     int mode = taoTransparencyMode(window);
     NSNumber *stored = objc_getAssociatedObject(window, &kTaoBackgroundArgbKey);
     jint argb = stored != nil ? stored.intValue : (jint)0xFFFFFFFF;
+    if (mode == TAO_TRANSPARENCY_FULL) {
+        // #416: non-opaque window; ARGB (incl. alpha) on NSWindow; layers clear
+        // so Compose clear alpha is what the compositor sees.
+        window.opaque = NO;
+        window.backgroundColor = colorFromArgb(argb);
+        clearLayerBackgrounds(window, view);
+        NucleusTaoMetalAttachment *att = attachmentForWindow(window);
+        if (att != NULL && att->layer != nil) {
+            att->layer.opaque = NO;
+        }
+        return;
+    }
     if (mode == TAO_TRANSPARENCY_REGIONS) {
         // Window keeps the themed color (it IS opaque — that is what makes
         // WindowServer feed the materials the wallpaper-only backdrop), but
@@ -403,22 +415,36 @@ static void applyStoredWindowBackground(NSWindow *window, NSView *view) {
     applyWindowBackgroundColor(window, view, argb);
 }
 
-// Glass-region transparency path: moves the window between OFF and REGIONS.
+// Single transparency-mode applier: OFF / REGIONS / FULL.
+// FULL is sticky for the window lifetime of a DecoratedWindow(transparent=true):
+// glass REGIONS/OFF must not demote it (would re-opaque the top-level).
 static void taoApplyWindowTransparencyMode(NSWindow *win, NSView *view, int mode) {
+    if (win == nil) return;
+    int current = taoTransparencyMode(win);
+    if (current == TAO_TRANSPARENCY_FULL && mode != TAO_TRANSPARENCY_FULL) {
+        // Keep FULL. Glass still wants clear layers for material panes.
+        if (mode == TAO_TRANSPARENCY_REGIONS) {
+            NucleusTaoMetalAttachment *att = attachmentForWindow(win);
+            if (att != NULL && att->layer != nil) {
+                att->layer.opaque = NO;
+            }
+            clearLayerBackgrounds(win, view);
+        }
+        return;
+    }
+
     objc_setAssociatedObject(win, &kTaoTransparentModeKey,
                              @(mode),
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    // The window always stays opaque: that is precisely what makes the system
-    // give its behind-window materials the System Settings-style
-    // desktop-tinted backdrop rather than compositing whatever is behind.
-    win.opaque = YES;
+
+    // REGIONS needs an opaque window for System Settings materials.
+    // FULL needs a non-opaque window so the desktop composites through.
+    win.opaque = (mode == TAO_TRANSPARENCY_FULL) ? NO : YES;
+
     // The CAMetalLayer is only ever made non-opaque, never opaque again: a
     // live layer keeps already-issued opaque drawables, and the first frames
     // after flipping back render alpha-0 pixels as solid black. Leaving it
-    // non-opaque costs nothing once the window itself is opaque again — the
-    // window background is painted underneath — and it lets a transparency
-    // mode be turned off and on freely, which the region ref-counting relies
-    // on.
+    // non-opaque costs nothing once the window itself is opaque again.
     NucleusTaoMetalAttachment *att = attachmentForWindow(win);
     if (att != NULL && att->layer != nil && mode != TAO_TRANSPARENCY_OFF) {
         att->layer.opaque = NO;
@@ -1593,12 +1619,51 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeSetWindowTransp
     dispatch_block_t apply = ^{
         NSWindow *win = view.window;
         if (win == nil) return;
-        taoApplyWindowTransparencyMode(
-            win, view,
-            enabled == JNI_TRUE ? TAO_TRANSPARENCY_REGIONS : TAO_TRANSPARENCY_OFF);
+        // Glass regions: REGIONS on, OFF when the last region releases.
+        // No-op demotion if FULL is sticky (#416).
+        int current = taoTransparencyMode(win);
+        if (enabled == JNI_TRUE) {
+            taoApplyWindowTransparencyMode(win, view, TAO_TRANSPARENCY_REGIONS);
+        } else if (current == TAO_TRANSPARENCY_REGIONS) {
+            taoApplyWindowTransparencyMode(win, view, TAO_TRANSPARENCY_OFF);
+        }
     };
     if ([NSThread isMainThread]) apply();
     else                          dispatch_sync(dispatch_get_main_queue(), apply);
+}
+
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeSetFullyTransparent(
+        JNIEnv *env, jclass clazz, jlong nsViewPtr, jboolean enabled) {
+    NSView *view = (__bridge NSView *)(void *)(uintptr_t)nsViewPtr;
+    if (view == nil) return;
+    dispatch_block_t apply = ^{
+        NSWindow *win = view.window;
+        if (win == nil) return;
+        // #416: FULL mode on the single transparency-mode slot.
+        if (enabled == JNI_TRUE) {
+            taoApplyWindowTransparencyMode(win, view, TAO_TRANSPARENCY_FULL);
+        } else if (taoTransparencyMode(win) == TAO_TRANSPARENCY_FULL) {
+            taoApplyWindowTransparencyMode(win, view, TAO_TRANSPARENCY_OFF);
+        }
+    };
+    if ([NSThread isMainThread]) apply();
+    else                          dispatch_sync(dispatch_get_main_queue(), apply);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeIsWindowOpaque(
+        JNIEnv *env, jclass clazz, jlong nsViewPtr) {
+    NSView *view = (__bridge NSView *)(void *)(uintptr_t)nsViewPtr;
+    if (view == nil) return JNI_TRUE;
+    __block jboolean result = JNI_TRUE;
+    dispatch_block_t read = ^{
+        NSWindow *win = view.window;
+        result = (win != nil && win.opaque) ? JNI_TRUE : JNI_FALSE;
+    };
+    if ([NSThread isMainThread]) read();
+    else                          dispatch_sync(dispatch_get_main_queue(), read);
+    return result;
 }
 
 // ── Glass regions: hosted NSSplitViewController (the Apple pattern) ──────

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -192,6 +192,7 @@ pub(crate) fn run_event_loop_blocking() {
                     popup_of,
                     skip_taskbar,
                     transparent,
+                    undecorated_shadow,
                 } => {
                     #[allow(unused_mut)]
                     let mut builder = WindowBuilder::new()
@@ -205,11 +206,17 @@ pub(crate) fn run_event_loop_blocking() {
                     // attribute — tao re-derives GWL_EXSTYLE from its
                     // WindowFlags on every state change, so a post-creation
                     // style poke is clobbered on the next activation.
+                    // Also wire undecorated DWM drop-shadow (tao default true;
+                    // borderless overlays pass false so no soft contour).
                     #[cfg(target_os = "windows")]
                     {
                         use tao::platform::windows::WindowBuilderExtWindows;
-                        builder = builder.with_skip_taskbar(skip_taskbar);
+                        builder = builder
+                            .with_skip_taskbar(skip_taskbar)
+                            .with_undecorated_shadow(undecorated_shadow);
                     }
+                    #[cfg(not(target_os = "windows"))]
+                    let _ = undecorated_shadow;
                     // Linux: GTK skip-taskbar + skip-pager hints
                     // (_NET_WM_STATE_SKIP_TASKBAR). Effective on X11 and
                     // XWayland; silently ignored on native Wayland, which has

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -215,19 +215,27 @@ pub(crate) fn run_event_loop_blocking() {
                             .with_skip_taskbar(skip_taskbar)
                             .with_undecorated_shadow(undecorated_shadow);
                     }
-                    #[cfg(not(target_os = "windows"))]
-                    let _ = undecorated_shadow;
+                    // macOS: NSWindow.hasShadow — same intent as Windows
+                    // undecorated_shadow. Borderless transparent overlays
+                    // pass false so AppKit does not draw a soft contour.
+                    #[cfg(target_os = "macos")]
+                    {
+                        use tao::platform::macos::WindowBuilderExtMacOS;
+                        builder = builder.with_has_shadow(undecorated_shadow);
+                        let _ = skip_taskbar;
+                    }
                     // Linux: GTK skip-taskbar + skip-pager hints
                     // (_NET_WM_STATE_SKIP_TASKBAR). Effective on X11 and
                     // XWayland; silently ignored on native Wayland, which has
                     // no client-side taskbar opt-out protocol.
+                    // Undecorated shadow is a Win/mac concept; Linux uses the
+                    // CSD shadow subsurface gated separately in the host.
                     #[cfg(target_os = "linux")]
                     {
                         use tao::platform::unix::WindowBuilderExtUnix;
                         builder = builder.with_skip_taskbar(skip_taskbar);
+                        let _ = undecorated_shadow;
                     }
-                    #[cfg(target_os = "macos")]
-                    let _ = skip_taskbar;
                     // Linux: build cursor-following overlays as GTK_WINDOW_POPUP
                     // transient children — on Wayland GDK maps them as
                     // `wl_subsurface`s, the only client-positionable window

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -191,6 +191,7 @@ pub(crate) fn run_event_loop_blocking() {
                     maximized,
                     popup_of,
                     skip_taskbar,
+                    transparent,
                 } => {
                     #[allow(unused_mut)]
                     let mut builder = WindowBuilder::new()
@@ -240,18 +241,14 @@ pub(crate) fn run_event_loop_blocking() {
                     }
                     #[cfg(not(target_os = "linux"))]
                     let _ = popup_of;
-                    // Linux: request an ARGB visual so the GTK window's X
-                    // visual matches the canonical visual that Mesa's EGL
-                    // exposes through its EGLConfigs. Without this, GDK
-                    // assigns a non-canonical 24-bit RGB visual and
-                    // `eglCreateWindowSurface` fails with EGL_BAD_CONFIG
-                    // because no EGLConfig advertises that visual ID.
-                    // The GLX path is unaffected — its `glXChooseVisual`
-                    // already requests ALPHA_SIZE=8, and ARGB GTK lets the
-                    // helper render directly into the parent without the
-                    // child-window fallback.
-                    #[cfg(target_os = "linux")]
-                    {
+                    // Full-window transparency (#416): tao sets NSWindow.opaque=NO
+                    // (macOS), DWM blur-behind empty region (Windows), ARGB visual
+                    // (Linux). Linux always needs with_transparent for the EGL
+                    // canonical visual even when the app did not ask for a
+                    // see-through window — without it Mesa fails eglCreateWindowSurface.
+                    // The app-level flag still drives the Kotlin clear path via
+                    // host `fullyTransparent`; builder just needs the ARGB path.
+                    if transparent || cfg!(target_os = "linux") {
                         builder = builder.with_transparent(true);
                     }
                     let window = builder.build(target);

--- a/decorated-window-tao/src/main/native/src/events.rs
+++ b/decorated-window-tao/src/main/native/src/events.rs
@@ -271,9 +271,10 @@ pub(crate) enum UserEvent {
         // of this flag (canonical visual); the flag still controls whether the
         // host starts with an alpha-0 clear and keeps the top-level non-opaque.
         transparent: bool,
-        // Windows: `WindowBuilderExtWindows::with_undecorated_shadow`. Tao
-        // defaults true (DWM drop shadow + outer-rect inset). False for
-        // borderless overlays. Ignored on other platforms.
+        // Drop shadow for borderless windows. Windows:
+        // `with_undecorated_shadow` (DWM + outer-rect inset). macOS:
+        // `with_has_shadow` (NSWindow). False for borderless overlays.
+        // Ignored on Linux (CSD shadow is host-gated).
         undecorated_shadow: bool,
     },
     SetVisible {

--- a/decorated-window-tao/src/main/native/src/events.rs
+++ b/decorated-window-tao/src/main/native/src/events.rs
@@ -271,6 +271,10 @@ pub(crate) enum UserEvent {
         // of this flag (canonical visual); the flag still controls whether the
         // host starts with an alpha-0 clear and keeps the top-level non-opaque.
         transparent: bool,
+        // Windows: `WindowBuilderExtWindows::with_undecorated_shadow`. Tao
+        // defaults true (DWM drop shadow + outer-rect inset). False for
+        // borderless overlays. Ignored on other platforms.
+        undecorated_shadow: bool,
     },
     SetVisible {
         handle: u64,

--- a/decorated-window-tao/src/main/native/src/events.rs
+++ b/decorated-window-tao/src/main/native/src/events.rs
@@ -265,6 +265,12 @@ pub(crate) enum UserEvent {
         // XWayland, ignored on native Wayland. Ignored on macOS (Dock hiding
         // goes through the activation policy).
         skip_taskbar: bool,
+        // Full-window per-pixel transparency (#416). Maps to tao's
+        // `WindowBuilder::with_transparent(true)` so alpha-0 pixels composite
+        // the desktop. Linux always requests an ARGB visual for EGL regardless
+        // of this flag (canonical visual); the flag still controls whether the
+        // host starts with an alpha-0 clear and keeps the top-level non-opaque.
+        transparent: bool,
     },
     SetVisible {
         handle: u64,

--- a/decorated-window-tao/src/main/native/src/window_jni.rs
+++ b/decorated-window-tao/src/main/native/src/window_jni.rs
@@ -70,6 +70,7 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_
     popup_of: jlong,
     skip_taskbar: jboolean,
     transparent: jboolean,
+    undecorated_shadow: jboolean,
 ) {
     let title: String = match env.get_string(&title) {
         Ok(s) => s.into(),
@@ -87,6 +88,7 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_
         popup_of: popup_of as u64,
         skip_taskbar: skip_taskbar != JNI_FALSE,
         transparent: transparent != JNI_FALSE,
+        undecorated_shadow: undecorated_shadow != JNI_FALSE,
     });
 }
 

--- a/decorated-window-tao/src/main/native/src/window_jni.rs
+++ b/decorated-window-tao/src/main/native/src/window_jni.rs
@@ -69,6 +69,7 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_
     maximized: jboolean,
     popup_of: jlong,
     skip_taskbar: jboolean,
+    transparent: jboolean,
 ) {
     let title: String = match env.get_string(&title) {
         Ok(s) => s.into(),
@@ -85,6 +86,7 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_
         maximized: maximized != JNI_FALSE,
         popup_of: popup_of as u64,
         skip_taskbar: skip_taskbar != JNI_FALSE,
+        transparent: transparent != JNI_FALSE,
     });
 }
 

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -146,6 +146,12 @@ typedef struct {
      * buttons stay Compose-drawn and Compose-handled: the NC mouse messages
      * for these hit codes are forwarded back as client messages. */
     RECT    captionButtonRects[3];
+    /* Fully borderless chrome (DecoratedWindow(undecorated = true) overlays /
+     * ghosts). Suppresses DWM caption+border colours and the 1px bottom
+     * frame extension that keeps the drop shadow — otherwise a transparent
+     * window still shows a 1px system contour (themed border, often black
+     * when the clear colour is alpha-0). */
+    BOOL    borderlessChrome;
 } DecoState;
 
 /* Order inside DecoState.captionButtonRects. */
@@ -180,6 +186,10 @@ static BOOL isCaptionButtonHit(WPARAM code) {
 /* DWM_WINDOW_CORNER_PREFERENCE wire values (avoid depending on a 22H2 SDK). */
 #define NUCLEUS_DWMWCP_DEFAULT    0
 #define NUCLEUS_DWMWCP_DONOTROUND 1
+#ifndef DWMWA_VISIBLE_FRAME_BORDER_THICKNESS
+/* Win11 22000+: thickness of the visible non-client border (logical px). */
+#define DWMWA_VISIBLE_FRAME_BORDER_THICKNESS 37
+#endif
 
 /* Backdrop styles below this are "no backdrop": DWMSBT_AUTO (0) leaves the
  * choice to DWM, which means none for an ordinary window, and DWMSBT_NONE (1)
@@ -373,6 +383,7 @@ static void revertBackdropForClose(HWND hwnd, DecoState *state) {
  * as a bare black line instead of the subtle system frame. */
 static void applyCaptionColors(HWND hwnd, DecoState *state) {
     BOOL backdrop = state && state->backdropActive;
+    BOOL borderless = state && state->borderlessChrome;
     COLORREF themed = state ? state->bgColor : RGB(255, 255, 255);
     COLORREF caption = backdrop ? (COLORREF)DWMWA_COLOR_NONE : themed;
     COLORREF border = backdrop ? (COLORREF)DWMWA_COLOR_DEFAULT : themed;
@@ -380,8 +391,8 @@ static void applyCaptionColors(HWND hwnd, DecoState *state) {
      * fill DWM still draws for these attributes shows as a 1px contour of
      * the wrong colour around the content — the issue-413 white edge (worst
      * with a backdrop, where the border is otherwise the light system
-     * default). */
-    if (state && state->isFullscreen) {
+     * default). Same for borderlessChrome overlays (no system frame at all). */
+    if (state && (state->isFullscreen || borderless)) {
         caption = (COLORREF)DWMWA_COLOR_NONE;
         border = (COLORREF)DWMWA_COLOR_NONE;
     }
@@ -393,15 +404,28 @@ static void applyCaptionColors(HWND hwnd, DecoState *state) {
  * keeps the 1px bottom extension that preserves the DWM drop shadow (or the
  * full sheet of glass while a DWM backdrop tier is live). Fullscreen drops
  * the 1px band: with the window covering the monitor it composites as a
- * light hairline along the bottom edge (issue 413). */
+ * light hairline along the bottom edge (issue 413).
+ *
+ * borderlessChrome uses ZERO margins on purpose. The classic {0,0,0,1}
+ * bottom extension exists *only* to keep the DWM drop shadow; sheet-of-glass
+ * {-1,-1,-1,-1} also keeps a soft system shadow around the window. Ghost
+ * overlays (`DecoratedWindow(undecorated = true)`) want neither — per-pixel
+ * transparency still works via tao's DwmEnableBlurBehindWindow empty region
+ * (`with_transparent`). */
 static void applyFrameMargins(HWND hwnd, DecoState *state) {
-    BOOL sheet = state && state->sheetOfGlass;
+    BOOL borderless = state && state->borderlessChrome;
+    BOOL sheet = state && state->sheetOfGlass && !borderless;
     BOOL fs = state && state->isFullscreen;
     MARGINS margins;
-    margins.cxLeftWidth    = sheet ? -1 : 0;
-    margins.cxRightWidth   = sheet ? -1 : 0;
-    margins.cyTopHeight    = sheet ? -1 : 0;
-    margins.cyBottomHeight = sheet ? -1 : (fs ? 0 : 1);
+    if (borderless) {
+        margins.cxLeftWidth = margins.cxRightWidth = 0;
+        margins.cyTopHeight = margins.cyBottomHeight = 0;
+    } else {
+        margins.cxLeftWidth    = sheet ? -1 : 0;
+        margins.cxRightWidth   = sheet ? -1 : 0;
+        margins.cyTopHeight    = sheet ? -1 : 0;
+        margins.cyBottomHeight = sheet ? -1 : (fs ? 0 : 1);
+    }
     DwmExtendFrameIntoClientArea(hwnd, &margins);
 }
 
@@ -589,6 +613,12 @@ static LRESULT CALLBACK decoWndProc(
      * background only for that startup gap; after the first native redraw event
      * this is disabled to avoid solid-color flicker while resizing or dragging. */
     case WM_ERASEBKGND:
+        /* Borderless transparent overlays: claim the erase and paint nothing.
+         * A solid fill would reappear as a contour; the GL surface + tao
+         * DwmEnableBlurBehindWindow empty region already present the desktop. */
+        if (state->borderlessChrome) {
+            return 1;
+        }
         /* With a backdrop, newly exposed areas must be erased to GDI black:
          * GDI writes alpha 0 on the 32bpp redirection surface, which the
          * sheet-of-glass frame composites as "show the backdrop" (the classic
@@ -971,6 +1001,59 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeSetTit
     if (!hwnd) return;
     DecoState *state = getState(hwnd);
     if (state) state->titleBarHeightPx = (int)heightPx;
+}
+
+/**
+ * Fully borderless chrome for overlay/ghost windows
+ * (`DecoratedWindow(undecorated = true)`).
+ *
+ * Kills every DWM source of contour / drop shadow we can:
+ *  - caption + border colours → COLOR_NONE
+ *  - frame margins → {0,0,0,0} (the 1px bottom band exists *only* for shadow)
+ *  - squared corners (no rounded AA outline)
+ *  - visible frame border thickness 0 (Win11)
+ *  - system backdrop none (no Mica/Acrylic halo)
+ *
+ * Per-pixel transparency still comes from tao's DwmEnableBlurBehindWindow
+ * empty region. Safe to call repeatedly (e.g. after show()).
+ */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeSetBorderlessChrome(
+    JNIEnv *env, jclass clazz, jlong hwndLong, jboolean borderless)
+{
+    (void)env; (void)clazz;
+    HWND hwnd = (HWND)(uintptr_t)hwndLong;
+    if (!hwnd) return;
+    DecoState *state = getState(hwnd);
+    if (!state) return;
+    BOOL wanted = borderless ? TRUE : FALSE;
+    state->borderlessChrome = wanted;
+    /* Backdrop sheet-of-glass would re-arm frame extension + shadow. */
+    if (wanted) {
+        state->sheetOfGlass = FALSE;
+        state->backdropActive = FALSE;
+    }
+    applyCaptionColors(hwnd, state);
+    applyFrameMargins(hwnd, state);
+
+    int corner = wanted ? NUCLEUS_DWMWCP_DONOTROUND : NUCLEUS_DWMWCP_DEFAULT;
+    DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE,
+                          &corner, sizeof(corner));
+
+    if (wanted) {
+        /* Win11: zero the visible 1px non-client border thickness. */
+        UINT thickness = 0;
+        DwmSetWindowAttribute(hwnd, DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
+                              &thickness, sizeof(thickness));
+        /* DWMSBT_NONE — no system material halo around the HWND. */
+        int none = 1;
+        DwmSetWindowAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE,
+                              &none, sizeof(none));
+    }
+
+    SetWindowPos(hwnd, NULL, 0, 0, 0, 0,
+        SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE |
+        SWP_NOZORDER | SWP_NOACTIVATE);
 }
 
 /**

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ChromeReviewHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ChromeReviewHeadfulCases.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import dev.nucleusframework.core.runtime.Platform
@@ -27,8 +28,10 @@ import dev.nucleusframework.window.WindowsBackdrop
 import dev.nucleusframework.window.WindowsBackdropStyle
 import dev.nucleusframework.window.newFullscreenControls
 import dev.nucleusframework.window.noWindowDrag
+import dev.nucleusframework.window.tao.LocalRequestedGlassBackground
 import dev.nucleusframework.window.tao.LocalRequestedTransparentBackground
 import dev.nucleusframework.window.tao.LocalWindowClearColorLayers
+import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
 import dev.nucleusframework.window.windowDragArea
@@ -58,6 +61,9 @@ internal object ChromeReviewHeadfulCases {
             noWindowDragBlocksAncestorDragArea(),
             hideBarZerosControlsInsetsInFullscreen(),
             fullscreenToggleVisualCapture(),
+            fullyTransparentWindowIssue416(),
+            fullyTransparentSurvivesTitleBarIssue416(),
+            fullyTransparentHonoursSemiTintIssue416(),
         )
 
     /**
@@ -494,5 +500,177 @@ internal object ChromeReviewHeadfulCases {
                 }
             },
         )
+    }
+
+    /**
+     * Issue #416 — baseline: `DecoratedWindow(transparent = true)` alone
+     * (opaque theme style coerced to alpha-0 clear) + non-opaque top-level.
+     * No AWT Robot — host clear + macOS `isOpaque`.
+     */
+    private fun fullyTransparentWindowIssue416(): TaoWindowTestCase {
+        val resolvedClear = AtomicInteger(Int.MIN_VALUE)
+        val glassArmed = AtomicBoolean(false)
+        val backdropTransparentArmed = AtomicBoolean(false)
+        val sawLocals = AtomicBoolean(false)
+        return TaoWindowTestCase(
+            name = "#416 fully transparent Tao window",
+            paintDefaultBackground = false,
+            transparent = true,
+            content = {
+                // No WindowBackground / TitleBar: only the style layer + coerce policy.
+                val layers = LocalWindowClearColorLayers.current
+                val glass = LocalRequestedGlassBackground.current
+                val backdrop = LocalRequestedTransparentBackground.current
+                SideEffect {
+                    resolvedClear.set(layers?.resolved ?: 0)
+                    glassArmed.set(glass?.value == true)
+                    backdropTransparentArmed.set(backdrop?.value == true)
+                    sawLocals.set(true)
+                }
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(24.dp),
+                    contentAlignment = Alignment.TopStart,
+                ) {
+                    Box(Modifier.size(48.dp).background(Color(0xFFFF00AA)))
+                }
+            },
+            driver = {
+                awaitUntil("window mapped") { bounds() != null }
+                awaitUntil("composition locals published") { sawLocals.get() }
+                settle(400)
+                assertTransparentClearAndNative(resolvedClear.get(), glassArmed.get(), backdropTransparentArmed.get())
+                System.err.println("[#416/tao] VERDICT: OK — transparent alone (style coerce + native)")
+            },
+        )
+    }
+
+    /**
+     * Regression for the TitleBar footgun: stock TitleBar used to write an
+     * opaque chrome colour into the clear stack and paint the empty client
+     * solid. Under transparent=true the clear must stay alpha-0 (TitleBar
+     * still paints its own bar pixels).
+     */
+    private fun fullyTransparentSurvivesTitleBarIssue416(): TaoWindowTestCase {
+        val resolvedClear = AtomicInteger(Int.MIN_VALUE)
+        val sawLocals = AtomicBoolean(false)
+        return TaoWindowTestCase(
+            name = "#416 transparent survives TitleBar clear",
+            paintDefaultBackground = false,
+            transparent = true,
+            content = {
+                TitleBar()
+                val layers = LocalWindowClearColorLayers.current
+                SideEffect {
+                    resolvedClear.set(layers?.resolved ?: 0)
+                    sawLocals.set(true)
+                }
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(top = 40.dp, start = 24.dp),
+                    contentAlignment = Alignment.TopStart,
+                ) {
+                    Box(Modifier.size(48.dp).background(Color(0xFFFF00AA)))
+                }
+            },
+            driver = {
+                awaitUntil("window mapped") { bounds() != null }
+                awaitUntil("composition locals published") { sawLocals.get() }
+                settle(500)
+                val clear = resolvedClear.get()
+                val clearAlpha = (clear ushr 24) and 0xFF
+                System.err.println(
+                    "[#416/titlebar] clear ARGB=0x${clear.toUInt().toString(16)} alpha=$clearAlpha " +
+                        "platform=${Platform.Current}",
+                )
+                check(clearAlpha == 0) {
+                    "TitleBar wrote opaque clear under transparent=true: " +
+                        "0x${clear.toUInt().toString(16)} — empty client would hide the desktop"
+                }
+                if (isMac && NativeMetalBridge.isLoaded) {
+                    val nsView = NativeTaoBridge.nativeNsViewHandle(window.handle)
+                    check(nsView != 0L)
+                    check(!NativeMetalBridge.nativeIsWindowOpaque(nsView)) {
+                        "NSWindow re-opaqued under TitleBar + transparent=true"
+                    }
+                }
+                System.err.println("[#416/titlebar] VERDICT: OK — TitleBar does not kill transparent clear")
+            },
+        )
+    }
+
+    /**
+     * Semi-transparent WindowBackground must keep its alpha (coerce only
+     * targets fully opaque ARGB), so apps can tint a see-through window.
+     */
+    private fun fullyTransparentHonoursSemiTintIssue416(): TaoWindowTestCase {
+        val resolvedClear = AtomicInteger(Int.MIN_VALUE)
+        val sawLocals = AtomicBoolean(false)
+        // 50% white tint — alpha must survive.
+        val tint = Color(0x80FFFFFF)
+        val tintArgb = tint.toArgb()
+        return TaoWindowTestCase(
+            name = "#416 transparent keeps semi-transparent WindowBackground",
+            paintDefaultBackground = false,
+            transparent = true,
+            content = {
+                WindowBackground(tint)
+                val layers = LocalWindowClearColorLayers.current
+                SideEffect {
+                    resolvedClear.set(layers?.resolved ?: 0)
+                    sawLocals.set(true)
+                }
+                Box(Modifier.size(48.dp).background(Color(0xFFFF00AA)))
+            },
+            driver = {
+                awaitUntil("window mapped") { bounds() != null }
+                awaitUntil("composition locals published") { sawLocals.get() }
+                settle(400)
+                val clear = resolvedClear.get()
+                System.err.println(
+                    "[#416/tint] clear ARGB=0x${clear.toUInt().toString(16)} " +
+                        "expected=0x${tintArgb.toUInt().toString(16)}",
+                )
+                check(clear == tintArgb) {
+                    "semi-transparent WindowBackground was coerced away: " +
+                        "got 0x${clear.toUInt().toString(16)}, expected 0x${tintArgb.toUInt().toString(16)}"
+                }
+                System.err.println("[#416/tint] VERDICT: OK — semi tint preserved under transparent=true")
+            },
+        )
+    }
+
+    private fun TaoWindowTestScope.assertTransparentClearAndNative(
+        clear: Int,
+        glassArmed: Boolean,
+        backdropTransparentArmed: Boolean,
+    ) {
+        val clearAlpha = (clear ushr 24) and 0xFF
+        System.err.println(
+            "[#416/tao] clear ARGB=0x${clear.toUInt().toString(16)} alpha=$clearAlpha " +
+                "glassArmed=$glassArmed backdropTransparentArmed=$backdropTransparentArmed " +
+                "platform=${Platform.Current}",
+        )
+        check(clearAlpha == 0) {
+            "transparent window clear is not alpha-0: 0x${clear.toUInt().toString(16)}"
+        }
+        check(!glassArmed) {
+            "glassBackgroundState armed — regional glass is not full-window transparency"
+        }
+        check(!backdropTransparentArmed) {
+            "transparentBackgroundState armed without WindowsBackdrop — unexpected"
+        }
+        if (isMac && NativeMetalBridge.isLoaded) {
+            val nsView = NativeTaoBridge.nativeNsViewHandle(window.handle)
+            check(nsView != 0L) { "NSView handle missing for #416 probe" }
+            val opaque = NativeMetalBridge.nativeIsWindowOpaque(nsView)
+            System.err.println("[#416/tao] NSWindow.isOpaque=$opaque")
+            check(!opaque) {
+                "NSWindow still opaque under DecoratedWindow(transparent=true) — " +
+                    "desktop cannot composite through"
+            }
+        }
     }
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -188,10 +188,15 @@ public object TaoHeadfulTestSuiteMain {
                     DecoratedWindow(
                         onCloseRequest = { /* cases drive their own lifecycle */ },
                         title = "tao-headful: ${case.name}",
+                        transparent = case.transparent,
                     ) {
                         // Default chrome surface; cases may paint over it via
                         // [TaoWindowTestCase.content] (scaffold, backdrop, …).
-                        Box(Modifier.fillMaxSize().background(Color.DarkGray))
+                        // Fully-transparent probes opt out so the Skia clear is
+                        // what the compositor sees in empty regions.
+                        if (case.paintDefaultBackground) {
+                            Box(Modifier.fillMaxSize().background(Color.DarkGray))
+                        }
                         case.content(this)
                         val w = window
                         LaunchedEffect(w) { windowHolder.value = w }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
@@ -25,6 +25,17 @@ internal class TaoWindowTestCase(
     val timeoutMillis: Long = DEFAULT_TIMEOUT_MILLIS,
     /** Platforms the case runs on; empty = all. */
     val skip: () -> String? = { null },
+    /**
+     * When true (default), the suite paints a full-size DarkGray chrome under
+     * [content]. Cases that need an empty / alpha-cleared client (e.g. fully
+     * transparent window probes) set this to false.
+     */
+    val paintDefaultBackground: Boolean = true,
+    /**
+     * Forwarded to [dev.nucleusframework.window.tao.DecoratedWindow]'s
+     * `transparent` parameter (#416). Creation-time only.
+     */
+    val transparent: Boolean = false,
     /** Optional extra window content composed inside the DecoratedWindow. */
     val content: @Composable TaoDecoratedWindowScope.() -> Unit = {},
     val driver: suspend TaoWindowTestScope.() -> Unit,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TransparentWindowSmokeMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TransparentWindowSmokeMain.kt
@@ -37,7 +37,9 @@ import kotlin.system.exitProcess
  * marker over the desktop.
  *
  * Capture backend:
- * - **macOS / Linux**: [java.awt.Robot] (sees per-pixel-alpha Tao windows).
+ * - **macOS / Linux-X11**: [java.awt.Robot] (sees per-pixel-alpha Tao windows).
+ *   On Linux that means XWayland too, but *only* if the window itself is an X
+ *   client — see [checkCaptureCapableSession].
  * - **Windows**: Robot omits layered windows — shell out to a CAPTUREBLT helper
  *   (`capture_region.exe`) pointed at by
  *   `-Dnucleus.tao.transparent.smoke.captureTool=`.
@@ -56,9 +58,10 @@ object TransparentWindowSmokeMain {
 
     // Hold the window on screen so a manual look is possible; override with
     // -Dnucleus.tao.transparent.smoke.holdMs=…
-    private val SETTLE_MS: Long =
+    private val holdMs: Long? =
         System.getProperty("nucleus.tao.transparent.smoke.holdMs")?.toLongOrNull()
-            ?: 1_200L
+
+    private val SETTLE_MS: Long = holdMs ?: 1_200L
 
     // Marker is 48.dp at 24.dp padding — sample near centre of the square.
     private const val EMPTY_SAMPLE_X_DP = 300.0
@@ -68,9 +71,53 @@ object TransparentWindowSmokeMain {
     private val isWindows: Boolean =
         System.getProperty("os.name", "").lowercase().contains("win")
 
+    private val isLinux: Boolean =
+        System.getProperty("os.name", "").lowercase().contains("linux")
+
+    /**
+     * A native Wayland session defeats this probe twice over, so bail out rather
+     * than print a verdict that means nothing:
+     * - [java.awt.Robot] captures through the X server, which cannot see a
+     *   native Wayland surface — baseline and window shots come back
+     *   byte-identical, so "empty matches the desktop" passes for the wrong
+     *   reason while the opaque marker is never found.
+     * - xdg-shell has no client positioning, so `setOuterPosition` is a no-op
+     *   and the capture rect is not where the compositor mapped the window.
+     *
+     * `NUCLEUS_TAO_LINUX_RENDERER=x11` builds the window as an X client under
+     * XWayland, where both hold. The Gradle task sets it by default; this guard
+     * only fires when the main class is launched directly (IDE) or with the
+     * variable explicitly overridden. A manual look
+     * (`-Dnucleus.tao.transparent.smoke.holdMs=…`) is judged by eye, not by
+     * Robot, so it runs on Wayland regardless — only the verdict is withheld.
+     */
+    private fun checkCaptureCapableSession() {
+        if (!isLinux || System.getenv("NUCLEUS_TAO_LINUX_RENDERER") == "x11") return
+        val nativeWayland =
+            System.getenv("WAYLAND_DISPLAY") != null ||
+                System.getenv("XDG_SESSION_TYPE") == "wayland"
+        if (!nativeWayland) return
+        System.err.println(
+            "[smoke/#416] native Wayland session: AWT Robot cannot see Wayland surfaces " +
+                "and xdg-shell ignores setOuterPosition, so no pixel verdict is possible. " +
+                "Re-run with NUCLEUS_TAO_LINUX_RENDERER=x11 — what " +
+                ":decorated-window-tao:taoTransparentSmoke sets for you.",
+        )
+        if (holdMs == null) exitProcess(0)
+        System.err.println(
+            "[smoke/#416] holdMs set — showing the window for ${holdMs}ms for a manual " +
+                "look. The compositor centres it (no client positioning).",
+        )
+        manualLookOnly = true
+    }
+
+    /** Set by [checkCaptureCapableSession]: show the window, skip the pixel verdict. */
+    private var manualLookOnly = false
+
     @JvmStatic
     fun main(args: Array<String>) {
         // Do not touch AWT here on macOS (Robot / GraphicsEnvironment).
+        checkCaptureCapableSession()
         val outDir =
             File(
                 System.getProperty(
@@ -140,6 +187,11 @@ object TransparentWindowSmokeMain {
         w.setInnerSize(OUTER_W_DP, OUTER_H_DP)
         w.focus()
         kotlinx.coroutines.delay(SETTLE_MS)
+
+        if (manualLookOnly) {
+            System.err.println("[smoke/#416] manual look done — no verdict on native Wayland")
+            exitProcess(0)
+        }
 
         val bounds = w.outerBoundsPx()
         check(bounds != null && bounds.size >= 4) { "outerBoundsPx null after settle" }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TransparentWindowSmokeMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TransparentWindowSmokeMain.kt
@@ -120,151 +120,168 @@ object TransparentWindowSmokeMain {
             }
 
             LaunchedEffect(Unit) {
-                val deadline = System.currentTimeMillis() + 15_000L
-                while (window == null) {
-                    check(System.currentTimeMillis() < deadline) { "window never published" }
-                    kotlinx.coroutines.delay(25)
-                }
-                val w = window!!
-                w.setOuterPosition(OUTER_X_DP, OUTER_Y_DP)
-                w.setInnerSize(OUTER_W_DP, OUTER_H_DP)
-                w.focus()
-                kotlinx.coroutines.delay(SETTLE_MS)
-
-                val bounds = w.outerBoundsPx()
-                check(bounds != null && bounds.size >= 4) { "outerBoundsPx null after settle" }
-                val bx = bounds[0].toInt()
-                val by = bounds[1].toInt()
-                val bw = bounds[2].toInt()
-                val bh = bounds[3].toInt()
-                val scale = w.scaleFactor.toDouble().coerceAtLeast(1.0)
-                System.err.println(
-                    "[smoke/#416] outerBoundsPx=[$bx,$by ${bw}x$bh] scale=$scale " +
-                        "platform=${System.getProperty("os.name")}",
-                )
-
-                // Baseline = desktop under the window rect with the window hidden.
-                // Must run *after* taoApplication so AWT/Robot is not the first
-                // AppKit client on macOS.
-                w.hide()
-                kotlinx.coroutines.delay(300)
-                val baseline =
-                    captureScreen(
-                        captureTool,
-                        bx,
-                        by,
-                        bw,
-                        bh,
-                        File(outDir, "01-baseline-desktop.png"),
-                    )
-                val emptySampleX = (EMPTY_SAMPLE_X_DP * scale).toInt().coerceIn(0, bw - 1)
-                val emptySampleY = (EMPTY_SAMPLE_Y_DP * scale).toInt().coerceIn(0, bh - 1)
-                val half = (SAMPLE_HALF_DP * scale).toInt().coerceAtLeast(2)
-                val desktopRef = averageRgb(baseline, emptySampleX, emptySampleY, half)
-                System.err.println(
-                    "[smoke/#416] baseline empty RGB=(%d,%d,%d)".format(
-                        desktopRef[0],
-                        desktopRef[1],
-                        desktopRef[2],
-                    ),
-                )
-
-                w.show()
-                w.focus()
-                kotlinx.coroutines.delay(SETTLE_MS)
-
-                val withWindow =
-                    captureScreen(
-                        captureTool,
-                        bx,
-                        by,
-                        bw,
-                        bh,
-                        File(outDir, "02-transparent-window.png"),
-                    )
-
-                val markerPadPx = (24.0 * scale).toInt()
-                val markerSampleX = (markerPadPx + 24.0 * scale).toInt().coerceIn(0, withWindow.width - 1)
-                val markerSampleY = (markerPadPx + 24.0 * scale).toInt().coerceIn(0, withWindow.height - 1)
-
-                val marker = averageRgb(withWindow, markerSampleX, markerSampleY, half)
-                val empty =
-                    averageRgb(
-                        withWindow,
-                        emptySampleX.coerceIn(0, withWindow.width - 1),
-                        emptySampleY.coerceIn(0, withWindow.height - 1),
-                        half,
-                    )
-                System.err.println(
-                    "[smoke/#416] marker RGB=(%d,%d,%d) empty RGB=(%d,%d,%d)".format(
-                        marker[0],
-                        marker[1],
-                        marker[2],
-                        empty[0],
-                        empty[1],
-                        empty[2],
-                    ),
-                )
-
-                val failures = mutableListOf<String>()
-
-                if (!isMagenta(marker)) {
-                    val found = findMagenta(withWindow)
-                    if (found == null) {
-                        failures +=
-                            "opaque marker not magenta anywhere: sample RGB=" +
-                            "(${marker[0]},${marker[1]},${marker[2]})"
-                    } else {
-                        System.err.println(
-                            "[smoke/#416] marker found by scan at ${found.first},${found.second}",
-                        )
-                    }
-                }
-
-                if (isNearSolid(empty, 0xFF, 0xFF, 0xFF, tol = 18)) {
-                    failures += "empty client looks opaque white — transparency not applied"
-                }
-                if (isNearSolid(empty, 0x00, 0x00, 0x00, tol = 12)) {
-                    failures += "empty client looks solid black — opaque surface with alpha-0 clear"
-                }
-                if (isMagenta(empty)) {
-                    failures += "empty client is magenta — marker bled across whole surface"
-                }
-
-                val dist = rgbDistance(empty, desktopRef)
-                System.err.println(
-                    "[smoke/#416] empty vs desktop Δ=$dist " +
-                        "(desktop RGB=(${desktopRef[0]},${desktopRef[1]},${desktopRef[2]}), max 90)",
-                )
-                if (dist > 90) {
-                    failures +=
-                        "empty client RGB=(${empty[0]},${empty[1]},${empty[2]}) diverges from " +
-                        "desktop RGB=(${desktopRef[0]},${desktopRef[1]},${desktopRef[2]}) " +
-                        "Δ=$dist — desktop not compositing through"
-                }
-
-                val blackEdge = countNearBlackPerimeter(withWindow, thickness = 2, maxChannel = 6)
-                System.err.println(
-                    "[smoke/#416] near-black perimeter pixels=$blackEdge (max allowed 40)",
-                )
-                if (blackEdge > 40) {
-                    failures +=
-                        "near-black perimeter contour still present ($blackEdge px) — " +
-                        "borderless chrome / shadow not fully stripped"
-                }
-
-                if (failures.isEmpty()) {
-                    System.err.println("[smoke/#416] VERDICT: OK — transparent window over desktop")
-                    System.err.println("[smoke/#416] screenshots: $outDir")
-                    exitProcess(0)
-                } else {
-                    System.err.println("[smoke/#416] VERDICT: FAIL")
-                    failures.forEach { System.err.println("  - $it") }
-                    System.err.println("[smoke/#416] screenshots: $outDir")
-                    exitProcess(1)
-                }
+                runProbe(windowHolder = { window }, captureTool = captureTool, outDir = outDir)
             }
         }
+    }
+
+    private suspend fun runProbe(
+        windowHolder: () -> TaoWindow?,
+        captureTool: File?,
+        outDir: File,
+    ) {
+        val deadline = System.currentTimeMillis() + 15_000L
+        while (windowHolder() == null) {
+            check(System.currentTimeMillis() < deadline) { "window never published" }
+            kotlinx.coroutines.delay(25)
+        }
+        val w = windowHolder()!!
+        w.setOuterPosition(OUTER_X_DP, OUTER_Y_DP)
+        w.setInnerSize(OUTER_W_DP, OUTER_H_DP)
+        w.focus()
+        kotlinx.coroutines.delay(SETTLE_MS)
+
+        val bounds = w.outerBoundsPx()
+        check(bounds != null && bounds.size >= 4) { "outerBoundsPx null after settle" }
+        val bx = bounds[0].toInt()
+        val by = bounds[1].toInt()
+        val bw = bounds[2].toInt()
+        val bh = bounds[3].toInt()
+        val scale = w.scaleFactor.toDouble().coerceAtLeast(1.0)
+        System.err.println(
+            "[smoke/#416] outerBoundsPx=[$bx,$by ${bw}x$bh] scale=$scale " +
+                "platform=${System.getProperty("os.name")}",
+        )
+
+        // Baseline = desktop under the window rect with the window hidden.
+        // Must run *after* taoApplication so AWT/Robot is not the first
+        // AppKit client on macOS.
+        w.hide()
+        kotlinx.coroutines.delay(300)
+        val baseline =
+            captureScreen(
+                captureTool,
+                bx,
+                by,
+                bw,
+                bh,
+                File(outDir, "01-baseline-desktop.png"),
+            )
+        val emptySampleX = (EMPTY_SAMPLE_X_DP * scale).toInt().coerceIn(0, bw - 1)
+        val emptySampleY = (EMPTY_SAMPLE_Y_DP * scale).toInt().coerceIn(0, bh - 1)
+        val half = (SAMPLE_HALF_DP * scale).toInt().coerceAtLeast(2)
+        val desktopRef = averageRgb(baseline, emptySampleX, emptySampleY, half)
+        System.err.println(
+            "[smoke/#416] baseline empty RGB=(%d,%d,%d)".format(
+                desktopRef[0],
+                desktopRef[1],
+                desktopRef[2],
+            ),
+        )
+
+        w.show()
+        w.focus()
+        kotlinx.coroutines.delay(SETTLE_MS)
+
+        val withWindow =
+            captureScreen(
+                captureTool,
+                bx,
+                by,
+                bw,
+                bh,
+                File(outDir, "02-transparent-window.png"),
+            )
+
+        val markerPadPx = (24.0 * scale).toInt()
+        val markerSampleX = (markerPadPx + 24.0 * scale).toInt().coerceIn(0, withWindow.width - 1)
+        val markerSampleY = (markerPadPx + 24.0 * scale).toInt().coerceIn(0, withWindow.height - 1)
+
+        val marker = averageRgb(withWindow, markerSampleX, markerSampleY, half)
+        val empty =
+            averageRgb(
+                withWindow,
+                emptySampleX.coerceIn(0, withWindow.width - 1),
+                emptySampleY.coerceIn(0, withWindow.height - 1),
+                half,
+            )
+        System.err.println(
+            "[smoke/#416] marker RGB=(%d,%d,%d) empty RGB=(%d,%d,%d)".format(
+                marker[0],
+                marker[1],
+                marker[2],
+                empty[0],
+                empty[1],
+                empty[2],
+            ),
+        )
+
+        val failures = evaluateTransparency(withWindow, marker, empty, desktopRef)
+        if (failures.isEmpty()) {
+            System.err.println("[smoke/#416] VERDICT: OK — transparent window over desktop")
+            System.err.println("[smoke/#416] screenshots: $outDir")
+            exitProcess(0)
+        } else {
+            System.err.println("[smoke/#416] VERDICT: FAIL")
+            failures.forEach { System.err.println("  - $it") }
+            System.err.println("[smoke/#416] screenshots: $outDir")
+            exitProcess(1)
+        }
+    }
+
+    private fun evaluateTransparency(
+        withWindow: BufferedImage,
+        marker: IntArray,
+        empty: IntArray,
+        desktopRef: IntArray,
+    ): List<String> {
+        val failures = mutableListOf<String>()
+
+        if (!isMagenta(marker)) {
+            val found = findMagenta(withWindow)
+            if (found == null) {
+                failures +=
+                    "opaque marker not magenta anywhere: sample RGB=" +
+                    "(${marker[0]},${marker[1]},${marker[2]})"
+            } else {
+                System.err.println(
+                    "[smoke/#416] marker found by scan at ${found.first},${found.second}",
+                )
+            }
+        }
+
+        if (isNearSolid(empty, 0xFF, 0xFF, 0xFF, tol = 18)) {
+            failures += "empty client looks opaque white — transparency not applied"
+        }
+        if (isNearSolid(empty, 0x00, 0x00, 0x00, tol = 12)) {
+            failures += "empty client looks solid black — opaque surface with alpha-0 clear"
+        }
+        if (isMagenta(empty)) {
+            failures += "empty client is magenta — marker bled across whole surface"
+        }
+
+        val dist = rgbDistance(empty, desktopRef)
+        System.err.println(
+            "[smoke/#416] empty vs desktop Δ=$dist " +
+                "(desktop RGB=(${desktopRef[0]},${desktopRef[1]},${desktopRef[2]}), max 90)",
+        )
+        if (dist > 90) {
+            failures +=
+                "empty client RGB=(${empty[0]},${empty[1]},${empty[2]}) diverges from " +
+                "desktop RGB=(${desktopRef[0]},${desktopRef[1]},${desktopRef[2]}) " +
+                "Δ=$dist — desktop not compositing through"
+        }
+
+        val blackEdge = countNearBlackPerimeter(withWindow, thickness = 2, maxChannel = 6)
+        System.err.println(
+            "[smoke/#416] near-black perimeter pixels=$blackEdge (max allowed 40)",
+        )
+        if (blackEdge > 40) {
+            failures +=
+                "near-black perimeter contour still present ($blackEdge px) — " +
+                "borderless chrome / shadow not fully stripped"
+        }
+        return failures
     }
 
     private fun captureScreen(
@@ -451,8 +468,9 @@ object TransparentWindowSmokeMain {
                 val r = (rgb ushr 16) and 0xFF
                 val g = (rgb ushr 8) and 0xFF
                 val b = rgb and 0xFF
-                if (r >= 0xC0 && g <= 0x40 && b >= 0x70) continue
-                if (r <= maxChannel && g <= maxChannel && b <= maxChannel) n++
+                val isMagenta = r >= 0xC0 && g <= 0x40 && b >= 0x70
+                val isNearBlack = r <= maxChannel && g <= maxChannel && b <= maxChannel
+                if (!isMagenta && isNearBlack) n++
             }
         }
         return n

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TransparentWindowSmokeMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TransparentWindowSmokeMain.kt
@@ -1,0 +1,417 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.rememberWindowState
+import dev.nucleusframework.window.tao.DecoratedWindow
+import dev.nucleusframework.window.tao.TaoWindow
+import dev.nucleusframework.window.tao.taoApplication
+import java.awt.image.BufferedImage
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import kotlin.system.exitProcess
+
+/**
+ * Manual smoke for #416 / PR #419:
+ * `DecoratedWindow(transparent = true)` + a small opaque marker over the desktop.
+ *
+ * On Windows, [java.awt.Robot] omits layered/per-pixel-alpha windows (no
+ * CAPTUREBLT). This smoke shells out to a tiny Win32 helper
+ * (`capture_region.exe`) that BitBlts with `SRCCOPY | CAPTUREBLT`.
+ *
+ * Run: `./gradlew :decorated-window-tao:taoTransparentSmoke`
+ */
+object TransparentWindowSmokeMain {
+    private const val OUTER_X = 120
+    private const val OUTER_Y = 120
+    private const val OUTER_W = 480
+    private const val OUTER_H = 360
+    // Hold the window on screen so a manual look is possible; override with
+    // -Dnucleus.tao.transparent.smoke.holdMs=…
+    private val SETTLE_MS: Long =
+        System.getProperty("nucleus.tao.transparent.smoke.holdMs")?.toLongOrNull()
+            ?: 1_200L
+    // Marker is 48.dp at 24.dp padding → ~centre of square around (48, 48).
+    private const val MARKER_SAMPLE_X = 48
+    private const val MARKER_SAMPLE_Y = 48
+    private const val EMPTY_SAMPLE_X = 300
+    private const val EMPTY_SAMPLE_Y = 240
+    private const val SAMPLE_HALF = 6
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val outDir =
+            File(
+                System.getProperty(
+                    "nucleus.tao.transparent.smoke.outdir",
+                    "build/reports/tao-transparent-smoke",
+                ),
+            ).absoluteFile
+        outDir.mkdirs()
+        val captureTool =
+            File(
+                System.getProperty(
+                    "nucleus.tao.transparent.smoke.captureTool",
+                    "build/tmp-smoke/capture_region.exe",
+                ),
+            ).absoluteFile
+        check(captureTool.isFile) {
+            "capture tool missing: $captureTool — run the gradle task (it builds the helper)"
+        }
+
+        val baselineBmp = File(outDir, "01-baseline-desktop.bmp")
+        captureRegion(captureTool, OUTER_X, OUTER_Y, OUTER_W, OUTER_H, baselineBmp)
+        val baseline = readBmp24(baselineBmp)
+        ImageIO.write(baseline, "png", File(outDir, "01-baseline-desktop.png"))
+        val baselineEmpty = averageRgb(baseline, EMPTY_SAMPLE_X, EMPTY_SAMPLE_Y, SAMPLE_HALF)
+        System.err.println(
+            "[smoke/#416] baseline empty RGB=(%d,%d,%d)".format(
+                baselineEmpty[0],
+                baselineEmpty[1],
+                baselineEmpty[2],
+            ),
+        )
+
+        taoApplication {
+            val state =
+                rememberWindowState(
+                    position = WindowPosition(OUTER_X.dp, OUTER_Y.dp),
+                    size = DpSize(OUTER_W.dp, OUTER_H.dp),
+                )
+            var window by remember { mutableStateOf<TaoWindow?>(null) }
+
+            DecoratedWindow(
+                onCloseRequest = { /* smoke owns lifecycle */ },
+                state = state,
+                title = "tao transparent smoke #416",
+                alwaysOnTop = true,
+                // Borderless overlay (no CSD outline) + full-window transparency.
+                undecorated = true,
+                transparent = true,
+            ) {
+                // No WindowBackground / TitleBar — empty client must composite desktop.
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(24.dp),
+                    contentAlignment = Alignment.TopStart,
+                ) {
+                    Box(Modifier.size(48.dp).background(Color(0xFFFF00AA)))
+                }
+                val w = this.window
+                LaunchedEffect(w) { window = w }
+            }
+
+            LaunchedEffect(Unit) {
+                val deadline = System.currentTimeMillis() + 15_000L
+                while (window == null) {
+                    check(System.currentTimeMillis() < deadline) { "window never published" }
+                    kotlinx.coroutines.delay(25)
+                }
+                val w = window!!
+                w.setOuterPosition(OUTER_X.toDouble(), OUTER_Y.toDouble())
+                w.setInnerSize(OUTER_W.toDouble(), OUTER_H.toDouble())
+                w.focus()
+                kotlinx.coroutines.delay(SETTLE_MS)
+
+                val bounds = w.outerBoundsPx()
+                System.err.println(
+                    "[smoke/#416] outerBoundsPx=" +
+                        (bounds?.joinToString(prefix = "[", postfix = "]") ?: "null") +
+                        " scale=${w.scaleFactor}",
+                )
+
+                val withBmp = File(outDir, "02-transparent-window.bmp")
+                captureRegion(captureTool, OUTER_X, OUTER_Y, OUTER_W, OUTER_H, withBmp)
+                val withWindow = readBmp24(withBmp)
+                ImageIO.write(withWindow, "png", File(outDir, "02-transparent-window.png"))
+
+                val ox =
+                    if (bounds != null && bounds.size >= 4) {
+                        (bounds[0] - OUTER_X).toInt()
+                    } else {
+                        0
+                    }
+                val oy =
+                    if (bounds != null && bounds.size >= 4) {
+                        (bounds[1] - OUTER_Y).toInt()
+                    } else {
+                        0
+                    }
+
+                val marker =
+                    averageRgb(
+                        withWindow,
+                        (ox + MARKER_SAMPLE_X).coerceIn(0, withWindow.width - 1),
+                        (oy + MARKER_SAMPLE_Y).coerceIn(0, withWindow.height - 1),
+                        SAMPLE_HALF,
+                    )
+                val empty =
+                    averageRgb(
+                        withWindow,
+                        (ox + EMPTY_SAMPLE_X).coerceIn(0, withWindow.width - 1),
+                        (oy + EMPTY_SAMPLE_Y).coerceIn(0, withWindow.height - 1),
+                        SAMPLE_HALF,
+                    )
+                System.err.println(
+                    "[smoke/#416] marker RGB=(%d,%d,%d) empty RGB=(%d,%d,%d) origin=(%d,%d)".format(
+                        marker[0],
+                        marker[1],
+                        marker[2],
+                        empty[0],
+                        empty[1],
+                        empty[2],
+                        ox,
+                        oy,
+                    ),
+                )
+
+                val failures = mutableListOf<String>()
+
+                if (!isMagenta(marker)) {
+                    // Scan a band for the marker in case chrome inset shifted it.
+                    val found = findMagenta(withWindow)
+                    if (found == null) {
+                        failures +=
+                            "opaque marker not magenta anywhere: sample " +
+                                "RGB=(${marker[0]},${marker[1]},${marker[2]})"
+                    } else {
+                        System.err.println(
+                            "[smoke/#416] marker found by scan at ${found.first},${found.second}",
+                        )
+                    }
+                }
+
+                if (isNearSolid(empty, 0xFF, 0xFF, 0xFF, tol = 18)) {
+                    failures += "empty client looks opaque white — transparency not applied"
+                }
+                if (isMagenta(empty)) {
+                    failures += "empty client is magenta — marker bled across whole surface"
+                }
+
+                val dist = rgbDistance(empty, baselineEmpty)
+                System.err.println("[smoke/#416] empty vs baseline Δ=$dist (max allowed 90)")
+                if (dist > 90) {
+                    failures +=
+                        "empty client RGB=(${empty[0]},${empty[1]},${empty[2]}) " +
+                            "diverges from baseline desktop " +
+                            "RGB=(${baselineEmpty[0]},${baselineEmpty[1]},${baselineEmpty[2]}) " +
+                            "Δ=$dist — desktop not compositing through"
+                }
+
+                // Marker region must differ from the pre-window desktop.
+                val baselineMarker =
+                    averageRgb(baseline, MARKER_SAMPLE_X, MARKER_SAMPLE_Y, SAMPLE_HALF)
+                val markerDelta = rgbDistance(marker, baselineMarker)
+                System.err.println("[smoke/#416] marker vs baseline Δ=$markerDelta (min expected 80)")
+                if (isMagenta(marker) && markerDelta < 80) {
+                    failures += "marker sample matches desktop — opaque marker not composited"
+                }
+
+                // Undecorated + transparent must not leave a pure-black DWM/
+                // erase contour around the window (the regression the user
+                // spotted after Compose border was already skipped).
+                val blackEdge = countNearBlackPerimeter(withWindow, thickness = 2, maxChannel = 6)
+                System.err.println("[smoke/#416] near-black perimeter pixels=$blackEdge (max allowed 40)")
+                if (blackEdge > 40) {
+                    failures +=
+                        "near-black perimeter contour still present ($blackEdge px) — " +
+                            "DWM borderless chrome not applied"
+                }
+
+                if (failures.isEmpty()) {
+                    System.err.println("[smoke/#416] VERDICT: OK — transparent window over desktop")
+                    System.err.println("[smoke/#416] screenshots: $outDir")
+                    exitProcess(0)
+                } else {
+                    System.err.println("[smoke/#416] VERDICT: FAIL")
+                    failures.forEach { System.err.println("  - $it") }
+                    System.err.println("[smoke/#416] screenshots: $outDir")
+                    exitProcess(1)
+                }
+            }
+        }
+    }
+
+    private fun captureRegion(
+        tool: File,
+        x: Int,
+        y: Int,
+        w: Int,
+        h: Int,
+        out: File,
+    ) {
+        val pb =
+            ProcessBuilder(
+                tool.absolutePath,
+                x.toString(),
+                y.toString(),
+                w.toString(),
+                h.toString(),
+                out.absolutePath,
+            )
+        pb.redirectErrorStream(true)
+        val proc = pb.start()
+        val log = proc.inputStream.bufferedReader().readText()
+        val code = proc.waitFor()
+        check(code == 0 && out.isFile) {
+            "capture failed (exit=$code): $log"
+        }
+        System.err.println("[smoke/#416] capture: ${out.name} (${out.length()} bytes) $log".trim())
+    }
+
+    /** Reads a 24-bit top-down or bottom-up BMP produced by capture_region.exe. */
+    private fun readBmp24(file: File): BufferedImage {
+        RandomAccessFile(file, "r").use { raf ->
+            val header = ByteArray(14)
+            raf.readFully(header)
+            check(header[0] == 'B'.code.toByte() && header[1] == 'M'.code.toByte()) {
+                "not a BMP: $file"
+            }
+            val dibSizeBuf = ByteArray(4)
+            raf.readFully(dibSizeBuf)
+            val dibSize = ByteBuffer.wrap(dibSizeBuf).order(ByteOrder.LITTLE_ENDIAN).int
+            val dib = ByteArray(dibSize - 4)
+            raf.readFully(dib)
+            val bb = ByteBuffer.wrap(dib).order(ByteOrder.LITTLE_ENDIAN)
+            val width = bb.int
+            val heightRaw = bb.int
+            val topDown = heightRaw < 0
+            val height = abs(heightRaw)
+            bb.short // planes
+            val bpp = bb.short.toInt() and 0xFFFF
+            check(bpp == 24) { "expected 24-bpp BMP, got $bpp" }
+            raf.seek(ByteBuffer.wrap(header, 10, 4).order(ByteOrder.LITTLE_ENDIAN).int.toLong())
+            val row = (width * 3 + 3) and inv3
+            val img = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+            val rowBytes = ByteArray(row)
+            for (rowIndex in 0 until height) {
+                raf.readFully(rowBytes)
+                val y = if (topDown) rowIndex else height - 1 - rowIndex
+                for (x in 0 until width) {
+                    val i = x * 3
+                    val b = rowBytes[i].toInt() and 0xFF
+                    val g = rowBytes[i + 1].toInt() and 0xFF
+                    val r = rowBytes[i + 2].toInt() and 0xFF
+                    img.setRGB(x, y, (r shl 16) or (g shl 8) or b)
+                }
+            }
+            return img
+        }
+    }
+
+    private const val inv3 = 3.inv()
+
+    private fun averageRgb(
+        image: BufferedImage,
+        cx: Int,
+        cy: Int,
+        half: Int,
+    ): IntArray {
+        var r = 0L
+        var g = 0L
+        var b = 0L
+        var n = 0L
+        val x0 = (cx - half).coerceAtLeast(0)
+        val y0 = (cy - half).coerceAtLeast(0)
+        val x1 = (cx + half).coerceAtMost(image.width - 1)
+        val y1 = (cy + half).coerceAtMost(image.height - 1)
+        for (y in y0..y1) {
+            for (x in x0..x1) {
+                val rgb = image.getRGB(x, y)
+                r += (rgb ushr 16) and 0xFF
+                g += (rgb ushr 8) and 0xFF
+                b += rgb and 0xFF
+                n++
+            }
+        }
+        check(n > 0) { "empty sample region" }
+        return intArrayOf((r / n).toInt(), (g / n).toInt(), (b / n).toInt())
+    }
+
+    private fun findMagenta(image: BufferedImage): Pair<Int, Int>? {
+        // Coarse grid scan — marker is 48px.
+        var y = 0
+        while (y < image.height) {
+            var x = 0
+            while (x < image.width) {
+                val rgb = image.getRGB(x, y)
+                val r = (rgb ushr 16) and 0xFF
+                val g = (rgb ushr 8) and 0xFF
+                val b = rgb and 0xFF
+                if (r >= 0xC0 && g <= 0x40 && b >= 0x70) return x to y
+                x += 8
+            }
+            y += 8
+        }
+        return null
+    }
+
+    private fun isMagenta(rgb: IntArray): Boolean {
+        val (r, g, b) = rgb
+        return r >= 0xC0 && g <= 0x40 && b >= 0x70
+    }
+
+    private fun isNearSolid(
+        rgb: IntArray,
+        tr: Int,
+        tg: Int,
+        tb: Int,
+        tol: Int,
+    ): Boolean =
+        abs(rgb[0] - tr) <= tol &&
+            abs(rgb[1] - tg) <= tol &&
+            abs(rgb[2] - tb) <= tol
+
+    private fun rgbDistance(
+        a: IntArray,
+        b: IntArray,
+    ): Int = abs(a[0] - b[0]) + abs(a[1] - b[1]) + abs(a[2] - b[2])
+
+    /** Counts near-black pixels on a [thickness]-px ring around the image. */
+    private fun countNearBlackPerimeter(
+        image: BufferedImage,
+        thickness: Int,
+        maxChannel: Int,
+    ): Int {
+        var n = 0
+        val w = image.width
+        val h = image.height
+        for (y in 0 until h) {
+            for (x in 0 until w) {
+                val onEdge =
+                    x < thickness ||
+                        y < thickness ||
+                        x >= w - thickness ||
+                        y >= h - thickness
+                if (!onEdge) continue
+                val rgb = image.getRGB(x, y)
+                val r = (rgb ushr 16) and 0xFF
+                val g = (rgb ushr 8) and 0xFF
+                val b = rgb and 0xFF
+                // Skip the opaque magenta marker if it touches the top edge.
+                if (r >= 0xC0 && g <= 0x40 && b >= 0x70) continue
+                if (r <= maxChannel && g <= maxChannel && b <= maxChannel) n++
+            }
+        }
+        return n
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TransparentWindowSmokeMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TransparentWindowSmokeMain.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.window.rememberWindowState
 import dev.nucleusframework.window.tao.DecoratedWindow
 import dev.nucleusframework.window.tao.TaoWindow
 import dev.nucleusframework.window.tao.taoApplication
+import java.awt.Rectangle
+import java.awt.Robot
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.RandomAccessFile
@@ -31,33 +33,44 @@ import kotlin.system.exitProcess
 
 /**
  * Manual smoke for #416 / PR #419:
- * `DecoratedWindow(transparent = true)` + a small opaque marker over the desktop.
+ * `DecoratedWindow(transparent = true, undecorated = true)` + a small opaque
+ * marker over the desktop.
  *
- * On Windows, [java.awt.Robot] omits layered/per-pixel-alpha windows (no
- * CAPTUREBLT). This smoke shells out to a tiny Win32 helper
- * (`capture_region.exe`) that BitBlts with `SRCCOPY | CAPTUREBLT`.
+ * Capture backend:
+ * - **macOS / Linux**: [java.awt.Robot] (sees per-pixel-alpha Tao windows).
+ * - **Windows**: Robot omits layered windows — shell out to a CAPTUREBLT helper
+ *   (`capture_region.exe`) pointed at by
+ *   `-Dnucleus.tao.transparent.smoke.captureTool=`.
+ *
+ * Important (macOS): do **not** touch AWT before [taoApplication] — initializing
+ * AppKit/AWT on the launcher thread deadlocks the Tao event loop (same rule as
+ * the headful suite: no `-XstartOnFirstThread`, no pre-loop Robot).
  *
  * Run: `./gradlew :decorated-window-tao:taoTransparentSmoke`
  */
 object TransparentWindowSmokeMain {
-    private const val OUTER_X = 120
-    private const val OUTER_Y = 120
-    private const val OUTER_W = 480
-    private const val OUTER_H = 360
+    private const val OUTER_X_DP = 120.0
+    private const val OUTER_Y_DP = 120.0
+    private const val OUTER_W_DP = 480.0
+    private const val OUTER_H_DP = 360.0
+
     // Hold the window on screen so a manual look is possible; override with
     // -Dnucleus.tao.transparent.smoke.holdMs=…
     private val SETTLE_MS: Long =
         System.getProperty("nucleus.tao.transparent.smoke.holdMs")?.toLongOrNull()
             ?: 1_200L
-    // Marker is 48.dp at 24.dp padding → ~centre of square around (48, 48).
-    private const val MARKER_SAMPLE_X = 48
-    private const val MARKER_SAMPLE_Y = 48
-    private const val EMPTY_SAMPLE_X = 300
-    private const val EMPTY_SAMPLE_Y = 240
-    private const val SAMPLE_HALF = 6
+
+    // Marker is 48.dp at 24.dp padding — sample near centre of the square.
+    private const val EMPTY_SAMPLE_X_DP = 300.0
+    private const val EMPTY_SAMPLE_Y_DP = 240.0
+    private const val SAMPLE_HALF_DP = 6.0
+
+    private val isWindows: Boolean =
+        System.getProperty("os.name", "").lowercase().contains("win")
 
     @JvmStatic
     fun main(args: Array<String>) {
+        // Do not touch AWT here on macOS (Robot / GraphicsEnvironment).
         val outDir =
             File(
                 System.getProperty(
@@ -67,34 +80,22 @@ object TransparentWindowSmokeMain {
             ).absoluteFile
         outDir.mkdirs()
         val captureTool =
-            File(
-                System.getProperty(
-                    "nucleus.tao.transparent.smoke.captureTool",
-                    "build/tmp-smoke/capture_region.exe",
-                ),
-            ).absoluteFile
-        check(captureTool.isFile) {
-            "capture tool missing: $captureTool — run the gradle task (it builds the helper)"
+            System
+                .getProperty("nucleus.tao.transparent.smoke.captureTool")
+                ?.takeIf { it.isNotBlank() }
+                ?.let { File(it).absoluteFile }
+        if (isWindows) {
+            check(captureTool != null && captureTool.isFile) {
+                "capture tool missing: $captureTool — on Windows Robot cannot " +
+                    "see layered windows; build capture_region.exe (CAPTUREBLT)"
+            }
         }
-
-        val baselineBmp = File(outDir, "01-baseline-desktop.bmp")
-        captureRegion(captureTool, OUTER_X, OUTER_Y, OUTER_W, OUTER_H, baselineBmp)
-        val baseline = readBmp24(baselineBmp)
-        ImageIO.write(baseline, "png", File(outDir, "01-baseline-desktop.png"))
-        val baselineEmpty = averageRgb(baseline, EMPTY_SAMPLE_X, EMPTY_SAMPLE_Y, SAMPLE_HALF)
-        System.err.println(
-            "[smoke/#416] baseline empty RGB=(%d,%d,%d)".format(
-                baselineEmpty[0],
-                baselineEmpty[1],
-                baselineEmpty[2],
-            ),
-        )
 
         taoApplication {
             val state =
                 rememberWindowState(
-                    position = WindowPosition(OUTER_X.dp, OUTER_Y.dp),
-                    size = DpSize(OUTER_W.dp, OUTER_H.dp),
+                    position = WindowPosition(OUTER_X_DP.dp, OUTER_Y_DP.dp),
+                    size = DpSize(OUTER_W_DP.dp, OUTER_H_DP.dp),
                 )
             var window by remember { mutableStateOf<TaoWindow?>(null) }
 
@@ -103,11 +104,9 @@ object TransparentWindowSmokeMain {
                 state = state,
                 title = "tao transparent smoke #416",
                 alwaysOnTop = true,
-                // Borderless overlay (no CSD outline) + full-window transparency.
                 undecorated = true,
                 transparent = true,
             ) {
-                // No WindowBackground / TitleBar — empty client must composite desktop.
                 Box(
                     Modifier
                         .fillMaxSize()
@@ -127,72 +126,94 @@ object TransparentWindowSmokeMain {
                     kotlinx.coroutines.delay(25)
                 }
                 val w = window!!
-                w.setOuterPosition(OUTER_X.toDouble(), OUTER_Y.toDouble())
-                w.setInnerSize(OUTER_W.toDouble(), OUTER_H.toDouble())
+                w.setOuterPosition(OUTER_X_DP, OUTER_Y_DP)
+                w.setInnerSize(OUTER_W_DP, OUTER_H_DP)
                 w.focus()
                 kotlinx.coroutines.delay(SETTLE_MS)
 
                 val bounds = w.outerBoundsPx()
+                check(bounds != null && bounds.size >= 4) { "outerBoundsPx null after settle" }
+                val bx = bounds[0].toInt()
+                val by = bounds[1].toInt()
+                val bw = bounds[2].toInt()
+                val bh = bounds[3].toInt()
+                val scale = w.scaleFactor.toDouble().coerceAtLeast(1.0)
                 System.err.println(
-                    "[smoke/#416] outerBoundsPx=" +
-                        (bounds?.joinToString(prefix = "[", postfix = "]") ?: "null") +
-                        " scale=${w.scaleFactor}",
+                    "[smoke/#416] outerBoundsPx=[$bx,$by ${bw}x$bh] scale=$scale " +
+                        "platform=${System.getProperty("os.name")}",
                 )
 
-                val withBmp = File(outDir, "02-transparent-window.bmp")
-                captureRegion(captureTool, OUTER_X, OUTER_Y, OUTER_W, OUTER_H, withBmp)
-                val withWindow = readBmp24(withBmp)
-                ImageIO.write(withWindow, "png", File(outDir, "02-transparent-window.png"))
-
-                val ox =
-                    if (bounds != null && bounds.size >= 4) {
-                        (bounds[0] - OUTER_X).toInt()
-                    } else {
-                        0
-                    }
-                val oy =
-                    if (bounds != null && bounds.size >= 4) {
-                        (bounds[1] - OUTER_Y).toInt()
-                    } else {
-                        0
-                    }
-
-                val marker =
-                    averageRgb(
-                        withWindow,
-                        (ox + MARKER_SAMPLE_X).coerceIn(0, withWindow.width - 1),
-                        (oy + MARKER_SAMPLE_Y).coerceIn(0, withWindow.height - 1),
-                        SAMPLE_HALF,
+                // Baseline = desktop under the window rect with the window hidden.
+                // Must run *after* taoApplication so AWT/Robot is not the first
+                // AppKit client on macOS.
+                w.hide()
+                kotlinx.coroutines.delay(300)
+                val baseline =
+                    captureScreen(
+                        captureTool,
+                        bx,
+                        by,
+                        bw,
+                        bh,
+                        File(outDir, "01-baseline-desktop.png"),
                     )
+                val emptySampleX = (EMPTY_SAMPLE_X_DP * scale).toInt().coerceIn(0, bw - 1)
+                val emptySampleY = (EMPTY_SAMPLE_Y_DP * scale).toInt().coerceIn(0, bh - 1)
+                val half = (SAMPLE_HALF_DP * scale).toInt().coerceAtLeast(2)
+                val desktopRef = averageRgb(baseline, emptySampleX, emptySampleY, half)
+                System.err.println(
+                    "[smoke/#416] baseline empty RGB=(%d,%d,%d)".format(
+                        desktopRef[0],
+                        desktopRef[1],
+                        desktopRef[2],
+                    ),
+                )
+
+                w.show()
+                w.focus()
+                kotlinx.coroutines.delay(SETTLE_MS)
+
+                val withWindow =
+                    captureScreen(
+                        captureTool,
+                        bx,
+                        by,
+                        bw,
+                        bh,
+                        File(outDir, "02-transparent-window.png"),
+                    )
+
+                val markerPadPx = (24.0 * scale).toInt()
+                val markerSampleX = (markerPadPx + 24.0 * scale).toInt().coerceIn(0, withWindow.width - 1)
+                val markerSampleY = (markerPadPx + 24.0 * scale).toInt().coerceIn(0, withWindow.height - 1)
+
+                val marker = averageRgb(withWindow, markerSampleX, markerSampleY, half)
                 val empty =
                     averageRgb(
                         withWindow,
-                        (ox + EMPTY_SAMPLE_X).coerceIn(0, withWindow.width - 1),
-                        (oy + EMPTY_SAMPLE_Y).coerceIn(0, withWindow.height - 1),
-                        SAMPLE_HALF,
+                        emptySampleX.coerceIn(0, withWindow.width - 1),
+                        emptySampleY.coerceIn(0, withWindow.height - 1),
+                        half,
                     )
                 System.err.println(
-                    "[smoke/#416] marker RGB=(%d,%d,%d) empty RGB=(%d,%d,%d) origin=(%d,%d)".format(
+                    "[smoke/#416] marker RGB=(%d,%d,%d) empty RGB=(%d,%d,%d)".format(
                         marker[0],
                         marker[1],
                         marker[2],
                         empty[0],
                         empty[1],
                         empty[2],
-                        ox,
-                        oy,
                     ),
                 )
 
                 val failures = mutableListOf<String>()
 
                 if (!isMagenta(marker)) {
-                    // Scan a band for the marker in case chrome inset shifted it.
                     val found = findMagenta(withWindow)
                     if (found == null) {
                         failures +=
-                            "opaque marker not magenta anywhere: sample " +
-                                "RGB=(${marker[0]},${marker[1]},${marker[2]})"
+                            "opaque marker not magenta anywhere: sample RGB=" +
+                            "(${marker[0]},${marker[1]},${marker[2]})"
                     } else {
                         System.err.println(
                             "[smoke/#416] marker found by scan at ${found.first},${found.second}",
@@ -203,38 +224,33 @@ object TransparentWindowSmokeMain {
                 if (isNearSolid(empty, 0xFF, 0xFF, 0xFF, tol = 18)) {
                     failures += "empty client looks opaque white — transparency not applied"
                 }
+                if (isNearSolid(empty, 0x00, 0x00, 0x00, tol = 12)) {
+                    failures += "empty client looks solid black — opaque surface with alpha-0 clear"
+                }
                 if (isMagenta(empty)) {
                     failures += "empty client is magenta — marker bled across whole surface"
                 }
 
-                val dist = rgbDistance(empty, baselineEmpty)
-                System.err.println("[smoke/#416] empty vs baseline Δ=$dist (max allowed 90)")
+                val dist = rgbDistance(empty, desktopRef)
+                System.err.println(
+                    "[smoke/#416] empty vs desktop Δ=$dist " +
+                        "(desktop RGB=(${desktopRef[0]},${desktopRef[1]},${desktopRef[2]}), max 90)",
+                )
                 if (dist > 90) {
                     failures +=
-                        "empty client RGB=(${empty[0]},${empty[1]},${empty[2]}) " +
-                            "diverges from baseline desktop " +
-                            "RGB=(${baselineEmpty[0]},${baselineEmpty[1]},${baselineEmpty[2]}) " +
-                            "Δ=$dist — desktop not compositing through"
+                        "empty client RGB=(${empty[0]},${empty[1]},${empty[2]}) diverges from " +
+                        "desktop RGB=(${desktopRef[0]},${desktopRef[1]},${desktopRef[2]}) " +
+                        "Δ=$dist — desktop not compositing through"
                 }
 
-                // Marker region must differ from the pre-window desktop.
-                val baselineMarker =
-                    averageRgb(baseline, MARKER_SAMPLE_X, MARKER_SAMPLE_Y, SAMPLE_HALF)
-                val markerDelta = rgbDistance(marker, baselineMarker)
-                System.err.println("[smoke/#416] marker vs baseline Δ=$markerDelta (min expected 80)")
-                if (isMagenta(marker) && markerDelta < 80) {
-                    failures += "marker sample matches desktop — opaque marker not composited"
-                }
-
-                // Undecorated + transparent must not leave a pure-black DWM/
-                // erase contour around the window (the regression the user
-                // spotted after Compose border was already skipped).
                 val blackEdge = countNearBlackPerimeter(withWindow, thickness = 2, maxChannel = 6)
-                System.err.println("[smoke/#416] near-black perimeter pixels=$blackEdge (max allowed 40)")
+                System.err.println(
+                    "[smoke/#416] near-black perimeter pixels=$blackEdge (max allowed 40)",
+                )
                 if (blackEdge > 40) {
                     failures +=
                         "near-black perimeter contour still present ($blackEdge px) — " +
-                            "DWM borderless chrome not applied"
+                        "borderless chrome / shadow not fully stripped"
                 }
 
                 if (failures.isEmpty()) {
@@ -251,7 +267,30 @@ object TransparentWindowSmokeMain {
         }
     }
 
-    private fun captureRegion(
+    private fun captureScreen(
+        tool: File?,
+        x: Int,
+        y: Int,
+        w: Int,
+        h: Int,
+        outPng: File,
+    ): BufferedImage {
+        val img =
+            if (isWindows && tool != null) {
+                val bmp = File(outPng.parentFile, outPng.nameWithoutExtension + ".bmp")
+                captureRegionWin(tool, x, y, w, h, bmp)
+                readBmp24(bmp)
+            } else {
+                val robot = Robot()
+                robot.autoDelay = 0
+                robot.createScreenCapture(Rectangle(x, y, w.coerceAtLeast(1), h.coerceAtLeast(1)))
+            }
+        ImageIO.write(img, "png", outPng)
+        System.err.println("[smoke/#416] capture: ${outPng.name} (${outPng.length()} bytes)")
+        return img
+    }
+
+    private fun captureRegionWin(
         tool: File,
         x: Int,
         y: Int,
@@ -275,7 +314,6 @@ object TransparentWindowSmokeMain {
         check(code == 0 && out.isFile) {
             "capture failed (exit=$code): $log"
         }
-        System.err.println("[smoke/#416] capture: ${out.name} (${out.length()} bytes) $log".trim())
     }
 
     /** Reads a 24-bit top-down or bottom-up BMP produced by capture_region.exe. */
@@ -299,8 +337,14 @@ object TransparentWindowSmokeMain {
             bb.short // planes
             val bpp = bb.short.toInt() and 0xFFFF
             check(bpp == 24) { "expected 24-bpp BMP, got $bpp" }
-            raf.seek(ByteBuffer.wrap(header, 10, 4).order(ByteOrder.LITTLE_ENDIAN).int.toLong())
-            val row = (width * 3 + 3) and inv3
+            raf.seek(
+                ByteBuffer
+                    .wrap(header, 10, 4)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                    .int
+                    .toLong(),
+            )
+            val row = (width * 3 + 3) and BMP_ROW_PAD_MASK
             val img = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
             val rowBytes = ByteArray(row)
             for (rowIndex in 0 until height) {
@@ -318,7 +362,8 @@ object TransparentWindowSmokeMain {
         }
     }
 
-    private const val inv3 = 3.inv()
+    /** BMP rows are padded to 4-byte boundaries: `(width * 3 + 3) & ~3`. */
+    private const val BMP_ROW_PAD_MASK = 3.inv()
 
     private fun averageRgb(
         image: BufferedImage,
@@ -348,7 +393,6 @@ object TransparentWindowSmokeMain {
     }
 
     private fun findMagenta(image: BufferedImage): Pair<Int, Int>? {
-        // Coarse grid scan — marker is 48px.
         var y = 0
         while (y < image.height) {
             var x = 0
@@ -407,7 +451,6 @@ object TransparentWindowSmokeMain {
                 val r = (rgb ushr 16) and 0xFF
                 val g = (rgb ushr 8) and 0xFF
                 val b = rgb and 0xFF
-                // Skip the opaque magenta marker if it touches the top edge.
                 if (r >= 0xC0 && g <= 0x40 && b >= 0x70) continue
                 if (r <= maxChannel && g <= maxChannel && b <= maxChannel) n++
             }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneScrollTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneScrollTest.kt
@@ -77,10 +77,25 @@ class TaoSceneScrollTest {
             scroll(scrollEvent(dy = 1f))
             frameUntilIdle()
             val afterDown = scrollValue.value
-            assertTrue(afterDown > 0)
+            assertTrue(afterDown > 0, "scroll state must advance after down (got $afterDown)")
             scroll(scrollEvent(dy = -1f))
-            frameUntilIdle()
-            assertEquals(0, scrollValue.value, "one notch down then one notch up must return to origin")
+            // The scrollable pipeline can re-arm one dispatch after the first
+            // quiet window (documented as a rare 8px residue in
+            // frameUntilIdle). Drain until origin so Windows CI load does not
+            // flake the reverse notch.
+            var leftover = scrollValue.value
+            var passes = 0
+            while (leftover != 0 && passes < SYMMETRY_SETTLE_PASSES) {
+                frameUntilIdle()
+                leftover = scrollValue.value
+                passes++
+            }
+            assertEquals(
+                0,
+                leftover,
+                "one notch down then one notch up must return to origin " +
+                    "(afterDown=$afterDown, leftover=$leftover after $passes extra settle passes)",
+            )
         }
 
     @Test
@@ -141,5 +156,7 @@ class TaoSceneScrollTest {
     private companion object {
         const val RED = 0xFFFF0000.toInt()
         const val BLUE = 0xFF0000FF.toInt()
+        /** Extra frameUntilIdle rounds after the reverse notch (Windows CI flake). */
+        const val SYMMETRY_SETTLE_PASSES = 8
     }
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneScrollTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneScrollTest.kt
@@ -156,6 +156,7 @@ class TaoSceneScrollTest {
     private companion object {
         const val RED = 0xFFFF0000.toInt()
         const val BLUE = 0xFF0000FF.toInt()
+
         /** Extra frameUntilIdle rounds after the reverse notch (Windows CI flake). */
         const val SYMMETRY_SETTLE_PASSES = 8
     }


### PR DESCRIPTION
Closes #416.

## Summary

- Add creation-time `DecoratedWindow(transparent = true)` on the Tao backend (AWT out of scope).
- Wire `with_transparent` through JNI → tao WindowBuilder (macOS non-opaque / Windows DWM blur-behind / Linux ARGB; Linux always ARGB for EGL).
- Hosts start with alpha-0 clear; `WindowClearColorLayers` coerces fully opaque style/TitleBar/WindowBackground clears to alpha-0 so empty client regions stay see-through; semi-transparent tints are preserved.
- macOS: single transparency mode `OFF | REGIONS | FULL` (FULL sticky — glass regions cannot re-opaque the window).
- Headful probes for baseline transparent, TitleBar survival, and semi-tint.

### Borderless overlays (`undecorated = true`)

Aligns ghost overlays with vanilla Compose Desktop (`Window(undecorated = true, transparent = true)`):

- Skip Compose CSD outline (`rememberUndecoratedWindowBorder`) on Windows/Linux; disable Linux CSD drop-shadow subsurface.
- Windows: `with_undecorated_shadow(false)` so tao does not grow the outer rect for a DWM drop shadow.
- Windows: `nativeSetBorderlessChrome` — `COLOR_NONE` caption/border, **zero** frame margins (the classic `{0,0,0,1}` bottom band exists only to keep DWM shadow), squared corners, `VISIBLE_FRAME_BORDER_THICKNESS = 0`, `DWMSBT_NONE`.
- Transparency still comes from tao’s empty-region `DwmEnableBlurBehindWindow`.

Ghost recipe:

```kotlin
DecoratedWindow(
    onCloseRequest = …,
    undecorated = true,  // no frame, no DWM shadow
    transparent = true,  // empty client composites the desktop
) {
    Box(Modifier.size(48.dp).background(Color(0xFFFF00AA)))
}
```

## Test plan

- [x] `./gradlew :decorated-window-tao:taoHeadfulTest -Dnucleus.tao.headful.filter='#416'` (macOS) — 3 pass
- [x] `./gradlew :decorated-window-tao:apiCheck`
- [x] Windows headful `#416` — 3/3 + full suite 16 pass / 0 fail (local)
- [x] Manual smoke Windows (`:decorated-window-tao:taoTransparentSmoke`):
  - CAPTUREBLT: marker RGB=(255,0,170), empty client matches desktop Δ=0
  - `undecorated + transparent`: outerBounds exact (no shadow inset), near-black perimeter = 0
  - 10s visual hold confirmed clean (no frame, no DWM shadow)
- [x] Linux: same API + empty client shows desktop