### PR TITLE
fix(plugin): pathing jar for Linux jpackage classpath (JDK-8380085)

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/PathingJarClasspath.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/PathingJarClasspath.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal
+
+import org.gradle.api.logging.Logger
+import java.io.File
+import java.util.jar.Attributes
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+
+/**
+ * Collapses multi-entry `app.classpath=` lines in jpackage `.cfg` files into a single
+ * pathing jar whose manifest Class-Path lists the sibling jars in order.
+ *
+ * jpackage's Linux launcher (JDK 25 and earlier) serializes the full expanded classpath into a
+ * JvmlLauncherData blob and transfers it parent-to-child over a pipe with a single plain
+ * read() and no loop. When the payload is large enough that the pipe returns a short read,
+ * envVarNames / envVarValues stay uninitialized and setenv() SIGSEGVs (JDK-8380085 /
+ * Nucleus issue 454). A pathing jar shrinks the launcher payload to a few KB (typically under
+ * PIPE_BUF), so the transfer always completes.
+ *
+ * Manifest Class-Path entries resolve relative to the pathing jar itself, so the layout stays
+ * relocatable. Order is preserved. Sibling jars remain on disk; only the `.cfg` classpath is
+ * rewritten.
+ *
+ * Safe to call when there is 0 or 1 classpath entry (no-op).
+ */
+internal object PathingJarClasspath {
+    /** Default name for the generated pathing jar; intentionally unlikely to collide. */
+    const val PATHING_JAR_NAME: String = "pathing-classpath.jar"
+
+    private const val CLASSPATH_PREFIX = "app.classpath="
+    private const val APPDIR_PREFIX = "\$APPDIR/"
+
+    /**
+     * Walks every launcher `.cfg` under [appJarDir] and collapses multi-entry classpaths.
+     *
+     * @return number of `.cfg` files rewritten
+     */
+    fun collapseInAppJarDir(
+        appJarDir: File,
+        logger: Logger,
+        pathingJarName: String = PATHING_JAR_NAME,
+    ): Int {
+        if (!appJarDir.isDirectory) return 0
+
+        val cfgFiles =
+            appJarDir
+                .listFiles()
+                .orEmpty()
+                .filter { it.isFile && it.extension.equals("cfg", ignoreCase = true) && it.name != "jvm.cfg" }
+                .sortedBy { it.name }
+
+        var rewritten = 0
+        for (cfg in cfgFiles) {
+            if (collapseCfg(cfg, appJarDir, pathingJarName, logger)) {
+                rewritten++
+            }
+        }
+        return rewritten
+    }
+
+    /**
+     * Locates the Linux jpackage `lib/app` directory under a createDistributable output root
+     * and collapses classpaths there.
+     *
+     * Layout: destinationDir/packageName/lib/app/ (launcher .cfg files)
+     */
+    fun collapseInLinuxAppImage(
+        destinationDir: File,
+        packageName: String,
+        logger: Logger,
+    ): Int {
+        val appImageDir = resolveLinuxAppImageDir(destinationDir, packageName) ?: return 0
+        val appJarDir = appImageDir.resolve("lib").resolve("app")
+        if (!appJarDir.isDirectory) {
+            logger.info(
+                "Skipping pathing-jar classpath collapse: no lib/app under ${appImageDir.absolutePath}",
+            )
+            return 0
+        }
+        return collapseInAppJarDir(appJarDir, logger)
+    }
+
+    internal fun resolveLinuxAppImageDir(
+        destinationDir: File,
+        packageName: String,
+    ): File? {
+        val named = destinationDir.resolve(packageName)
+        if (named.isDirectory) return named
+
+        val children =
+            destinationDir
+                .listFiles()
+                .orEmpty()
+                .filter { it.isDirectory && it.name != ".DS_Store" }
+        return when (children.size) {
+            1 -> children.single()
+            else -> null
+        }
+    }
+
+    /**
+     * @return true if [cfgFile] was rewritten
+     */
+    internal fun collapseCfg(
+        cfgFile: File,
+        appJarDir: File,
+        pathingJarName: String,
+        logger: Logger,
+    ): Boolean {
+        val lines = cfgFile.readLines()
+        val classpathEntries =
+            lines.mapNotNull { line ->
+                val trimmed = line.trim()
+                if (trimmed.startsWith(CLASSPATH_PREFIX)) {
+                    trimmed.substringAfter(CLASSPATH_PREFIX).trim()
+                } else {
+                    null
+                }
+            }
+
+        // 0 or 1 entry: either already collapsed or a single main jar — nothing to do.
+        if (classpathEntries.size <= 1) return false
+
+        val jarNames =
+            classpathEntries.map { entry ->
+                entry
+                    .removePrefix(APPDIR_PREFIX)
+                    .removePrefix("./")
+                    .substringAfterLast('/')
+                    .substringAfterLast('\\')
+            }
+
+        // Never put the pathing jar on its own Class-Path (would recurse / self-ref).
+        val siblingJars = jarNames.filter { it.isNotEmpty() && it != pathingJarName }
+        if (siblingJars.size <= 1) return false
+
+        val pathingJar = appJarDir.resolve(pathingJarName)
+        writePathingJar(pathingJar, siblingJars)
+
+        val rewritten =
+            buildList {
+                var classpathWritten = false
+                for (line in lines) {
+                    val trimmed = line.trim()
+                    if (trimmed.startsWith(CLASSPATH_PREFIX)) {
+                        if (!classpathWritten) {
+                            add("$CLASSPATH_PREFIX$APPDIR_PREFIX$pathingJarName")
+                            classpathWritten = true
+                        }
+                    } else {
+                        add(line)
+                    }
+                }
+            }
+
+        cfgFile.writeText(rewritten.joinToString(System.lineSeparator()) + System.lineSeparator())
+
+        logger.lifecycle(
+            "Collapsed ${siblingJars.size} classpath entries in ${cfgFile.name} into " +
+                "$pathingJarName (JDK-8380085 / Linux launcher short-read workaround)",
+        )
+        return true
+    }
+
+    internal fun writePathingJar(
+        pathingJar: File,
+        siblingJarNames: List<String>,
+    ) {
+        pathingJar.parentFile?.mkdirs()
+        val manifest =
+            Manifest().apply {
+                mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+                // Space-separated relative URLs; Manifest writer wraps at 72 bytes.
+                mainAttributes[Attributes.Name.CLASS_PATH] =
+                    siblingJarNames.joinToString(" ") { encodeClassPathEntry(it) }
+                mainAttributes.putValue("Created-By", "Nucleus")
+            }
+        JarOutputStream(pathingJar.outputStream().buffered(), manifest).use {
+            // Pathing jar: manifest only, no class entries.
+        }
+    }
+
+    /**
+     * Manifest Class-Path entries are space-separated URLs. Encode spaces so a jar name
+     * containing whitespace does not split into multiple entries.
+     */
+    internal fun encodeClassPathEntry(name: String): String = name.replace(" ", "%20")
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractJPackageTask.kt
@@ -21,6 +21,7 @@ import dev.nucleusframework.desktop.application.internal.MacAssetsTool
 import dev.nucleusframework.desktop.application.internal.MacSigner
 import dev.nucleusframework.desktop.application.internal.MacSignerImpl
 import dev.nucleusframework.desktop.application.internal.NoCertificateSigner
+import dev.nucleusframework.desktop.application.internal.PathingJarClasspath
 import dev.nucleusframework.desktop.application.internal.PlistKeys
 import dev.nucleusframework.desktop.application.internal.SKIKO_LIBRARY_PATH
 import dev.nucleusframework.desktop.application.internal.cliArg
@@ -627,6 +628,15 @@ abstract class AbstractJPackageTask
         override fun checkResult(result: ExecResult) {
             super.checkResult(result)
             modifyRuntimeOnMacOsIfNeeded()
+            // Linux only: shrink the jpackage launcher's serialized classpath so the parent
+            // process's single pipe read cannot short-read (JDK-8380085 / Nucleus #454).
+            if (currentOS == OS.Linux && targetFormat == TargetFormat.RawAppImage) {
+                PathingJarClasspath.collapseInLinuxAppImage(
+                    destinationDir = destinationDir.ioFile,
+                    packageName = packageName.get(),
+                    logger = logger,
+                )
+            }
             val outputFile = findOutputFileOrDir(destinationDir.ioFile, targetFormat)
             logger.lifecycle("The distribution is written to ${outputFile.canonicalPath}")
         }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/PathingJarClasspathTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/PathingJarClasspathTest.kt
@@ -1,0 +1,138 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.jar.JarFile
+import java.util.jar.Attributes
+
+class PathingJarClasspathTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val logger: Logger = Logging.getLogger(PathingJarClasspathTest::class.java)
+
+    @Test
+    fun `collapses multi-entry cfg into a single pathing jar preserving order`() {
+        val appDir = tmp.newFolder("lib-app")
+        listOf("main.jar", "lib-a.jar", "lib-b.jar").forEach { appDir.resolve(it).writeText("x") }
+
+        val cfg =
+            appDir.resolve("Demo.cfg").apply {
+                writeText(
+                    """
+                    [Application]
+                    app.classpath=${'$'}APPDIR/main.jar
+                    app.mainclass=com.example.Main
+                    app.classpath=${'$'}APPDIR/lib-a.jar
+                    app.classpath=${'$'}APPDIR/lib-b.jar
+
+                    [JavaOptions]
+                    java-options=-Xmx1g
+                    """.trimIndent() + "\n",
+                )
+            }
+
+        assertTrue(PathingJarClasspath.collapseCfg(cfg, appDir, PathingJarClasspath.PATHING_JAR_NAME, logger))
+
+        val lines = cfg.readLines().map { it.trim() }.filter { it.isNotEmpty() }
+        val classpathLines = lines.filter { it.startsWith("app.classpath=") }
+        assertEquals(1, classpathLines.size)
+        assertEquals(
+            "app.classpath=${'$'}APPDIR/${PathingJarClasspath.PATHING_JAR_NAME}",
+            classpathLines.single(),
+        )
+        assertTrue(lines.contains("app.mainclass=com.example.Main"))
+        assertTrue(lines.contains("java-options=-Xmx1g"))
+
+        val pathing = appDir.resolve(PathingJarClasspath.PATHING_JAR_NAME)
+        assertTrue(pathing.isFile)
+        JarFile(pathing).use { jar ->
+            val classPath = jar.manifest.mainAttributes.getValue(Attributes.Name.CLASS_PATH)
+            assertEquals("main.jar lib-a.jar lib-b.jar", classPath)
+        }
+    }
+
+    @Test
+    fun `is a no-op when classpath has a single entry`() {
+        val appDir = tmp.newFolder("single")
+        val cfg =
+            appDir.resolve("Demo.cfg").apply {
+                writeText(
+                    """
+                    [Application]
+                    app.classpath=${'$'}APPDIR/main.jar
+                    app.mainclass=com.example.Main
+                    """.trimIndent() + "\n",
+                )
+            }
+        val before = cfg.readText()
+        assertFalse(PathingJarClasspath.collapseCfg(cfg, appDir, PathingJarClasspath.PATHING_JAR_NAME, logger))
+        assertEquals(before, cfg.readText())
+        assertFalse(appDir.resolve(PathingJarClasspath.PATHING_JAR_NAME).exists())
+    }
+
+    @Test
+    fun `is a no-op when already collapsed`() {
+        val appDir = tmp.newFolder("already")
+        val cfg =
+            appDir.resolve("Demo.cfg").apply {
+                writeText(
+                    """
+                    [Application]
+                    app.classpath=${'$'}APPDIR/${PathingJarClasspath.PATHING_JAR_NAME}
+                    app.mainclass=com.example.Main
+                    """.trimIndent() + "\n",
+                )
+            }
+        assertFalse(PathingJarClasspath.collapseCfg(cfg, appDir, PathingJarClasspath.PATHING_JAR_NAME, logger))
+    }
+
+    @Test
+    fun `encodes spaces in jar names for the Class-Path attribute`() {
+        assertEquals("my%20lib.jar", PathingJarClasspath.encodeClassPathEntry("my lib.jar"))
+    }
+
+    @Test
+    fun `collapseInLinuxAppImage finds lib-app under the package dir`() {
+        val dest = tmp.newFolder("dest")
+        val appImage = dest.resolve("DemoApp").apply { mkdirs() }
+        val appJarDir = appImage.resolve("lib").resolve("app").apply { mkdirs() }
+        listOf("a.jar", "b.jar", "c.jar").forEach { appJarDir.resolve(it).writeText("x") }
+        appJarDir.resolve("DemoApp.cfg").writeText(
+            """
+            [Application]
+            app.classpath=${'$'}APPDIR/a.jar
+            app.mainclass=Main
+            app.classpath=${'$'}APPDIR/b.jar
+            app.classpath=${'$'}APPDIR/c.jar
+            """.trimIndent() + "\n",
+        )
+
+        val rewritten = PathingJarClasspath.collapseInLinuxAppImage(dest, "DemoApp", logger)
+        assertEquals(1, rewritten)
+        assertTrue(appJarDir.resolve(PathingJarClasspath.PATHING_JAR_NAME).isFile)
+        val cp =
+            appJarDir
+                .resolve("DemoApp.cfg")
+                .readLines()
+                .filter { it.trim().startsWith("app.classpath=") }
+        assertEquals(1, cp.size)
+    }
+
+    @Test
+    fun `writePathingJar produces a readable empty jar with Class-Path`() {
+        val jar = tmp.newFile("pathing.jar")
+        PathingJarClasspath.writePathingJar(jar, listOf("one.jar", "two.jar"))
+        JarFile(jar).use { jf ->
+            assertEquals("one.jar two.jar", jf.manifest.mainAttributes.getValue(Attributes.Name.CLASS_PATH))
+            assertEquals(0, jf.entries().asSequence().count { !it.name.startsWith("META-INF/") })
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Work around [JDK-8380085](https://bugs.openjdk.org/browse/JDK-8380085): the Linux jpackage launcher can short-read the serialized classpath over a pipe and SIGSEGV in `setenv()` when many jars are listed in the `.cfg` (Nucleus Demo ~90 jars).
- After `jpackage` on Linux only, collapse multi-entry `app.classpath=` lines into a single pathing jar (`pathing-classpath.jar`) whose manifest `Class-Path` lists sibling jars in order.
- Matches the OpenJDK-documented workaround to “flatten the classpath”; macOS/Windows unchanged (bug is Linux-launcher-specific). GraalVM native images unaffected.

Fixes #454

## Test plan

- [x] Unit tests: `PathingJarClasspathTest` (collapse, no-op single entry, order, Linux layout, spaces encoding)
- [x] Manual: official nucleus-demo 2.2.0 AppImage rewritten with pathing jar starts; forced short-read no longer SIGSEGVs
- [ ] `createDistributable` / package Linux demo and launch the resulting app image
- [ ] Confirm `.cfg` has a single `app.classpath=$APPDIR/pathing-classpath.jar` and siblings remain on disk