### PR TITLE
fix(graalvm): treat metadata dirs as nativeImageCompile inputs

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/AnalyzeStaticMetadataTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/AnalyzeStaticMetadataTask.kt
@@ -38,11 +38,18 @@ abstract class AnalyzeStaticMetadataTask : DefaultTask() {
 
     @TaskAction
     fun analyze() {
+        // Always materialize the output directory so consumers can declare it as a
+        // non-optional @InputDirectory / inputs.dir without fingerprint failures when
+        // the classpath is empty (Gradle requires @OutputDirectory to exist after the task).
+        val outDir = outputDir.get().asFile
+        outDir.mkdirs()
+
         val classpathEntries = runtimeClasspath.files.filter { it.exists() }
         val jars = classpathEntries.filter { it.name.endsWith(".jar") }
         val classDirs = classpathEntries.filter { it.isDirectory }
         if (jars.isEmpty() && classDirs.isEmpty()) {
             logger.info("No JARs or class directories to analyze for static metadata")
+            File(outDir, "reachability-metadata.json").writeText("{}\n")
             return
         }
 
@@ -63,9 +70,6 @@ abstract class AnalyzeStaticMetadataTask : DefaultTask() {
                 "${jniEntries.size} JNI, " +
                 "${resources.size} resource entries",
         )
-
-        val outDir = outputDir.get().asFile
-        outDir.mkdirs()
 
         val json = buildReachabilityMetadataJson(allReflection, jniEntries, resources)
         File(outDir, "reachability-metadata.json").writeText(json)

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -799,8 +799,6 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             generateWindowsResources?.let { dependsOn(it) }
 
             val uberJarFile = packageUberJar.flatMap { it.archiveFile }
-            inputs.file(uberJarFile)
-            inputs.file(metadataRepoDirsFile).optional()
             val outputDir = nativeCompileDir.get().asFile
             outputs.dir(outputDir)
 
@@ -860,7 +858,6 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                 ).flag
             // Quick build (`-Ob`) wins over the configured optimization for the fast dev run.
             val resolvedQuickBuild = quickBuildRequested
-            inputs.property("quickBuild", resolvedQuickBuild)
             val resolvedOptimizationFlag =
                 if (resolvedQuickBuild) "-Ob" else graalvm.optimization.orNull?.flag
             val resolvedAllCharsets = graalvm.allCharsets.get()
@@ -869,77 +866,93 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             val resolvedPgoEnabled = graalvm.pgo.enabled.get()
             val resolvedPgoProfile = pgoProfileFile
             val resolvedAdvancedObfuscation = graalvm.advancedObfuscation.get()
-            inputs.property("advancedObfuscation", resolvedAdvancedObfuscation)
             // Exact reachability: only the package list matters for the image binary; the
             // reporting mode is a runtime flag on runGraalvmNative. Track the packages (and
             // whether we are in quick-build) so a mode/package change recompiles.
             val (resolvedExactPackages, resolvedExactPackageWarning) =
                 resolveExactReachabilityPackages(exactReachabilitySetting, mainClassName)
+            val resolvedMissingRegistrationMode = missingRegistrationMode
+            val resolvedMaxHeapSize = graalvm.maxHeapSize.orNull
+            val resolvedMaxHeapSizePercent = graalvm.maxHeapSizePercent.get()
+            val resolvedGarbageCollector = graalvm.garbageCollector.orNull
+            val resolvedImageName = imageName.get()
+            val resolvedUberJar = uberJarFile.get().asFile.absolutePath
+            val resolvedMacOsMinVersion =
+                if (currentOS == OS.MacOS) graalvm.macOS.minimumSystemVersion.get() else null
+            // Keep File (not path strings) so inputs and -H:NativeLinkerOption share one value.
+            val resolvedStubObjFile: File? =
+                if (currentOS == OS.MacOS && compileStubs != null) {
+                    appTmpDir.get().file("graalvm/cursor_stub.o").asFile
+                } else {
+                    null
+                }
+            val resolvedResFile: File? =
+                if (currentOS == OS.Windows && generateWindowsResources != null) {
+                    appTmpDir.get().file("graalvm/icon.res").asFile
+                } else {
+                    null
+                }
+
+            // ── Inputs ──
+            // Args are assembled in doFirst, so Gradle cannot infer them from the command
+            // line. Declare every value that affects the binary here in one place (issue #431).
+            // Prefer producer task outputs for generated dirs so fingerprinting stays tied
+            // to the tasks that write them (dependsOn alone does not make outputs inputs).
+            //
+            // Optional paths that may not exist (user graalvm/ dir, Oracle extraction tree
+            // when the repo is empty, PGO profile before the first instrumented run) use
+            // fileTree / files() — inputs.dir(...).optional() still fails validation in
+            // Gradle 9 when the path is set but missing.
+            inputs.file(uberJarFile)
+            inputs
+                .files(project.fileTree(resolvedConfigDir))
+                .withPropertyName("nativeImageConfigDir")
+            inputs
+                .dir(filterLibraryMetadata.flatMap { it.outputDir })
+                .withPropertyName("libraryMetadataDir")
+            inputs
+                .files(generatePlatformMetadata.map { it.outputs.files })
+                .withPropertyName("platformMetadataDir")
+            inputs
+                .dir(analyzeStaticMetadata.flatMap { it.outputDir })
+                .withPropertyName("staticMetadataDir")
+            generateProjectResourceMetadata?.let { producer ->
+                inputs
+                    .dir(producer.flatMap { it.outputDir })
+                    .withPropertyName("projectResourceMetadataDir")
+            }
+            // Path list + extracted tree: a repo ZIP change that reuses the same relative
+            // dir names must still recompile.
+            inputs.files(project.layout.files(metadataRepoDirsFile)).withPropertyName("metadataRepoDirsFile")
+            inputs
+                .files(metadataRepoOutputDir.map { project.fileTree(it.asFile) })
+                .withPropertyName("metadataRepositoryDir")
+            resolvedStubObjFile?.let {
+                inputs.files(project.layout.files(it)).withPropertyName("cursorStubObj")
+            }
+            resolvedResFile?.let {
+                inputs.files(project.layout.files(it)).withPropertyName("windowsIconRes")
+            }
+            inputs.files(project.files(pgoProfileFile)).withPropertyName("pgoProfile")
+            inputs.property("quickBuild", resolvedQuickBuild)
+            inputs.property("optimization", resolvedOptimizationFlag ?: "")
+            inputs.property("advancedObfuscation", resolvedAdvancedObfuscation)
             inputs.property(
                 "exactReachabilityMetadata",
                 if (resolvedQuickBuild) resolvedExactPackages.joinToString(",") else "off",
             )
-            val resolvedMissingRegistrationMode = missingRegistrationMode
-            val resolvedMaxHeapSize = graalvm.maxHeapSize.orNull
-            val resolvedMaxHeapSizePercent = graalvm.maxHeapSizePercent.get()
             inputs.property("maxHeapSize", resolvedMaxHeapSize ?: "")
             inputs.property("maxHeapSizePercent", resolvedMaxHeapSizePercent)
-            val resolvedGarbageCollector = graalvm.garbageCollector.orNull
             inputs.property("garbageCollector", resolvedGarbageCollector?.name ?: "")
-            // Args assembled in doFirst are invisible to Gradle's up-to-date checks unless
-            // declared here. Missing inputs made metadata edits a silent no-op (issue #431).
-            inputs
-                .dir(resolvedConfigDir)
-                .optional()
-                .withPropertyName("nativeImageConfigDir")
-            inputs.dir(libraryMetadataDir).withPropertyName("libraryMetadataDir")
-            inputs.dir(platformMetadataDir).withPropertyName("platformMetadataDir")
-            inputs.dir(staticMetadataDir).withPropertyName("staticMetadataDir")
-            if (generateProjectResourceMetadata != null) {
-                inputs.dir(projectResourceMetadataDir).withPropertyName("projectResourceMetadataDir")
-            }
-            // The path list file is already an input; also fingerprint the extracted tree so a
-            // repo ZIP change that reuses the same relative dir names still recompiles.
-            inputs.dir(metadataRepoOutputDir).optional().withPropertyName("metadataRepositoryDir")
             inputs.property("march", resolvedMarch)
-            inputs.property("optimization", resolvedOptimizationFlag ?: "")
             inputs.property("allCharsets", resolvedAllCharsets)
             inputs.property("mlProfileInference", resolvedMlProfileInference)
             inputs.property("buildArgs", resolvedBuildArgs)
             inputs.property("pgoMode", resolvedPgoMode)
             inputs.property("pgoEnabled", resolvedPgoEnabled)
-            inputs.files(project.files(pgoProfileFile))
-            val resolvedImageName = imageName.get()
             inputs.property("imageName", resolvedImageName)
-            val resolvedUberJar = uberJarFile.get().asFile.absolutePath
-            val resolvedMacOsMinVersion =
-                if (currentOS == OS.MacOS) graalvm.macOS.minimumSystemVersion.get() else null
             if (resolvedMacOsMinVersion != null) {
                 inputs.property("macOsMinVersion", resolvedMacOsMinVersion)
-            }
-            val resolvedStubObj =
-                if (currentOS == OS.MacOS && compileStubs != null) {
-                    appTmpDir
-                        .get()
-                        .file("graalvm/cursor_stub.o")
-                        .asFile.absolutePath
-                } else {
-                    null
-                }
-            if (resolvedStubObj != null) {
-                inputs.file(File(resolvedStubObj)).optional().withPropertyName("cursorStubObj")
-            }
-            val resolvedResFile =
-                if (currentOS == OS.Windows && generateWindowsResources != null) {
-                    appTmpDir
-                        .get()
-                        .file("graalvm/icon.res")
-                        .asFile.absolutePath
-                } else {
-                    null
-                }
-            if (resolvedResFile != null) {
-                inputs.file(File(resolvedResFile)).optional().withPropertyName("windowsIconRes")
             }
 
             doFirst {
@@ -1114,13 +1127,13 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                         }
 
                         // macOS: link C stubs
-                        if (resolvedStubObj != null) {
-                            add("-H:NativeLinkerOption=$resolvedStubObj")
+                        if (resolvedStubObjFile != null) {
+                            add("-H:NativeLinkerOption=${resolvedStubObjFile.absolutePath}")
                         }
 
                         // Windows: link .res for icon + version info, configure subsystem
                         if (resolvedResFile != null) {
-                            add("-H:NativeLinkerOption=$resolvedResFile")
+                            add("-H:NativeLinkerOption=${resolvedResFile.absolutePath}")
                             add("-H:NativeLinkerOption=/SUBSYSTEM:WINDOWS")
                             add("-H:NativeLinkerOption=/ENTRY:mainCRTStartup")
                         }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -886,14 +886,37 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             inputs.property("maxHeapSizePercent", resolvedMaxHeapSizePercent)
             val resolvedGarbageCollector = graalvm.garbageCollector.orNull
             inputs.property("garbageCollector", resolvedGarbageCollector?.name ?: "")
-            // Rerun the compile when the PGO mode or the recorded profile changes — the args are
-            // assembled in doFirst, so they are not tracked as inputs by themselves.
+            // Args assembled in doFirst are invisible to Gradle's up-to-date checks unless
+            // declared here. Missing inputs made metadata edits a silent no-op (issue #431).
+            inputs
+                .dir(resolvedConfigDir)
+                .optional()
+                .withPropertyName("nativeImageConfigDir")
+            inputs.dir(libraryMetadataDir).withPropertyName("libraryMetadataDir")
+            inputs.dir(platformMetadataDir).withPropertyName("platformMetadataDir")
+            inputs.dir(staticMetadataDir).withPropertyName("staticMetadataDir")
+            if (generateProjectResourceMetadata != null) {
+                inputs.dir(projectResourceMetadataDir).withPropertyName("projectResourceMetadataDir")
+            }
+            // The path list file is already an input; also fingerprint the extracted tree so a
+            // repo ZIP change that reuses the same relative dir names still recompiles.
+            inputs.dir(metadataRepoOutputDir).optional().withPropertyName("metadataRepositoryDir")
+            inputs.property("march", resolvedMarch)
+            inputs.property("optimization", resolvedOptimizationFlag ?: "")
+            inputs.property("allCharsets", resolvedAllCharsets)
+            inputs.property("mlProfileInference", resolvedMlProfileInference)
+            inputs.property("buildArgs", resolvedBuildArgs)
             inputs.property("pgoMode", resolvedPgoMode)
+            inputs.property("pgoEnabled", resolvedPgoEnabled)
             inputs.files(project.files(pgoProfileFile))
             val resolvedImageName = imageName.get()
+            inputs.property("imageName", resolvedImageName)
             val resolvedUberJar = uberJarFile.get().asFile.absolutePath
             val resolvedMacOsMinVersion =
                 if (currentOS == OS.MacOS) graalvm.macOS.minimumSystemVersion.get() else null
+            if (resolvedMacOsMinVersion != null) {
+                inputs.property("macOsMinVersion", resolvedMacOsMinVersion)
+            }
             val resolvedStubObj =
                 if (currentOS == OS.MacOS && compileStubs != null) {
                     appTmpDir
@@ -903,6 +926,9 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                 } else {
                     null
                 }
+            if (resolvedStubObj != null) {
+                inputs.file(File(resolvedStubObj)).optional().withPropertyName("cursorStubObj")
+            }
             val resolvedResFile =
                 if (currentOS == OS.Windows && generateWindowsResources != null) {
                     appTmpDir
@@ -912,6 +938,9 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                 } else {
                     null
                 }
+            if (resolvedResFile != null) {
+                inputs.file(File(resolvedResFile)).optional().withPropertyName("windowsIconRes")
+            }
 
             doFirst {
                 outputDir.mkdirs()


### PR DESCRIPTION
## Summary

- Declare GraalVM metadata directories as `nativeImageCompile` inputs so editing reachability metadata actually invalidates the task instead of silently reusing the previous binary (`UP-TO-DATE`).
- Fingerprint the Oracle reachability-metadata extraction tree in addition to the path-list file.
- Track the remaining doFirst-assembled args that had the same class of bug (`march`, optimization, `buildArgs`, PGO enablement, image name, macOS min version, linker artifacts).
- Always materialize `analyzeStaticMetadata` output; register inputs from producer task outputs in one block; use `fileTree` for optional paths that may not exist (Gradle 9 rejects `inputs.dir(...).optional()` when the path is set but missing).

Closes #431

## Test plan

Verified e2e on Linux (`:examples:tao-native-test`, JDK 17 host / GraalVM CE 25 native-image), 2026-08-06:

- [x] Build a native image (`./gradlew :examples:tao-native-test:createGraalvmNativeDistributable`) — `nativeImageCompile` ran, `Finished generating`, packaging OK
- [x] Edit the app's `graalvm/reachability-metadata.json` (or a generated project-resource glob) — also re-checked via real `src/main/resources` change driving `generateGraalvmProjectResourceMetadata`
- [x] Re-run the same task → `nativeImageCompile` is **not** `UP-TO-DATE` and recompiles (`Finished generating` ~40s)
- [x] Confirm a no-op second run still reports `UP-TO-DATE` (~1s)