### PR TITLE
fix(global-hotkey): stable portal shortcut ids and coalesced BindShortcuts

### DIFF
--- a/global-hotkey/build.gradle.kts
+++ b/global-hotkey/build.gradle.kts
@@ -13,8 +13,32 @@ val publishVersion =
         ?.removePrefix("refs/tags/v")
         ?: "1.0.0"
 
+// Controlled repro for issue #264 residual portal bugs (see src/repro/...).
+val repro by sourceSets.creating {
+    kotlin.srcDir("src/repro/kotlin")
+}
+
+configurations {
+    named("reproImplementation") { extendsFrom(configurations["implementation"]) }
+    named("reproRuntimeOnly") { extendsFrom(configurations["runtimeOnly"]) }
+}
+
 dependencies {
     implementation(project(":core-runtime"))
+    add("reproImplementation", sourceSets["main"].output)
+}
+
+val reproOrder = providers.gradleProperty("reproOrder").orElse("a")
+
+tasks.register<JavaExec>("runIssue264Repro") {
+    group = "verification"
+    description = "Reproduce issue #264 portal shortcut_id / multi-BindShortcuts bugs (Wayland)"
+    dependsOn(tasks.named("compileReproKotlin"), tasks.named("processResources"))
+    classpath = repro.runtimeClasspath
+    mainClass.set("dev.nucleusframework.globalhotkey.repro.Issue264ReproKt")
+    systemProperty("repro.order", reproOrder.get())
+    // Real portal path needs a session bus + Wayland; do not force headless.
+    isIgnoreExitValue = true
 }
 
 java {

--- a/global-hotkey/src/main/kotlin/dev/nucleusframework/globalhotkey/GlobalHotKeyManager.kt
+++ b/global-hotkey/src/main/kotlin/dev/nucleusframework/globalhotkey/GlobalHotKeyManager.kt
@@ -4,9 +4,16 @@ import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.globalhotkey.linux.NativeLinuxHotKeyBridge
 import dev.nucleusframework.globalhotkey.macos.NativeMacOsHotKeyBridge
 import dev.nucleusframework.globalhotkey.windows.NativeWindowsHotKeyBridge
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.logging.Logger
 
 private const val WIN32_MOD_NOREPEAT = 0x4000
+
+/** Quiet period before auto-flushing portal BindShortcuts after register/unregister. */
+private const val PORTAL_BIND_DEBOUNCE_MS = 50L
 
 /**
  * Cross-platform manager for system-wide global hotkeys.
@@ -21,6 +28,9 @@ private const val WIN32_MOD_NOREPEAT = 0x4000
  * - **Linux (X11)**: X11 `XGrabKey` / `XUngrabKey` via JNI.
  * - **Linux (Wayland)**: `org.freedesktop.portal.GlobalShortcuts` D-Bus portal via JNI.
  *   Requires a reverse-DNS `.desktop` file and the app launched from it.
+ *   Portal shortcut ids are stable (`nucleus_m{mods}_k{keyCode}`) so the system
+ *   remembers grants across launches. Multiple [register] calls are coalesced into
+ *   a single BindShortcuts dialog (debounced; call [commitRegistrations] to flush now).
  *
  * Thread-safe singleton.
  *
@@ -48,6 +58,14 @@ object GlobalHotKeyManager {
     /** The last error from a native operation, or null if the last operation succeeded. */
     var lastError: String? = null
         private set
+
+    private val portalBindExecutor =
+        Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "nucleus-global-hotkey-portal-bind").apply { isDaemon = true }
+        }
+    private val portalBindLock = Any()
+    private var portalBindFuture: ScheduledFuture<*>? = null
+    private val portalBindPending = AtomicBoolean(false)
 
     /** Whether the native library is loaded and functional on this platform. */
     val isAvailable: Boolean
@@ -92,6 +110,10 @@ object GlobalHotKeyManager {
 
     /**
      * Register a global hotkey.
+     *
+     * On Linux/Wayland the portal BindShortcuts dialog is debounced: a tight loop of
+     * [register] calls produces a single system dialog. Call [commitRegistrations]
+     * to flush immediately and surface portal errors synchronously.
      *
      * @param keyCode AWT virtual key code (e.g., [java.awt.event.KeyEvent.VK_F12]).
      * @param modifiers bitmask of [HotKeyModifier] values (e.g., `HotKeyModifier.CONTROL + HotKeyModifier.ALT`).
@@ -161,12 +183,47 @@ object GlobalHotKeyManager {
     }
 
     /**
+     * Flush pending Linux/Wayland portal BindShortcuts immediately.
+     *
+     * [register] / [unregister] on the portal backend only update the local set and
+     * schedule a debounced bind; call this after a batch of registrations to show the
+     * system dialog once and learn whether the portal accepted the set.
+     *
+     * No-op on Windows, macOS, and Linux/X11.
+     *
+     * @return true if the flush succeeded (or was a no-op).
+     */
+    @Synchronized
+    fun commitRegistrations(): Boolean {
+        if (!ensureReady()) return false
+        if (Platform.Current != Platform.Linux) {
+            lastError = null
+            return true
+        }
+        cancelScheduledPortalBind()
+        return flushPortalBind()
+    }
+
+    /**
+     * Linux/Wayland portal `shortcut_id` for [handle], or null if unknown / not Linux.
+     *
+     * Stable across process launches for a given key+modifiers pair
+     * (`nucleus_m{mods}_k{keyCode}`), independent of registration order.
+     */
+    fun portalShortcutId(handle: Long): String? {
+        if (Platform.Current != Platform.Linux || !initialized) return null
+        return NativeLinuxHotKeyBridge.nativeShortcutId(handle)
+    }
+
+    /**
      * Shut down the hotkey subsystem.
      * Unregisters all hotkeys and stops the native message loop.
      */
     @Synchronized
     fun shutdown() {
         if (!initialized) return
+
+        cancelScheduledPortalBind()
 
         when (Platform.Current) {
             Platform.Windows -> {
@@ -268,6 +325,8 @@ object GlobalHotKeyManager {
             return -1
         }
         lastError = null
+        // Portal: coalesce BindShortcuts across a register() burst (X11 is a no-op bind).
+        schedulePortalBind()
         return id
     }
 
@@ -277,6 +336,43 @@ object GlobalHotKeyManager {
         lastError = error
         if (error != null) {
             logger.warning("unregister(handle=$handle) failed: $error")
+            return false
+        }
+        schedulePortalBind()
+        return true
+    }
+
+    private fun schedulePortalBind() {
+        if (!Platform.isWayland) return
+        portalBindPending.set(true)
+        synchronized(portalBindLock) {
+            portalBindFuture?.cancel(false)
+            portalBindFuture =
+                portalBindExecutor.schedule(
+                    {
+                        if (portalBindPending.compareAndSet(true, false)) {
+                            flushPortalBind()
+                        }
+                    },
+                    PORTAL_BIND_DEBOUNCE_MS,
+                    TimeUnit.MILLISECONDS,
+                )
+        }
+    }
+
+    private fun cancelScheduledPortalBind() {
+        synchronized(portalBindLock) {
+            portalBindFuture?.cancel(false)
+            portalBindFuture = null
+        }
+        portalBindPending.set(false)
+    }
+
+    private fun flushPortalBind(): Boolean {
+        val error = NativeLinuxHotKeyBridge.nativeBindShortcuts()
+        lastError = error
+        if (error != null) {
+            logger.warning("portal BindShortcuts failed: $error")
             return false
         }
         return true

--- a/global-hotkey/src/main/kotlin/dev/nucleusframework/globalhotkey/linux/NativeLinuxHotKeyBridge.kt
+++ b/global-hotkey/src/main/kotlin/dev/nucleusframework/globalhotkey/linux/NativeLinuxHotKeyBridge.kt
@@ -17,6 +17,11 @@ internal object NativeLinuxHotKeyBridge {
     @JvmStatic
     external fun nativeInit(): String?
 
+    /**
+     * Store a hotkey entry. On the portal (Wayland) backend this does **not** call
+     * BindShortcuts — use [nativeBindShortcuts] after a batch of registrations so the
+     * system dialog appears once. X11 still grabs the key immediately.
+     */
     @JvmStatic
     external fun nativeRegister(
         id: Long,
@@ -27,6 +32,17 @@ internal object NativeLinuxHotKeyBridge {
 
     @JvmStatic
     external fun nativeUnregister(id: Long): String?
+
+    /**
+     * Push the full current hotkey set to `org.freedesktop.portal.GlobalShortcuts`
+     * via a single BindShortcuts call. No-op on X11.
+     */
+    @JvmStatic
+    external fun nativeBindShortcuts(): String?
+
+    /** Portal shortcut_id for [id], or null if unknown. Stable across launches. */
+    @JvmStatic
+    external fun nativeShortcutId(id: Long): String?
 
     @JvmStatic
     external fun nativeShutdown()

--- a/global-hotkey/src/main/native/linux/nucleus_global_hotkey_linux.c
+++ b/global-hotkey/src/main/native/linux/nucleus_global_hotkey_linux.c
@@ -10,6 +10,10 @@
  *   - The portal thread stays permanently attached to the JVM.
  *   - GNOME requires the app_id to pass g_application_id_is_valid (reverse-DNS).
  *   - BindShortcuts sends the full shortcut set each time (portal API design).
+ *   - shortcut_id is stable (mods+keyCode), not a per-process counter — the portal
+ *     persists grants by (app_id, shortcut_id) across launches (issue #264).
+ *   - nativeRegister only stores; nativeBindShortcuts performs BindShortcuts so a
+ *     burst of register() calls can share a single system dialog.
  */
 
 #include <jni.h>
@@ -46,8 +50,9 @@ typedef struct {
     /* X11 */
     unsigned int x11_keycode;
     unsigned int x11_modifiers;
-    /* Portal */
-    char shortcut_id[32];
+    /* Portal — shortcut_id must be stable across launches (portal persistence key).
+     * Derived from modifiers+keyCode, NOT from the per-process listener handle. */
+    char shortcut_id[64];
     char description[256];   /* user-readable action label for the portal dialog */
 } HotKeyEntry;
 
@@ -586,22 +591,39 @@ Java_dev_nucleusframework_globalhotkey_linux_NativeLinuxHotKeyBridge_nativeInit(
     return NULL;
 }
 
+/* Stable portal shortcut id: same physical chord → same id across launches and
+ * registration order. The portal persists grants by (app_id, shortcut_id); a
+ * registration-order counter (nucleus_1, nucleus_2, …) re-prompts every time the
+ * app starts with a different register() order (issue #264). */
+static void format_shortcut_id(char *buf, int sz, int modifiers, int keyCode) {
+    snprintf(buf, sz, "nucleus_m%x_k%x", (unsigned)modifiers, (unsigned)keyCode);
+}
+
 JNIEXPORT jstring JNICALL
 Java_dev_nucleusframework_globalhotkey_linux_NativeLinuxHotKeyBridge_nativeRegister(
     JNIEnv *env, jclass clazz, jlong id, jint modifiers, jint keyCode, jstring description) {
     (void)clazz;
     if (!g_running) return (*env)->NewStringUTF(env, "Not initialized");
 
+    char sid[64];
+    format_shortcut_id(sid, sizeof(sid), modifiers, keyCode);
+
     pthread_mutex_lock(&g_mutex);
     if (g_hotkeyCount >= MAX_HOTKEYS) {
         pthread_mutex_unlock(&g_mutex);
         return (*env)->NewStringUTF(env, "Max hotkeys reached");
     }
+    for (int i = 0; i < g_hotkeyCount; i++) {
+        if (strcmp(g_hotkeys[i].shortcut_id, sid) == 0) {
+            pthread_mutex_unlock(&g_mutex);
+            return (*env)->NewStringUTF(env, "Hotkey already registered");
+        }
+    }
 
     HotKeyEntry *e = &g_hotkeys[g_hotkeyCount];
     e->id = id; e->keyCode = keyCode; e->modifiers = modifiers;
     e->x11_keycode = 0; e->x11_modifiers = 0;
-    snprintf(e->shortcut_id, sizeof(e->shortcut_id), "nucleus_%ld", (long)id);
+    snprintf(e->shortcut_id, sizeof(e->shortcut_id), "%s", sid);
 
     e->description[0] = '\0';
     if (description) {
@@ -626,13 +648,10 @@ Java_dev_nucleusframework_globalhotkey_linux_NativeLinuxHotKeyBridge_nativeRegis
         }
 
     } else if (g_backend == BACKEND_PORTAL) {
+        /* Store only — BindShortcuts is deferred to nativeBindShortcuts so a
+         * loop of register() can coalesce into a single portal dialog. */
         g_hotkeyCount++;
         pthread_mutex_unlock(&g_mutex);
-        char err[512] = {0};
-        if (portal_bind_sync(err, sizeof(err)) != 0) {
-            pthread_mutex_lock(&g_mutex); g_hotkeyCount--; pthread_mutex_unlock(&g_mutex);
-            return (*env)->NewStringUTF(env, err);
-        }
 
     } else {
         pthread_mutex_unlock(&g_mutex);
@@ -660,10 +679,42 @@ Java_dev_nucleusframework_globalhotkey_linux_NativeLinuxHotKeyBridge_nativeUnreg
     pthread_mutex_unlock(&g_mutex);
 
     if (g_backend == BACKEND_X11) x11_ungrab(&entry);
-    else if (g_backend == BACKEND_PORTAL) {
-        char err[512] = {0};
-        portal_bind_sync(err, sizeof(err)); /* rebind remaining; errors are non-fatal */
+    /* Portal: rebind is deferred to nativeBindShortcuts (coalesced). */
+    return NULL;
+}
+
+/**
+ * Push the current hotkey set to the portal via BindShortcuts.
+ * No-op (success) on X11. On portal, recreates the session and binds once —
+ * call after a batch of nativeRegister/nativeUnregister to show a single dialog.
+ */
+JNIEXPORT jstring JNICALL
+Java_dev_nucleusframework_globalhotkey_linux_NativeLinuxHotKeyBridge_nativeBindShortcuts(
+    JNIEnv *env, jclass clazz) {
+    (void)clazz;
+    if (!g_running) return (*env)->NewStringUTF(env, "Not initialized");
+    if (g_backend != BACKEND_PORTAL) return NULL;
+
+    char err[512] = {0};
+    if (portal_bind_sync(err, sizeof(err)) != 0)
+        return (*env)->NewStringUTF(env, err);
+    return NULL;
+}
+
+/** Debug/test: copy the portal shortcut_id for a listener handle into outBuf. */
+JNIEXPORT jstring JNICALL
+Java_dev_nucleusframework_globalhotkey_linux_NativeLinuxHotKeyBridge_nativeShortcutId(
+    JNIEnv *env, jclass clazz, jlong id) {
+    (void)clazz;
+    pthread_mutex_lock(&g_mutex);
+    for (int i = 0; i < g_hotkeyCount; i++) {
+        if (g_hotkeys[i].id == id) {
+            jstring s = (*env)->NewStringUTF(env, g_hotkeys[i].shortcut_id);
+            pthread_mutex_unlock(&g_mutex);
+            return s;
+        }
     }
+    pthread_mutex_unlock(&g_mutex);
     return NULL;
 }
 

--- a/global-hotkey/src/repro/kotlin/dev/nucleusframework/globalhotkey/repro/Issue264Repro.kt
+++ b/global-hotkey/src/repro/kotlin/dev/nucleusframework/globalhotkey/repro/Issue264Repro.kt
@@ -1,0 +1,107 @@
+package dev.nucleusframework.globalhotkey.repro
+
+import dev.nucleusframework.globalhotkey.GlobalHotKeyManager
+import dev.nucleusframework.globalhotkey.HotKeyModifier
+import dev.nucleusframework.globalhotkey.plus
+import java.awt.event.KeyEvent
+
+/**
+ * Controlled reproduction / verification for
+ * https://github.com/NucleusFramework/Nucleus/issues/264 residual bugs (post #265):
+ *
+ * 1. Portal shortcut_id must be stable across registration order (not AtomicLong).
+ * 2. A loop of register() must produce a single BindShortcuts (one system dialog).
+ *
+ *   ./gradlew :global-hotkey:runIssue264Repro -PreproOrder=a
+ *   ./gradlew :global-hotkey:runIssue264Repro -PreproOrder=b
+ *
+ * Expected after the fix:
+ * - Ctrl+A → nucleus_m2_k41, Ctrl+B → nucleus_m2_k42, Ctrl+C → nucleus_m2_k43
+ *   in both orders (same physical key → same shortcut_id).
+ * - One commitRegistrations() → one portal bind for the whole set.
+ */
+fun main() {
+    val order = System.getProperty("repro.order", "a")
+    val keys =
+        when (order) {
+            "b" ->
+                listOf(
+                    "Ctrl+C" to KeyEvent.VK_C,
+                    "Ctrl+B" to KeyEvent.VK_B,
+                    "Ctrl+A" to KeyEvent.VK_A,
+                )
+            else ->
+                listOf(
+                    "Ctrl+A" to KeyEvent.VK_A,
+                    "Ctrl+B" to KeyEvent.VK_B,
+                    "Ctrl+C" to KeyEvent.VK_C,
+                )
+        }
+
+    println("=== Issue #264 repro (order=$order) ===")
+    println("session=${System.getenv("XDG_SESSION_TYPE")} wayland=${System.getenv("WAYLAND_DISPLAY")}")
+    println("Registering ${keys.size} hotkeys via GlobalHotKeyManager (real portal path)...")
+
+    if (!GlobalHotKeyManager.initialize()) {
+        System.err.println("initialize failed: ${GlobalHotKeyManager.lastError}")
+        kotlin.system.exitProcess(1)
+    }
+
+    val results = mutableListOf<Triple<String, Long, String?>>()
+    val t0 = System.nanoTime()
+    for ((label, keyCode) in keys) {
+        val tReg = System.nanoTime()
+        println("-- register($label) ...")
+        val handle =
+            GlobalHotKeyManager.register(
+                keyCode = keyCode,
+                modifiers = 0 + HotKeyModifier.CONTROL,
+                description = "Issue264 $label",
+            ) { _, _ -> println("activated $label") }
+        val ms = (System.nanoTime() - tReg) / 1_000_000
+        if (handle < 0) {
+            System.err.println("   FAILED after ${ms}ms: ${GlobalHotKeyManager.lastError}")
+        } else {
+            val sid = GlobalHotKeyManager.portalShortcutId(handle)
+            println("   handle=$handle shortcut_id=$sid in ${ms}ms")
+            results += Triple(label, handle, sid)
+        }
+    }
+    val regMs = (System.nanoTime() - t0) / 1_000_000
+    println("Stored ${results.size}/${keys.size} in ${regMs}ms (bind deferred)")
+
+    val tBind = System.nanoTime()
+    println("-- commitRegistrations() (single BindShortcuts) ...")
+    val ok = GlobalHotKeyManager.commitRegistrations()
+    val bindMs = (System.nanoTime() - tBind) / 1_000_000
+    println("   commit ok=$ok in ${bindMs}ms error=${GlobalHotKeyManager.lastError}")
+
+    println("Mapping (label → handle → shortcut_id):")
+    for ((label, handle, sid) in results) {
+        println("  $label → handle=$handle → $sid")
+    }
+
+    // Stability check for the chords we care about
+    val byLabel = results.associate { it.first to it.third }
+    val expected =
+        mapOf(
+            "Ctrl+A" to "nucleus_m2_k41",
+            "Ctrl+B" to "nucleus_m2_k42",
+            "Ctrl+C" to "nucleus_m2_k43",
+        )
+    var stable = true
+    for ((label, want) in expected) {
+        val got = byLabel[label]
+        if (got != want) {
+            System.err.println("UNSTABLE/WRONG id for $label: got=$got want=$want")
+            stable = false
+        }
+    }
+    println(if (stable) "PASS: shortcut_ids stable and order-independent" else "FAIL: shortcut_ids incorrect")
+
+    println("Sleeping 1s, then shutdown...")
+    Thread.sleep(1000)
+    GlobalHotKeyManager.shutdown()
+    println("Done.")
+    if (!stable) kotlin.system.exitProcess(2)
+}


### PR DESCRIPTION
## Summary

- Derive Linux/Wayland portal `shortcut_id` from modifiers+keyCode (`nucleus_m{mods}_k{keyCode}`) instead of a per-process AtomicLong, so the same chord keeps the same id across launches and registration order. The portal persists grants by `(app_id, shortcut_id)` — unstable ids forced a re-prompt every start (remaining part of #264 after #265).
- Defer `BindShortcuts` until a debounced flush (or explicit `commitRegistrations()`), so a loop of `register()` produces one system dialog instead of N.
- Expose `GlobalHotKeyManager.commitRegistrations()` and `portalShortcutId(handle)` for sync flush and debugging.
- Add `:global-hotkey:runIssue264Repro` for a controlled real-portal repro of both failures.

## Test plan

- [x] Controlled repro on Wayland/GNOME before fix: order A vs B gave different `nucleus_N` for the same chords; 3× `register()` → 3× BindShortcuts.
- [x] After fix: both orders map Ctrl+A/B/C to `nucleus_m2_k41/42/43`; single `commitRegistrations()` → one BindShortcuts.
- [x] Second process with the same set re-binds quickly without re-prompting (stable ids).
- [x] Existing native trigger-format test (`nucleus_hotkey_keys_test.c`) still passes.
- [x] Manual: nucleus-demo Hotkeys screen on Wayland (`runDistributable`) — register several shortcuts, confirm one dialog and persistence after restart.

Closes #264
