### PR TITLE
feat(graalvm): exact reachability metadata on runGraalvmNative

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/ExactReachabilityMetadata.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/ExactReachabilityMetadata.kt
@@ -1,0 +1,104 @@
+package dev.nucleusframework.desktop.application.dsl
+
+import java.io.Serializable
+
+/**
+ * Controls GraalVM's `--exact-reachability-metadata` on the `runGraalvmNative` (quick-build)
+ * dev loop.
+ *
+ * When enabled, unregistered reflective lookups throw `MissingReflectionRegistrationError`
+ * naming the missing element, instead of degrading into a nested `ClassNotFoundException`
+ * chain. Applied **only** on the fast dev loop — never on
+ * `createGraalvmNativeDistributable` / `packageGraalvmNativeDistributionForCurrentOS` —
+ * because optional-dependency probes (`try { Class.forName(...) } catch`) stop taking
+ * their fallback path under exact mode.
+ *
+ * Scoped to app packages by default so third-party / JDK probes (e.g.
+ * `sun.net.www.protocol.http.HttpURLConnection`) do not false-positive. See
+ * [oracle/graal#10264](https://github.com/oracle/graal/discussions/10264).
+ *
+ * ```kotlin
+ * graalvm {
+ *     // Default on the dev loop: scope to the package of mainClass
+ *     exactReachabilityMetadata = ExactReachabilityMetadata.APP_PACKAGES
+ *
+ *     // Multiple roots:
+ *     exactReachabilityMetadata = ExactReachabilityMetadata.packages(
+ *         "io.github.acme",
+ *         "com.acme.shared",
+ *     )
+ *
+ *     // Opt out entirely:
+ *     exactReachabilityMetadata = ExactReachabilityMetadata.OFF
+ * }
+ * ```
+ */
+class ExactReachabilityMetadata
+    private constructor(
+        internal val kind: Kind,
+        internal val packages: List<String> = emptyList(),
+    ) : Serializable {
+        internal enum class Kind {
+            OFF,
+            APP_PACKAGES,
+            PACKAGES,
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ExactReachabilityMetadata) return false
+            return kind == other.kind && packages == other.packages
+        }
+
+        override fun hashCode(): Int = 31 * kind.hashCode() + packages.hashCode()
+
+        override fun toString(): String =
+            when (kind) {
+                Kind.OFF -> "ExactReachabilityMetadata.OFF"
+                Kind.APP_PACKAGES -> "ExactReachabilityMetadata.APP_PACKAGES"
+                Kind.PACKAGES -> "ExactReachabilityMetadata.packages(${packages.joinToString()})"
+            }
+
+        companion object {
+            private const val serialVersionUID: Long = 1L
+
+            /** Never emit `--exact-reachability-metadata`, even on the dev loop. */
+            @JvmField
+            val OFF: ExactReachabilityMetadata = ExactReachabilityMetadata(Kind.OFF)
+
+            /**
+             * On the dev loop, scope exact reachability to the package of
+             * [dev.nucleusframework.desktop.application.dsl.JvmApplication.mainClass]
+             * (and its subpackages). Default.
+             */
+            @JvmField
+            val APP_PACKAGES: ExactReachabilityMetadata = ExactReachabilityMetadata(Kind.APP_PACKAGES)
+
+            /**
+             * On the dev loop, scope exact reachability to the given package prefixes
+             * (comma-separated list passed to `--exact-reachability-metadata=`).
+             * Subpackages are covered by prefix matching.
+             */
+            @JvmStatic
+            fun packages(vararg packages: String): ExactReachabilityMetadata =
+                packages(packages.asList())
+
+            /**
+             * On the dev loop, scope exact reachability to the given package prefixes.
+             * Empty or blank entries are ignored; if none remain the mode is treated as [OFF].
+             */
+            @JvmStatic
+            fun packages(packages: Collection<String>): ExactReachabilityMetadata {
+                val cleaned =
+                    packages
+                        .map { it.trim().trimEnd('.') }
+                        .filter { it.isNotEmpty() }
+                        .distinct()
+                return if (cleaned.isEmpty()) {
+                    OFF
+                } else {
+                    ExactReachabilityMetadata(Kind.PACKAGES, cleaned)
+                }
+            }
+        }
+    }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -99,6 +99,18 @@ abstract class GraalvmSettings
         // which does not know the former option.
         val garbageCollector: Property<NativeImageGarbageCollector> = objects.nullableProperty()
 
+        // Exact reachability metadata on the `runGraalvmNative` (quick-build) dev loop only.
+        // Unregistered reflective lookups then throw `MissingReflectionRegistrationError` naming
+        // the missing element, instead of a nested ClassNotFoundException chain. Never applied to
+        // create/package distributable tasks — optional-dependency probes in third-party code die
+        // under exact mode. Defaults to [ExactReachabilityMetadata.APP_PACKAGES] (scoped to the
+        // package of mainClass). Set [ExactReachabilityMetadata.OFF] to opt out, or
+        // [ExactReachabilityMetadata.packages] for multi-root apps.
+        // Runtime reporting mode is selected with `-Pnucleus.graalvm.missingRegistration=warn|exit|throw`
+        // (default warn) so one run surfaces every missing registration.
+        val exactReachabilityMetadata: Property<ExactReachabilityMetadata> =
+            objects.notNullProperty(ExactReachabilityMetadata.APP_PACKAGES)
+
         // Extra `native-image` arguments appended verbatim, after everything the plugin derives.
         //
         // Nucleus deliberately leaves the SLF4J lifecycle alone: the API and the app-selected

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NucleusProjectProperties.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NucleusProjectProperties.kt
@@ -42,6 +42,14 @@ internal object NucleusProperties {
     /** GraalVM PGO mode override: `instrument` or `off`. Unset = use a recorded profile when present. */
     internal const val GRAALVM_PGO_MODE = "nucleus.graalvm.pgo"
 
+    /**
+     * Runtime reporting for missing reachability registrations on `runGraalvmNative`
+     * (`-XX:MissingRegistrationReportingMode=`): `warn` (default), `exit`, or `throw`.
+     * Only effective when the image was built with exact reachability metadata (quick-build
+     * dev loop).
+     */
+    internal const val GRAALVM_MISSING_REGISTRATION = "nucleus.graalvm.missingRegistration"
+
     fun isVerbose(providers: ProviderFactory): Provider<Boolean> = providers.valueOrNull(VERBOSE).toBooleanProvider(false)
 
     fun preserveWorkingDir(providers: ProviderFactory): Provider<Boolean> = providers.valueOrNull(PRESERVE_WD).toBooleanProvider(false)
@@ -105,6 +113,9 @@ internal object NucleusProperties {
     fun electronBuilderPublishMode(providers: ProviderFactory): Provider<String> = providers.valueOrNull(ELECTRON_BUILDER_PUBLISH_MODE)
 
     fun graalvmPgoMode(providers: ProviderFactory): Provider<String> = providers.valueOrNull(GRAALVM_PGO_MODE)
+
+    fun graalvmMissingRegistration(providers: ProviderFactory): Provider<String> =
+        providers.valueOrNull(GRAALVM_MISSING_REGISTRATION)
 
     // providers.valueOrNull works only with root gradle.properties
     fun dontSyncResources(project: Project): Provider<Boolean> =

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -180,6 +180,15 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             it.substringAfterLast(':').equals(quickBuildRunTaskName, ignoreCase = true)
         }
 
+    // Exact reachability metadata (dev loop only). See ExactReachabilityMetadata / issue #440.
+    // Resolved packages are tracked as a compile input so switching OFF ↔ APP_PACKAGES /
+    // packages(...) recompiles instead of reusing a binary with the other mode baked in.
+    val exactReachabilitySetting = graalvm.exactReachabilityMetadata.get()
+    val missingRegistrationMode =
+        MissingRegistrationReportingMode.parse(
+            NucleusProperties.graalvmMissingRegistration(project.providers).orNull,
+        )
+
     // ── Uber JAR (reuse existing task) ──
 
     // We need the uber JAR from the existing pipeline (respects build type classifier)
@@ -846,6 +855,16 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             val resolvedPgoProfile = pgoProfileFile
             val resolvedAdvancedObfuscation = graalvm.advancedObfuscation.get()
             inputs.property("advancedObfuscation", resolvedAdvancedObfuscation)
+            // Exact reachability: only the package list matters for the image binary; the
+            // reporting mode is a runtime flag on runGraalvmNative. Track the packages (and
+            // whether we are in quick-build) so a mode/package change recompiles.
+            val (resolvedExactPackages, resolvedExactPackageWarning) =
+                resolveExactReachabilityPackages(exactReachabilitySetting, mainClassName)
+            inputs.property(
+                "exactReachabilityMetadata",
+                if (resolvedQuickBuild) resolvedExactPackages.joinToString(",") else "off",
+            )
+            val resolvedMissingRegistrationMode = missingRegistrationMode
             val resolvedMaxHeapSize = graalvm.maxHeapSize.orNull
             val resolvedMaxHeapSizePercent = graalvm.maxHeapSizePercent.get()
             inputs.property("maxHeapSize", resolvedMaxHeapSize ?: "")
@@ -1016,6 +1035,22 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                                 )
                             }
                         }
+
+                        // Exact reachability metadata (quick-build / runGraalvmNative only).
+                        // Makes missing reflection registrations throw a named
+                        // MissingReflectionRegistrationError instead of a buried ClassNotFoundException.
+                        // Scoped to app packages so third-party optional-dependency probes still work.
+                        val exactResolution =
+                            resolveExactReachabilityMetadata(
+                                packages = resolvedExactPackages,
+                                packageWarning = resolvedExactPackageWarning,
+                                quickBuild = resolvedQuickBuild,
+                                javaHome = File(resolvedGraalvmHome),
+                                reportingMode = resolvedMissingRegistrationMode,
+                            )
+                        exactResolution.warning?.let { logger.warn(it) }
+                        exactResolution.lifecycleMessage?.let { logger.lifecycle(it) }
+                        addAll(exactResolution.buildArgs)
 
                         // macOS: force the link-time deployment target. native-image does NOT
                         // propagate MACOSX_DEPLOYMENT_TARGET to its internal linker, so the link
@@ -1204,11 +1239,23 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
         taskNameAction = "run",
         taskNameObject = "graalvmNative",
     ) {
-        description = "Build and run the GraalVM native image in quick-build mode (-Ob) for fast dev iteration"
+        description =
+            "Build and run the GraalVM native image in quick-build mode (-Ob) for fast dev iteration " +
+                "(exact reachability metadata scoped to the app packages)"
         dependsOn(packageGraalvmNative)
 
         executable = packagedBinaryFile.get().asFile.absolutePath
-        args = app.args
+        // Runtime counterpart of --exact-reachability-metadata: default Warn surfaces every
+        // missing registration in one run. Only passed when packages resolve (same condition
+        // that enables the build-time flag on the quick-build path). Selectable via
+        // -Pnucleus.graalvm.missingRegistration=warn|exit|throw.
+        val exactRuntimeArgs =
+            resolveExactReachabilityPackages(exactReachabilitySetting, mainClassName)
+                .first
+                .takeIf { it.isNotEmpty() }
+                ?.let { listOf(missingRegistrationMode.runtimeFlag) }
+                .orEmpty()
+        args = exactRuntimeArgs + app.args
     }
 
     // ── Record a PGO profile (Oracle GraalVM only) ──

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/exactReachabilityMetadata.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/exactReachabilityMetadata.kt
@@ -1,0 +1,225 @@
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.desktop.application.dsl.ExactReachabilityMetadata
+import java.io.File
+
+/**
+ * Resolved native-image / runtime flags for exact reachability metadata.
+ *
+ * [buildArgs] is empty when the mode is off, the build is not a quick-build dev loop, the
+ * package list could not be derived, or the toolchain is older than JDK 23 and the legacy
+ * host option is also unavailable. [runtimeArgs] mirrors that decision so a binary not
+ * built with exact mode never gets a useless reporting flag.
+ */
+internal data class ExactReachabilityResolution(
+    val buildArgs: List<String>,
+    val runtimeArgs: List<String>,
+    val packages: List<String>,
+    val warning: String?,
+    val lifecycleMessage: String?,
+)
+
+/**
+ * Reporting mode for missing registrations at runtime
+ * (`-XX:MissingRegistrationReportingMode=`).
+ *
+ * - [WARN] — log every miss and keep running (default; surfaces all gaps in one run)
+ * - [EXIT] — terminate the process on the first miss (catches code that swallows `Throwable`)
+ * - [THROW] — throw `MissingReflectionRegistrationError` (default GraalVM behaviour under
+ *   exact mode without this option)
+ */
+internal enum class MissingRegistrationReportingMode(
+    val id: String,
+) {
+    WARN("Warn"),
+    EXIT("Exit"),
+    THROW("Throw"),
+    ;
+
+    val runtimeFlag: String get() = "-XX:MissingRegistrationReportingMode=$id"
+
+    companion object {
+        fun parse(raw: String?): MissingRegistrationReportingMode {
+            if (raw.isNullOrBlank()) return WARN
+            return entries.find { it.name.equals(raw.trim(), ignoreCase = true) }
+                ?: entries.find { it.id.equals(raw.trim(), ignoreCase = true) }
+                ?: WARN
+        }
+    }
+}
+
+/** Feature version from which `--exact-reachability-metadata` is available (GraalVM for JDK 23). */
+internal const val EXACT_REACHABILITY_METADATA_MIN_JAVA = 23
+
+/**
+ * Package of [mainClassName] used as the default exact-reachability scope.
+ * `com.example.demo.MainKt` → `com.example.demo`. Returns `null` for the default package
+ * or a blank/null main class so we never enable unscoped exact mode by accident.
+ */
+internal fun packagePrefixOfMainClass(mainClassName: String?): String? {
+    if (mainClassName.isNullOrBlank()) return null
+    val lastDot = mainClassName.lastIndexOf('.')
+    if (lastDot <= 0) return null
+    return mainClassName.substring(0, lastDot).trimEnd('.')
+}
+
+/**
+ * JDK feature major from a GraalVM/JDK `release` file (`JAVA_VERSION="25.0.4"` → 25).
+ * Returns 0 when the file is missing or unparsable.
+ */
+internal fun graalvmJavaFeatureVersion(javaHome: File): Int {
+    val release = javaHome.resolve("release")
+    if (!release.isFile) return 0
+    val raw =
+        release
+            .readLines()
+            .firstOrNull { it.startsWith("JAVA_VERSION=") }
+            ?.substringAfter('=')
+            ?.trim()
+            ?.trim('"')
+            ?: return 0
+    return raw.substringBefore('.').toIntOrNull() ?: 0
+}
+
+/**
+ * Resolves the package list the DSL wants applied on the quick-build dev loop.
+ * Empty when exact mode is off or no packages can be derived.
+ */
+internal fun resolveExactReachabilityPackages(
+    setting: ExactReachabilityMetadata,
+    mainClassName: String?,
+): Pair<List<String>, String?> {
+    return when (setting.kind) {
+        ExactReachabilityMetadata.Kind.OFF -> emptyList<String>() to null
+        ExactReachabilityMetadata.Kind.PACKAGES -> setting.packages to null
+        ExactReachabilityMetadata.Kind.APP_PACKAGES -> {
+            val prefix = packagePrefixOfMainClass(mainClassName)
+            if (prefix == null) {
+                emptyList<String>() to
+                    "exactReachabilityMetadata = APP_PACKAGES but mainClass " +
+                        "'$mainClassName' has no package — skipping " +
+                        "--exact-reachability-metadata (set ExactReachabilityMetadata.packages(...) " +
+                        "or OFF explicitly)."
+            } else {
+                listOf(prefix) to null
+            }
+        }
+    }
+}
+
+/**
+ * Builds the native-image and runtime args for exact reachability metadata.
+ *
+ * Only active when [quickBuild] is true (the `runGraalvmNative` dev loop). Distributable
+ * builds always get empty args so packaging is byte-for-byte unaffected.
+ *
+ * On JDK 23+ emits `--exact-reachability-metadata=<packages>`; on older toolchains falls
+ * back to `-H:ThrowMissingRegistrationErrors=<packages>` when a feature version is known,
+ * otherwise logs a warning and skips.
+ */
+internal fun resolveExactReachabilityMetadata(
+    setting: ExactReachabilityMetadata,
+    mainClassName: String?,
+    quickBuild: Boolean,
+    javaHome: File,
+    reportingMode: MissingRegistrationReportingMode,
+): ExactReachabilityResolution {
+    if (!quickBuild) {
+        return ExactReachabilityResolution(
+            buildArgs = emptyList(),
+            runtimeArgs = emptyList(),
+            packages = emptyList(),
+            warning = null,
+            lifecycleMessage = null,
+        )
+    }
+    val (packages, packageWarning) = resolveExactReachabilityPackages(setting, mainClassName)
+    return resolveExactReachabilityMetadata(
+        packages = packages,
+        packageWarning = packageWarning,
+        quickBuild = true,
+        javaHome = javaHome,
+        reportingMode = reportingMode,
+    )
+}
+
+/**
+ * Same as [resolveExactReachabilityMetadata] when the package list is already resolved
+ * (avoids re-deriving it inside the native-image task action).
+ */
+internal fun resolveExactReachabilityMetadata(
+    packages: List<String>,
+    packageWarning: String? = null,
+    quickBuild: Boolean,
+    javaHome: File,
+    reportingMode: MissingRegistrationReportingMode,
+): ExactReachabilityResolution {
+    if (!quickBuild) {
+        return ExactReachabilityResolution(
+            buildArgs = emptyList(),
+            runtimeArgs = emptyList(),
+            packages = emptyList(),
+            warning = null,
+            lifecycleMessage = null,
+        )
+    }
+    if (packages.isEmpty()) {
+        return ExactReachabilityResolution(
+            buildArgs = emptyList(),
+            runtimeArgs = emptyList(),
+            packages = emptyList(),
+            warning = packageWarning,
+            lifecycleMessage = null,
+        )
+    }
+
+    val featureVersion = graalvmJavaFeatureVersion(javaHome)
+    val packageList = packages.joinToString(",")
+    val buildArgs: List<String>
+    val warning: String?
+    when {
+        featureVersion >= EXACT_REACHABILITY_METADATA_MIN_JAVA -> {
+            buildArgs = listOf("--exact-reachability-metadata=$packageList")
+            warning = packageWarning
+        }
+        featureVersion > 0 -> {
+            // Pre-JDK 23 equivalent (host option). Empty value enables globally; with a
+            // package list it scopes the same way as the public flag.
+            buildArgs = listOf("-H:ThrowMissingRegistrationErrors=$packageList")
+            warning =
+                listOfNotNull(
+                    packageWarning,
+                    "exact-reachability-metadata: toolchain is JDK $featureVersion " +
+                        "(needs $EXACT_REACHABILITY_METADATA_MIN_JAVA+ for " +
+                        "--exact-reachability-metadata); using " +
+                        "-H:ThrowMissingRegistrationErrors=$packageList instead.",
+                ).joinToString(" ")
+                    .ifBlank { null }
+        }
+        else -> {
+            return ExactReachabilityResolution(
+                buildArgs = emptyList(),
+                runtimeArgs = emptyList(),
+                packages = packages,
+                warning =
+                    listOfNotNull(
+                        packageWarning,
+                        "exact-reachability-metadata: could not read JAVA_VERSION from " +
+                            "${javaHome.resolve("release")} — skipping " +
+                            "--exact-reachability-metadata.",
+                    ).joinToString(" "),
+                lifecycleMessage = null,
+            )
+        }
+    }
+
+    return ExactReachabilityResolution(
+        buildArgs = buildArgs,
+        runtimeArgs = listOf(reportingMode.runtimeFlag),
+        packages = packages,
+        warning = warning,
+        lifecycleMessage =
+            "Exact reachability metadata (dev loop): ${buildArgs.single()} " +
+                "(runtime ${reportingMode.runtimeFlag})",
+    )
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ExactReachabilityMetadataTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ExactReachabilityMetadataTest.kt
@@ -1,0 +1,179 @@
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.desktop.application.dsl.ExactReachabilityMetadata
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ExactReachabilityMetadataTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun `package prefix strips the simple class name`() {
+        assertEquals("com.example.demo", packagePrefixOfMainClass("com.example.demo.MainKt"))
+        assertEquals("com.example", packagePrefixOfMainClass("com.example.Main"))
+    }
+
+    @Test
+    fun `package prefix is null for the default package or blank main class`() {
+        assertNull(packagePrefixOfMainClass("MainKt"))
+        assertNull(packagePrefixOfMainClass(""))
+        assertNull(packagePrefixOfMainClass(null))
+        assertNull(packagePrefixOfMainClass("."))
+    }
+
+    @Test
+    fun `APP_PACKAGES resolves to the main class package`() {
+        val (packages, warning) =
+            resolveExactReachabilityPackages(
+                ExactReachabilityMetadata.APP_PACKAGES,
+                "com.example.demo.MainKt",
+            )
+        assertEquals(listOf("com.example.demo"), packages)
+        assertNull(warning)
+    }
+
+    @Test
+    fun `APP_PACKAGES without a package warns and yields nothing`() {
+        val (packages, warning) =
+            resolveExactReachabilityPackages(ExactReachabilityMetadata.APP_PACKAGES, "MainKt")
+        assertTrue(packages.isEmpty())
+        assertTrue(warning!!.contains("no package"))
+    }
+
+    @Test
+    fun `explicit packages are cleaned and de-duplicated`() {
+        val setting =
+            ExactReachabilityMetadata.packages(
+                " io.github.acme ",
+                "com.acme.shared.",
+                "io.github.acme",
+                "",
+                "  ",
+            )
+        val (packages, warning) = resolveExactReachabilityPackages(setting, "ignored.Main")
+        assertEquals(listOf("io.github.acme", "com.acme.shared"), packages)
+        assertNull(warning)
+    }
+
+    @Test
+    fun `OFF never resolves packages`() {
+        val (packages, warning) =
+            resolveExactReachabilityPackages(ExactReachabilityMetadata.OFF, "com.example.Main")
+        assertTrue(packages.isEmpty())
+        assertNull(warning)
+    }
+
+    @Test
+    fun `distributable build never emits exact reachability args`() {
+        val javaHome = fakeJavaHome(feature = 25)
+        val resolution =
+            resolveExactReachabilityMetadata(
+                setting = ExactReachabilityMetadata.APP_PACKAGES,
+                mainClassName = "com.example.demo.MainKt",
+                quickBuild = false,
+                javaHome = javaHome,
+                reportingMode = MissingRegistrationReportingMode.WARN,
+            )
+        assertTrue(resolution.buildArgs.isEmpty())
+        assertTrue(resolution.runtimeArgs.isEmpty())
+        assertNull(resolution.warning)
+        assertNull(resolution.lifecycleMessage)
+    }
+
+    @Test
+    fun `quick build on JDK 23+ emits scoped exact-reachability-metadata`() {
+        val javaHome = fakeJavaHome(feature = 25)
+        val resolution =
+            resolveExactReachabilityMetadata(
+                setting = ExactReachabilityMetadata.APP_PACKAGES,
+                mainClassName = "com.example.demo.MainKt",
+                quickBuild = true,
+                javaHome = javaHome,
+                reportingMode = MissingRegistrationReportingMode.WARN,
+            )
+        assertEquals(
+            listOf("--exact-reachability-metadata=com.example.demo"),
+            resolution.buildArgs,
+        )
+        assertEquals(
+            listOf("-XX:MissingRegistrationReportingMode=Warn"),
+            resolution.runtimeArgs,
+        )
+        assertEquals(listOf("com.example.demo"), resolution.packages)
+        assertNull(resolution.warning)
+        assertTrue(resolution.lifecycleMessage!!.contains("--exact-reachability-metadata=com.example.demo"))
+    }
+
+    @Test
+    fun `quick build on pre-23 falls back to ThrowMissingRegistrationErrors`() {
+        val javaHome = fakeJavaHome(feature = 21)
+        val resolution =
+            resolveExactReachabilityMetadata(
+                setting = ExactReachabilityMetadata.packages("io.acme", "com.acme"),
+                mainClassName = "io.acme.Main",
+                quickBuild = true,
+                javaHome = javaHome,
+                reportingMode = MissingRegistrationReportingMode.EXIT,
+            )
+        assertEquals(
+            listOf("-H:ThrowMissingRegistrationErrors=io.acme,com.acme"),
+            resolution.buildArgs,
+        )
+        assertEquals(
+            listOf("-XX:MissingRegistrationReportingMode=Exit"),
+            resolution.runtimeArgs,
+        )
+        val warning = requireNotNull(resolution.warning)
+        assertTrue(warning.contains("JDK 21"))
+        assertTrue(warning.contains("ThrowMissingRegistrationErrors"))
+    }
+
+    @Test
+    fun `unreadable release file skips with a warning`() {
+        val javaHome = tmp.newFolder("no-release")
+        val resolution =
+            resolveExactReachabilityMetadata(
+                setting = ExactReachabilityMetadata.APP_PACKAGES,
+                mainClassName = "com.example.Main",
+                quickBuild = true,
+                javaHome = javaHome,
+                reportingMode = MissingRegistrationReportingMode.THROW,
+            )
+        assertTrue(resolution.buildArgs.isEmpty())
+        assertTrue(resolution.runtimeArgs.isEmpty())
+        assertTrue(requireNotNull(resolution.warning).contains("could not read JAVA_VERSION"))
+    }
+
+    @Test
+    fun `missing registration mode parses warn exit throw and defaults to warn`() {
+        assertEquals(MissingRegistrationReportingMode.WARN, MissingRegistrationReportingMode.parse(null))
+        assertEquals(MissingRegistrationReportingMode.WARN, MissingRegistrationReportingMode.parse(""))
+        assertEquals(MissingRegistrationReportingMode.WARN, MissingRegistrationReportingMode.parse("warn"))
+        assertEquals(MissingRegistrationReportingMode.EXIT, MissingRegistrationReportingMode.parse("Exit"))
+        assertEquals(MissingRegistrationReportingMode.THROW, MissingRegistrationReportingMode.parse("THROW"))
+        assertEquals(MissingRegistrationReportingMode.WARN, MissingRegistrationReportingMode.parse("nope"))
+    }
+
+    @Test
+    fun `empty packages factory collapses to OFF`() {
+        assertEquals(ExactReachabilityMetadata.OFF, ExactReachabilityMetadata.packages())
+        assertEquals(ExactReachabilityMetadata.OFF, ExactReachabilityMetadata.packages("", "  "))
+    }
+
+    private fun fakeJavaHome(feature: Int): File {
+        val home = tmp.newFolder("graalvm-$feature")
+        File(home, "release").writeText(
+            """
+            IMPLEMENTOR="GraalVM Community"
+            JAVA_VERSION="$feature.0.0"
+            """.trimIndent(),
+        )
+        return home
+    }
+}


### PR DESCRIPTION
## Summary

- Enable `--exact-reachability-metadata` on the `runGraalvmNative` (quick-build) dev loop only, scoped to the app’s packages by default (`ExactReachabilityMetadata.APP_PACKAGES` from `mainClass`).
- Pass `-XX:MissingRegistrationReportingMode=Warn` at run time so one run reports every missing registration; selectable via `-Pnucleus.graalvm.missingRegistration=warn|exit|throw`.
- Leave `createGraalvmNativeDistributable` / `packageGraalvmNativeDistributionForCurrentOS` / `runGraalvmNativeDistributable` byte-for-byte unchanged (no flag).
- Track packages as a compile input so switching quick ↔ distributable recompiles.
- Degrade on pre-JDK 23 toolchains to `-H:ThrowMissingRegistrationErrors=` (or skip with a warning).

Closes #440

## Test plan

- [x] Unit tests: `ExactReachabilityMetadataTest` (package derivation, OFF / APP_PACKAGES / packages, quick vs distributable, JDK 23+ vs pre-23, reporting mode parse)
- [x] `ktlintCheck` on the plugin module
- [x] Example configure: `:examples:tao-demo:tasks --all` lists updated `runGraalvmNative` description
- [x] native-image smoke (non-constant `Class.forName("…AppDatabase_Impl")`):
  - plain → `ClassNotFoundException`
  - `--exact-reachability-metadata=com.example.exact` + Throw → `MissingReflectionRegistrationError` naming the type + JSON snippet
  - scoped to `com.other` → still CNFE (scoping)
  - Warn mode → reports miss then continues