### PR TITLE
fix(tao): invoke NsView setBounds/resize on layout changes

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeView.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeView.kt
@@ -278,6 +278,11 @@ private fun NsViewEmbedding(
                     lastRect[3] = hPx
                     host.setFrame(handle, xPx, yPx, wPx, hPx)
                     overlay.setBounds(xPx, yPx, wPx, hPx)
+                    // Parity with HwndEmbedding: notify the view-impl so
+                    // custom NsView hosts (child NSWindows, controller-style
+                    // APIs) can react to layout changes.
+                    view.resize(wPx, hPx)
+                    view.setBounds(xPx, yPx, wPx, hPx)
                 }
                 // Re-applied on every size change because circular mode
                 // (Infinity) needs the radius rebound to min(w,h)/2;


### PR DESCRIPTION
## Summary

- Call `view.resize` / `view.setBounds` from macOS `NsViewEmbedding` when Compose layout bounds change
- Matches existing Windows `HwndEmbedding` behavior so custom `NucleusPlatformView.NsView` implementations get layout notifications

## Context

On Windows, embedded platform views receive:

```kotlin
host.setFrame(...)
overlay.setBounds(...)
view.resize(...)
view.setBounds(...)
```

macOS only updated the host frame and overlay, so overrides of `setBounds` on `NsView` were never invoked (e.g. hosted child `NSWindow`s or controller-style native APIs).

## Type

fix

Closes #417