### PR TITLE
fix(fs-watcher): deliver events for roots reached through a symlink

### DIFF
--- a/fs-watcher/src/main/kotlin/dev/nucleusframework/fswatcher/FsWatcher.kt
+++ b/fs-watcher/src/main/kotlin/dev/nucleusframework/fswatcher/FsWatcher.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 
@@ -41,6 +42,14 @@ sealed interface FsWatchDeliveryMode {
 }
 
 data class FsWatcherConfig(
+    /**
+     * Whether the backend descends into symlinks it meets inside a watched tree, and whether a
+     * watch root that *is itself* a symlink reports its target's events under the root's own path.
+     *
+     * This does not affect roots merely reached *through* a symlink — a root such as
+     * `/var/folders/…/T/app` on macOS is delivered either way, under the spelling it was
+     * registered with.
+     */
     val followSymlinks: Boolean = false,
     val backend: FsWatchBackendStrategy = FsWatchBackendStrategy.Auto,
     val eventBufferCapacity: Int = 64,
@@ -77,6 +86,17 @@ interface FsWatcher : AutoCloseable {
     val events: Flow<FsWatchEvent>
     val errors: Flow<FsWatchError>
 
+    /**
+     * Watches [path], optionally [recursive]ly, under an optional [name] used to tell registrations
+     * of the same root apart.
+     *
+     * [path] needs no canonicalization: delivered [FsWatchEvent] paths are rooted at the spelling
+     * passed here, whatever form the platform backend reports internally. Registering the same
+     * directory under two spellings does yield two independent registrations and two native
+     * watches, so pick one form per root if that matters.
+     *
+     * @throws FsWatchException if the root cannot be watched.
+     */
     fun watch(
         path: Path,
         recursive: Boolean = true,
@@ -214,16 +234,10 @@ private data class NativeWatchKey(
     val recursive: Boolean,
 )
 
-private enum class MatchRootKind {
-    ORIGINAL,
-    RESOLVED,
-}
-
 private data class LogicalMatch(
     val source: FsWatchSource,
     val originalRoot: Path,
-    val resolvedRoot: Path,
-    val rootKind: MatchRootKind,
+    val matchedRoot: Path,
 )
 
 private sealed interface RoutedFsWatchEvent {
@@ -464,28 +478,11 @@ internal class NativeBackedFsWatcher(
     private fun logicalMatchesForInstallationLocked(
         nativeInstallation: NativeWatchInstallation,
         path: Path,
-    ): List<LogicalMatch> {
-        return nativeInstallation.logicalSourcesLocked().mapNotNull { source ->
+    ): List<LogicalMatch> =
+        nativeInstallation.logicalSourcesLocked().mapNotNull { source ->
             val logical = logicalRegistrationsBySource[source] ?: return@mapNotNull null
-            when {
-                coversPath(logical.originalRoot, source.recursive, path) ->
-                    LogicalMatch(
-                        source = source,
-                        originalRoot = logical.originalRoot,
-                        resolvedRoot = logical.resolvedRoot,
-                        rootKind = MatchRootKind.ORIGINAL,
-                    )
-                config.followSymlinks && coversPath(logical.resolvedRoot, source.recursive, path) ->
-                    LogicalMatch(
-                        source = source,
-                        originalRoot = logical.originalRoot,
-                        resolvedRoot = logical.resolvedRoot,
-                        rootKind = MatchRootKind.RESOLVED,
-                    )
-                else -> null
-            }
+            logicalMatchForSource(logical, source, path)
         }
-    }
 
     private fun routeEventPayload(
         payload: NativeFsWatchEventPayload,
@@ -598,16 +595,11 @@ internal class NativeBackedFsWatcher(
         path: Path,
         match: LogicalMatch,
     ): Path? {
-        val matchedRoot =
-            when (match.rootKind) {
-                MatchRootKind.ORIGINAL -> match.originalRoot
-                MatchRootKind.RESOLVED -> match.resolvedRoot
-            }
-        if (path == matchedRoot) return match.originalRoot
+        if (path == match.matchedRoot) return match.originalRoot
 
         val relativeSuffix =
             try {
-                matchedRoot.relativize(path).normalize()
+                match.matchedRoot.relativize(path).normalize()
             } catch (_: IllegalArgumentException) {
                 return null
             }
@@ -620,24 +612,26 @@ internal class NativeBackedFsWatcher(
         logical: LogicalRegistrationState,
         source: FsWatchSource,
         path: Path,
-    ): LogicalMatch? =
-        when {
-            coversPath(logical.originalRoot, source.recursive, path) ->
-                LogicalMatch(
-                    source = source,
-                    originalRoot = logical.originalRoot,
-                    resolvedRoot = logical.resolvedRoot,
-                    rootKind = MatchRootKind.ORIGINAL,
-                )
-            config.followSymlinks && coversPath(logical.resolvedRoot, source.recursive, path) ->
-                LogicalMatch(
-                    source = source,
-                    originalRoot = logical.originalRoot,
-                    resolvedRoot = logical.resolvedRoot,
-                    rootKind = MatchRootKind.RESOLVED,
-                )
-            else -> null
-        }
+    ): LogicalMatch? {
+        // When the root is not a symlink itself, its resolved form is merely a second spelling of
+        // the same directory — macOS /var -> /private/var, so every Files.createTempDirectory()
+        // result — and FSEvents only ever reports that canonical spelling. Matching it is not
+        // symlink following, so it must not depend on followSymlinks. Resolving a root that *is* a
+        // symlink does follow one, and stays opt-in.
+        val resolvedRootMatchable = !logical.rootIsSymbolicLink || config.followSymlinks
+        val matchedRoot =
+            when {
+                coversPath(logical.originalRoot, source.recursive, path) -> logical.originalRoot
+                resolvedRootMatchable && coversPath(logical.resolvedRoot, source.recursive, path) ->
+                    logical.resolvedRoot
+                else -> return null
+            }
+        return LogicalMatch(
+            source = source,
+            originalRoot = logical.originalRoot,
+            matchedRoot = matchedRoot,
+        )
+    }
 
     private fun remapMovedEndpoint(
         path: Path,
@@ -877,6 +871,7 @@ internal class NativeBackedFsWatcher(
         var nativeInstallation: NativeWatchInstallation,
         val originalRoot: Path,
         val resolvedRoot: Path,
+        val rootIsSymbolicLink: Boolean,
         var refCount: Int,
     )
 
@@ -899,6 +894,7 @@ internal class NativeBackedFsWatcher(
                         nativeInstallation = this,
                         originalRoot = source.root,
                         resolvedRoot = resolveRootPath(source.root),
+                        rootIsSymbolicLink = Files.isSymbolicLink(source.root),
                         refCount = 1,
                     )
             } else {

--- a/fs-watcher/src/test/kotlin/dev/nucleusframework/fswatcher/FsWatcherEventFlowTest.kt
+++ b/fs-watcher/src/test/kotlin/dev/nucleusframework/fswatcher/FsWatcherEventFlowTest.kt
@@ -1504,7 +1504,9 @@ class FsWatcherEventFlowTest {
         runBlocking {
             if (!FsWatchers.isSupported()) return@runBlocking
 
-            val realRoot = Files.createTempDirectory("fs-watcher-moved-endpoint-projection-real")
+            // The symlink target has to be canonical for realTo below to be the path form a
+            // backend would actually report: on macOS a temp dir is reached through /var -> /private/var.
+            val realRoot = Files.createTempDirectory("fs-watcher-moved-endpoint-projection-real").toRealPath()
             val lexicalParent = Files.createTempDirectory("fs-watcher-moved-endpoint-projection-lexical")
             val lexicalRoot = lexicalParent.resolve("alias")
             try {
@@ -1527,11 +1529,13 @@ class FsWatcherEventFlowTest {
 
                 val event =
                     async(start = CoroutineStart.UNDISPATCHED) {
-                        watcher.events.first {
-                            it is FsWatchEvent.Moved &&
-                                it.source == registration.source &&
-                                it.from == from &&
-                                it.to == lexicalTo
+                        withTimeout(5_000) {
+                            watcher.events.first {
+                                it is FsWatchEvent.Moved &&
+                                    it.source == registration.source &&
+                                    it.from == from &&
+                                    it.to == lexicalTo
+                            }
                         }
                     }
 

--- a/fs-watcher/src/test/kotlin/dev/nucleusframework/fswatcher/FsWatcherRealFileSystemTest.kt
+++ b/fs-watcher/src/test/kotlin/dev/nucleusframework/fswatcher/FsWatcherRealFileSystemTest.kt
@@ -711,6 +711,101 @@ class FsWatcherRealFileSystemTest {
         }
 
     @Test
+    fun uncanonicalizedTempDirectoryRootDeliversRealFileEvents() =
+        runBlocking {
+            if (!FsWatchers.isSupported()) return@runBlocking
+
+            // macOS temp directories live under the symlinked /var -> /private/var, so
+            // Files.createTempDirectory() on its own hands watch() a non-canonical root spelling.
+            val root = Files.createTempDirectory("fs-watcher-real-fs-uncanonical-root")
+            val target = root.resolve("alpha.txt")
+
+            try {
+                FsWatchers
+                    .create(
+                        FsWatcherConfig(deliveryMode = FsWatchDeliveryMode.Raw),
+                    ).use { watcher ->
+                        val registration = watcher.watch(root, recursive = true)
+
+                        val seen = java.util.Collections.synchronizedList(mutableListOf<FsWatchEvent>())
+                        val collector =
+                            launch(start = CoroutineStart.UNDISPATCHED) {
+                                watcher.events.collect { seen += it }
+                            }
+
+                        try {
+                            Files.writeString(target, "one")
+
+                            awaitEvents {
+                                seen.hasEventFromSource(target, registration.source)
+                            }
+
+                            assertTrue(seen.hasEventFromSource(target, registration.source))
+                        } finally {
+                            collector.cancelAndJoin()
+                        }
+                    }
+            } finally {
+                deleteRecursively(root)
+            }
+        }
+
+    @Test
+    fun rootReachedThroughSymlinkedParentDeliversEventsWithRegisteredPathForm() =
+        runBlocking {
+            if (!FsWatchers.isSupported()) return@runBlocking
+
+            val canonicalParent = createRealTempDirectory("fs-watcher-real-fs-symlinked-parent")
+            val symlinkedParent = canonicalParent.parent.resolve("${canonicalParent.fileName}-parent-link")
+
+            try {
+                try {
+                    Files.deleteIfExists(symlinkedParent)
+                    Files.createSymbolicLink(symlinkedParent, canonicalParent)
+                } catch (_: UnsupportedOperationException) {
+                    return@runBlocking
+                } catch (_: java.nio.file.FileSystemException) {
+                    return@runBlocking
+                }
+
+                val canonicalRoot = Files.createDirectory(canonicalParent.resolve("watched"))
+                val lexicalRoot = symlinkedParent.resolve("watched")
+                // Only the parent is a symlink: the watched root itself is a plain directory,
+                // so delivery must not depend on followSymlinks.
+                assertFalse(Files.isSymbolicLink(lexicalRoot))
+
+                val lexicalTarget = lexicalRoot.resolve("beta.txt")
+                FsWatchers
+                    .create(
+                        FsWatcherConfig(deliveryMode = FsWatchDeliveryMode.Raw),
+                    ).use { watcher ->
+                        val registration = watcher.watch(lexicalRoot, recursive = true)
+
+                        val seen = java.util.Collections.synchronizedList(mutableListOf<FsWatchEvent>())
+                        val collector =
+                            launch(start = CoroutineStart.UNDISPATCHED) {
+                                watcher.events.collect { seen += it }
+                            }
+
+                        try {
+                            Files.writeString(canonicalRoot.resolve("beta.txt"), "one")
+
+                            awaitEvents {
+                                seen.hasEventFromSource(lexicalTarget, registration.source)
+                            }
+
+                            assertTrue(seen.hasEventFromSource(lexicalTarget, registration.source))
+                        } finally {
+                            collector.cancelAndJoin()
+                        }
+                    }
+            } finally {
+                Files.deleteIfExists(symlinkedParent)
+                deleteRecursively(canonicalParent)
+            }
+        }
+
+    @Test
     fun canonicalAndSymlinkRegistrationsObserveSameRealChangeWithDistinctLexicalPaths() =
         runBlocking {
             if (!FsWatchers.isSupported()) return@runBlocking


### PR DESCRIPTION
Fixes #442.

## The bug

Event routing matched incoming paths against the registered root by prefix, falling back to the
resolved root only when `followSymlinks` was set (default `false`). FSEvents reports **canonical**
paths, so on macOS a root of `/var/folders/…/T/app` never matched its own event at
`/private/var/folders/…/T/app` — both branches missed, `routeEventPayload` returned no matches, and
every event was discarded. `watch()` still returned a live registration, so a watch that could never
fire looked exactly like a healthy one.

`Files.createTempDirectory()` alone is enough to hit it, since `/var` and `/tmp` are symlinks on macOS.

## The fix

A root reached *through* a symlink is only a second spelling of the same directory — no link is
being followed — so matching its resolved form must not depend on `followSymlinks`. The fallback is
now gated on whether the root **is itself** a symlink; resolving one of those genuinely does follow
a link and stays opt-in:

```kotlin
val resolvedRootMatchable = !logical.rootIsSymbolicLink || config.followSymlinks
```

`remapPathForMatch` already re-roots delivered paths onto the registered spelling, so callers keep
seeing the path form they passed to `watch()`. No API-visible change beyond events now arriving.

The `MatchRootKind` enum went away in the process: the match now carries the root that matched
instead of an enum to index back with, and `logicalMatchesForInstallationLocked` delegates to
`logicalMatchForSource` so event and `Moved` routing can't drift apart. Net effect on
`FsWatcher.kt` is 100 lines changed for a slightly smaller file.

## Verification (real macOS host, real FSEvents — not synthetic)

Two new real-filesystem tests in `FsWatcherRealFileSystemTest`:

- `uncanonicalizedTempDirectoryRootDeliversRealFileEvents` — the issue verbatim: watch a raw
  `Files.createTempDirectory()` result, write a file, expect delivery.
- `rootReachedThroughSymlinkedParentDeliversEventsWithRegisteredPathForm` — builds the symlinked
  parent explicitly so it is a genuine test on every platform, and asserts the watched root itself
  is *not* a symlink, pinning down that delivery must not depend on `followSymlinks`.

Both fail on `main` and pass with the fix, against the **same** prebuilt dylib — the change is
Kotlin-only, so the red→green transition isolates the defect to the routing layer:

| | result |
|---|---|
| production fix reverted, tests kept | **2 failures** — exactly the two new tests |
| with the fix | **104 tests, 0 failures, 0 errors, 0 skipped** |

`:fs-watcher:ktlintCheck` passes; `detekt` reports the same 23 pre-existing findings before and
after this diff (none in the changed code).

## Also fixed: a pre-existing macOS hang

`movedEventOnlyProjectsMatchingEndpointForLogicalSource` built a synthetic event path from an
*unresolved* temp dir while routing compared against the canonical form, then blocked on
`event.await()` with no timeout — so the suite hung forever on macOS, on `main`, independently of
this fix. Verified by running it against unmodified code. Its symlink target is now canonicalized
(matching what its five sibling tests already do) and the await is bounded, consistent with the
`withTimeout(5_000)` used elsewhere in the file.

## Upstream check

Not an upstream bug, and no upstream fix to wait for. We are already on the newest stable `notify`
(8.2.0) and `notify-debouncer-full` (0.7.0) — the only newer releases are pre-releases
(`9.0.0-rc.4`, `0.8.0-rc.2`), and `cargo update` moves nothing on those crates. `notify`
canonicalizes by design on macOS (`fsevent.rs` keys its recursion bookkeeping on
`path.canonicalize()`) because the FSEvents API itself only reports canonical paths, and our own
Rust bridge already matched both root forms ungated. The drop was entirely in the Kotlin layer.

## Scope

Windows with an unresolved root is still untested here, as the issue notes. If
`ReadDirectoryChangesW` echoes back the caller's spelling — as inotify does — `originalRoot` matches
and nothing changes; if it reports a different form, that form is now matched too whenever the root
is not a symlink.

## Docs

Added the KDoc the issue asks for: `watch()` now states that no canonicalization is required and
that delivered paths follow the registered spelling, and `followSymlinks` documents that it does not
govern roots merely reached through a symlink.