### PR TITLE
fix(core): accept scheme-only deep link URIs (#414)

### DIFF
--- a/core-runtime/src/main/kotlin/dev/nucleusframework/core/runtime/DeepLinkHandler.kt
+++ b/core-runtime/src/main/kotlin/dev/nucleusframework/core/runtime/DeepLinkHandler.kt
@@ -117,7 +117,9 @@ object DeepLinkHandler {
     }
 
     private fun parseUriFromArgs(args: Array<String>) {
-        val raw = args.firstOrNull { it.contains("://") } ?: return
+        // Accept hierarchical (`myapp://host`) and opaque (`myapp:?q=1`) forms.
+        // The previous `://` filter dropped valid scheme-only URIs (issue #414).
+        val raw = args.firstOrNull(::isDeepLinkArg) ?: return
         try {
             val parsed = URI(raw)
             debugLog { "Received URI via CLI args: $parsed" }
@@ -181,4 +183,26 @@ object DeepLinkHandler {
     private fun errorLog(msg: () -> String) {
         errorln { "[$TAG] ${msg()}" }
     }
+}
+
+/**
+ * Whether [arg] looks like a deep-link URI (RFC 3986 scheme).
+ *
+ * Matches `scheme:` for any valid scheme so opaque URIs such as
+ * `myapp:?queryParam=123` are accepted alongside hierarchical
+ * `myapp://host/path` forms. Windows drive paths (`C:\…`, `D:/…`)
+ * are rejected even though they contain a colon.
+ */
+internal fun isDeepLinkArg(arg: String): Boolean {
+    val colon = arg.indexOf(':')
+    if (colon <= 0) return false
+    val scheme = arg.substring(0, colon)
+    if (!scheme[0].isLetter()) return false
+    if (scheme.any { !it.isLetterOrDigit() && it != '+' && it != '-' && it != '.' }) return false
+    // Windows absolute paths: single-letter scheme + \ or /
+    if (scheme.length == 1 && arg.length > colon + 1) {
+        val next = arg[colon + 1]
+        if (next == '\\' || next == '/') return false
+    }
+    return true
 }

--- a/core-runtime/src/test/kotlin/dev/nucleusframework/core/runtime/DeepLinkCaptureHolder.kt
+++ b/core-runtime/src/test/kotlin/dev/nucleusframework/core/runtime/DeepLinkCaptureHolder.kt
@@ -1,0 +1,30 @@
+package dev.nucleusframework.core.runtime
+
+/**
+ * Subprocess helper that exercises [DeepLinkHandler.captureFromArgs] — the path
+ * used by secondary single-instance launches before [DeepLinkHandler.writeUriTo].
+ *
+ * Args: zero or more command-line tokens that may include a deep-link URI.
+ *
+ * Prints a single line to stdout:
+ *   "URI:<uri>"  — [DeepLinkHandler.uri] was set
+ *   "NONE"       — no URI was captured
+ *   "ERROR:..."  — unexpected failure
+ */
+fun main(args: Array<String>) {
+    try {
+        DeepLinkHandler.captureFromArgs(args)
+        val uri = DeepLinkHandler.uri
+        if (uri != null) {
+            println("URI:$uri")
+        } else {
+            println("NONE")
+        }
+        System.out.flush()
+        System.exit(0)
+    } catch (e: Throwable) {
+        println("ERROR:${e.javaClass.simpleName}:${e.message}")
+        System.out.flush()
+        System.exit(2)
+    }
+}

--- a/core-runtime/src/test/kotlin/dev/nucleusframework/core/runtime/DeepLinkHandlerEndToEndTest.kt
+++ b/core-runtime/src/test/kotlin/dev/nucleusframework/core/runtime/DeepLinkHandlerEndToEndTest.kt
@@ -1,0 +1,167 @@
+package dev.nucleusframework.core.runtime
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end tests for [DeepLinkHandler] CLI URI parsing.
+ *
+ * Each test launches a real subprocess so the [DeepLinkHandler] object
+ * singleton state (cold-start flag, last URI) does not leak across cases.
+ *
+ * Covers issue #414: scheme-only URIs (`myapp:?query=…`) must be accepted,
+ * not only authority-form URIs (`myapp://host/…`).
+ */
+class DeepLinkHandlerEndToEndTest {
+    private val javaBin = File(System.getProperty("java.home"), "bin/java").absolutePath
+    private val classpath = System.getProperty("java.class.path")
+    private val processes = mutableListOf<Process>()
+
+    @After
+    fun tearDown() {
+        processes.forEach { p ->
+            if (p.isAlive) p.destroyForcibly()
+        }
+        processes.forEach { p -> p.waitFor(5, TimeUnit.SECONDS) }
+    }
+
+    // ── isDeepLinkArg unit checks ──────────────────────────────────────
+
+    @Test
+    fun `isDeepLinkArg accepts hierarchical and opaque schemes`() {
+        assertTrue(isDeepLinkArg("myapp://open/item?id=42"))
+        assertTrue(isDeepLinkArg("myapp:?queryParam=123"))
+        assertTrue(isDeepLinkArg("https://example.com/path"))
+        assertTrue(isDeepLinkArg("file:///tmp/x"))
+        assertTrue(isDeepLinkArg("svn+ssh://host/repo"))
+    }
+
+    @Test
+    fun `isDeepLinkArg rejects non-URI CLI tokens`() {
+        assertFalse(isDeepLinkArg("--verbose"))
+        assertFalse(isDeepLinkArg("path/to/file.txt"))
+        assertFalse(isDeepLinkArg("/absolute/path"))
+        assertFalse(isDeepLinkArg(""))
+        // Windows drive letters must not be mistaken for schemes
+        assertFalse(isDeepLinkArg("C:\\Users\\foo\\bar.txt"))
+        assertFalse(isDeepLinkArg("D:/work/file.txt"))
+    }
+
+    // ── setHandler e2e ─────────────────────────────────────────────────
+
+    @Test
+    fun `authority-form deep link is delivered via setHandler`() {
+        val process = startProcess("myapp://open/item?id=42")
+        assertEquals("URI:myapp://open/item?id=42", readSignal(process))
+        assertTrue(process.waitFor(5, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+    }
+
+    @Test
+    fun `scheme-only deep link without authority is delivered via setHandler - issue 414`() {
+        // xdg-open 'myapp:?queryParam=123' (and protocol handlers on Linux/Windows)
+        // can pass scheme-only URIs that have no "://" authority separator.
+        val process = startProcess("myapp:?queryParam=123")
+        assertEquals(
+            "Issue #414: setHandler must accept scheme-only URIs (scheme:), not only scheme://",
+            "URI:myapp:?queryParam=123",
+            readSignal(process),
+        )
+        assertTrue(process.waitFor(5, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+    }
+
+    @Test
+    fun `scheme-only deep link is found among mixed CLI args - issue 414`() {
+        val process =
+            startProcess(
+                "--verbose",
+                "myapp:?queryParam=123",
+                "some-other-arg",
+            )
+        assertEquals(
+            "Issue #414: scheme-only URI buried in args must still be detected",
+            "URI:myapp:?queryParam=123",
+            readSignal(process),
+        )
+        assertTrue(process.waitFor(5, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+    }
+
+    @Test
+    fun `plain args without URI yield NONE`() {
+        val process = startProcess("--help", "path/to/file.txt")
+        assertEquals("NONE", readSignal(process))
+        assertTrue(process.waitFor(5, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+    }
+
+    @Test
+    fun `windows drive path is not delivered as deep link`() {
+        val process = startProcess("C:\\Users\\foo\\bar.txt")
+        assertEquals("NONE", readSignal(process))
+        assertTrue(process.waitFor(5, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+    }
+
+    // ── captureFromArgs e2e (secondary-instance path) ──────────────────
+
+    @Test
+    fun `captureFromArgs records authority-form URI`() {
+        val process = startCaptureProcess("myapp://host/path")
+        assertEquals("URI:myapp://host/path", readSignal(process))
+        assertTrue(process.waitFor(5, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+    }
+
+    @Test
+    fun `captureFromArgs records scheme-only URI - issue 414`() {
+        val process = startCaptureProcess("myapp:?queryParam=123")
+        assertEquals(
+            "Issue #414: captureFromArgs (secondary instance path) must accept scheme-only URIs",
+            "URI:myapp:?queryParam=123",
+            readSignal(process),
+        )
+        assertTrue(process.waitFor(5, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private fun startProcess(vararg cliArgs: String): Process {
+        val args =
+            mutableListOf(
+                javaBin,
+                "-cp",
+                classpath,
+                "dev.nucleusframework.core.runtime.DeepLinkHolderKt",
+            )
+        args.addAll(cliArgs)
+        val process = ProcessBuilder(args).start()
+        processes.add(process)
+        return process
+    }
+
+    private fun startCaptureProcess(vararg cliArgs: String): Process {
+        val args =
+            mutableListOf(
+                javaBin,
+                "-cp",
+                classpath,
+                "dev.nucleusframework.core.runtime.DeepLinkCaptureHolderKt",
+            )
+        args.addAll(cliArgs)
+        val process = ProcessBuilder(args).start()
+        processes.add(process)
+        return process
+    }
+
+    private fun readSignal(process: Process): String =
+        process.inputStream.bufferedReader().readLine()
+            ?: "NO_OUTPUT (exit=${if (process.waitFor(2, TimeUnit.SECONDS)) process.exitValue() else "alive"})"
+}

--- a/core-runtime/src/test/kotlin/dev/nucleusframework/core/runtime/DeepLinkHolder.kt
+++ b/core-runtime/src/test/kotlin/dev/nucleusframework/core/runtime/DeepLinkHolder.kt
@@ -1,0 +1,45 @@
+package dev.nucleusframework.core.runtime
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Subprocess helper that exercises [DeepLinkHandler.setHandler] against CLI args.
+ *
+ * Args: zero or more command-line tokens that may include a deep-link URI.
+ *
+ * Prints a single line to stdout:
+ *   "URI:<uri>"  — callback was invoked with that URI
+ *   "NONE"       — callback was never invoked (handler registered but no URI parsed)
+ *   "ERROR:..."  — unexpected failure
+ *
+ * Exit codes: 0 = success (URI or NONE), 2 = error
+ */
+fun main(args: Array<String>) {
+    val received = AtomicReference<String?>(null)
+    val latch = CountDownLatch(1)
+
+    try {
+        DeepLinkHandler.setHandler(args) { uri ->
+            received.set(uri.toString())
+            latch.countDown()
+        }
+
+        // setHandler delivers cold-start args synchronously; brief wait for safety.
+        latch.await(200, TimeUnit.MILLISECONDS)
+
+        val uri = received.get()
+        if (uri != null) {
+            println("URI:$uri")
+        } else {
+            println("NONE")
+        }
+        System.out.flush()
+        System.exit(0)
+    } catch (e: Throwable) {
+        println("ERROR:${e.javaClass.simpleName}:${e.message}")
+        System.out.flush()
+        System.exit(2)
+    }
+}


### PR DESCRIPTION
## Summary
- `DeepLinkHandler.parseUriFromArgs` no longer requires `://` in CLI args, so opaque URIs like `myapp:?queryParam=123` (e.g. from `xdg-open`) reach `onDeepLink` / `captureFromArgs`
- New `isDeepLinkArg` matcher accepts RFC 3986 schemes and rejects Windows drive paths (`C:\…`, `D:/…`)
- E2E subprocess tests cover hierarchical + opaque forms, mixed args, secondary-instance capture, and drive-path rejection

Closes #414

## Test plan
- [x] `./gradlew :core-runtime:test --tests 'dev.nucleusframework.core.runtime.DeepLinkHandlerEndToEndTest'`
- [x] `./gradlew :core-runtime:test`
- [x] `./gradlew ktlintCheck detekt`
- [ ] Manual: package app with `protocol("MyApp", "myapp")`, run, then `xdg-open 'myapp:?queryParam=123'` and confirm `onDeepLink` fires