### PR TITLE
explore(graalvm): layered images cut a native-image update 2.3x

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -325,13 +325,18 @@ abstract class MetadataRepositorySettings
  * scaffolding is correct and the payoff is measured (2.3x less traffic per update, break-even after
  * ~1.2 updates on a macOS ZIP of `nucleus-demo`), but three things stand in the way:
  *
- *  - **The build is unstable.** The application layer intermittently fails with "This type is
- *    incomplete and should not be used" — the same inputs produced 18 errors, then 48, then none.
- *  - **Text fields crash at runtime.** Constructing a `java.awt.Cursor` (what `PointerIcon` does for
- *    any text field) needs `sun.awt.resources.awtosx`, and that bundle cannot be registered: from the
- *    application layer the lookup still fails, and registering it in the base layer that owns
- *    `java.desktop` — by `-H:IncludeResourceBundles` or by reachability metadata — makes the
- *    application layer fail to compile.
+ *  - **Reflection metadata versus base-layer types.** The application layer fails with "This type is
+ *    incomplete and should not be used", thrown from `BaseLayerType.getStaticFields` under
+ *    `ReflectionDataBuilder.checkHidingFields`: registering a type for reflection makes the builder
+ *    walk its subtypes and read their static fields, and a subtype that lives in the base layer is
+ *    only a stub in the application layer. There is no option that disables that walk, and the
+ *    metadata that triggers it is the metadata every real application needs. The number of errors
+ *    reported scales with `-H:NumberOfThreads` (the walk runs on a parallel executor), which makes it
+ *    look intermittent; the failure itself is not.
+ *  - **Text fields need an AWT resource bundle.** Constructing a `java.awt.Cursor` — what
+ *    `PointerIcon` does for any text field — reads `sun.awt.resources.awtosx`. A base-layer build
+ *    reaches no AWT code on its own, so native-image never registers those bundles the way it does
+ *    for a monolithic image; [resourceBundles] registers them explicitly.
  *  - **Requires GraalVM 25.2 or newer.** On 25.1 an application layer's JNI registrations are
  *    invisible to `FindClass`, so every native bridge breaks: the window opens and never renders.
  *
@@ -375,6 +380,26 @@ abstract class GraalvmLayerSettings
                     "java.sql",
                     "java.instrument",
                     "jdk.unsupported",
+                ),
+            )
+
+        /**
+         * Resource bundles the base layer embeds.
+         *
+         * The layer that owns `java.desktop` is where its localization support is built, and nothing
+         * in a base-layer build reaches `java.awt.Cursor`, so native-image never registers the AWT
+         * bundles on its own the way it does for a monolithic image. Without them any text field dies
+         * at runtime with "Resource bundle lookup must be loaded during native image generation:
+         * class sun.awt.resources.awtosx" — `PointerIcon` constructs a `Cursor`.
+         */
+        val resourceBundles: ListProperty<String> =
+            objects.listProperty(String::class.java).convention(
+                listOf(
+                    "sun.awt.resources.awt",
+                    "sun.awt.resources.awtosx",
+                    "sun.print.resources.serviceui",
+                    "com.sun.swing.internal.plaf.basic.resources.basic",
+                    "com.sun.swing.internal.plaf.metal.resources.metal",
                 ),
             )
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -341,6 +341,16 @@ abstract class MetadataRepositorySettings
  *    leaves the runtime lookup failing — but it is also what makes the reflection defect above fire,
  *    so the two cannot currently be satisfied at once.
  *
+ * Past that, the application layer stops on a second wall: "The core type
+ * `com.oracle.svm.core.jdk.AtomicFieldUpdaterAccessCheck` was not seen as reachable the initial layer.
+ * It is illegal for core types to become reachable in subsequent layers." A base layer holding only
+ * JDK modules analyses no application code, so it never sees the SVM internals the application will
+ * reach. Putting the application's classes on the base layer's class path does make it see them — and
+ * collapses the split: the base layer then analyses 28,400 types and 173,197 methods while the
+ * application layer is left with 158 types. GraalVM's prescribed escape is to pin those types via
+ * `LayeredCompilationBehavior` / `InitialLayerFeature`, which needs the set of SVM internals a given
+ * application reaches to be known up front — the opposite of working for any application.
+ *
  * Two further routes were tried and are dead ends worth not repeating. Substituting
  * `Toolkit.getProperty` to return its default (the JDK already does that for a missing bundle) has to
  * be applied in the layer that compiles `java.awt.Toolkit`, and a base layer only sees substitutions
@@ -388,7 +398,6 @@ abstract class GraalvmLayerSettings
                     "java.prefs",
                     "java.xml",
                     "java.net.http",
-                    "java.sql",
                     "java.instrument",
                     "jdk.unsupported",
                 ),

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -336,7 +336,18 @@ abstract class MetadataRepositorySettings
  *  - **Text fields need an AWT resource bundle.** Constructing a `java.awt.Cursor` — what
  *    `PointerIcon` does for any text field — reads `sun.awt.resources.awtosx`. A base-layer build
  *    reaches no AWT code on its own, so native-image never registers those bundles the way it does
- *    for a monolithic image; [resourceBundles] registers them explicitly.
+ *    for a monolithic image; [resourceBundles] registers them explicitly, in the layer that owns
+ *    `java.desktop`. That is the only place it works — registering them from the application layer
+ *    leaves the runtime lookup failing — but it is also what makes the reflection defect above fire,
+ *    so the two cannot currently be satisfied at once.
+ *
+ * Two further routes were tried and are dead ends worth not repeating. Substituting
+ * `Toolkit.getProperty` to return its default (the JDK already does that for a missing bundle) has to
+ * be applied in the layer that compiles `java.awt.Toolkit`, and a base layer only sees substitutions
+ * if it is given a class path — at which point it absorbs the whole application and the application
+ * layer has nothing left to compile ("0 types, 0 fields, and 2 methods found reachable"). Moving
+ * `java.desktop` out of the base layer is not possible either: a base layer without it fails with
+ * "Newly seen boot package java.awt.datatransfer".
  *  - **Requires GraalVM 25.2 or newer.** On 25.1 an application layer's JNI registrations are
  *    invisible to `FindClass`, so every native bridge breaks: the window opens and never renders.
  *

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -351,6 +351,14 @@ abstract class MetadataRepositorySettings
  * `LayeredCompilationBehavior` / `InitialLayerFeature`, which needs the set of SVM internals a given
  * application reaches to be known up front — the opposite of working for any application.
  *
+ * Those two failures are the same coin. A base layer that *analyses* framework code — whether the
+ * framework is selected with `package=` or simply put on the base layer's class path — makes the
+ * application layer bail out on Kotlin's `synchronized` intrinsic. A base layer that analyses nothing
+ * leaves the SVM core types unseen. There is no setting in between: the configuration space was walked
+ * (base with and without a class path, framework selected by package and by class path, layer option
+ * verification on and off, `-H:NumberOfThreads=1`, `-H:-UseSharedLayerGraphs`, GraalVM 25.1 and 25.2)
+ * and every combination lands on one wall or the other.
+ *
  * Two further routes were tried and are dead ends worth not repeating. Substituting
  * `Toolkit.getProperty` to return its default (the JDK already does that for a missing bundle) has to
  * be applied in the layer that compiles `java.awt.Toolkit`, and a base layer only sees substitutions

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -356,7 +356,8 @@ abstract class MetadataRepositorySettings
  * application layer bail out on Kotlin's `synchronized` intrinsic. A base layer that analyses nothing
  * leaves the SVM core types unseen. There is no setting in between: the configuration space was walked
  * (base with and without a class path, framework selected by package and by class path, layer option
- * verification on and off, `-H:NumberOfThreads=1`, `-H:-UseSharedLayerGraphs`, GraalVM 25.1 and 25.2)
+ * verification on and off, `-H:NumberOfThreads=1`, `-H:-UseSharedLayerGraphs`,
+ * `-H:InlineBeforeAnalysisAllowedDepth=0`, GraalVM 25.1 and 25.2)
  * and every combination lands on one wall or the other.
  *
  * Two further routes were tried and are dead ends worth not repeating. Substituting

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -363,6 +363,12 @@ abstract class MetadataRepositorySettings
  * default native-image emits the broken binary without a word. That alone is reason enough for this
  * flag to stay off.
  *
+ * An open type world is not the missing piece: the discrepancy is identical with the defaults, with
+ * `-H:-ClosedTypeWorld`, and with `-H:-ClosedTypeWorld -H:-ClosedTypeWorldHubLayout` on both layers —
+ * the coherent combination, since the hub layout defaults to enabled and is documented as valid only
+ * under a closed world. The layer type counts do not move either, which suggests the layered dispatch
+ * tables do not key on the type-world mode at all.
+ *
  * The other two failures are the same coin. A base layer that *analyses* framework code — whether the
  * framework is selected with `package=` or simply put on the base layer's class path — makes the
  * application layer bail out on Kotlin's `synchronized` intrinsic. A base layer that analyses nothing

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -351,7 +351,19 @@ abstract class MetadataRepositorySettings
  * `LayeredCompilationBehavior` / `InitialLayerFeature`, which needs the set of SVM internals a given
  * application reaches to be known up front — the opposite of working for any application.
  *
- * Those two failures are the same coin. A base layer that *analyses* framework code — whether the
+ * There is one configuration that gets past both compile walls: a base layer that analyses Kotlin,
+ * the coroutines runtime and the framework's own modules — enough for the SVM core types to be seen —
+ * while Compose stays in the application layer, so nothing re-parses `SnapshotKt.sync`. It compiles:
+ * 28,045 types in the base layer, 10,478 types and a 42.8 MB executable in the application layer.
+ *
+ * And the result does not run. The two layers disagree on virtual dispatch tables, so the binary dies
+ * at startup with "Fatal error: Virtual method call used an illegal vtable entry that was seen as
+ * unused by the static analysis". `-H:+AbortOnLayeredDispatchTableDiscrepancies` turns that into a
+ * build failure ("Issue while comparing dispatch table info"), which is the safer behaviour — by
+ * default native-image emits the broken binary without a word. That alone is reason enough for this
+ * flag to stay off.
+ *
+ * The other two failures are the same coin. A base layer that *analyses* framework code — whether the
  * framework is selected with `package=` or simply put on the base layer's class path — makes the
  * application layer bail out on Kotlin's `synchronized` intrinsic. A base layer that analyses nothing
  * leaves the SVM core types unseen. There is no setting in between: the configuration space was walked

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -106,9 +106,14 @@ abstract class GraalvmSettings
         val windows: GraalvmWindowsSettings = objects.new()
         val metadataRepository: MetadataRepositorySettings = objects.new()
         val pgo: GraalvmPgoSettings = objects.new()
+        val layers: GraalvmLayerSettings = objects.new()
 
         fun toolchain(fn: Action<GraalvmToolchainSettings>) {
             fn.execute(toolchain)
+        }
+
+        fun layers(fn: Action<GraalvmLayerSettings>) {
+            fn.execute(layers)
         }
 
         fun macOS(fn: Action<GraalvmMacOSSettings>) {
@@ -302,4 +307,75 @@ abstract class MetadataRepositorySettings
          */
         val moduleToConfigVersion: MapProperty<String, String> =
             objects.mapProperty(String::class.java, String::class.java)
+    }
+
+/**
+ * Splits the native image into a reusable base layer and a thin application layer.
+ *
+ * A monolithic native image is one blob whose layout `native-image` reshuffles globally, so a
+ * one-line source change invalidates nearly all of its blocks and an auto-update has to refetch the
+ * whole executable. With layers the AOT-compiled JDK lives in a shared library the application links
+ * against, and a release that only changes application code ships the same library byte for byte —
+ * so a differential update reuses it in full instead of downloading it again.
+ *
+ * The trade is disk for traffic: the base layer is not pruned against what the application actually
+ * uses, so the first download grows while every later one shrinks.
+ *
+ * **Not usable for a shipping application as of GraalVM 25.2.** Kept behind this flag because the
+ * scaffolding is correct and the payoff is measured (2.3x less traffic per update, break-even after
+ * ~1.2 updates on a macOS ZIP of `nucleus-demo`), but three things stand in the way:
+ *
+ *  - **The build is unstable.** The application layer intermittently fails with "This type is
+ *    incomplete and should not be used" — the same inputs produced 18 errors, then 48, then none.
+ *  - **Text fields crash at runtime.** Constructing a `java.awt.Cursor` (what `PointerIcon` does for
+ *    any text field) needs `sun.awt.resources.awtosx`, and that bundle cannot be registered: from the
+ *    application layer the lookup still fails, and registering it in the base layer that owns
+ *    `java.desktop` — by `-H:IncludeResourceBundles` or by reachability metadata — makes the
+ *    application layer fail to compile.
+ *  - **Requires GraalVM 25.2 or newer.** On 25.1 an application layer's JNI registrations are
+ *    invisible to `FindClass`, so every native bridge breaks: the window opens and never renders.
+ *
+ * When the build does succeed the application runs, Compose renders and the native macOS menu bar
+ * works, so only the two items above separate this from being usable.
+ *
+ * Only the JDK goes into the base layer. Putting classpath packages there as well would shrink the
+ * application layer further, but as of GraalVM 25.2 it makes the application layer fail to compile
+ * with a permanent Graal bailout ("Unstructured locking: too few monitorexits exiting frame") on
+ * Kotlin's `synchronized` intrinsic — which any Compose application reaches.
+ */
+abstract class GraalvmLayerSettings
+    @Inject
+    constructor(
+        objects: ObjectFactory,
+    ) {
+        /** Build the image as a base layer plus an application layer. Defaults to `false`. */
+        val isEnabled: Property<Boolean> = objects.notNullProperty(false)
+
+        /**
+         * JDK modules the base layer holds. The default covers what a Compose Desktop application
+         * reaches; `java.base` alone is not enough, and a module the application needs but the layer
+         * omits fails the build with "Newly seen boot package".
+         */
+        val modules: ListProperty<String> =
+            objects.listProperty(String::class.java).convention(
+                // The order is part of the recipe, not cosmetic: it changes the produced layer (a
+                // reordered list yields a differently sized library) and a layer built from another
+                // order made the application layer fail with "This type is incomplete and should not
+                // be used". This is the sequence that was validated end to end.
+                listOf(
+                    "java.base",
+                    "java.datatransfer",
+                    "java.desktop",
+                    "java.logging",
+                    "java.management",
+                    "java.naming",
+                    "java.prefs",
+                    "java.xml",
+                    "java.net.http",
+                    "java.sql",
+                    "java.instrument",
+                    "jdk.unsupported",
+                ),
+            )
+
     }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -815,10 +815,12 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                 val outputDir = layerDir.get().asFile
                 outputs.dir(outputDir)
                 inputs.property("modules", graalvm.layers.modules)
+                inputs.property("resourceBundles", graalvm.layers.resourceBundles)
                 inputs.property("march", resolvedMarchFlag)
 
                 val nativeImageExe = graalvmHome.map { File(it).resolve("bin/native-image").absolutePath }
                 val modules = graalvm.layers.modules.get()
+                val bundles = graalvm.layers.resourceBundles.get()
                 val archive = layerArchiveFile.get().asFile
 
                 doFirst {
@@ -831,6 +833,11 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                             "-march=$resolvedMarchFlag",
                             "-H:+UnlockExperimentalVMOptions",
                             "-H:LayerCreate=${archive.name}," + modules.joinToString(",") { "module=$it" },
+                            // The layer that owns java.desktop is where its localization support is
+                            // built, and nothing in a base-layer build reaches java.awt.Cursor, so
+                            // the AWT bundles are never registered on their own. Without this, any
+                            // text field dies at runtime on sun.awt.resources.awtosx.
+                            "-H:IncludeResourceBundles=${bundles.joinToString(",")}",
                             "-o",
                             "lib$GRAALVM_LAYER_NAME",
                         )

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -63,6 +63,13 @@ private fun isOracleGraalvm(javaHome: File): Boolean = isOracleGraalvmInstallati
 private fun escapeNativeImageArgFileArgument(arg: String): String =
     "\"" + arg.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
 
+/**
+ * Base name of the native image base layer: the archive `<name>.nil` that application-layer builds
+ * consume, and the shared library `lib<name>.dylib` that ships beside the executable. native-image
+ * requires a layer library's name to start with "lib".
+ */
+private const val GRAALVM_LAYER_NAME = "nucleusbase"
+
 // The GraalVM native app folder, placed under `compose/binaries/<appDirName>/graalvm-app`
 // to mirror the JVM distributable layout (`compose/binaries/<appDirName>/app`) instead of
 // hiding it in the build tmp dir.
@@ -756,6 +763,82 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             }
         }
 
+    // Target CPU instruction set, shared by the base layer and the application layer: native-image
+    // rejects a layered pair whose CPU features disagree. Default: portable baseline everywhere,
+    // except macOS on Apple Silicon where the armv8-a baseline is already universal so "native" is a
+    // free perf win.
+    val resolvedMarchFlag =
+        (
+            graalvm.march.orNull ?: if (currentOS == OS.MacOS && currentArch == Arch.Arm64) {
+                NativeImageMarch.NATIVE
+            } else {
+                NativeImageMarch.COMPATIBILITY
+            }
+        ).flag
+
+    // ── nativeImageBaseLayer ──
+    //
+    // Compiles the JDK into a shared library the application layer links against, plus the `.nil`
+    // archive that layer consumes. A release that only changes application code reuses this file
+    // byte for byte, which is the whole point: a differential update then skips it entirely.
+    //
+    // Deliberately minimal on options. `-H:+LayerOptionVerification` requires every option the base
+    // layer records to reappear at the same position in the application layer's command line, so
+    // anything added here has to be mirrored there — see where -H:LayerUse is added.
+    //
+    // macOS-only for now: it is the platform this was validated on, and shipping the layer library
+    // needs per-platform handling (extension, install name, signing).
+    val layeredImage =
+        graalvm.layers.isEnabled.get().also { requested ->
+            if (requested && currentOS != OS.MacOS) {
+                project.logger.warn(
+                    "graalvm { layers { isEnabled = true } } is only supported on macOS for now; " +
+                        "building a monolithic image instead.",
+                )
+            }
+        } && currentOS == OS.MacOS
+
+    val layerDir = appTmpDir.map { it.dir("graalvm/layer") }
+    val layerArchiveFile = layerDir.map { it.file("$GRAALVM_LAYER_NAME.nil") }
+    val layerLibraryFile = layerDir.map { it.file("lib$GRAALVM_LAYER_NAME.dylib") }
+
+    val nativeImageBaseLayer =
+        if (!layeredImage) {
+            null
+        } else {
+            tasks.register<Exec>(
+                taskNameAction = "nativeImage",
+                taskNameObject = "baseLayer",
+            ) {
+                description = "Compile the JDK into a reusable GraalVM native image base layer"
+
+                val outputDir = layerDir.get().asFile
+                outputs.dir(outputDir)
+                inputs.property("modules", graalvm.layers.modules)
+                inputs.property("march", resolvedMarchFlag)
+
+                val nativeImageExe = graalvmHome.map { File(it).resolve("bin/native-image").absolutePath }
+                val modules = graalvm.layers.modules.get()
+                val archive = layerArchiveFile.get().asFile
+
+                doFirst {
+                    outputDir.mkdirs()
+                    // Resolved here rather than at configuration time: this is the call that
+                    // provisions the toolchain, and it must only happen when a layer is built.
+                    executable = nativeImageExe.get()
+                    args =
+                        listOf(
+                            "-march=$resolvedMarchFlag",
+                            "-H:+UnlockExperimentalVMOptions",
+                            "-H:LayerCreate=${archive.name}," + modules.joinToString(",") { "module=$it" },
+                            "-o",
+                            "lib$GRAALVM_LAYER_NAME",
+                        )
+                    workingDir = outputDir
+                }
+            }
+        }
+
     // ── nativeImageCompile ──
 
     val nativeImageCompile =
@@ -766,6 +849,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             description = "Compile the application into a GraalVM native image"
 
             dependsOn(packageUberJar)
+            nativeImageBaseLayer?.let { dependsOn(it) }
             dependsOn(generatePlatformMetadata)
             dependsOn(resolveReachabilityMetadata)
             dependsOn(analyzeStaticMetadata)
@@ -776,6 +860,8 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
 
             val uberJarFile = packageUberJar.flatMap { it.archiveFile }
             inputs.file(uberJarFile)
+            // Rebuilding the base layer must recompile the application layer on top of it.
+            if (layeredImage) inputs.file(layerArchiveFile)
             inputs.file(metadataRepoDirsFile).optional()
             val outputDir = nativeCompileDir.get().asFile
             outputs.dir(outputDir)
@@ -824,16 +910,8 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                 if (generateProjectResourceMetadata != null) projectResourceMetadataDir.get().asFile else null
             val resolvedMetadataRepoDirsFile = metadataRepoDirsFile.get().asFile
             val resolvedBuildArgs = graalvm.buildArgs.get()
-            // Default: portable baseline everywhere, except macOS on Apple Silicon where the
-            // armv8-a baseline is already universal so "native" is a free perf win.
-            val resolvedMarch =
-                (
-                    graalvm.march.orNull ?: if (currentOS == OS.MacOS && currentArch == Arch.Arm64) {
-                        NativeImageMarch.NATIVE
-                    } else {
-                        NativeImageMarch.COMPATIBILITY
-                    }
-                ).flag
+            val resolvedMarch = resolvedMarchFlag
+            val resolvedLayerArchive = if (layeredImage) layerArchiveFile.get().asFile else null
             // Quick build (`-Ob`) wins over the configured optimization for the fast dev run.
             val resolvedQuickBuild = quickBuildRequested
             inputs.property("quickBuild", resolvedQuickBuild)
@@ -1081,6 +1159,14 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                             }
                         }
 
+                        // Build on the base layer. Placed where buildArgs land because
+                        // -H:+LayerOptionVerification compares the two layers' options
+                        // positionally, and this is the position the base layer records them at.
+                        if (resolvedLayerArchive != null) {
+                            add("-H:+UnlockExperimentalVMOptions")
+                            add("-H:LayerUse=${resolvedLayerArchive.absolutePath}")
+                        }
+
                         addAll(resolvedBuildArgs)
                     }
 
@@ -1273,6 +1359,10 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
     unpackDefaultResources: TaskProvider<AbstractUnpackDefaultApplicationResourcesTask>,
     packageUberJar: TaskProvider<Jar>,
 ): TaskProvider<DefaultTask> {
+    // This function only runs on macOS, so the platform gate is already satisfied here.
+    val layeredImage = graalvm.layers.isEnabled.get()
+    val layerLibraryFile = appTmpDir.map { it.file("graalvm/layer/lib$GRAALVM_LAYER_NAME.dylib") }
+
     val appBundleName = resolvedMacBundleNameProvider().map { "$it.app" }
     val appBundleDir =
         graalvmOutputDir.map { outDir ->
@@ -1301,6 +1391,58 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
             doNotTrackState("Output directory is modified by downstream strip/codesign tasks")
             from(nativeCompileDir.map { it.file(imageName.get()) })
             into(appBundleDir.map { it.dir("MacOS") })
+        }
+
+    // The application layer links the base layer by @loader_path, so the library only has to sit
+    // beside the executable — native-image already emits a relocatable reference, no install-name
+    // patching needed. Signing runs after this, so the added file is sealed with the bundle.
+    val copyLayerLibrary =
+        if (!layeredImage) {
+            null
+        } else {
+            tasks.register<Copy>(
+                taskNameAction = "copy",
+                taskNameObject = "graalvmLayerLibrary",
+            ) {
+                description = "Copy the GraalVM base layer library into the .app bundle"
+                dependsOn(nativeImageCompile, cleanAppBundle)
+                doNotTrackState("Output directory is modified by downstream strip/codesign tasks")
+                from(layerLibraryFile)
+                into(appBundleDir.map { it.dir("MacOS") })
+
+                // native-image records the layer library by its absolute build-directory path, so
+                // the bundle would only run on the machine that produced it. Rewrite the reference
+                // to @loader_path, which the executable already carries as an rpath. Signing runs
+                // after this task, so the mutated binary is sealed correctly.
+                val executableName = imageName
+                doLast {
+                    val macosDir = appBundleDir.get().dir("MacOS").asFile
+                    val executable = File(macosDir, executableName.get())
+                    val library = "lib$GRAALVM_LAYER_NAME.dylib"
+                    val recorded =
+                        ProcessBuilder("otool", "-L", executable.absolutePath)
+                            .redirectErrorStream(true)
+                            .start()
+                            .inputStream
+                            .bufferedReader()
+                            .readLines()
+                            .map { it.trim().substringBefore(" (") }
+                            .firstOrNull { it.endsWith("/$library") }
+                    if (recorded != null && recorded != "@loader_path/$library") {
+                        val patch =
+                            ProcessBuilder(
+                                "install_name_tool",
+                                "-change",
+                                recorded,
+                                "@loader_path/$library",
+                                executable.absolutePath,
+                            ).redirectErrorStream(true).start()
+                        val output = patch.inputStream.bufferedReader().readText()
+                        check(patch.waitFor() == 0) { "install_name_tool failed: $output" }
+                        logger.info("Rewrote the base layer reference in ${executable.name} to @loader_path")
+                    }
+                }
+            }
         }
 
     val copyAwtDylibs =
@@ -1373,6 +1515,9 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
         ) {
             description = "Strip debug symbols from dylibs"
             dependsOn(copyAwtDylibs)
+            // The base layer library lands in the same directory and must be in place before the
+            // strip/codesign passes sweep it.
+            copyLayerLibrary?.let { dependsOn(it) }
 
             doLast {
                 val macosDir = appBundleDir.get().dir("MacOS").asFile
@@ -1712,6 +1857,7 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
             copyBinary,
             copyAwtDylibs,
             copyJawtToLib,
+            *listOfNotNull(copyLayerLibrary).toTypedArray(),
             copySkikoLib,
             stripDylibs,
             stripBinary,

--- a/scripts/measure-graalvm-layers.sh
+++ b/scripts/measure-graalvm-layers.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# measure-graalvm-layers.sh — Measures what GraalVM layered images buy a differential update.
+#
+# A monolithic native image is one blob whose layout `native-image` reshuffles globally, so a
+# one-line source change invalidates nearly all of its blocks and an auto-update has to refetch the
+# whole executable. A layered image compiles the stable part (the JDK, and potentially the framework)
+# into a shared library that a release does not rebuild, leaving a thinner application layer to
+# change — so the unchanged part becomes a separate archive entry the updater reuses verbatim.
+#
+# This script builds both shapes of the same app, one source line apart, and reports how many bytes
+# an update transfers in each case. It is a measurement harness, not part of the build.
+#
+# Usage: scripts/measure-graalvm-layers.sh [output-dir]
+#
+# Requires:
+#   - macOS on Apple silicon (the layer dylib is patched with install_name_tool)
+#   - node/npm, to fetch electron-builder's `app-builder` (it computes the block maps the updater
+#     actually matches, so measuring with anything else would measure a different algorithm)
+#   - a GraalVM the plugin has already provisioned under ~/.gradle/nucleus/graalvm
+#   - `RealMacArtifactDeltaTest` in :updater-runtime, which lands with PR #428
+set -u
+
+OUT="${1:-/tmp/nucleus-layer-measure}"
+DEMO=examples/nucleus-demo
+MAIN="$DEMO/src/main/kotlin/com/example/demo/Main.kt"
+BUILD="$DEMO/build.gradle.kts"
+
+# The JDK modules the base layer holds. Compose needs java.desktop and java.datatransfer on top of
+# java.base; the rest are what the demo's dependencies reach.
+BASE_MODULES=(
+    java.base java.datatransfer java.desktop java.logging java.management
+    java.naming java.prefs java.xml java.net.http java.sql java.instrument jdk.unsupported
+)
+
+restore() { git checkout -- "$MAIN" "$BUILD" 2>/dev/null || true; }
+trap restore EXIT
+
+die() {
+    echo "!! $*" >&2
+    exit 1
+}
+
+# ── Tooling ───────────────────────────────────────────────────────────────────────────────────────
+
+resolve_native_image() {
+    find "$HOME/.gradle/nucleus/graalvm" -name native-image -type f -perm -u+x 2>/dev/null |
+        grep '/lib/svm/bin/' | head -1
+}
+
+resolve_app_builder() {
+    local bin="$OUT/node_modules/app-builder-bin/mac/app-builder_arm64"
+    if [ ! -x "$bin" ]; then
+        (cd "$OUT" && npm i app-builder-bin --no-save --silent >/dev/null 2>&1)
+        chmod +x "$bin" 2>/dev/null || true
+    fi
+    [ -x "$bin" ] && echo "$bin"
+}
+
+# ── Building ──────────────────────────────────────────────────────────────────────────────────────
+
+# Compiles the base layer: a shared library holding the AOT-compiled JDK, plus the .nil archive that
+# app-layer builds consume. `-march` must match what the plugin passes for the app layer, or
+# native-image rejects the pair ("CPU Features should be consistent across layers").
+build_base_layer() {
+    local ni="$1" march="$2" spec="base.nil" module
+    for module in "${BASE_MODULES[@]}"; do spec="$spec,module=$module"; done
+
+    echo "=== base layer (-march=$march) ==="
+    (cd "$OUT" && "$ni" -H:+UnlockExperimentalVMOptions "-march=$march" \
+        "-H:LayerCreate=$spec" -o libbase 2>&1 | grep -E "Generating|Finished|Failed|Error:")
+    [ -f "$OUT/libbase.dylib" ] || die "no base layer produced"
+    [ -f "$OUT/base.nil" ] || die "no .nil archive produced"
+}
+
+# Adds the layer options to the demo's graalvm block. buildArgs reaches native-image verbatim, which
+# is the only hook a layered build needs from the plugin today.
+inject_layer_option() {
+    python3 - "$BUILD" "$1" <<'PY'
+import sys
+path, nil = sys.argv[1], sys.argv[2]
+anchor = '        imageName = "nucleus-sample"\n'
+source = open(path).read()
+if anchor not in source:
+    sys.exit("anchor not found in " + path)
+injected = anchor + (
+    "        buildArgs.addAll(\n"
+    '            "-H:+UnlockExperimentalVMOptions",\n'
+    f'            "-H:LayerUse={nil}",\n'
+    "        )\n"
+)
+open(path, "w").write(source.replace(anchor, injected, 1))
+PY
+    grep -q LayerUse "$BUILD" || die "could not inject the layer option"
+}
+
+# Packages the demo's GraalVM ZIP, as an application layer when a .nil is given and as a monolith
+# otherwise.
+package_zip() {
+    local version="$1" layer="${2:-}"
+    restore
+    [ -n "$layer" ] && inject_layer_option "$layer"
+    RELEASE_VERSION="$version" ./gradlew ":examples:nucleus-demo:packageGraalvmZip" \
+        --no-configuration-cache --console=plain >"$OUT/gradle.log" 2>&1 || {
+        grep -E "Error:|Failed generating|What went wrong" -A3 "$OUT/gradle.log" | head -20
+        die "build failed (full log: $OUT/gradle.log)"
+    }
+}
+
+# Copies the ZIP the plugin produced, plus the block map electron-builder wrote beside it.
+collect() {
+    local dest="$1" label="$2" ab="$3" zip
+    zip="$(ls "$DEMO/build/compose/binaries/main/graalvm-zip"/*.zip 2>/dev/null | head -1)"
+    [ -n "$zip" ] || die "no ZIP produced"
+    mkdir -p "$dest"
+    cp "$zip" "$dest/$label.zip"
+    if [ -f "$zip.blockmap" ]; then
+        cp "$zip.blockmap" "$dest/$label.zip.blockmap"
+    else
+        "$ab" blockmap --input "$dest/$label.zip" --output "$dest/$label.zip.blockmap" >/dev/null
+    fi
+    echo "++ $label: $(stat -f%z "$dest/$label.zip") bytes"
+}
+
+# Repackages the bundle so it also carries the base-layer dylib, which the plugin does not know to
+# ship. The executable references it by absolute path, so the reference is rewritten to @loader_path
+# and the bundle re-signed — what plugin support for layers would have to do itself.
+repackage_with_base_layer() {
+    local dest="$1" label="$2" ab="$3" app name macos absolute
+    app="$(ls -d "$DEMO/build/compose/binaries/main/graalvm-app"/*.app 2>/dev/null | head -1)"
+    [ -n "$app" ] || die "no app bundle to repackage"
+    name="$(basename "$app")"
+
+    mkdir -p "$dest/$label-staged"
+    ditto "$app" "$dest/$label-staged/$name"
+    macos="$dest/$label-staged/$name/Contents/MacOS"
+    cp "$OUT/libbase.dylib" "$macos/"
+    absolute="$(otool -L "$macos/nucleus-sample" | awk '/libbase\.dylib/ {print $1}' | head -1)"
+    if [ -n "$absolute" ] && [ "$absolute" != "@loader_path/libbase.dylib" ]; then
+        install_name_tool -change "$absolute" @loader_path/libbase.dylib "$macos/nucleus-sample"
+    fi
+    codesign --force --deep --sign - "$dest/$label-staged/$name" >/dev/null 2>&1
+    mkdir -p "$dest"
+    (cd "$dest/$label-staged" && zip -q -r -9 "$dest/$label.zip" .)
+    "$ab" blockmap --input "$dest/$label.zip" --output "$dest/$label.zip.blockmap" >/dev/null
+    echo "++ $label (with base layer): $(stat -f%z "$dest/$label.zip") bytes"
+}
+
+patch_source() {
+    sed -i '' 's/title = "Nucleus Demo",/title = "Nucleus Demo v2",/' "$MAIN"
+    grep -q 'title = "Nucleus Demo v2"' "$MAIN" || die "the source patch did not apply"
+}
+
+# ── Measuring ─────────────────────────────────────────────────────────────────────────────────────
+
+# Runs the real updater over the pair: it resolves the block maps, issues range requests against a
+# loopback host that counts what it sends, and reports the bytes that crossed the wire.
+measure() {
+    local dir="$1" label="$2"
+    echo "=== $label ==="
+    ./gradlew :updater-runtime:test --no-configuration-cache --console=plain -i \
+        --tests '*RealMacArtifactDeltaTest*' \
+        "-Dnucleus.e2e.mac.old=$dir/v1.zip" \
+        "-Dnucleus.e2e.mac.new=$dir/v2.zip" 2>&1 |
+        grep -E "artifact:|differential:|transferred:" | head -4
+}
+
+# ── Run ───────────────────────────────────────────────────────────────────────────────────────────
+
+[ -f "$BUILD" ] || die "run this from the repository root"
+mkdir -p "$OUT"
+
+NI="$(resolve_native_image)"
+[ -n "$NI" ] || die "no provisioned native-image found; run a GraalVM task once first"
+AB="$(resolve_app_builder)"
+[ -n "$AB" ] || die "could not obtain app-builder (needs npm)"
+
+# The plugin uses -march=native on Apple silicon and compatibility elsewhere.
+MARCH=compatibility
+[ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ] && MARCH=native
+
+build_base_layer "$NI" "$MARCH"
+
+echo "=== monolithic pair ==="
+package_zip 1.0.0
+collect "$OUT/mono" v1 "$AB"
+patch_source
+package_zip 1.0.1
+collect "$OUT/mono" v2 "$AB"
+
+echo "=== layered pair ==="
+restore
+package_zip 1.0.0 "$OUT/base.nil"
+repackage_with_base_layer "$OUT/layered" v1 "$AB"
+patch_source
+package_zip 1.0.1 "$OUT/base.nil"
+repackage_with_base_layer "$OUT/layered" v2 "$AB"
+restore
+
+measure "$OUT/mono" monolithic
+measure "$OUT/layered" layered
+
+echo "=== done: artifacts under $OUT ==="

--- a/scripts/measure-graalvm-layers.sh
+++ b/scripts/measure-graalvm-layers.sh
@@ -10,6 +10,19 @@
 # This script builds both shapes of the same app, one source line apart, and reports how many bytes
 # an update transfers in each case. It is a measurement harness, not part of the build.
 #
+# STATUS: the layered path does not currently produce a working Compose application. The application
+# layer fails to compile with a permanent Graal bailout on `androidx.compose.runtime.snapshots
+# .SnapshotKt.sync` — Kotlin's `synchronized` intrinsic wrapping an inlined lambda:
+#
+#     PermanentBailoutException: Unstructured locking: too few monitorexits exiting frame
+#         at BytecodeParser.handleUnstructuredLockingForUnwindTarget
+#
+# A monolithic build compiles the same method without complaint. Reproduced on GraalVM CE 25.1.3 and
+# 25.2.4, with the layer option verification on and off, with the package assigned to either layer,
+# and with -H:-UseSharedLayerGraphs. Nothing works around it: the bailout is permanent, and
+# SnapshotKt.sync is reachable from any Compose application. The delta figures below were therefore
+# measured on a JDK-only base layer, whose application layer does build.
+#
 # Usage: scripts/measure-graalvm-layers.sh [output-dir]
 #
 # Requires:
@@ -59,14 +72,80 @@ resolve_app_builder() {
 # ── Building ──────────────────────────────────────────────────────────────────────────────────────
 
 # Compiles the base layer: a shared library holding the AOT-compiled JDK, plus the .nil archive that
-# app-layer builds consume. `-march` must match what the plugin passes for the app layer, or
-# native-image rejects the pair ("CPU Features should be consistent across layers").
+# app-layer builds consume.
+#
+# Both layers have to be built from the same option set, which is why real support belongs in the
+# plugin rather than in a script: it owns both invocations and can derive them from one list. Three
+# ways this bites, in the order they surface:
+#   - `-march` must match, or the pair is rejected ("CPU Features should be consistent across
+#     layers");
+#   - the same `-H:ConfigurationFileDirectories` must be passed to both, or class initialization
+#     diverges ("Class initialization info not stable between layers", first seen on
+#     kotlinx.coroutines.swing.Swing, whose directive comes from the Oracle metadata repository);
+#   - the shared options must appear at the same position, which `-H:+LayerOptionVerification`
+#     enforces. Disabling that check is not a fix: the build then proceeds into a miscompilation.
+# The -H:ConfigurationFileDirectories the plugin passes to the application layer. The base layer
+# needs the identical set (see above), and they only exist after one GraalVM build has run.
+collect_metadata_dirs() {
+    local tmp="$PWD/$DEMO/build/compose/tmp/main/graalvm" dir args=""
+    for dir in libraryMetadata platformMetadata staticAnalysis projectResources; do
+        [ -d "$tmp/$dir" ] && args="$args -H:ConfigurationFileDirectories=$tmp/$dir"
+    done
+    if [ -f "$tmp/metadataRepoDirs.txt" ]; then
+        while IFS= read -r line; do
+            [ -n "$line" ] && args="$args -H:ConfigurationFileDirectories=$line"
+        done <"$tmp/metadataRepoDirs.txt"
+    fi
+    echo "$args"
+}
+
+# Every package in the uberjar that is not the application's own, as `package=` selectors. This is
+# the split worth having — the framework stops changing between releases — and it is what plugin
+# support would compute, since the plugin knows which packages the project itself produces. `path=`
+# cannot do it: the plugin hands native-image a single flattened uberjar.
+library_package_spec() {
+    local uber="$1"
+    python3 - "$uber" <<'PYTHON'
+import re, sys, zipfile
+uber = sys.argv[1]
+# The application's own packages stay in the application layer.
+APP_PREFIXES = ("com/example/demo",)
+IDENT = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
+
+def is_package(path):
+    # META-INF/versions/<n>/... are multi-release entries, not packages, and native-image rejects
+    # them outright ("could not find requested packages").
+    if path.startswith(("META-INF/", "WEB-INF/")):
+        return False
+    return all(IDENT.match(part) for part in path.split("/"))
+
+packages = {
+    name.rsplit("/", 1)[0]
+    for name in zipfile.ZipFile(uber).namelist()
+    if name.endswith(".class") and "/" in name
+}
+libraries = sorted(
+    p for p in packages
+    if is_package(p) and not p.startswith(APP_PREFIXES)
+)
+print(",".join("package=" + p.replace("/", ".") for p in libraries))
+PYTHON
+}
+
 build_base_layer() {
     local ni="$1" march="$2" spec="base.nil" module
     for module in "${BASE_MODULES[@]}"; do spec="$spec,module=$module"; done
+    # Opt in with LAYER_SPLIT=packages once the bailout above is fixed upstream.
+    if [ "${LAYER_SPLIT:-modules}" = "packages" ]; then
+        spec="$spec,$(library_package_spec "$(ls "$PWD/$DEMO"/build/compose/jars/*.jar | head -1)")"
+    fi
 
     echo "=== base layer (-march=$march) ==="
+    local metadata
+    metadata="$(collect_metadata_dirs)"
+    # shellcheck disable=SC2086  # word splitting is how the -H: flags are passed
     (cd "$OUT" && "$ni" -H:+UnlockExperimentalVMOptions "-march=$march" \
+        --enable-native-access=ALL-UNNAMED $metadata \
         "-H:LayerCreate=$spec" -o libbase 2>&1 | grep -E "Generating|Finished|Failed|Error:")
     [ -f "$OUT/libbase.dylib" ] || die "no base layer produced"
     [ -f "$OUT/base.nil" ] || die "no .nil archive produced"
@@ -178,8 +257,8 @@ AB="$(resolve_app_builder)"
 MARCH=compatibility
 [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ] && MARCH=native
 
-build_base_layer "$NI" "$MARCH"
-
+# The monolithic pair comes first: it produces the uberjar and the metadata directories that the
+# base layer has to be built against.
 echo "=== monolithic pair ==="
 package_zip 1.0.0
 collect "$OUT/mono" v1 "$AB"
@@ -189,6 +268,7 @@ collect "$OUT/mono" v2 "$AB"
 
 echo "=== layered pair ==="
 restore
+build_base_layer "$NI" "$MARCH"
 package_zip 1.0.0 "$OUT/base.nil"
 repackage_with_base_layer "$OUT/layered" v1 "$AB"
 patch_source


### PR DESCRIPTION
## Summary

Investigation, not a feature: **can a GraalVM native image be made to produce small differential updates?** PR #428 concluded it cannot — 70.3 % of the artifact was refetched for a one-line change, and `-Os` measured the same as `-O3`, so the churn looked intrinsic. That conclusion turns out to be right about the cause and wrong about the consequence: there *is* a lever, and it is worth 2.3×.

Branched off `feat/updater-differential-download` (#428) because the measurement runs through its `RealMacArtifactDeltaTest`. The only code here is `scripts/measure-graalvm-layers.sh`, which reproduces everything below.

Everything was measured on macOS arm64, GraalVM **CE 25.1.3** (`25i1`), on `nucleus-demo`, with two builds one source line apart (a window title) and a real version bump (1.0.0 → 1.0.1). Block maps come from electron-builder's own `app-builder`, and the byte counts come from the real updater driving range requests against a loopback host that counts what it sends. **Note:** `main` has since moved to `25i2`, so the layer behaviour below should be re-confirmed there.

## The result

Same OS, same format, same change:

| macOS ZIP, GraalVM | Artifact | Transferred per update | Ratio |
|---|---|---|---|
| monolithic | 59.2 MB | **39.47 MB** | 66.7 % |
| **layered** | 86.4 MB | **17.05 MB** | **19.7 %** |

**2.3× less traffic per update** (−57 %), against +27.2 MB on the first download. Break-even:

```
+27,172,142 bytes once  /  −22,416,437 bytes per update  =  1.2 updates
```

From the **second** update on, the layered build has transferred less in total. For an app that ships more than twice, this is not a close call.

It also shrinks the part that changes: the monolithic executable is **122.2 MB**, the application layer **87.5 MB** (−28 %), and the 175.4 MB base-layer dylib leaves the update stream entirely because a release ships the same file rather than rebuilding it.

## Why it works — and why the original diagnosis was still correct

Layered images do not fix the churn, they **quarantine** it. A block map over the *raw, uncompressed* application-layer binaries confirms the churn is as bad as #428 said:

```
app layer, uncompressed:  57,962,440 bytes -> 51,911,776 to fetch  (89.6 %)
                          2703 blocks, 283 reused                  (10.5 %)
```

So a one-line source change really does invalidate ~90 % of a native image's blocks, on the raw bytes, with no compression involved. This refutes the alternative theory that the 70 % was an artifact of the compressor desynchronising — it is not. `native-image` reassigns addresses and reorders the image heap globally, exactly as #428 argued, and no optimisation flag touches that.

What layers change is *what the churn can reach*. The stable half becomes a separate archive entry whose bytes are byte-identical by construction, so the block map matches it in full. The gain is therefore proportional to how much of the image you can push into the base layer.

## How it is built

`-H:LayerCreate` produces a **shared library**, which is the "binary plus dylibs" shape a native image normally refuses to have:

```
libbase.dylib   175.4 MB   ← the AOT-compiled JDK, a real dylib
base.nil        1.22 GB    ← build-time metadata, not shipped
```

and `-H:LayerUse` builds an executable that links it:

```
$ otool -L nucleus-sample
    @loader_path/libbase.dylib
```

The base layer holds 12 JDK modules — `java.base` alone is not enough for Compose, which reaches `java.desktop` and `java.datatransfer` (`Newly seen boot package java.awt.datatransfer` otherwise).

Two things had to line up:

- **`-march` must match across layers.** The plugin passes `-march=native` on Apple silicon; a base layer built with the default is rejected with *"The runtime checked CPU Features should be consistent across layers"*.
- **The build must go through the plugin.** A hand-rolled `native-image` invocation dies at link on `_nucleus_init_platform_encoding` and then at runtime on `InternalError: platform encoding not initialized`. The plugin's `graalvm { buildArgs }` is enough of a hook: the C shim, `GraalVmInitializer`, resources, `LC_BUILD_VERSION` patching and signing all apply, and `nativeImageCompile` finishes in 51 s.

## What blocks shipping it

### 1. The app opens, but Compose never renders

The bundle can be made self-contained by hand — copy `libbase.dylib` into `Contents/MacOS/`, rewrite the absolute reference to `@loader_path` with `install_name_tool`, re-sign. `codesign --verify --deep --strict` then passes, the app **launches**, and the window appears with the right title. But it is blank:

```
java.lang.NoClassDefFoundError: dev/nucleusframework/window/tao/ffi/NativeMetalBridge
    at ...JNIFunctions.FindClass(JNIFunctions.java:369)
    at ...NativeMetalBridge.nativeAttach(Native Method)
    at ...TaoComposeSceneHost.attach(TaoComposeSceneHost.kt:280)
```

The tao event loop starts and creates the window, then attaching Metal fails: **`FindClass` does not see the application layer's JNI registrations.** The class is in the image — `nativeAttach` was resolved against it — but the JNI dictionary does not know it. Nucleus is JNI-heavy throughout, so this is fatal rather than cosmetic.

Two fixes were tried and both failed:

- **Move the framework into the base layer**, so its JNI registrations live where `FindClass` looks. A base layer with all 89 library jars builds fine (`libbase4.dylib`, 356 MB), but the app layer is then rejected: *"The entry … included in the classpath of the previous layered build was not found in the classpath of the current layered build."* The reason is structural — the plugin flattens every jar into **one** 80 MB archive (`AbstractJarsFlattenTask`, `build/compose/jars/NucleusDemo-*.jar`) before calling `native-image`, so with a single classpath entry `path=` cannot separate libraries from application code.
- **Force the JNI dictionary into the application layer** with `-H:ApplicationLayerOnlySingletons=com.oracle.svm.core.jni.access.JNIReflectionDictionary`. The build fails outright, repeatedly: `Should not reach here: This type is incomplete and should not be used`.

**The `package=` avenue was tried after this was first written** — it works as a mechanism, and it is no longer the open question. See **Attempt to make a layered app actually run** at the end of this description.

### 2. The plugin has no notion of a layer

`libbase.dylib` is not copied into the bundle, so the artifact the plugin produces today cannot run. Plugin support would need to: ship the layer dylib, rewrite its `install_name` to `@loader_path` (`SafeMachOFileMutation` already exists for this kind of Mach-O edit), sign it, and keep the base layer's `.nil` between CI runs so a patch release rebuilds only the application layer. That last point is not small: **1.22 GB** for a JDK-only base layer, **2.53 GB** with the libraries in it.

### 3. It is experimental

`-H:LayerCreate` requires `-H:+UnlockExperimentalVMOptions`, and the companion options say the rest — `-H:±AbortOnLayeredDispatchTableDiscrepancies`, `-H:±LogLayeredDispatchTableDiscrepancies`, `-H:±LogUniqueNameInconsistencies`, all documented as "experimental option which will be removed". `NativeImageLayers.md`, which every layer option's help text points at, is not shipped in the distribution.

## An idea that measured to nothing

Before reaching for layers, the cheaper theory was that the blob is fat with embedded resources — fonts, SVGs, `composeResources` baked into the image heap — and that shipping those as files beside the executable would both shrink it and delta well. Measured on the demo's payload:

| | share of jar content |
|---|---|
| `.class` | **99.0 %** (62.7 MB of 63.4 MB) |
| everything else | 1.0 % |
| fonts / SVG / composeResources | **0.0 %** |

The blob is code. There is nothing to move out, so splitting the code is the only lever — which is what layers do.

## Reproducing

```bash
scripts/measure-graalvm-layers.sh [output-dir]
```

Builds the base layer, then a monolithic pair and a layered pair of `nucleus-demo`, and measures both through `RealMacArtifactDeltaTest`. macOS arm64 only, needs `npm` for `app-builder` and a GraalVM the plugin has already provisioned.

## Why this is a draft

Nothing here is shippable: the layered app does not render, and the plugin cannot produce a working layered artifact. It is opened as a draft so the measurements have a home and the `package=` avenue can be picked up with the numbers already in hand. Happy to close it in favour of an issue if that reads better.

---

## Attempt to make a layered app actually run — blocked upstream

The goal was to get a layered image running, and generically: any existing app, not a hand-patched demo. That means real plugin support, and it means fixing the blank window. It ends at a **permanent Graal bailout that no flag works around**.

### The wall

The application layer fails to compile `androidx.compose.runtime.snapshots.SnapshotKt.sync` — Kotlin's `synchronized` intrinsic wrapping an inlined lambda:

```
PermanentBailoutException: Unstructured locking: too few monitorexits exiting frame
    at jdk.graal.compiler.java.BytecodeParser.handleUnstructuredLockingForUnwindTarget
    at androidx.compose.runtime.snapshots.SnapshotKt.sync
    at androidx.compose.runtime.snapshots.SnapshotStateObserver.forEachScopeMap
```

A **monolithic build compiles the same method without complaint**, so this is specific to the layered build path. Everything tried, all producing the identical bailout:

| Attempt | Result |
|---|---|
| GraalVM CE **25.1.3** | bailout |
| GraalVM CE **25.2.4** (what `main` now defaults to) | bailout |
| `-H:+LayerOptionVerification` (on, args matched by hand) | bailout |
| verification off | bailout |
| the package moved into the **application** layer | bailout |
| the package left in the **base** layer | bailout |
| `-H:-UseSharedLayerGraphs` | bailout |

`SnapshotKt.sync` is central to the Compose runtime and reachable from any Compose application, and a `PermanentBailoutException` is by definition not negotiable. **So this blocks every app, which is exactly the generality the goal asked for.** It needs an upstream fix; the error reports are reproducible with the committed harness.

### What the attempt did establish

Two findings that were not known before, and that make a retry cheap once the bailout is fixed. Both are now encoded in `scripts/measure-graalvm-layers.sh`.

**1. Both layers must be built from a single option set — which is why support belongs in the plugin.** Three distinct failures enforce this, each surfacing only after the previous is fixed:

- `-march` must match, or the pair is rejected outright: *"The runtime checked CPU Features should be consistent across layers"*. The plugin passes `-march=native` on Apple silicon.
- The same `-H:ConfigurationFileDirectories` must reach both layers, or class initialization diverges: *"Class initialization info not stable between layers for type `kotlinx.coroutines.swing.Swing`"*. That directive comes from the Oracle metadata repository, one of **14** metadata directories the plugin passes — none of which a base layer built by hand would know about.
- Shared options must sit at the **same position**, which `-H:+LayerOptionVerification` enforces (*"This is also required to be specified for the current layered image build at the same position"*). Disabling the check is not a workaround: the build then proceeds past verification into a miscompilation.

A script cannot satisfy these reliably. The plugin can, trivially, because it already builds the argument list in one place — that part of the design is settled.

**2. The framework/application split must be expressed with `package=`, not `path=`.** The plugin hands native-image a single flattened uberjar (`-jar build/compose/jars/<app>.jar`, 80 MB), so there is exactly one classpath entry and `path=` has nothing to select. `package=` works and the selectors are fully derivable — every package in the uberjar that the project does not itself produce. For the demo that is **379 library packages against 4 application packages**, a 15.7 KB option value that native-image accepts.

One filter is required: `META-INF/versions/<n>/…` entries are multi-release jar paths, not packages, and native-image rejects them with *"could not find requested packages"*.

Built this way the base layer is real: **`libbase.dylib` 385 MB, `base.nil` 2.64 GB**. It compiles cleanly — it is the *application* layer on top of it that hits the bailout.

### Where that leaves it

The delta result at the top of this PR stands: it was measured on a **JDK-only** base layer, whose application layer does build, and it is worth 2.3×. What does not work is the split that would make it worth much more — and, on any Compose app, the layered path at all.

So the sequence is: upstream fixes the bailout → re-run the harness with `LAYER_SPLIT=packages` → if the numbers hold, implement plugin support (a base-layer task sharing the argument list, `package=` selectors derived from the project's own packages, shipping and `@loader_path`-patching and signing the layer dylib, and carrying the `.nil` between CI runs).

Nothing in the middle of that chain is worth building until the first link is fixed.

---

## Update: it runs — GraalVM 25.2 lifts the JNI wall, and there is now plugin support

The bailout section above was written against GraalVM 25.1.3 and is **partly superseded**. Two things changed.

### 1. The blank window was a 25.1 bug, fixed in 25.2

`FindClass` not seeing an application layer's JNI registrations — the thing that opened a window and never rendered a pixel — does not happen on **GraalVM CE 25.2.4**, which is what `main` now defaults to. On 25.2 the layered application **runs and renders**: the full demo UI, and the native macOS menu bar with it (`Event Log: Menu bar installed`), so the JNI bridges work.

### 2. The compile bailout is about *what you put in the base layer*, not about layering

`PermanentBailoutException: Unstructured locking` only appears once the base layer holds **classpath packages**. With a **JDK-only** base layer the application layer compiles fine. That correction matters: the earlier claim that layering "blocks every app" was too strong — what is blocked is the framework-in-base split, which is the split that would make the delta much better than 19.7 %.

### Plugin support, generic by construction

`graalvm { layers { isEnabled = true } }`, default off. Nothing about it is app-specific: the base layer holds a fixed list of JDK modules, and the application layer is the plugin's normal build plus `-H:LayerUse`.

- **`nativeImageBaseLayer`** compiles `lib<name>.dylib` + `<name>.nil`.
- **`copyGraalvmLayerLibrary`** ships the library beside the executable and rewrites its recorded reference to `@loader_path` — native-image records an absolute build-directory path, so the bundle would otherwise only run on the machine that produced it.

Three constraints found the hard way, all encoded in the code:

- Both layers must share an option set, and `-H:+LayerOptionVerification` compares options **positionally**. The base layer is therefore deliberately minimal: anything added there has to be mirrored in the application layer.
- **The module list's order is part of the recipe.** Reordering the same twelve modules produces a differently sized library and made the application layer fail with "This type is incomplete and should not be used".
- Disabling the verification is not a workaround — the build then proceeds into a miscompilation.

### Why it still cannot ship

**Reflection metadata cannot coexist with base-layer types.** This is the blocker, and it is not intermittent — earlier drafts of this description called it unstable, which was wrong. Single-threaded, with stack traces:

```
AnalysisError: Should not reach here: This type is incomplete and should not be used.
    at BaseLayerType.getStaticFields(BaseLayerType.java:300)
    at AnalysisType.getStaticFields
    at JVMCIReflectionUtil.getAllFields
    at ReflectionDataBuilder.checkSubtypeForOverridingField(ReflectionDataBuilder.java:757)
    at ReflectionDataBuilder.lambda$checkHidingFields$0
    at ConditionalConfigurationRegistry.lambda$runConditionalTask$1
```

Registering a type for reflection makes the builder walk its subtypes and read their static fields; a subtype that lives in the base layer is only a stub in the application layer, and reading it throws. No option disables that walk, and the metadata that triggers it is exactly the metadata the plugin exists to supply. The *error count* scales with `-H:NumberOfThreads` because the walk runs on a parallel executor (18 errors, then 48, then 3 single-threaded) — which is what made it look random. The failure does not go away.

**Text fields needed an AWT resource bundle — this one is fixed.** A base-layer build reaches no AWT code on its own, so native-image never registers the AWT bundles the way it does for a monolithic image, and any text field died on:

```
UnsupportedFeatureError: Resource bundle lookup must be loaded during native image generation:
    class sun.awt.resources.awtosx
  at java.awt.Cursor.<init>  ←  PointerIcon  ←  TextField
```

The demo's Menu tab worked; its Gallery tab, which has a text field, did not. The base layer now embeds those bundles (`graalvm { layers { resourceBundles } }`). Registering them from the *application* layer does not work — the lookup still fails at runtime — and `java.desktop` cannot be moved out of the base layer either, since a base layer without it fails with "Newly seen boot package java.awt.datatransfer".

This fix could not be observed end to end: every build after it hit the reflection-metadata failure above.

### Where that leaves it

The measured payoff stands and the scaffolding is in place. What remains is a single upstream defect: `ReflectionDataBuilder.checkHidingFields` must not read static fields off a base-layer stub. Until that is fixed, no application that registers reflection metadata — which is every real one — can be built as a layered image. Reproducible with the harness in this branch.

One caveat on the code: the `@loader_path` rewrite is also unobserved end to end, for the same reason.
---

## Two more walls, and where this stops

Continuing past the reflection failure produced one real fix and one hard stop.

### Fixed: the reflection failure was narrow

`ReflectionDataBuilder.checkHidingFields` was walking to exactly one base-layer stub. The metadata registers `com.sun.rowset.RowSetResourceBundle`; `java.sql` was in the base layer's module list, so that type became a stub in the application layer, and reading its static fields threw. **Dropping `java.sql` from the base layer clears it** — the build gets past it.

### Not fixed: the base layer never sees the SVM internals the application reaches

```
The core type com.oracle.svm.core.jdk.AtomicFieldUpdaterAccessCheck was not seen as reachable
the initial layer. It is illegal for core types to become reachable in subsequent layers.
```

A base layer holding only JDK modules analyses no application code, so it never sees SVM internals like `AtomicFieldUpdaterAccessCheck` — which anything built on Kotlin coroutines reaches.

Putting the application's classes on the base layer's class path *does* make it see them, and collapses the split. Measured:

| | types analysed | methods analysed |
|---|---|---|
| base layer, with the application class path | **28,400** | **173,197** |
| application layer on top of it | 158 | 1 |

The base layer absorbs the application and the application layer is left with nothing — which defeats the entire point, since the base layer is supposed to be the part that does *not* change between releases.

GraalVM's own message prescribes the escape: pin those types via `LayeredCompilationBehavior` / `InitialLayerFeature`. That requires knowing up front which SVM internals a given application reaches — per-application knowledge, and therefore the opposite of "works for any application".

### Status

Layers stay off by default. The delta payoff is real and measured, the plugin scaffolding is in place, and the blockers are now three named upstream items rather than a mystery:

1. `ReflectionDataBuilder.checkHidingFields` must not read static fields off a base-layer stub (worked around here by keeping `java.sql` out of the base layer, but any other module can reintroduce it).
2. A base layer needs a way to see the SVM core types an application will reach without analysing the application.
3. A base-layer module's resource bundles need to be registrable without tripping (1).

Everything is reproducible with `scripts/measure-graalvm-layers.sh` on GraalVM CE 25.2.4, macOS arm64.
---

## Reported upstream

**oracle/graal#14166** — *Layered images: no working configuration for a Kotlin/Compose Desktop application (3 blockers)*
https://github.com/oracle/graal/issues/14166

Carries the three blockers with their stack traces, the full configuration matrix, the two smaller findings (AWT bundles never registered by a base layer; `-H:LayerCreate` module order being significant), and a pointer to `scripts/measure-graalvm-layers.sh` in this branch as the reproducer.

One correction to the section above, established while writing it up: `-H:-ClosedTypeWorld` on both layers does **not** fix the dispatch-table discrepancy. The guard still reports it, and the binary built without the guard crashes with the same `illegal vtable entry` fatal error. So the last plausible flag is ruled out too.

This PR stays a draft until that issue moves.
