### PR TITLE
fix(graalvm): gate mlProfileInference opt-out on Oracle toolchains

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -55,7 +55,9 @@ abstract class GraalvmSettings
         // generally a small win, but it is Oracle-specific and non-deterministic across GraalVM
         // versions. Set to `false` to opt out (`-H:-MLProfileInference`), yielding `PGO: off`. Only
         // effective at optimization levels that run the ML pass (i.e. `-O2`); ignored under `-Os`.
-        // Defaults to `true` to match Oracle GraalVM's out-of-the-box behavior.
+        // Ignored on non-Oracle toolchains (a warning is logged) — community builds have no ML
+        // profile inference, so they already behave as if it were disabled. Defaults to `true` to
+        // match Oracle GraalVM's out-of-the-box behavior.
         val mlProfileInference: Property<Boolean> = objects.notNullProperty(true)
 
         // Automatically register the project's own resources (its source-set resource directories

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -980,11 +980,17 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                             ),
                         )
 
-                        // Opt out of Oracle GraalVM's default ML-inferred PGO profile. Placed before
-                        // user buildArgs so an explicit override there still wins.
-                        if (!resolvedMlProfileInference) {
-                            add("-H:-MLProfileInference")
-                        }
+                        // Opt out of Oracle GraalVM's default ML-inferred PGO profile. Oracle-only:
+                        // community toolchains reject -H:-MLProfileInference as unknown. Placed
+                        // before user buildArgs so an explicit override there still wins.
+                        val mlProfileResolution =
+                            resolveMlProfileInferenceArgs(
+                                mlProfileInference = resolvedMlProfileInference,
+                                isOracleGraalvm = oracleGraalvm,
+                                graalvmHome = resolvedGraalvmHome,
+                            )
+                        mlProfileResolution.warning?.let { logger.warn(it) }
+                        addAll(mlProfileResolution.args)
 
                         // PGO: either instrument (collect a profile) or apply a recorded one.
                         when {

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/mlProfileInferenceArgs.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/mlProfileInferenceArgs.kt
@@ -1,0 +1,40 @@
+package dev.nucleusframework.desktop.application.internal
+
+/**
+ * Oracle GraalVM's ML-inferred PGO profile opt-out, checked against the resolved toolchain.
+ *
+ * [args] is empty when ML profile inference stays at its default (enabled), or when the opt-out
+ * is dropped on a community toolchain — in which case [warning] explains why. Community builds
+ * have no ML profile inference in the first place, so the configuration is already a no-op there.
+ */
+internal data class MlProfileInferenceResolution(
+    val args: List<String>,
+    val warning: String?,
+)
+
+/**
+ * Resolves the `-H:-MLProfileInference` flag. The option is Oracle GraalVM-only; community
+ * toolchains (GraalVM CE, Liberica NIK, Mandrel) reject it as unknown and fail the build.
+ */
+internal fun resolveMlProfileInferenceArgs(
+    mlProfileInference: Boolean,
+    isOracleGraalvm: Boolean,
+    graalvmHome: String,
+): MlProfileInferenceResolution {
+    if (mlProfileInference) {
+        return MlProfileInferenceResolution(args = emptyList(), warning = null)
+    }
+    if (isOracleGraalvm) {
+        return MlProfileInferenceResolution(
+            args = listOf("-H:-MLProfileInference"),
+            warning = null,
+        )
+    }
+    return MlProfileInferenceResolution(
+        args = emptyList(),
+        warning =
+            "mlProfileInference = false ignored — -H:-MLProfileInference requires Oracle " +
+                "GraalVM (current toolchain: $graalvmHome). ML profile inference is " +
+                "Oracle-only, so community builds already behave as if it were disabled.",
+    )
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/MlProfileInferenceArgsTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/MlProfileInferenceArgsTest.kt
@@ -1,0 +1,49 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MlProfileInferenceArgsTest {
+    @Test
+    fun `enabled leaves args empty on any toolchain`() {
+        listOf(true, false).forEach { oracle ->
+            val resolution =
+                resolveMlProfileInferenceArgs(
+                    mlProfileInference = true,
+                    isOracleGraalvm = oracle,
+                    graalvmHome = "/opt/graalvm",
+                )
+            assertEquals(emptyList<String>(), resolution.args)
+            assertNull(resolution.warning)
+        }
+    }
+
+    @Test
+    fun `disabled emits the opt-out flag on Oracle GraalVM`() {
+        val resolution =
+            resolveMlProfileInferenceArgs(
+                mlProfileInference = false,
+                isOracleGraalvm = true,
+                graalvmHome = "/opt/graalvm-oracle",
+            )
+        assertEquals(listOf("-H:-MLProfileInference"), resolution.args)
+        assertNull(resolution.warning)
+    }
+
+    @Test
+    fun `disabled drops the flag and warns on a community toolchain`() {
+        val resolution =
+            resolveMlProfileInferenceArgs(
+                mlProfileInference = false,
+                isOracleGraalvm = false,
+                graalvmHome = "/opt/graalvm-ce",
+            )
+        assertEquals(emptyList<String>(), resolution.args)
+        val warning = requireNotNull(resolution.warning)
+        assertTrue(warning.contains("mlProfileInference = false ignored"))
+        assertTrue(warning.contains("requires Oracle GraalVM"))
+        assertTrue(warning.contains("/opt/graalvm-ce"))
+    }
+}


### PR DESCRIPTION
## Summary

- `mlProfileInference = false` no longer passes `-H:-MLProfileInference` on Community toolchains, where native-image rejects it as unrecognized and fails the build with exit code 20.
- The opt-out is gated on the resolved Oracle GraalVM toolchain (same pattern as `--pgo`, advanced obfuscation, and G1); community builds log a warning and skip the flag, which is already a no-op there.
- Adds a pure `resolveMlProfileInferenceArgs` helper with unit tests, and documents the community behavior on the DSL property.

Closes #452

## Test plan

- [x] Reproduced on GraalVM CE 25.2.4: `native-image -H:-MLProfileInference` → `Unrecognized option`
- [x] Confirmed Oracle lists `-H:±MLProfileInference` in `--expert-options`; CE does not
- [x] `./gradlew -p plugin-build :plugin:test --tests '*MlProfileInferenceArgsTest'`
- [ ] Optional: `graalvm { isEnabled = true; mlProfileInference = false }` then `:examples:tao-native-test:nativeImageCompile` on the default Community toolchain — should start without the unrecognized-option error