### PR TITLE
feat(application): expose NucleusApplicationScope as a CompositionLocal

### DIFF
--- a/examples/nucleus-demo/src/main/kotlin/com/example/demo/FillCenterDemoWindow.kt
+++ b/examples/nucleus-demo/src/main/kotlin/com/example/demo/FillCenterDemoWindow.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
 import com.example.demo.gallery.GalleryScreen
-import dev.nucleusframework.application.NucleusApplicationScope
+import dev.nucleusframework.application.LocalNucleusApplicationScope
 import dev.nucleusframework.application.NucleusDecoratedWindowScope
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.TitleBarLayoutPolicy
@@ -42,8 +42,13 @@ import dev.nucleusframework.window.material.MaterialDecoratedWindow
 import dev.nucleusframework.window.material.MaterialTitleBar
 import dev.nucleusframework.window.newFullscreenControls
 
+/**
+ * Opened from inside the main window's content, not from the
+ * `nucleusApplication { … }` lambda — the application scope is read from
+ * [LocalNucleusApplicationScope] instead of being threaded down as a receiver.
+ */
 @Composable
-fun NucleusApplicationScope.FillCenterDemoWindow(
+fun FillCenterDemoWindow(
     visible: Boolean,
     onCloseRequest: () -> Unit,
     seedColor: Color,
@@ -57,7 +62,8 @@ fun NucleusApplicationScope.FillCenterDemoWindow(
             size = DpSize(1340.dp, 480.dp),
         )
 
-    MaterialDecoratedWindow(
+    val applicationScope = LocalNucleusApplicationScope.current
+    applicationScope.MaterialDecoratedWindow(
         state = fillCenterWindowState,
         onCloseRequest = onCloseRequest,
         title = "Fill Title",

--- a/examples/nucleus-demo/src/main/kotlin/com/example/demo/Main.kt
+++ b/examples/nucleus-demo/src/main/kotlin/com/example/demo/Main.kt
@@ -354,13 +354,16 @@ fun main(args: Array<String>) =
                         }
                     }
                 }
-            }
 
-            FillCenterDemoWindow(
-                visible = isFillCenterWindowVisible,
-                onCloseRequest = { isFillCenterWindowVisible = false },
-                seedColor = seedColor,
-            )
+                // Declared inside the main window's content: the secondary
+                // window reaches the application scope through
+                // LocalNucleusApplicationScope, no receiver plumbing.
+                FillCenterDemoWindow(
+                    visible = isFillCenterWindowVisible,
+                    onCloseRequest = { isFillCenterWindowVisible = false },
+                    seedColor = seedColor,
+                )
+            }
         }
     }
 

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedDialog.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedDialog.kt
@@ -80,6 +80,42 @@ fun NucleusApplicationScope.DecoratedDialog(
     }
 }
 
+/**
+ * Receiver-less [DecoratedDialog], resolving the application scope from
+ * [LocalNucleusApplicationScope]. Parameters behave exactly like the
+ * [NucleusApplicationScope] overload. Fails outside a `nucleusApplication { … }`
+ * block, where no scope exists.
+ */
+@Suppress("FunctionNaming", "LongParameterList")
+@Composable
+fun DecoratedDialog(
+    onCloseRequest: () -> Unit,
+    state: DialogState = rememberDialogState(),
+    visible: Boolean = true,
+    title: String = "",
+    icon: Painter? = null,
+    resizable: Boolean = false,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
+    onKeyEvent: (KeyEvent) -> Boolean = { false },
+    content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+) {
+    LocalNucleusApplicationScope.current.DecoratedDialog(
+        onCloseRequest = onCloseRequest,
+        state = state,
+        visible = visible,
+        title = title,
+        icon = icon,
+        resizable = resizable,
+        enabled = enabled,
+        focusable = focusable,
+        onPreviewKeyEvent = onPreviewKeyEvent,
+        onKeyEvent = onKeyEvent,
+        content = content,
+    )
+}
+
 internal class AwtNucleusDecoratedDialogScope(
     private val delegate: AwtDecoratedDialogScope,
     override val nucleusWindow: NucleusWindow,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -112,6 +112,58 @@ fun NucleusApplicationScope.DecoratedWindow(
     }
 }
 
+/**
+ * Receiver-less [DecoratedWindow], resolving the application scope from
+ * [LocalNucleusApplicationScope]. Parameters behave exactly like the
+ * [NucleusApplicationScope] overload.
+ *
+ * Use it to open a window from anywhere in the composition — a navigation
+ * destination, a row action — the way Compose Desktop's `Window` can be
+ * called. Fails outside a `nucleusApplication { … }` block, where no scope
+ * exists.
+ */
+@Suppress("FunctionNaming", "LongParameterList")
+@Composable
+fun DecoratedWindow(
+    onCloseRequest: () -> Unit,
+    state: WindowState = rememberWindowState(),
+    visible: Boolean = true,
+    title: String = "",
+    icon: Painter? = null,
+    resizable: Boolean = true,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    alwaysOnTop: Boolean = false,
+    undecorated: Boolean = false,
+    popupFor: NucleusWindow? = null,
+    nativePopupLayers: Boolean = false,
+    hiddenFromDock: Boolean = false,
+    minimumSize: DpSize? = null,
+    onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
+    onKeyEvent: (KeyEvent) -> Boolean = { false },
+    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+) {
+    LocalNucleusApplicationScope.current.DecoratedWindow(
+        onCloseRequest = onCloseRequest,
+        state = state,
+        visible = visible,
+        title = title,
+        icon = icon,
+        resizable = resizable,
+        enabled = enabled,
+        focusable = focusable,
+        alwaysOnTop = alwaysOnTop,
+        undecorated = undecorated,
+        popupFor = popupFor,
+        nativePopupLayers = nativePopupLayers,
+        hiddenFromDock = hiddenFromDock,
+        minimumSize = minimumSize,
+        onPreviewKeyEvent = onPreviewKeyEvent,
+        onKeyEvent = onKeyEvent,
+        content = content,
+    )
+}
+
 internal class AwtNucleusDecoratedWindowScope(
     private val delegate: AwtDecoratedWindowScope,
     override val nucleusWindow: NucleusWindow,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
@@ -89,7 +89,10 @@ fun nucleusApplication(
         NucleusBackend.Awt, NucleusBackend.Auto ->
             application {
                 val nucleusScope = AwtNucleusApplicationScope(this, args)
-                CompositionLocalProvider(LocalNucleusBackend provides NucleusBackend.Awt) {
+                CompositionLocalProvider(
+                    LocalNucleusBackend provides NucleusBackend.Awt,
+                    LocalNucleusApplicationScope provides nucleusScope,
+                ) {
                     nucleusScope.content()
                 }
             }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplicationScope.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplicationScope.kt
@@ -1,6 +1,7 @@
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
 import dev.nucleusframework.aot.runtime.AotRuntime
 import dev.nucleusframework.aot.runtime.AotRuntimeMode
 import dev.nucleusframework.core.runtime.DeepLinkHandler
@@ -54,6 +55,35 @@ sealed interface NucleusApplicationScope : AwtApplicationScope {
      */
     fun onDeepLink(block: (URI) -> Unit)
 }
+
+/**
+ * The [NucleusApplicationScope] of the surrounding [nucleusApplication].
+ *
+ * Secondary windows are rarely opened from the `nucleusApplication { … }`
+ * lambda — they come from a navigation destination, a row action, an "edit in
+ * a new window" button. This local makes the scope reachable from there
+ * without threading the receiver through every layer in between:
+ *
+ * ```
+ * @Composable
+ * fun EditorWindow(onClose: () -> Unit) {
+ *     with(LocalNucleusApplicationScope.current) {
+ *         MaterialDecoratedWindow(onCloseRequest = onClose) { … }
+ *     }
+ * }
+ * ```
+ *
+ * For plain [DecoratedWindow] / [DecoratedDialog] the receiver-less overloads
+ * already read this local, so no `with` is needed.
+ *
+ * Provided by [nucleusApplication] on both backends. On Tao each window owns
+ * its own `ComposeScene`, but the whole parent local context is bridged into
+ * it, so the scope stays reachable from nested window content too.
+ */
+val LocalNucleusApplicationScope =
+    staticCompositionLocalOf<NucleusApplicationScope> {
+        error("LocalNucleusApplicationScope not provided — use it inside a nucleusApplication { … } block.")
+    }
 
 internal class AwtNucleusApplicationScope(
     val composeScope: AwtApplicationScope,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoLauncher.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoLauncher.kt
@@ -3,6 +3,7 @@ package dev.nucleusframework.application.internal
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import dev.nucleusframework.application.LocalNucleusApplicationScope
 import dev.nucleusframework.application.LocalNucleusBackend
 import dev.nucleusframework.application.NucleusApplicationScope
 import dev.nucleusframework.application.NucleusBackend
@@ -27,7 +28,10 @@ internal object TaoLauncher {
         // URIs received before then are buffered and replayed by `TaoDeepLinkBridge`.
         taoApplication {
             val scope = TaoNucleusApplicationScope(this, args)
-            CompositionLocalProvider(LocalNucleusBackend provides NucleusBackend.Tao) {
+            CompositionLocalProvider(
+                LocalNucleusBackend provides NucleusBackend.Tao,
+                LocalNucleusApplicationScope provides scope,
+            ) {
                 // Apply the Dock-follows-windows opt-in on the Tao main thread
                 // (this composition) so a tray-only app drops out of the Dock at
                 // startup; visible DecoratedWindows then promote it as needed.


### PR DESCRIPTION
Closes #438.

## Summary

`DecoratedWindow` / `DecoratedDialog` (and the Material / Jewel wrappers) are extensions on `NucleusApplicationScope`, a receiver that only exists at the top of `main()`. Real apps open secondary windows from deep inside the composition — a navigation destination, a row action — where the scope is long gone, so it had to be threaded through every layer or replaced by an app-owned CompositionLocal.

- Add `LocalNucleusApplicationScope`, provided by `nucleusApplication` next to the existing `LocalNucleusBackend` on **both** backends (AWT branch + `TaoLauncher`).
- Add receiver-less `DecoratedWindow` / `DecoratedDialog` overloads that read it, making the port from Compose Desktop's `Window` a near drop-in.
- `examples/nucleus-demo`: `FillCenterDemoWindow` drops its scope receiver and its call site moves from the application lambda into the main window's content — the demo now exercises the new path.

On Tao the local reaches nested window content for free: both adapters already bridge the parent's `currentCompositionLocalContext` across the per-window `ComposeScene` (`CompositionLocalProvider(outerLocals)` for windows, `compositionLocalContext =` for dialogs).

Receiver-less overloads were **not** added for `MaterialDecoratedWindow` / `JewelDecoratedDialog`: those names already have top-level AWT-only functions in the same packages, and a second top-level overload taking a trailing lambda would be genuinely ambiguous. From deep in the tree they are now one line — `with(LocalNucleusApplicationScope.current) { MaterialDecoratedWindow(…) }` — which is the issue's own workaround minus the boilerplate, and that is what the KDoc documents.

## Test plan

- [x] `:nucleus-application`, material2 / material3 / jewel, and the tao / nucleus / jewel / jni demos compile — no overload ambiguity at existing `DecoratedWindow(…)` call sites inside `nucleusApplication` (the extension still wins; the top-level fallback would be behaviourally identical anyway)
- [x] `:nucleus-application:detekt` + `ktlintCheck` and `:examples:nucleus-demo:ktlintCheck` pass
- [x] Runtime on Tao / Linux (XWayland): with the demo's secondary window forced visible at startup, both `Nucleus Demo` and `Fill Title` map as real toplevels, and the secondary window — declared inside the main window's content, resolving its scope from the local — renders its FillCenter title bar and inherited Material theme correctly
- [ ] AWT backend is compile-verified only (single provider added in the same composition tree, no `ComposeScene` boundary involved)
- [ ] macOS / Windows not exercised locally