### PR TITLE
feat(tao): opt-in hit-test pass-through for the Overlay title bar

### DIFF
--- a/decorated-window-tao/api/decorated-window-tao.api
+++ b/decorated-window-tao/api/decorated-window-tao.api
@@ -36,13 +36,15 @@ public final class dev/nucleusframework/window/TitleBarPlacement$Docked : dev/nu
 public final class dev/nucleusframework/window/TitleBarPlacement$Overlay : dev/nucleusframework/window/TitleBarPlacement {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Z)V
-	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZ)V
+	public synthetic fun <init> (ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
-	public final fun copy (Z)Ldev/nucleusframework/window/TitleBarPlacement$Overlay;
-	public static synthetic fun copy$default (Ldev/nucleusframework/window/TitleBarPlacement$Overlay;ZILjava/lang/Object;)Ldev/nucleusframework/window/TitleBarPlacement$Overlay;
+	public final fun component2 ()Z
+	public final fun copy (ZZ)Ldev/nucleusframework/window/TitleBarPlacement$Overlay;
+	public static synthetic fun copy$default (Ldev/nucleusframework/window/TitleBarPlacement$Overlay;ZZILjava/lang/Object;)Ldev/nucleusframework/window/TitleBarPlacement$Overlay;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAutoHideInFullscreen ()Z
+	public final fun getPassThroughToContent ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
@@ -479,106 +480,124 @@ private fun macTrafficLightInset(height: Dp): Dp {
 // `nativeConfigureChrome`, so clicks in the title bar reach Compose
 // undisturbed. The native side defers `performWindowDragWithEvent:` via
 // `dispatch_async`, mirroring JNI exactly.
+//
+// Deliberately does NOT opt into `sharePointerInputWithSiblings`: that flag is
+// read per layout node (`InnerNodeCoordinator` consults the immediate child's
+// chain), so it would not help the `TitleBarPlacement.Overlay` case it looks
+// like it addresses — but it WOULD let every overlapping sibling below a
+// `windowDragArea` (the macOS fullscreen bar, which is offset over the content
+// in the same Column; any app stacking chrome over content in a Box) receive
+// presses aimed at the opaque chrome. Pass-through is opted into explicitly,
+// at the scaffold level — see `Modifier.shareHitTestWithSiblings`.
+internal fun Modifier.titleBarHitTestHandler(window: TaoWindow): Modifier =
+    pointerInput(window) { titleBarDragPointerLoop(window) }
+
 @OptIn(ExperimentalComposeUiApi::class)
 @Suppress("CyclomaticComplexMethod")
-internal fun Modifier.titleBarHitTestHandler(window: TaoWindow): Modifier =
-    pointerInput(window) {
-        val ctx = currentCoroutineContext()
-        awaitPointerEventScope {
-            var inUserControl = false
-            var pendingDrag = false
-            // Windows touch drag state lives in [TaoWindow] and is driven by
-            // raw Tao touch events (see `TaoComposeSceneHostWindows.onTouchInput`
-            // → `window.updateWindowsTitleBarTouchDrag(…)`), so the drag keeps
-            // running even if Compose's pointer pipeline routing is disrupted
-            // by the layout-size change of a `maximized → floating` restore.
-            while (ctx.isActive) {
-                val event = awaitPointerEvent(PointerEventPass.Final)
-                event.changes.forEach {
-                    val isTouch = it.type == androidx.compose.ui.input.pointer.PointerType.Touch
-                    if (!it.isConsumed && !inUserControl) {
-                        when (event.type) {
-                            PointerEventType.Press -> {
-                                val touchOnWindows =
-                                    isTouch &&
-                                        Platform.Current == Platform.Windows &&
-                                        NativeTaoWindowsDecoBridge.isLoaded
-                                // Only the primary button (or touch) may drag the window.
-                                // A secondary/middle press must not arm the drag: on Linux
-                                // `dragWindow()` starts an interactive compositor move grab
-                                // that swallows every subsequent pointer event.
-                                val isPrimaryOrTouch =
-                                    event.button == PointerButton.Primary || isTouch
-                                pendingDrag = isPrimaryOrTouch && !touchOnWindows
-                                if (touchOnWindows) {
-                                    // Fallback touch drag (no Aero Snap): only reached if the
-                                    // native WndProc did NOT capture this title-bar touch (it
-                                    // normally consumes the whole interaction from WM_POINTERDOWN
-                                    // and hands it to the OS move loop). Subsequent samples run
-                                    // via `TaoComposeSceneHostWindows.onTouchInput` →
-                                    // `window.updateWindowsTitleBarTouchDrag(...)`, applying
-                                    // `SetWindowPos` directly so the window still follows the
-                                    // finger even when the OS-driven path is unavailable.
-                                    val hwnd =
-                                        dev.nucleusframework.window.tao.ffi.NativeTaoBridge
-                                            .nativeHwndHandle(window.handle)
-                                    val rect =
-                                        if (hwnd != 0L) {
-                                            NativeTaoWindowsDecoBridge
-                                                .nativeGetWindowRect(hwnd)
-                                        } else {
-                                            null
-                                        }
-                                    val screen =
-                                        if (hwnd != 0L) {
-                                            NativeTaoWindowsDecoBridge
-                                                .nativeClientToScreen(
-                                                    hwnd,
-                                                    it.position.x.toInt(),
-                                                    it.position.y.toInt(),
-                                                )
-                                        } else {
-                                            null
-                                        }
-                                    if (
-                                        rect != null &&
-                                        rect.size == WINDOW_RECT_COMPONENT_COUNT &&
-                                        screen != null &&
-                                        screen.size == SCREEN_POINT_COMPONENT_COUNT
-                                    ) {
-                                        window.beginWindowsTitleBarTouchDrag(
-                                            touchId = it.id.value,
-                                            hwnd = hwnd,
-                                            startScreenX = screen[0],
-                                            startScreenY = screen[1],
-                                            startOuterX = rect[0],
-                                            startOuterY = rect[1],
-                                            maximized =
-                                                NativeTaoWindowsDecoBridge
-                                                    .nativeIsMaximized(hwnd),
-                                        )
+private suspend fun PointerInputScope.titleBarDragPointerLoop(window: TaoWindow) {
+    val ctx = currentCoroutineContext()
+    awaitPointerEventScope {
+        var inUserControl = false
+        var pendingDrag = false
+        // Windows touch drag state lives in [TaoWindow] and is driven by
+        // raw Tao touch events (see `TaoComposeSceneHostWindows.onTouchInput`
+        // → `window.updateWindowsTitleBarTouchDrag(…)`), so the drag keeps
+        // running even if Compose's pointer pipeline routing is disrupted
+        // by the layout-size change of a `maximized → floating` restore.
+        while (ctx.isActive) {
+            val event = awaitPointerEvent(PointerEventPass.Final)
+            event.changes.forEach {
+                val isTouch = it.type == PointerType.Touch
+                if (!it.isConsumed && !inUserControl) {
+                    when (event.type) {
+                        PointerEventType.Press -> {
+                            val touchOnWindows =
+                                isTouch &&
+                                    Platform.Current == Platform.Windows &&
+                                    NativeTaoWindowsDecoBridge.isLoaded
+                            // Only the primary button (or touch) may drag the window.
+                            // A secondary/middle press must not arm the drag: on Linux
+                            // `dragWindow()` starts an interactive compositor move grab
+                            // that swallows every subsequent pointer event.
+                            val isPrimaryOrTouch =
+                                event.button == PointerButton.Primary || isTouch
+                            pendingDrag = isPrimaryOrTouch && !touchOnWindows
+                            if (touchOnWindows) {
+                                // Fallback touch drag (no Aero Snap): only reached if the
+                                // native WndProc did NOT capture this title-bar touch (it
+                                // normally consumes the whole interaction from WM_POINTERDOWN
+                                // and hands it to the OS move loop). Subsequent samples run
+                                // via `TaoComposeSceneHostWindows.onTouchInput` →
+                                // `window.updateWindowsTitleBarTouchDrag(...)`, applying
+                                // `SetWindowPos` directly so the window still follows the
+                                // finger even when the OS-driven path is unavailable.
+                                val hwnd =
+                                    dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+                                        .nativeHwndHandle(window.handle)
+                                val rect =
+                                    if (hwnd != 0L) {
+                                        NativeTaoWindowsDecoBridge
+                                            .nativeGetWindowRect(hwnd)
+                                    } else {
+                                        null
                                     }
+                                val screen =
+                                    if (hwnd != 0L) {
+                                        NativeTaoWindowsDecoBridge
+                                            .nativeClientToScreen(
+                                                hwnd,
+                                                it.position.x.toInt(),
+                                                it.position.y.toInt(),
+                                            )
+                                    } else {
+                                        null
+                                    }
+                                if (
+                                    rect != null &&
+                                    rect.size == WINDOW_RECT_COMPONENT_COUNT &&
+                                    screen != null &&
+                                    screen.size == SCREEN_POINT_COMPONENT_COUNT
+                                ) {
+                                    window.beginWindowsTitleBarTouchDrag(
+                                        touchId = it.id.value,
+                                        hwnd = hwnd,
+                                        startScreenX = screen[0],
+                                        startScreenY = screen[1],
+                                        startOuterX = rect[0],
+                                        startOuterY = rect[1],
+                                        maximized =
+                                            NativeTaoWindowsDecoBridge
+                                                .nativeIsMaximized(hwnd),
+                                    )
                                 }
                             }
-                            PointerEventType.Move ->
-                                if (pendingDrag) {
-                                    window.dragWindow()
-                                    pendingDrag = false
-                                }
-                            PointerEventType.Release -> {
+                        }
+                        PointerEventType.Move ->
+                            if (pendingDrag) {
+                                window.dragWindow()
                                 pendingDrag = false
                             }
-                        }
-                    } else {
-                        if (event.type == PointerEventType.Press) {
-                            inUserControl = true
+                        PointerEventType.Release -> {
                             pendingDrag = false
                         }
-                        if (event.type == PointerEventType.Release) {
-                            inUserControl = false
-                        }
+                    }
+                } else {
+                    // Someone else claimed this sample — a child gesture
+                    // detector, or (under an Overlay bar sharing its hit test)
+                    // a scrollable sibling below. Disarm: a consumer that stops
+                    // consuming mid-gesture — a list reaching its scroll limit —
+                    // would otherwise hand the still-pending drag a later
+                    // unconsumed Move and start a compositor move grab in the
+                    // middle of the scroll.
+                    pendingDrag = false
+                    if (event.type == PointerEventType.Press) {
+                        inUserControl = true
+                    }
+                    if (event.type == PointerEventType.Release) {
+                        inUserControl = false
                     }
                 }
             }
         }
     }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBarPlacement.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBarPlacement.kt
@@ -20,8 +20,17 @@ public sealed interface TitleBarPlacement {
      *
      * @param autoHideInFullscreen when `true`, the bar is not composed while
      * the window is fullscreen so the content is fully immersive.
+     * @param passThroughToContent when `true`, presses landing on the bar are
+     * ALSO hit-tested against the content below it, so controls the app merges
+     * into the title-bar band (a collapsed navigation pane's back/hamburger
+     * buttons, a tab strip) stay interactive through the overlay. Content that
+     * consumes the press vetoes the window drag, exactly like an interactive
+     * child of the bar itself. Off by default: with a full-bleed content layout
+     * (a list or an image scrolling behind the bar) it would make a click on
+     * the opaque chrome activate whatever sits underneath.
      */
     public data class Overlay(
         val autoHideInFullscreen: Boolean = true,
+        val passThroughToContent: Boolean = false,
     ) : TitleBarPlacement
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/WindowDragArea.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/WindowDragArea.kt
@@ -8,11 +8,16 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.PointerInputModifierNode
+import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.unit.IntSize
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.tao.LocalTaoWindow
 
@@ -96,3 +101,50 @@ public fun Modifier.noWindowDrag(): Modifier =
     onPointerEvent(PointerEventType.Press, PointerEventPass.Main) { event ->
         event.changes.forEach { it.consume() }
     }
+
+/**
+ * Marks this layout so Compose hit testing continues to the siblings BELOW it
+ * instead of stopping at it — the layout still receives every pointer event.
+ *
+ * Backs [WindowScaffold]'s `TitleBarPlacement.Overlay(passThroughToContent = true)`:
+ * the title bar is composed on top of the window content, and by default the
+ * topmost sibling wins the hit test for its whole bounds, so interactive content
+ * merged into the title-bar band (e.g. a collapsed navigation pane's
+ * back/hamburger buttons) would never receive pointer events at all. With this
+ * marker the content below is hit-tested too; when it consumes a press (Main
+ * pass), the bar's own drag handler sees the consumption (Final pass) and does
+ * not start a window move.
+ *
+ * Opt-in only: applied unconditionally it makes a click on the opaque chrome
+ * activate whatever clickable content happens to flow underneath it.
+ *
+ * The sibling-sharing flag only acts at the level of the layout node whose own
+ * modifier chain carries it (`InnerNodeCoordinator` consults the immediate
+ * child's chain), which is why the scaffold applies it to the wrapper box of
+ * the bar slot — a flag deeper inside the bar's subtree would not propagate.
+ */
+internal fun Modifier.shareHitTestWithSiblings(): Modifier = this then ShareHitTestWithSiblingsElement
+
+private data object ShareHitTestWithSiblingsElement : ModifierNodeElement<ShareHitTestWithSiblingsNode>() {
+    override fun create(): ShareHitTestWithSiblingsNode = ShareHitTestWithSiblingsNode()
+
+    override fun update(node: ShareHitTestWithSiblingsNode) = Unit
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "shareHitTestWithSiblings"
+    }
+}
+
+private class ShareHitTestWithSiblingsNode :
+    Modifier.Node(),
+    PointerInputModifierNode {
+    override fun onPointerEvent(
+        pointerEvent: PointerEvent,
+        pass: PointerEventPass,
+        bounds: IntSize,
+    ) = Unit
+
+    override fun onCancelPointerInput() = Unit
+
+    override fun sharePointerInputWithSiblings(): Boolean = true
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/WindowScaffold.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/WindowScaffold.kt
@@ -189,7 +189,24 @@ public fun DecoratedWindowScope.WindowScaffold(
                     Box(modifier = modifier.weight(1f).fillMaxWidth()) {
                         content(PaddingValues(top = chromeInsets.titleBarHeight))
                         if (!hideBar) {
-                            Box(modifier = Modifier.align(Alignment.TopStart)) {
+                            // `passThroughToContent`: the bar floats over the
+                            // content, so by default it wins the hit test for
+                            // its whole band. Opting in shares the hit test with
+                            // the content sibling below, keeping controls the app
+                            // merged into the band interactive (see
+                            // Modifier.shareHitTestWithSiblings).
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .align(Alignment.TopStart)
+                                        .let {
+                                            if (titleBarPlacement.passThroughToContent) {
+                                                it.shareHitTestWithSiblings()
+                                            } else {
+                                                it
+                                            }
+                                        },
+                            ) {
                                 barSlot()
                             }
                         }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/TitleBarHitTestTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/TitleBarHitTestTest.kt
@@ -1,0 +1,213 @@
+package dev.nucleusframework.window
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import dev.nucleusframework.window.tao.TaoWindow
+import dev.nucleusframework.window.tao.scene.TaoSceneTestScope
+import dev.nucleusframework.window.tao.scene.runTaoSceneTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Hit-test contract of the title-bar drag handler and of the Overlay
+ * pass-through marker, driven through the stage-1 scene harness.
+ *
+ * The layouts here mirror `WindowScaffold`'s `TitleBarPlacement.Overlay`
+ * branch (content first, bar wrapper on top, optionally carrying
+ * [shareHitTestWithSiblings]) rather than invoking the scaffold itself: the
+ * scaffold needs a `DecoratedWindowScope` and platform chrome probing, neither
+ * of which belongs in a stage-1 test.
+ */
+class TitleBarHitTestTest {
+    @Test
+    fun `opaque overlay bar does not leak clicks to the content below`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            var contentClicks = 0
+            setContent {
+                overlayLayout(
+                    passThroughToContent = false,
+                    window = TaoWindow(handle = 0L),
+                    content = {
+                        Box(Modifier.fillMaxWidth().height(BAR_HEIGHT).clickable { contentClicks++ })
+                    },
+                )
+            }
+            click(100f, 20f)
+            assertEquals(0, contentClicks, "a press on the chrome must stay in the chrome")
+        }
+
+    @Test
+    fun `pass-through overlay bar keeps content in the bar band interactive`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            var contentClicks = 0
+            setContent {
+                overlayLayout(
+                    passThroughToContent = true,
+                    window = TaoWindow(handle = 0L),
+                    content = {
+                        Box(Modifier.fillMaxWidth().height(BAR_HEIGHT).clickable { contentClicks++ })
+                    },
+                )
+            }
+            click(100f, 20f)
+            assertEquals(1, contentClicks, "opted-in pass-through must reach the content sibling")
+        }
+
+    @Test
+    fun `content consuming the press vetoes the window drag`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            val window = TaoWindow(handle = 0L)
+            var drags = 0
+            window.onDragWindow { drags++ }
+            setContent {
+                overlayLayout(passThroughToContent = true, window = window) {
+                    Box(Modifier.fillMaxWidth().height(BAR_HEIGHT).clickable { })
+                }
+            }
+            dragFromBar()
+            assertEquals(0, drags, "a consumed press must not arm the window move")
+        }
+
+    @Test
+    fun `an unclaimed press on the bar still drags the window`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            val window = TaoWindow(handle = 0L)
+            var drags = 0
+            window.onDragWindow { drags++ }
+            setContent {
+                overlayLayout(passThroughToContent = true, window = window) {
+                    Box(Modifier.fillMaxSize())
+                }
+            }
+            dragFromBar()
+            assertEquals(1, drags)
+        }
+
+    @Test
+    fun `a consumer that stops consuming mid-gesture never hands over the drag`() =
+        runTaoSceneTest(width = 200, height = 300) {
+            val window = TaoWindow(handle = 0L)
+            var drags = 0
+            window.onDragWindow { drags++ }
+            var consumedMoves = 0
+            setContent {
+                overlayLayout(passThroughToContent = true, window = window) {
+                    // A scrollable that reaches its limit behaves exactly like
+                    // this: it claims the first samples of the gesture, then
+                    // stops consuming. The drag must stay disarmed.
+                    Box(
+                        Modifier.fillMaxSize().pointerInput(Unit) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    val event = awaitPointerEvent(PointerEventPass.Main)
+                                    if (event.type == PointerEventType.Move && consumedMoves < 3) {
+                                        consumedMoves++
+                                        event.changes.forEach { it.consume() }
+                                    }
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+            dragFromBar(steps = 6)
+            assertEquals(3, consumedMoves, "the probe must actually have claimed the first samples")
+            assertEquals(0, drags, "the window must not start moving mid-gesture")
+        }
+
+    @Test
+    fun `a drag gesture under a pass-through bar is not stolen by the window move`() =
+        runTaoSceneTest(width = 200, height = 300) {
+            val window = TaoWindow(handle = 0L)
+            var drags = 0
+            window.onDragWindow { drags++ }
+            var dragged = 0
+            setContent {
+                overlayLayout(passThroughToContent = true, window = window) {
+                    Box(
+                        Modifier.fillMaxSize().pointerInput(Unit) {
+                            detectDragGestures { change, _ ->
+                                change.consume()
+                                dragged++
+                            }
+                        },
+                    )
+                }
+            }
+            dragFromBar(steps = 6)
+            assertEquals(6, dragged)
+            assertEquals(0, drags)
+        }
+
+    @Test
+    fun `a drag area does not leak clicks to an overlapping sibling`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            var contentClicks = 0
+            setContent {
+                // The macOS fullscreen bar shape: the bar is offset over the
+                // content and is its DIRECT sibling, so a sharing flag on the
+                // drag handler's own node would apply here.
+                Box(Modifier.fillMaxSize()) {
+                    Box(Modifier.fillMaxSize()) {
+                        Box(Modifier.fillMaxWidth().height(BAR_HEIGHT).clickable { contentClicks++ })
+                    }
+                    Box(
+                        Modifier
+                            .align(Alignment.TopStart)
+                            .fillMaxWidth()
+                            .height(BAR_HEIGHT)
+                            .titleBarHitTestHandler(TaoWindow(handle = 0L)),
+                    )
+                }
+            }
+            click(100f, 20f)
+            assertEquals(0, contentClicks)
+        }
+
+    private companion object {
+        val BAR_HEIGHT = 40.dp
+
+        @Composable
+        fun overlayLayout(
+            passThroughToContent: Boolean,
+            window: TaoWindow,
+            content: @Composable () -> Unit,
+        ) {
+            Box(Modifier.fillMaxSize()) {
+                content()
+                Box(
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopStart)
+                            .let { if (passThroughToContent) it.shareHitTestWithSiblings() else it },
+                ) {
+                    Box(Modifier.fillMaxWidth().height(BAR_HEIGHT).titleBarHitTestHandler(window))
+                }
+            }
+        }
+
+        /** Press inside the bar band, then drag straight down out of it. */
+        fun TaoSceneTestScope.dragFromBar(steps: Int = 3) {
+            moveMouse(100f, 20f)
+            pointerButton(PointerButton.Primary, pressed = true)
+            var y = 20f
+            repeat(steps) {
+                y += 40f
+                moveMouse(100f, y)
+            }
+            pointerButton(PointerButton.Primary, pressed = false)
+        }
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.window.tao
 
+import dev.nucleusframework.window.TitleBarHitTestTest
 import dev.nucleusframework.window.tao.TaoWindowResizableTest
 import dev.nucleusframework.window.tao.TaoWindowScrollTest
 import dev.nucleusframework.window.tao.a11y.TaoA11yProjectionTest
@@ -164,6 +165,27 @@ public object TaoSceneTestBattery {
         }
         run("TaoScenePointerTest: hover exit resets hover state via exitPointer") {
             TaoScenePointerTest().`hover exit resets hover state via exitPointer`()
+        }
+        run("TitleBarHitTestTest: opaque overlay bar does not leak clicks to the content below") {
+            TitleBarHitTestTest().`opaque overlay bar does not leak clicks to the content below`()
+        }
+        run("TitleBarHitTestTest: pass-through overlay bar keeps content in the bar band interactive") {
+            TitleBarHitTestTest().`pass-through overlay bar keeps content in the bar band interactive`()
+        }
+        run("TitleBarHitTestTest: content consuming the press vetoes the window drag") {
+            TitleBarHitTestTest().`content consuming the press vetoes the window drag`()
+        }
+        run("TitleBarHitTestTest: an unclaimed press on the bar still drags the window") {
+            TitleBarHitTestTest().`an unclaimed press on the bar still drags the window`()
+        }
+        run("TitleBarHitTestTest: a consumer that stops consuming mid-gesture never hands over the drag") {
+            TitleBarHitTestTest().`a consumer that stops consuming mid-gesture never hands over the drag`()
+        }
+        run("TitleBarHitTestTest: a drag gesture under a pass-through bar is not stolen by the window move") {
+            TitleBarHitTestTest().`a drag gesture under a pass-through bar is not stolen by the window move`()
+        }
+        run("TitleBarHitTestTest: a drag area does not leak clicks to an overlapping sibling") {
+            TitleBarHitTestTest().`a drag area does not leak clicks to an overlapping sibling`()
         }
         run("TaoSceneScrollTest: wheel down scrolls a vertical column") {
             TaoSceneScrollTest().`wheel down scrolls a vertical column`()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.window.tao
 
+import dev.nucleusframework.window.TitleBarHitTestTest
 import dev.nucleusframework.window.tao.a11y.TaoA11yProjectionTest
 import dev.nucleusframework.window.tao.dnd.TaoSyntheticDndTest
 import dev.nucleusframework.window.tao.dnd.TaoTransferableAccessGuardTest
@@ -49,6 +50,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoSceneAnimationTest::class.java,
             TaoSceneSemanticsTest::class.java,
             TaoA11yProjectionTest::class.java,
+            TitleBarHitTestTest::class.java,
         )
 
     /** Classes that must stay out of the battery, with the reason. */


### PR DESCRIPTION
## Summary

`TitleBarPlacement.Overlay` composes the bar on top of the content, so Compose stops hit testing at the bar. Controls an app merges into the caption band — a `LeftCollapsed` navigation header's back/hamburger buttons, a tab strip — are *siblings* of the bar, not descendants, so they never receive a press and `noWindowDrag()` cannot help them (it only cancels an **ancestor** `windowDragArea`).

- **`TitleBarPlacement.Overlay(passThroughToContent = …)`** — when set, the scaffold marks the bar wrapper with `sharePointerInputWithSiblings`, so hit testing continues to the content below; a consumed press vetoes the window drag exactly like an interactive child of the bar. Off by default: always on, a click on the opaque chrome activates whatever clickable content flows underneath it.
- **Drag loop fix** — `pendingDrag` stayed armed across samples another handler consumed. A scrollable under a pass-through bar that reaches its limit mid-gesture stops consuming, and the next unconsumed `Move` started a compositor move grab in the middle of the scroll.
- **No node-level sharing on `windowDragArea`** — `shouldSharePointerInputWithSiblings()` is read on `child.outerCoordinator`, i.e. only on the direct sibling layout node (`InnerNodeCoordinator.kt:234`, `NodeCoordinator.kt:1639` in Compose 1.11.1). Setting the flag inside the drag handler's own node does not reach the scaffold case, but does leak presses from every `windowDragArea` to overlapping siblings — the macOS fullscreen bar (offset over the content in the same Column), `DialogTitleBar`, any app stacking chrome over content in a `Box`.

API note: `Overlay` gains a second constructor parameter (`apiDump` regenerated). Source-compatible; binary-breaking for callers of the 1-arg constructor.

## Test plan

`TitleBarHitTestTest` — 7 stage-1 cases on the scene harness, registered in `TaoSceneTestBattery` so they also run in the GraalVM native image.

- [x] opaque overlay bar does not leak clicks to the content below
- [x] pass-through overlay bar keeps content in the bar band interactive
- [x] content consuming the press vetoes the window drag
- [x] an unclaimed press on the bar still drags the window
- [x] a consumer that stops consuming mid-gesture never hands over the drag
- [x] a drag gesture under a pass-through bar is not stolen by the window move
- [x] a drag area does not leak clicks to an overlapping sibling
- [x] each of the two defect fixes verified to fail the matching test when reverted
- [x] `:decorated-window-tao:test` (92), `detekt`, `ktlintCheck`, `apiCheck`

Not verified on screen: the on-device pass was blocked by the Wayland session (no X11 automation path).