### PR TITLE
fix(graalvm): fork runWithNativeAgent through a JavaLauncher

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ExternalJavaLauncher.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ExternalJavaLauncher.kt
@@ -14,35 +14,39 @@ import org.gradle.jvm.toolchain.JavaLauncher
 import java.io.File
 
 /**
- * [JavaLauncher] pointing to a vtool-patched copy of the source JDK's `java`
- * binary. Metadata is derived from the source JDK's `release` file so Gradle's
- * toolchain validation accepts the launcher alongside `executable`. Using a
- * real [JavaLauncher] — instead of launching the patched binary via
- * [ProcessBuilder] — keeps Gradle's [org.gradle.api.tasks.JavaExec] in charge
- * of the fork, so IntelliJ's Gradle debugger can inject JDWP and manage the
- * process lifecycle (breakpoints, stop button).
+ * [JavaLauncher] for a JDK that Gradle's toolchain machinery does not manage —
+ * a vtool-patched copy of the app JDK, or a GraalVM provisioned by Nucleus
+ * itself. Metadata is derived from the `release` file of [metadataJavaHome]
+ * (the installation itself, unless [javaBinary] lives in a partial copy).
+ *
+ * [org.gradle.api.tasks.JavaExec] rejects an `executable` that does not resolve
+ * to the same file as its `javaLauncher`, so a foreign JDK has to be handed over
+ * as a launcher rather than as a raw path. Using a real [JavaLauncher] — instead
+ * of forking via [ProcessBuilder] — also keeps `JavaExec` in charge of the
+ * process, so IntelliJ's Gradle debugger can inject JDWP and manage the
+ * lifecycle (breakpoints, stop button).
  */
-internal class PatchedJavaLauncher(
-    private val patchedJavaBinary: File,
-    private val patchedJavaHome: File,
-    private val sourceJavaHome: File,
+internal class ExternalJavaLauncher(
+    private val javaBinary: File,
+    private val javaHome: File,
     private val objects: ObjectFactory,
+    private val metadataJavaHome: File = javaHome,
 ) : JavaLauncher {
     private val lazyMetadata by lazy { buildMetadata() }
 
     override fun getMetadata(): JavaInstallationMetadata = lazyMetadata
 
     override fun getExecutablePath(): RegularFile =
-        objects.fileProperty().also { it.set(patchedJavaBinary) }.get()
+        objects.fileProperty().also { it.set(javaBinary) }.get()
 
     private fun buildMetadata(): JavaInstallationMetadata {
-        val releaseProps = readReleaseFile(sourceJavaHome)
+        val releaseProps = readReleaseFile(metadataJavaHome)
         val rawJavaVersion = releaseProps["JAVA_VERSION"] ?: "0"
         val languageMajor = rawJavaVersion.substringBefore('.').toIntOrNull() ?: 0
         val runtimeVersion = releaseProps["JAVA_RUNTIME_VERSION"] ?: rawJavaVersion
         val jvmVersion = releaseProps["JAVA_VERSION"] ?: rawJavaVersion
         val vendor = releaseProps["IMPLEMENTOR"] ?: "Unknown"
-        val installation: Directory = objects.directoryProperty().also { it.set(patchedJavaHome) }.get()
+        val installation: Directory = objects.directoryProperty().also { it.set(javaHome) }.get()
         return object : JavaInstallationMetadata {
             override fun getLanguageVersion(): JavaLanguageVersion = JavaLanguageVersion.of(languageMajor.coerceAtLeast(1))
             override fun getJavaRuntimeVersion(): String = runtimeVersion

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import java.io.File
@@ -90,7 +91,11 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
     }
 
     val graalvmHome: Provider<String>
-    val graalvmJavaExecutable: Provider<String>
+    // Forking a JVM out of the resolved GraalVM goes through a JavaLauncher, never through
+    // `JavaExec.executable`: JavaExec validates that the two agree and fails with "Toolchain
+    // from `executable` property does not match toolchain from `javaLauncher` property" as soon
+    // as the GraalVM differs from the JVM `javaLauncher` defaults to (the Gradle daemon's).
+    val graalvmJavaLauncher: Provider<JavaLauncher>
     if (graalvm.toolchain.autoDownload.get()) {
         // Auto-provisioned toolchain: GraalVM CE by default (Liberica NIK on Intel macs) is
         // downloaded on first use and cached under the Gradle user home, so once
@@ -117,7 +122,18 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                     ).absolutePath,
                 )
             }
-        graalvmJavaExecutable = graalvmHome.map { javaExecutable(it) }
+        // Gradle's toolchain machinery knows nothing about this installation, so wrap it in a
+        // JavaLauncher of our own. Built inside the `map` so the launcher — and with it the
+        // provisioning — stays as lazy as the home it points at.
+        val objects = project.objects
+        graalvmJavaLauncher =
+            graalvmHome.map { home ->
+                ExternalJavaLauncher(
+                    javaBinary = File(javaExecutable(home)),
+                    javaHome = File(home),
+                    objects = objects,
+                )
+            }
     } else {
         val javaToolchains = project.extensions.getByType(JavaToolchainService::class.java)
         val graalvmLauncher =
@@ -131,10 +147,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             graalvmLauncher.map { launcher ->
                 launcher.metadata.installationPath.asFile.absolutePath
             }
-        graalvmJavaExecutable =
-            graalvmLauncher.map { launcher ->
-                launcher.executablePath.asFile.absolutePath
-            }
+        graalvmJavaLauncher = graalvmLauncher
     }
 
     val nativeImageConfigDir = graalvm.nativeImageConfigBaseDir
@@ -200,9 +213,11 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             description = "Run the app with the GraalVM native-image-agent to collect reflection metadata"
 
             mainClass.set(app.mainClass)
-            // Resolved at execution time: querying the provider here would provision the
-            // toolchain as soon as the task is realized (an IDE sync, `gradlew tasks`).
-            doFirst { setExecutable(graalvmJavaExecutable.get()) }
+            // The launcher — not `executable`: JavaExec forks the JVM the launcher points at and
+            // rejects an `executable` resolving to a different one. Wired as a provider so the
+            // toolchain is only resolved when the task actually runs, never when it is merely
+            // realized (an IDE sync, `gradlew tasks`).
+            javaLauncher.set(graalvmJavaLauncher)
 
             useAppRuntimeFiles { (runtimeJars, _) ->
                 classpath = runtimeJars

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
@@ -1136,11 +1136,11 @@ private fun JvmApplicationContext.configureRunTask(
                 .asFile
             val patchedJavaHomeFile = patchedBinFile.parentFile.parentFile
             exec.javaLauncher.set(
-                PatchedJavaLauncher(
-                    patchedJavaBinary = patchedBinFile,
-                    patchedJavaHome = patchedJavaHomeFile,
-                    sourceJavaHome = java.io.File(javaHome),
+                ExternalJavaLauncher(
+                    javaBinary = patchedBinFile,
+                    javaHome = patchedJavaHomeFile,
                     objects = project.objects,
+                    metadataJavaHome = java.io.File(javaHome),
                 ),
             )
             // `executable` isn't Provider-aware in Gradle 9, but it isn't

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ExternalJavaLauncherTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ExternalJavaLauncherTest.kt
@@ -1,0 +1,104 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ExternalJavaLauncherTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val objects by lazy {
+        ProjectBuilder
+            .builder()
+            .withProjectDir(tmp.newFolder("project"))
+            .build()
+            .objects
+    }
+
+    @Test
+    fun `metadata is read from the installation's release file`() {
+        val home = javaHome("graalvm")
+        home.writeReleaseFile(
+            "JAVA_VERSION" to "25.0.1",
+            "JAVA_RUNTIME_VERSION" to "25.0.1+9-jvmci-b01",
+            "IMPLEMENTOR" to "GraalVM Community",
+        )
+
+        val metadata = launcherFor(home).metadata
+
+        assertEquals(JavaLanguageVersion.of(25), metadata.languageVersion)
+        assertEquals("25.0.1+9-jvmci-b01", metadata.javaRuntimeVersion)
+        assertEquals("25.0.1", metadata.jvmVersion)
+        assertEquals("GraalVM Community", metadata.vendor)
+        assertEquals(home, metadata.installationPath.asFile)
+    }
+
+    // JavaExec forks `javaLauncher.get().executablePath.toString()` — not `.asFile` — so the
+    // RegularFile must stringify to the absolute path of the binary.
+    @Test
+    fun `the executable path points at the binary and stringifies to its absolute path`() {
+        val home = javaHome("graalvm")
+        home.writeReleaseFile("JAVA_VERSION" to "25")
+        val binary = File(home, "bin/java")
+
+        val executablePath = launcherFor(home).executablePath
+
+        assertEquals(binary, executablePath.asFile)
+        assertEquals(binary.absolutePath, executablePath.toString())
+    }
+
+    // Gradle probes the language version before running the task; an installation without a
+    // `release` file (a partial copy, an unusual layout) must degrade instead of failing there.
+    @Test
+    fun `a missing release file yields a probeable language version`() {
+        val metadata = launcherFor(javaHome("no-release")).metadata
+
+        assertEquals(JavaLanguageVersion.of(1), metadata.languageVersion)
+        assertEquals("Unknown", metadata.vendor)
+    }
+
+    // The patched-JVM path points the launcher at a copy of the JDK that carries no `release`
+    // file of its own, so the metadata has to come from the JDK it was copied from.
+    @Test
+    fun `metadata can be read from a home other than the launcher's`() {
+        val patched = javaHome("patched")
+        val source = javaHome("source")
+        source.writeReleaseFile("JAVA_VERSION" to "21.0.4", "IMPLEMENTOR" to "JetBrains s.r.o.")
+
+        val metadata =
+            ExternalJavaLauncher(
+                javaBinary = File(patched, "bin/java"),
+                javaHome = patched,
+                objects = objects,
+                metadataJavaHome = source,
+            ).metadata
+
+        assertEquals(JavaLanguageVersion.of(21), metadata.languageVersion)
+        assertEquals("JetBrains s.r.o.", metadata.vendor)
+        assertEquals(patched, metadata.installationPath.asFile)
+    }
+
+    private fun launcherFor(home: File) =
+        ExternalJavaLauncher(
+            javaBinary = File(home, "bin/java"),
+            javaHome = home,
+            objects = objects,
+        )
+
+    private fun javaHome(name: String): File =
+        tmp.newFolder(name).also {
+            File(it, "bin").mkdirs()
+            File(it, "bin/java").writeText("")
+        }
+
+    private fun File.writeReleaseFile(vararg entries: Pair<String, String>) {
+        File(this, "release").writeText(
+            entries.joinToString("\n") { (key, value) -> "$key=\"$value\"" },
+        )
+    }
+}


### PR DESCRIPTION
Fixes #437.

## Summary

`runWithNativeAgent` set `JavaExec.executable` to the resolved GraalVM `java` and left `javaLauncher` on its convention (the project toolchain, or the Gradle daemon JVM when the module declares none). `JavaExec.exec()` calls `validateExecutableMatchesToolchain()` before forking, so the task failed with *"Toolchain from `executable` property does not match toolchain from `javaLauncher` property"* — always, under the default `autoDownload = true`, since the provisioned JDK lives under the Gradle user home and can never be the daemon's own `java`. It only worked by accident when Gradle itself ran on exactly the GraalVM the plugin resolves.

The executable was also redundant: `exec()` derives the forked binary from `javaLauncher.get().executablePath` regardless.

- Hand the resolved GraalVM over as a `Provider<JavaLauncher>` instead of a raw path:
  - `autoDownload = false` — reuse the branch's existing `javaToolchains.launcherFor { }` launcher directly.
  - `autoDownload = true` — wrap the provisioned home in `ExternalJavaLauncher`.
- Generalize `PatchedJavaLauncher` → `ExternalJavaLauncher`. It already solved the same problem for the vtool-patched JDK behind `run` on macOS; the metadata source is now a separate parameter (defaulting to the installation itself) so a full installation and a partial copy are both covered.
- Wire it as a provider, so provisioning stays exactly as lazy as before: realizing the task for an IDE sync or `gradlew tasks` still never downloads a toolchain.

The issue also asked for a precondition check printing both paths. That's moot now — there is no second path left to disagree with, so the failure mode cannot recur.

## Test plan

Verified end-to-end on Linux against `:examples:fs-watcher-smoke` (headless, self-exiting):

- [x] before the fix: task fails with the reported message
- [x] after the fix, `--no-configuration-cache`: the app runs under the agent and the merge step writes the config. `--info` confirms the forked binary is the provisioned GraalVM (`~/.gradle/nucleus/graalvm/graalvm-community-jdk-25i2-linux-x64/.../bin/java`) with `-agentlib:native-image-agent=…`, and the agent emits `reachability-metadata.json`
- [x] configuration cache on: entry stored, then reused, task working in both runs
- [x] `autoDownload = false` path (temporary edit to the example, reverted)
- [x] `gradlew :examples:fs-watcher-smoke:tasks --all` provisions nothing (no toolchain resolution at all)
- [x] new `ExternalJavaLauncherTest` — metadata parsed from `release`, `executablePath.toString()` is the absolute path (`exec()` reads `toString()`, not `asFile`), missing `release` still yields a probeable language version, separate metadata home
- [x] `:plugin:test`, `ktlintCheck`, `detekt` green

Not exercised here: the macOS patched-JDK path of `run`, which is a mechanical rename in this PR.