### PR TITLE
fix(graalvm): prune unresolvable cleanup metadata entries

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTask.kt
@@ -5,6 +5,7 @@ import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -25,11 +26,21 @@ import java.io.File
  * - **Static analysis**: Reflection/JNI/resource entries detected from bytecode
  * - **native-image.properties**: `-H:IncludeResources=` patterns from library JARs
  *
+ * After baseline dedup, a **resolvability** pass scans the runtime classpath for
+ * `.class` files and reports entries whose types cannot be found (typical tracing-agent
+ * noise such as mapped Kotlin types: `kotlin.Any`, `kotlin.collections.List`). Report
+ * is the default; removal requires
+ * `-Pnucleus.graalvm.cleanup.removeUnresolvable=true`. Types under
+ * [exactReachabilityPackages] are never removed — under exact reachability metadata a
+ * registration for a missing class restores `ClassNotFoundException` for optional probes.
+ *
+ * `-Pnucleus.graalvm.cleanup.dryRun=true` reports without rewriting the file.
+ *
  * Run with: `./gradlew cleanupGraalvmMetadata`
  */
 @DisableCachingByDefault(because = "Modifies user source files in-place")
 abstract class CleanupGraalvmMetadataTask : DefaultTask() {
-    /** Runtime classpath JARs (for L1 library metadata + native-image.properties). */
+    /** Runtime classpath JARs (for L1 library metadata + native-image.properties + class index). */
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val runtimeClasspath: ConfigurableFileCollection
@@ -59,6 +70,28 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
     @get:Input
     abstract val configDir: Property<File>
 
+    /**
+     * When true, drop unresolvable type entries after the baseline pass.
+     * Default false (report only) — see [NucleusProperties.GRAALVM_CLEANUP_REMOVE_UNRESOLVABLE].
+     */
+    @get:Input
+    abstract val removeUnresolvable: Property<Boolean>
+
+    /**
+     * When true, never rewrite the config file — only log what would change.
+     * See [NucleusProperties.GRAALVM_CLEANUP_DRY_RUN].
+     */
+    @get:Input
+    abstract val dryRun: Property<Boolean>
+
+    /**
+     * Package prefixes currently configured for exact reachability metadata
+     * (`APP_PACKAGES` / `packages(...)`). Unresolvable entries under these prefixes
+     * are reported but never removed, even with [removeUnresolvable].
+     */
+    @get:Input
+    abstract val exactReachabilityPackages: ListProperty<String>
+
     @TaskAction
     fun cleanup() {
         val targetDir = configDir.get()
@@ -66,6 +99,13 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
         if (!targetFile.exists()) {
             logger.lifecycle("No reachability-metadata.json found in $targetDir — nothing to clean up")
             return
+        }
+
+        val isDryRun = dryRun.getOrElse(false)
+        val shouldRemoveUnresolvable = removeUnresolvable.getOrElse(false)
+        val exactPackages = exactReachabilityPackages.getOrElse(emptyList())
+        if (isDryRun) {
+            logger.lifecycle("Dry run — will not rewrite $targetFile")
         }
 
         val slurper = JsonSlurper()
@@ -321,6 +361,51 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
             totalRemoved += before - targetResources.size
         }
 
+        // ── Resolvability pass ──
+        // Agent-recorded negative Class.forName lookups (kotlin.Any, kotlin.Int, …) and
+        // typos/stale renames never match a baseline. Scan the runtime classpath and
+        // report (default) or remove (opt-in) entries whose types resolve nowhere.
+        val classIndex = buildClasspathClassIndex(runtimeClasspath.files)
+        logger.lifecycle("Classpath class index: ${classIndex.size} types")
+
+        val unresolvableReported = mutableListOf<String>()
+        val unresolvableProtected = mutableListOf<String>()
+        for (section in listOf("reflection", "jni", "serialization")) {
+            @Suppress("UNCHECKED_CAST")
+            val targetArray = targetRoot[section] as? MutableList<Map<String, Any?>> ?: continue
+            val before = targetArray.size
+            targetArray.removeAll { projectEntry ->
+                if (isEntryResolvable(projectEntry, classIndex)) return@removeAll false
+                val label = entryDisplayName(projectEntry)
+                if (isEntryProtectedByExactReachability(projectEntry, exactPackages)) {
+                    unresolvableProtected.add("  [unresolvable/exact] [$section] $label")
+                    return@removeAll false
+                }
+                if (shouldRemoveUnresolvable) {
+                    removedEntries.add("  [unresolvable] [$section] $label")
+                    return@removeAll true
+                }
+                unresolvableReported.add("  [unresolvable] [$section] $label")
+                false
+            }
+            totalRemoved += before - targetArray.size
+        }
+
+        if (unresolvableReported.isNotEmpty()) {
+            logger.lifecycle(
+                "Unresolvable entries kept " +
+                    "(pass -P${NucleusProperties.GRAALVM_CLEANUP_REMOVE_UNRESOLVABLE}=true to remove):",
+            )
+            unresolvableReported.forEach { logger.lifecycle(it) }
+        }
+        if (unresolvableProtected.isNotEmpty()) {
+            logger.lifecycle(
+                "Unresolvable entries protected by exactReachabilityMetadata " +
+                    "(packages=${exactPackages.joinToString()}):",
+            )
+            unresolvableProtected.forEach { logger.lifecycle(it) }
+        }
+
         if (totalRemoved > 0) {
             // Remove empty sections
             for (section in listOf("reflection", "jni", "resources", "bundles", "serialization")) {
@@ -330,24 +415,37 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
                     targetRoot.remove(section)
                 }
             }
-            targetFile.writeText(JsonOutput.prettyPrint(JsonOutput.toJson(targetRoot)) + "\n")
-            logger.lifecycle("Removed $totalRemoved entries from $targetFile:")
+            if (!isDryRun) {
+                targetFile.writeText(JsonOutput.prettyPrint(JsonOutput.toJson(targetRoot)) + "\n")
+            }
+            val verb = if (isDryRun) "Would remove" else "Removed"
+            logger.lifecycle("$verb $totalRemoved entries from $targetFile:")
             removedEntries.forEach { logger.lifecycle(it) }
         } else {
             logger.lifecycle("No redundant entries found — manual config is already clean")
         }
 
-        // Report remaining entries
-        var remaining = 0
-        for (section in listOf("reflection", "jni")) {
+        // Report remaining entries that survived both baseline and resolvability passes.
+        // These are the ones worth a human look (member-less {"type": X} is not provably
+        // useless — it makes Class.forName(X) succeed — so it is never auto-removed).
+        val kept = mutableListOf<String>()
+        for (section in listOf("reflection", "jni", "serialization")) {
             @Suppress("UNCHECKED_CAST")
-            val arr = targetRoot[section] as? List<*>
-            remaining += arr?.size ?: 0
+            val arr = targetRoot[section] as? List<Map<String, Any?>> ?: continue
+            for (entry in arr) {
+                kept.add("  [kept — not covered by any managed source] [$section] ${entryDisplayName(entry)}")
+            }
         }
         @Suppress("UNCHECKED_CAST")
-        val resArr = targetRoot["resources"] as? List<*>
-        remaining += resArr?.size ?: 0
-        logger.lifecycle("Remaining manual entries: $remaining")
+        val resArr = targetRoot["resources"] as? List<Map<String, Any?>>
+        resArr?.forEach { entry ->
+            val glob = entry["glob"] ?: entry["bundle"] ?: "?"
+            kept.add("  [kept — not covered by any managed source] [resource] $glob")
+        }
+        logger.lifecycle("Remaining manual entries: ${kept.size}")
+        if (kept.isNotEmpty()) {
+            kept.forEach { logger.lifecycle(it) }
+        }
     }
 
     private fun countBaselineTypes(entries: Map<String, Map<String, MutableMap<String, Any?>>>): Int = entries.values.sumOf { it.size }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTask.kt
@@ -27,14 +27,18 @@ import java.io.File
  * - **native-image.properties**: `-H:IncludeResources=` patterns from library JARs
  *
  * After baseline dedup, a **resolvability** pass scans the runtime classpath for
- * `.class` files and reports entries whose types cannot be found (typical tracing-agent
- * noise such as mapped Kotlin types: `kotlin.Any`, `kotlin.collections.List`). Report
- * is the default; removal requires
- * `-Pnucleus.graalvm.cleanup.removeUnresolvable=true`. Types under
- * [exactReachabilityPackages] are never removed — under exact reachability metadata a
- * registration for a missing class restores `ClassNotFoundException` for optional probes.
+ * `.class` files and classifies each remaining type entry once:
+ * - `removed [baseline]` — covered by L1/L2/L3/static (or main class)
+ * - `removed [unresolvable]` — opt-in prune (`-Pnucleus.graalvm.cleanup.removeUnresolvable=true`)
+ * - `unresolvable (kept)` — missing type, default report-only
+ * - `unresolvable (exact-protected)` — missing type under [exactReachabilityPackages]
+ * - `kept` — resolvable but not covered by any managed baseline
  *
- * `-Pnucleus.graalvm.cleanup.dryRun=true` reports without rewriting the file.
+ * [exactReachabilityPackages] follows the DSL package list (`APP_PACKAGES` /
+ * `packages(...)`), not “was this image built with exact mode”, so cleanup never
+ * strips load-bearing negative lookups for apps that use exact mode on the dev loop.
+ *
+ * `-Pnucleus.graalvm.cleanup.dryRun=true` analyzes without rewriting the config file.
  *
  * Run with: `./gradlew cleanupGraalvmMetadata`
  */
@@ -85,9 +89,10 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
     abstract val dryRun: Property<Boolean>
 
     /**
-     * Package prefixes currently configured for exact reachability metadata
-     * (`APP_PACKAGES` / `packages(...)`). Unresolvable entries under these prefixes
-     * are reported but never removed, even with [removeUnresolvable].
+     * Package prefixes from the `exactReachabilityMetadata` DSL (`APP_PACKAGES` /
+     * `packages(...)`). Unresolvable entries under these prefixes are never removed,
+     * even with [removeUnresolvable]. Follows the configured scope, not whether a
+     * given native-image build actually emitted `--exact-reachability-metadata`.
      */
     @get:Input
     abstract val exactReachabilityPackages: ListProperty<String>
@@ -281,8 +286,13 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
         // Parse the project's manual config
         @Suppress("UNCHECKED_CAST")
         val targetRoot = slurper.parseText(targetFile.readText()) as MutableMap<String, Any?>
-        var totalRemoved = 0
-        val removedEntries = mutableListOf<String>()
+
+        // Single disposition table for the whole run (baseline + resolvability + leftovers).
+        val report = mutableListOf<String>()
+        var baselineRemoved = 0
+        var unresolvableRemoved = 0
+        var unresolvableReported = 0
+        var unresolvableProtected = 0
 
         // Clean reflection/jni sections against same-section AND cross-section baselines
         // (static analyzer puts SQLite in "jni", manual config may have it in "reflection")
@@ -293,10 +303,10 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
 
             targetArray.removeAll { projectEntry ->
                 // Handle proxy entries: {"type": {"proxy": [...]}}
-                val proxyKey = proxyKey(projectEntry)
-                if (proxyKey != null) {
-                    if (proxyKey in libraryProxies) {
-                        removedEntries.add("  [$projectSection proxy] $proxyKey")
+                val pk = proxyKey(projectEntry)
+                if (pk != null) {
+                    if (pk in libraryProxies) {
+                        report.add("  [removed/baseline] [$projectSection proxy] $pk")
                         return@removeAll true
                     }
                     return@removeAll false
@@ -309,8 +319,13 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
                     val sectionMap = libraryEntries[baselineSection] ?: continue
                     val libEntry = sectionMap[typeName] ?: continue
                     if (libraryCoversProjectEntry(libEntry, projectEntry)) {
-                        val source = if (baselineSection == projectSection) baselineSection else "$projectSection via $baselineSection"
-                        removedEntries.add("  [$source] $typeName")
+                        val source =
+                            if (baselineSection == projectSection) {
+                                projectSection
+                            } else {
+                                "$projectSection via $baselineSection"
+                            }
+                        report.add("  [removed/baseline] [$source] $typeName")
                         return@removeAll true
                     }
                 }
@@ -328,7 +343,7 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
                         val parentMethods = parentEntry["methods"] as? List<Map<String, Any?>>
                         val hasSerializer = parentMethods?.any { it["name"] == "serializer" } == true
                         if (hasSerializer) {
-                            removedEntries.add("  [$projectSection via parent] $typeName")
+                            report.add("  [removed/baseline] [$projectSection via parent] $typeName")
                             return@removeAll true
                         }
                     }
@@ -336,7 +351,7 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
 
                 false
             }
-            totalRemoved += before - targetArray.size
+            baselineRemoved += before - targetArray.size
         }
 
         // Clean resources section
@@ -354,60 +369,80 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
                     )
                 if (covered) {
                     val glob = entry["glob"] ?: entry["bundle"] ?: "?"
-                    removedEntries.add("  [resource] $glob")
+                    report.add("  [removed/baseline] [resource] $glob")
                 }
                 covered
             }
-            totalRemoved += before - targetResources.size
+            baselineRemoved += before - targetResources.size
         }
 
         // ── Resolvability pass ──
         // Agent-recorded negative Class.forName lookups (kotlin.Any, kotlin.Int, …) and
-        // typos/stale renames never match a baseline. Scan the runtime classpath and
-        // report (default) or remove (opt-in) entries whose types resolve nowhere.
+        // typos/stale renames never match a baseline. Classify each survivor once.
         val classIndex = buildClasspathClassIndex(runtimeClasspath.files)
         logger.lifecycle("Classpath class index: ${classIndex.size} types")
 
-        val unresolvableReported = mutableListOf<String>()
-        val unresolvableProtected = mutableListOf<String>()
+        // Track which survivors were already classified as unresolvable so the final
+        // "kept" pass does not re-list them.
+        val classifiedUnresolvableKeys = mutableSetOf<String>()
         for (section in listOf("reflection", "jni", "serialization")) {
             @Suppress("UNCHECKED_CAST")
             val targetArray = targetRoot[section] as? MutableList<Map<String, Any?>> ?: continue
             val before = targetArray.size
             targetArray.removeAll { projectEntry ->
-                if (isEntryResolvable(projectEntry, classIndex)) return@removeAll false
-                val label = entryDisplayName(projectEntry)
-                if (isEntryProtectedByExactReachability(projectEntry, exactPackages)) {
-                    unresolvableProtected.add("  [unresolvable/exact] [$section] $label")
-                    return@removeAll false
+                when (
+                    classifyUnresolvableEntry(
+                        projectEntry,
+                        classIndex,
+                        exactPackages,
+                        shouldRemoveUnresolvable,
+                    )
+                ) {
+                    UnresolvableDisposition.RESOLVABLE -> false
+                    UnresolvableDisposition.REMOVE -> {
+                        report.add(formatDispositionLine("removed/unresolvable", section, projectEntry))
+                        true
+                    }
+                    UnresolvableDisposition.REPORT -> {
+                        report.add(formatDispositionLine("unresolvable/kept", section, projectEntry))
+                        classifiedUnresolvableKeys.add("$section|${entryDisplayName(projectEntry)}")
+                        unresolvableReported++
+                        false
+                    }
+                    UnresolvableDisposition.PROTECT -> {
+                        report.add(formatDispositionLine("unresolvable/exact-protected", section, projectEntry))
+                        classifiedUnresolvableKeys.add("$section|${entryDisplayName(projectEntry)}")
+                        unresolvableProtected++
+                        false
+                    }
                 }
-                if (shouldRemoveUnresolvable) {
-                    removedEntries.add("  [unresolvable] [$section] $label")
-                    return@removeAll true
-                }
-                unresolvableReported.add("  [unresolvable] [$section] $label")
-                false
             }
-            totalRemoved += before - targetArray.size
+            unresolvableRemoved += before - targetArray.size
         }
 
-        if (unresolvableReported.isNotEmpty()) {
-            logger.lifecycle(
-                "Unresolvable entries kept " +
-                    "(pass -P${NucleusProperties.GRAALVM_CLEANUP_REMOVE_UNRESOLVABLE}=true to remove):",
-            )
-            unresolvableReported.forEach { logger.lifecycle(it) }
+        // Resolvable leftovers not covered by any managed baseline — worth a human look.
+        // Member-less {"type": X} is not provably useless (Class.forName(X) succeeds).
+        var keptResolvable = 0
+        for (section in listOf("reflection", "jni", "serialization")) {
+            @Suppress("UNCHECKED_CAST")
+            val arr = targetRoot[section] as? List<Map<String, Any?>> ?: continue
+            for (entry in arr) {
+                val key = "$section|${entryDisplayName(entry)}"
+                if (key in classifiedUnresolvableKeys) continue
+                report.add(formatDispositionLine("kept", section, entry))
+                keptResolvable++
+            }
         }
-        if (unresolvableProtected.isNotEmpty()) {
-            logger.lifecycle(
-                "Unresolvable entries protected by exactReachabilityMetadata " +
-                    "(packages=${exactPackages.joinToString()}):",
-            )
-            unresolvableProtected.forEach { logger.lifecycle(it) }
+        @Suppress("UNCHECKED_CAST")
+        val resArr = targetRoot["resources"] as? List<Map<String, Any?>>
+        resArr?.forEach { entry ->
+            val glob = entry["glob"] ?: entry["bundle"] ?: "?"
+            report.add("  [kept] [resource] $glob")
+            keptResolvable++
         }
 
+        val totalRemoved = baselineRemoved + unresolvableRemoved
         if (totalRemoved > 0) {
-            // Remove empty sections
             for (section in listOf("reflection", "jni", "resources", "bundles", "serialization")) {
                 @Suppress("UNCHECKED_CAST")
                 val arr = targetRoot[section] as? List<*>
@@ -418,45 +453,45 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
             if (!isDryRun) {
                 targetFile.writeText(JsonOutput.prettyPrint(JsonOutput.toJson(targetRoot)) + "\n")
             }
-            val verb = if (isDryRun) "Would remove" else "Removed"
-            logger.lifecycle("$verb $totalRemoved entries from $targetFile:")
-            removedEntries.forEach { logger.lifecycle(it) }
-        } else {
-            logger.lifecycle("No redundant entries found — manual config is already clean")
         }
 
-        // Report remaining entries that survived both baseline and resolvability passes.
-        // These are the ones worth a human look (member-less {"type": X} is not provably
-        // useless — it makes Class.forName(X) succeed — so it is never auto-removed).
-        val kept = mutableListOf<String>()
-        for (section in listOf("reflection", "jni", "serialization")) {
-            @Suppress("UNCHECKED_CAST")
-            val arr = targetRoot[section] as? List<Map<String, Any?>> ?: continue
-            for (entry in arr) {
-                kept.add("  [kept — not covered by any managed source] [$section] ${entryDisplayName(entry)}")
-            }
+        val verb = if (isDryRun) "Would remove" else "Removed"
+        when {
+            totalRemoved > 0 ->
+                logger.lifecycle(
+                    "$verb $totalRemoved entr${if (totalRemoved == 1) "y" else "ies"} " +
+                        "(baseline=$baselineRemoved, unresolvable=$unresolvableRemoved) from $targetFile",
+                )
+            unresolvableReported > 0 || unresolvableProtected > 0 ->
+                logger.lifecycle(
+                    "No baseline-redundant entries — " +
+                        "$unresolvableReported unresolvable kept" +
+                        (if (unresolvableProtected > 0) ", $unresolvableProtected exact-protected" else "") +
+                        (if (!shouldRemoveUnresolvable && unresolvableReported > 0) {
+                            " (pass -P${NucleusProperties.GRAALVM_CLEANUP_REMOVE_UNRESOLVABLE}=true to remove)"
+                        } else {
+                            ""
+                        }),
+                )
+            else ->
+                logger.lifecycle("No redundant or unresolvable entries — manual config is already clean")
         }
-        @Suppress("UNCHECKED_CAST")
-        val resArr = targetRoot["resources"] as? List<Map<String, Any?>>
-        resArr?.forEach { entry ->
-            val glob = entry["glob"] ?: entry["bundle"] ?: "?"
-            kept.add("  [kept — not covered by any managed source] [resource] $glob")
+
+        if (report.isNotEmpty()) {
+            logger.lifecycle("Disposition (${report.size}):")
+            report.forEach { logger.lifecycle(it) }
         }
-        logger.lifecycle("Remaining manual entries: ${kept.size}")
-        if (kept.isNotEmpty()) {
-            kept.forEach { logger.lifecycle(it) }
-        }
+        logger.lifecycle(
+            "Summary: removed=$totalRemoved " +
+                "(baseline=$baselineRemoved, unresolvable=$unresolvableRemoved), " +
+                "unresolvable/kept=$unresolvableReported, " +
+                "unresolvable/exact-protected=$unresolvableProtected, " +
+                "kept=$keptResolvable",
+        )
     }
 
-    private fun countBaselineTypes(entries: Map<String, Map<String, MutableMap<String, Any?>>>): Int = entries.values.sumOf { it.size }
-
-    /** Extract a canonical key for proxy entries, or null if not a proxy. */
-    @Suppress("UNCHECKED_CAST")
-    private fun proxyKey(entry: Map<String, Any?>): String? {
-        val typeValue = entry["type"] as? Map<String, Any?> ?: return null
-        val proxyList = typeValue["proxy"] as? List<String> ?: return null
-        return proxyList.sorted().joinToString(",")
-    }
+    private fun countBaselineTypes(entries: Map<String, Map<String, MutableMap<String, Any?>>>): Int =
+        entries.values.sumOf { it.size }
 
     private fun collectBaseline(
         slurper: JsonSlurper,

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/FilterLibraryMetadataTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/FilterLibraryMetadataTask.kt
@@ -12,7 +12,6 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import java.io.File
-import java.util.jar.JarFile
 
 /**
  * Filters per-library GraalVM metadata based on the runtime classpath and merges
@@ -98,39 +97,4 @@ abstract class FilterLibraryMetadataTask : DefaultTask() {
             "Library metadata: included $includedCount files, skipped $skippedCount conditional files",
         )
     }
-}
-
-/**
- * Scans classpath JARs and class directories to build a set of all Java package names present.
- * Only reads the ZIP central directory (fast) — no class file parsing.
- */
-private fun buildClasspathPackageIndex(files: Set<File>): Set<String> {
-    val packages = mutableSetOf<String>()
-    for (file in files) {
-        if (!file.exists()) continue
-        if (file.isDirectory) {
-            file
-                .walkTopDown()
-                .filter { it.isFile && it.name.endsWith(".class") }
-                .forEach { classFile ->
-                    val relative = classFile.relativeTo(file).path
-                    val pkg = relative.substringBeforeLast('/', "").replace('/', '.')
-                    if (pkg.isNotEmpty()) packages.add(pkg)
-                }
-        } else if (file.name.endsWith(".jar")) {
-            try {
-                JarFile(file).use { jar ->
-                    for (entry in jar.entries()) {
-                        if (entry.name.endsWith(".class") && !entry.isDirectory) {
-                            val pkg = entry.name.substringBeforeLast('/', "").replace('/', '.')
-                            if (pkg.isNotEmpty()) packages.add(pkg)
-                        }
-                    }
-                }
-            } catch (_: Exception) {
-                // Skip unreadable JARs
-            }
-        }
-    }
-    return packages
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvability.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvability.kt
@@ -1,0 +1,211 @@
+package dev.nucleusframework.desktop.application.internal
+
+import java.io.File
+import java.util.jar.JarFile
+
+/**
+ * Prefixes treated as always resolvable without scanning the runtime classpath.
+ * Covers the JDK and the classic `sun.*` / `com.sun.*` internal trees that live in
+ * the image runtime, not in application JARs.
+ */
+internal val JDK_TYPE_PREFIXES =
+    listOf(
+        "java.",
+        "javax.",
+        "jdk.",
+        "sun.",
+        "com.sun.",
+    )
+
+private val JVM_PRIMITIVE_ARRAY_ELEMENT =
+    setOf('Z', 'B', 'C', 'S', 'I', 'J', 'F', 'D')
+
+/**
+ * Scans classpath JARs and class directories for fully-qualified binary class names
+ * (dots, `$` for nested types). Reads only entry names / file paths — no classloading,
+ * so static initializers never run and no toolchain JVM is required.
+ */
+internal fun buildClasspathClassIndex(files: Collection<File>): Set<String> {
+    val classes = mutableSetOf<String>()
+    for (file in files) {
+        if (!file.exists()) continue
+        if (file.isDirectory) {
+            file
+                .walkTopDown()
+                .filter { it.isFile && it.name.endsWith(".class") }
+                .forEach { classFile ->
+                    val relative = classFile.relativeTo(file).path.replace(File.separatorChar, '/')
+                    classNameFromClassPath(relative)?.let { classes.add(it) }
+                }
+        } else if (file.name.endsWith(".jar")) {
+            try {
+                JarFile(file).use { jar ->
+                    for (entry in jar.entries()) {
+                        if (entry.isDirectory) continue
+                        classNameFromClassPath(entry.name)?.let { classes.add(it) }
+                    }
+                }
+            } catch (_: Exception) {
+                // Skip unreadable JARs
+            }
+        }
+    }
+    return classes
+}
+
+/**
+ * Converts a classpath-relative `.class` path into a binary name, or `null` when the
+ * path is not a regular class (e.g. `module-info.class`). Handles multi-release JAR
+ * prefixes (`META-INF/versions/N/...`).
+ */
+internal fun classNameFromClassPath(entryName: String): String? {
+    if (!entryName.endsWith(".class")) return null
+    if (entryName.endsWith("module-info.class")) return null
+    var path = entryName
+    if (path.startsWith("META-INF/versions/")) {
+        val afterVersion = path.removePrefix("META-INF/versions/")
+        val slash = afterVersion.indexOf('/')
+        if (slash < 0) return null
+        path = afterVersion.substring(slash + 1)
+        if (path.endsWith("module-info.class")) return null
+    }
+    return path.removeSuffix(".class").replace('/', '.')
+}
+
+/**
+ * Strips Java-style array suffixes (`[]`, possibly repeated) and decodes JVM array
+ * descriptors (`[B`, `[Ljava.lang.String;`) down to the element binary name.
+ * Returns the normalized name, or `null` when the descriptor is a primitive array
+ * (always resolvable — caller should treat as present).
+ */
+internal fun normalizeTypeForLookup(typeName: String): String? {
+    var name = typeName.trim()
+    if (name.isEmpty()) return name
+
+    // Java-style: "foo.Bar[][]"
+    while (name.endsWith("[]")) {
+        name = name.removeSuffix("[]").trimEnd()
+    }
+
+    // JVM descriptors: "[B", "[[Ljava.lang.String;"
+    if (name.startsWith('[')) {
+        var depth = 0
+        while (depth < name.length && name[depth] == '[') depth++
+        if (depth >= name.length) return name
+        return when (val tag = name[depth]) {
+            in JVM_PRIMITIVE_ARRAY_ELEMENT -> null // primitive array → always resolvable
+            'L' -> {
+                val semi = name.indexOf(';', depth)
+                if (semi < 0) name.substring(depth + 1) else name.substring(depth + 1, semi)
+            }
+            else -> name.substring(depth)
+        }
+    }
+
+    return name
+}
+
+/** True when [typeName] is a JDK / sun type that does not need a classpath hit. */
+internal fun isJdkType(typeName: String): Boolean {
+    val normalized = normalizeTypeForLookup(typeName) ?: return true
+    if (normalized.isEmpty()) return true
+    // Primitive keywords occasionally appear as agent noise.
+    if (normalized in JVM_PRIMITIVE_KEYWORDS) return true
+    return JDK_TYPE_PREFIXES.any { normalized.startsWith(it) }
+}
+
+private val JVM_PRIMITIVE_KEYWORDS =
+    setOf("boolean", "byte", "char", "short", "int", "long", "float", "double", "void")
+
+/**
+ * True when [typeName] can be found as a `.class` on the runtime classpath, or is a
+ * JDK/primitive type that lives in the image runtime rather than application JARs.
+ */
+internal fun isTypeResolvable(
+    typeName: String,
+    classIndex: Set<String>,
+): Boolean {
+    val normalized = normalizeTypeForLookup(typeName) ?: return true
+    if (normalized.isEmpty()) return true
+    if (isJdkType(normalized)) return true
+    return normalized in classIndex
+}
+
+/**
+ * True when [typeName] falls under any of the exact-reachability package prefixes
+ * (prefix match, same rule as `--exact-reachability-metadata=`).
+ * Empty [packages] means exact mode is off → nothing is protected.
+ */
+internal fun isUnderExactReachabilityPackages(
+    typeName: String,
+    packages: Collection<String>,
+): Boolean {
+    if (packages.isEmpty()) return false
+    val normalized = normalizeTypeForLookup(typeName) ?: return false
+    return packages.any { prefix ->
+        normalized == prefix || normalized.startsWith("$prefix.")
+    }
+}
+
+/**
+ * Extracts the type string from a reflection/jni/serialization entry, or `null` when
+ * the entry is a proxy (`{"type": {"proxy": [...]}}`) or has no type field.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun typeNameOfEntry(entry: Map<String, Any?>): String? {
+    val type = entry["type"] ?: return null
+    if (type is String) return type
+    return null
+}
+
+/**
+ * Interface names listed on a proxy entry, or empty when [entry] is not a proxy.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun proxyInterfaceNames(entry: Map<String, Any?>): List<String> {
+    val typeValue = entry["type"] as? Map<String, Any?> ?: return emptyList()
+    val proxyList = typeValue["proxy"] as? List<*> ?: return emptyList()
+    return proxyList.mapNotNull { it as? String }
+}
+
+/**
+ * True when every type referenced by [entry] resolves on [classIndex] (or is JDK).
+ * Proxy entries require every interface to resolve. Entries without a type field
+ * are treated as resolvable (nothing to check).
+ */
+internal fun isEntryResolvable(
+    entry: Map<String, Any?>,
+    classIndex: Set<String>,
+): Boolean {
+    val proxies = proxyInterfaceNames(entry)
+    if (proxies.isNotEmpty()) {
+        return proxies.all { isTypeResolvable(it, classIndex) }
+    }
+    val typeName = typeNameOfEntry(entry) ?: return true
+    return isTypeResolvable(typeName, classIndex)
+}
+
+/**
+ * True when the entry should be protected from unresolvable removal because exact
+ * reachability metadata is scoped to its package(s). For proxies, any interface
+ * under the scope is enough to keep the whole entry (a partial probe still needs CNFE).
+ */
+internal fun isEntryProtectedByExactReachability(
+    entry: Map<String, Any?>,
+    packages: Collection<String>,
+): Boolean {
+    if (packages.isEmpty()) return false
+    val proxies = proxyInterfaceNames(entry)
+    if (proxies.isNotEmpty()) {
+        return proxies.any { isUnderExactReachabilityPackages(it, packages) }
+    }
+    val typeName = typeNameOfEntry(entry) ?: return false
+    return isUnderExactReachabilityPackages(typeName, packages)
+}
+
+/** Display label for an entry used in task logs. */
+internal fun entryDisplayName(entry: Map<String, Any?>): String {
+    val proxies = proxyInterfaceNames(entry)
+    if (proxies.isNotEmpty()) return "proxy[${proxies.sorted().joinToString(",")}]"
+    return typeNameOfEntry(entry) ?: "?"
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvability.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvability.kt
@@ -20,6 +20,64 @@ internal val JDK_TYPE_PREFIXES =
 private val JVM_PRIMITIVE_ARRAY_ELEMENT =
     setOf('Z', 'B', 'C', 'S', 'I', 'J', 'F', 'D')
 
+private val JVM_PRIMITIVE_KEYWORDS =
+    setOf("boolean", "byte", "char", "short", "int", "long", "float", "double", "void")
+
+/**
+ * What to do with a type entry during the resolvability pass of [CleanupGraalvmMetadataTask].
+ *
+ * Pure policy — no I/O, no logging. The task only partitions and prints.
+ */
+internal enum class UnresolvableDisposition {
+    /** Type exists on the classpath (or is JDK/primitive). Leave alone. */
+    RESOLVABLE,
+
+    /** Missing type, outside exact packages, opt-in prune is off — keep and report. */
+    REPORT,
+
+    /**
+     * Missing type under [exactReachabilityPackages]. Keep always: under exact mode a
+     * registration for a non-existent class is what restores `ClassNotFoundException`
+     * for optional-dependency probes.
+     */
+    PROTECT,
+
+    /** Missing type, opt-in prune is on, not under exact packages — drop. */
+    REMOVE,
+}
+
+/**
+ * Classifies a reflection/jni/serialization entry for the resolvability pass.
+ *
+ * [exactPackages] is the DSL package list (`APP_PACKAGES` / `packages(...)`), not
+ * “was this image built with exact mode”. Protection follows the configured scope so
+ * cleanup never strips load-bearing negative lookups for apps that use exact mode on
+ * the dev loop.
+ */
+internal fun classifyUnresolvableEntry(
+    entry: Map<String, Any?>,
+    classIndex: Set<String>,
+    exactPackages: Collection<String>,
+    removeUnresolvable: Boolean,
+): UnresolvableDisposition {
+    if (isEntryResolvable(entry, classIndex)) return UnresolvableDisposition.RESOLVABLE
+    if (isEntryProtectedByExactReachability(entry, exactPackages)) {
+        return UnresolvableDisposition.PROTECT
+    }
+    return if (removeUnresolvable) {
+        UnresolvableDisposition.REMOVE
+    } else {
+        UnresolvableDisposition.REPORT
+    }
+}
+
+/** One-line log label for a classified entry: `[kind] [section] name`. */
+internal fun formatDispositionLine(
+    kind: String,
+    section: String,
+    entry: Map<String, Any?>,
+): String = "  [$kind] [$section] ${entryDisplayName(entry)}"
+
 /**
  * Scans classpath JARs and class directories for fully-qualified binary class names
  * (dots, `$` for nested types). Reads only entry names / file paths — no classloading,
@@ -54,6 +112,17 @@ internal fun buildClasspathClassIndex(files: Collection<File>): Set<String> {
 }
 
 /**
+ * Package names present on the classpath, derived from [buildClasspathClassIndex].
+ * Shared by library-metadata filtering and any other package-presence checks.
+ */
+internal fun buildClasspathPackageIndex(files: Collection<File>): Set<String> =
+    buildClasspathClassIndex(files)
+        .mapNotNull { className ->
+            val lastDot = className.lastIndexOf('.')
+            if (lastDot <= 0) null else className.substring(0, lastDot)
+        }.toSet()
+
+/**
  * Converts a classpath-relative `.class` path into a binary name, or `null` when the
  * path is not a regular class (e.g. `module-info.class`). Handles multi-release JAR
  * prefixes (`META-INF/versions/N/...`).
@@ -82,18 +151,16 @@ internal fun normalizeTypeForLookup(typeName: String): String? {
     var name = typeName.trim()
     if (name.isEmpty()) return name
 
-    // Java-style: "foo.Bar[][]"
     while (name.endsWith("[]")) {
         name = name.removeSuffix("[]").trimEnd()
     }
 
-    // JVM descriptors: "[B", "[[Ljava.lang.String;"
     if (name.startsWith('[')) {
         var depth = 0
         while (depth < name.length && name[depth] == '[') depth++
         if (depth >= name.length) return name
         return when (val tag = name[depth]) {
-            in JVM_PRIMITIVE_ARRAY_ELEMENT -> null // primitive array → always resolvable
+            in JVM_PRIMITIVE_ARRAY_ELEMENT -> null
             'L' -> {
                 val semi = name.indexOf(';', depth)
                 if (semi < 0) name.substring(depth + 1) else name.substring(depth + 1, semi)
@@ -105,18 +172,6 @@ internal fun normalizeTypeForLookup(typeName: String): String? {
     return name
 }
 
-/** True when [typeName] is a JDK / sun type that does not need a classpath hit. */
-internal fun isJdkType(typeName: String): Boolean {
-    val normalized = normalizeTypeForLookup(typeName) ?: return true
-    if (normalized.isEmpty()) return true
-    // Primitive keywords occasionally appear as agent noise.
-    if (normalized in JVM_PRIMITIVE_KEYWORDS) return true
-    return JDK_TYPE_PREFIXES.any { normalized.startsWith(it) }
-}
-
-private val JVM_PRIMITIVE_KEYWORDS =
-    setOf("boolean", "byte", "char", "short", "int", "long", "float", "double", "void")
-
 /**
  * True when [typeName] can be found as a `.class` on the runtime classpath, or is a
  * JDK/primitive type that lives in the image runtime rather than application JARs.
@@ -127,7 +182,8 @@ internal fun isTypeResolvable(
 ): Boolean {
     val normalized = normalizeTypeForLookup(typeName) ?: return true
     if (normalized.isEmpty()) return true
-    if (isJdkType(normalized)) return true
+    if (normalized in JVM_PRIMITIVE_KEYWORDS) return true
+    if (JDK_TYPE_PREFIXES.any { normalized.startsWith(it) }) return true
     return normalized in classIndex
 }
 
@@ -147,16 +203,8 @@ internal fun isUnderExactReachabilityPackages(
     }
 }
 
-/**
- * Extracts the type string from a reflection/jni/serialization entry, or `null` when
- * the entry is a proxy (`{"type": {"proxy": [...]}}`) or has no type field.
- */
-@Suppress("UNCHECKED_CAST")
-internal fun typeNameOfEntry(entry: Map<String, Any?>): String? {
-    val type = entry["type"] ?: return null
-    if (type is String) return type
-    return null
-}
+/** Type string from a reflection/jni/serialization entry, or null for proxies / missing type. */
+internal fun typeNameOfEntry(entry: Map<String, Any?>): String? = entry["type"] as? String
 
 /**
  * Interface names listed on a proxy entry, or empty when [entry] is not a proxy.
@@ -166,6 +214,16 @@ internal fun proxyInterfaceNames(entry: Map<String, Any?>): List<String> {
     val typeValue = entry["type"] as? Map<String, Any?> ?: return emptyList()
     val proxyList = typeValue["proxy"] as? List<*> ?: return emptyList()
     return proxyList.mapNotNull { it as? String }
+}
+
+/**
+ * Canonical key for proxy entries (`sorted interfaces joined by comma`), or null if not a proxy.
+ * Shared by baseline dedup and resolvability.
+ */
+internal fun proxyKey(entry: Map<String, Any?>): String? {
+    val interfaces = proxyInterfaceNames(entry)
+    if (interfaces.isEmpty()) return null
+    return interfaces.sorted().joinToString(",")
 }
 
 /**
@@ -187,8 +245,8 @@ internal fun isEntryResolvable(
 
 /**
  * True when the entry should be protected from unresolvable removal because exact
- * reachability metadata is scoped to its package(s). For proxies, any interface
- * under the scope is enough to keep the whole entry (a partial probe still needs CNFE).
+ * reachability packages cover it. For proxies, any interface under the scope keeps
+ * the whole entry.
  */
 internal fun isEntryProtectedByExactReachability(
     entry: Map<String, Any?>,

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NucleusProjectProperties.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NucleusProjectProperties.kt
@@ -50,6 +50,22 @@ internal object NucleusProperties {
      */
     internal const val GRAALVM_MISSING_REGISTRATION = "nucleus.graalvm.missingRegistration"
 
+    /**
+     * When `true`, `cleanupGraalvmMetadata` removes entries whose types are not on the
+     * runtime classpath (and not JDK). Default is report-only: unresolvable entries are
+     * listed as `[unresolvable]` but kept, because under `--exact-reachability-metadata`
+     * a registration for a missing type is what restores `ClassNotFoundException` for
+     * optional-dependency probes.
+     */
+    internal const val GRAALVM_CLEANUP_REMOVE_UNRESOLVABLE = "nucleus.graalvm.cleanup.removeUnresolvable"
+
+    /**
+     * When `true`, `cleanupGraalvmMetadata` reports what it would remove (baseline
+     * duplicates and unresolvable types) but never rewrites the project's
+     * `reachability-metadata.json`.
+     */
+    internal const val GRAALVM_CLEANUP_DRY_RUN = "nucleus.graalvm.cleanup.dryRun"
+
     fun isVerbose(providers: ProviderFactory): Provider<Boolean> = providers.valueOrNull(VERBOSE).toBooleanProvider(false)
 
     fun preserveWorkingDir(providers: ProviderFactory): Provider<Boolean> = providers.valueOrNull(PRESERVE_WD).toBooleanProvider(false)
@@ -116,6 +132,12 @@ internal object NucleusProperties {
 
     fun graalvmMissingRegistration(providers: ProviderFactory): Provider<String> =
         providers.valueOrNull(GRAALVM_MISSING_REGISTRATION)
+
+    fun graalvmCleanupRemoveUnresolvable(providers: ProviderFactory): Provider<Boolean> =
+        providers.valueOrNull(GRAALVM_CLEANUP_REMOVE_UNRESOLVABLE).toBooleanProvider(false)
+
+    fun graalvmCleanupDryRun(providers: ProviderFactory): Provider<Boolean> =
+        providers.valueOrNull(GRAALVM_CLEANUP_DRY_RUN).toBooleanProvider(false)
 
     // providers.valueOrNull works only with root gradle.properties
     fun dontSyncResources(project: Project): Provider<Boolean> =

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -740,6 +740,13 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
     // ── Cleanup manual metadata ──
     // Removes entries from the project's reachability-metadata.json that are already
     // covered by L1 (library JARs), L2 (Oracle repo), L3 (platform), or static analysis.
+    // Also reports (opt-in removes) types that do not exist on the runtime classpath.
+
+    // Exact packages for the cleanup gate (same list as the dev-loop compile input).
+    // When non-empty, unresolvable types under these prefixes stay — under exact mode
+    // they restore ClassNotFoundException for optional-dependency probes (issue #439).
+    val (cleanupExactPackages, _) =
+        resolveExactReachabilityPackages(exactReachabilitySetting, mainClassName)
 
     project.tasks
         .register(
@@ -748,7 +755,8 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
         ).apply {
             configure { task ->
                 task.description =
-                    "Remove entries from manual reachability-metadata.json that are already managed by Nucleus"
+                    "Remove entries from manual reachability-metadata.json that are already managed by Nucleus " +
+                        "(and report unresolvable types; remove with -Pnucleus.graalvm.cleanup.removeUnresolvable=true)"
                 task.group = NUCLEUS_TASK_GROUP
                 task.dependsOn(resolveReachabilityMetadata)
                 task.dependsOn(analyzeStaticMetadata)
@@ -777,6 +785,13 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                             .asFile
                     },
                 )
+                task.removeUnresolvable.set(
+                    NucleusProperties.graalvmCleanupRemoveUnresolvable(project.providers),
+                )
+                task.dryRun.set(
+                    NucleusProperties.graalvmCleanupDryRun(project.providers),
+                )
+                task.exactReachabilityPackages.set(cleanupExactPackages)
             }
         }
 

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTaskTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTaskTest.kt
@@ -1,0 +1,180 @@
+package dev.nucleusframework.desktop.application.internal
+
+import groovy.json.JsonSlurper
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * End-to-end coverage for issue #439: after baseline dedup, unresolvable agent noise
+ * (`kotlin.Any`, …) is reported by default and only removed under
+ * `removeUnresolvable=true`, except types under exact-reachability packages.
+ */
+class CleanupGraalvmMetadataTaskTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun writeMetadata(configDir: File, json: String): File {
+        configDir.mkdirs()
+        return File(configDir, "reachability-metadata.json").also { it.writeText(json) }
+    }
+
+    private fun classDirWith(fqcn: String): File {
+        val classes = tmp.newFolder("classes-${fqcn.hashCode()}")
+        val path = fqcn.replace('.', '/') + ".class"
+        val file = File(classes, path)
+        file.parentFile.mkdirs()
+        file.writeBytes(byteArrayOf(0xCA.toByte(), 0xFE.toByte()))
+        return classes
+    }
+
+    private fun createTask(
+        configDir: File,
+        classpath: List<File>,
+        removeUnresolvable: Boolean = false,
+        dryRun: Boolean = false,
+        exactPackages: List<String> = emptyList(),
+    ): CleanupGraalvmMetadataTask {
+        val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+        return project.tasks
+            .register("cleanupGraalvmMetadata", CleanupGraalvmMetadataTask::class.java) { task ->
+                task.runtimeClasspath.from(classpath)
+                task.platformName.set("linux")
+                // Leave mainClass blank so the fixture types are not deduped as "main entry".
+                task.mainClass.set("")
+                task.configDir.set(configDir)
+                task.removeUnresolvable.set(removeUnresolvable)
+                task.dryRun.set(dryRun)
+                task.exactReachabilityPackages.set(exactPackages)
+            }.get()
+    }
+
+    private fun typeNames(file: File, section: String = "reflection"): List<String> {
+        @Suppress("UNCHECKED_CAST")
+        val root = JsonSlurper().parseText(file.readText()) as Map<String, Any?>
+
+        @Suppress("UNCHECKED_CAST")
+        val entries = root[section] as? List<Map<String, Any?>> ?: return emptyList()
+        return entries.mapNotNull { it["type"] as? String }
+    }
+
+    /**
+     * Real app class on the fake classpath, plus agent-mapped kotlin.* noise and an optional
+     * probe type that only exists as a Class.forName string (no .class file).
+     * Package `acme.app` is intentionally outside every L1/L3 baseline so only the
+     * resolvability pass acts (L3 ships `java.lang.String` and would otherwise dedup it).
+     */
+    private val fixtureJson =
+        """
+        {
+          "reflection": [
+            { "type": "acme.app.RealClass" },
+            { "type": "kotlin.Any" },
+            { "type": "kotlin.Int" },
+            { "type": "kotlin.collections.List" },
+            { "type": "acme.app.OptionalProbe" }
+          ],
+          "serialization": [
+            { "type": "kotlin.Boolean" },
+            { "type": "acme.app.RealClass" }
+          ]
+        }
+        """.trimIndent()
+
+    @Test
+    fun `default mode reports unresolvable but does not rewrite them away`() {
+        val configDir = tmp.newFolder("graalvm-default")
+        val metadata = writeMetadata(configDir, fixtureJson)
+        val before = metadata.readText()
+
+        createTask(
+            configDir = configDir,
+            classpath = listOf(classDirWith("acme.app.RealClass")),
+            removeUnresolvable = false,
+        ).cleanup()
+
+        assertEquals("file must not drop unresolvable types by default", before, metadata.readText())
+        val types = typeNames(metadata)
+        assertTrue(types.contains("kotlin.Any"))
+        assertTrue(types.contains("kotlin.Int"))
+        assertTrue(types.contains("acme.app.RealClass"))
+        assertTrue(types.contains("acme.app.OptionalProbe"))
+    }
+
+    @Test
+    fun `removeUnresolvable drops agent noise but keeps resolvable classpath types`() {
+        val configDir = tmp.newFolder("graalvm-remove")
+        val metadata = writeMetadata(configDir, fixtureJson)
+
+        createTask(
+            configDir = configDir,
+            classpath = listOf(classDirWith("acme.app.RealClass")),
+            removeUnresolvable = true,
+            exactPackages = emptyList(),
+        ).cleanup()
+
+        val reflection = typeNames(metadata, "reflection")
+        val serialization = typeNames(metadata, "serialization")
+
+        assertTrue(reflection.contains("acme.app.RealClass"))
+        assertFalse(reflection.contains("kotlin.Any"))
+        assertFalse(reflection.contains("kotlin.Int"))
+        assertFalse(reflection.contains("kotlin.collections.List"))
+        assertFalse(reflection.contains("acme.app.OptionalProbe"))
+
+        assertFalse(serialization.contains("kotlin.Boolean"))
+        assertTrue(serialization.contains("acme.app.RealClass"))
+    }
+
+    @Test
+    fun `exact reachability packages protect unresolvable probes under scope`() {
+        val configDir = tmp.newFolder("graalvm-exact")
+        val metadata = writeMetadata(configDir, fixtureJson)
+
+        createTask(
+            configDir = configDir,
+            classpath = listOf(classDirWith("acme.app.RealClass")),
+            removeUnresolvable = true,
+            exactPackages = listOf("acme.app"),
+        ).cleanup()
+
+        val reflection = typeNames(metadata, "reflection")
+        // Under exact mode, optional Class.forName probes in app packages stay.
+        assertTrue(reflection.contains("acme.app.OptionalProbe"))
+        assertTrue(reflection.contains("acme.app.RealClass"))
+        // Mapped Kotlin types are outside the scope → removed.
+        assertFalse(reflection.contains("kotlin.Any"))
+        assertFalse(reflection.contains("kotlin.Int"))
+    }
+
+    @Test
+    fun `dryRun never rewrites the file even with removeUnresolvable`() {
+        val configDir = tmp.newFolder("graalvm-dry")
+        val metadata = writeMetadata(configDir, fixtureJson)
+        val before = metadata.readText()
+
+        createTask(
+            configDir = configDir,
+            classpath = listOf(classDirWith("acme.app.RealClass")),
+            removeUnresolvable = true,
+            dryRun = true,
+        ).cleanup()
+
+        assertEquals(before, metadata.readText())
+    }
+
+    @Test
+    fun `missing metadata file is a no-op`() {
+        val configDir = tmp.newFolder("graalvm-empty")
+        createTask(
+            configDir = configDir,
+            classpath = emptyList(),
+        ).cleanup()
+        assertFalse(File(configDir, "reachability-metadata.json").exists())
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTaskTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTaskTest.kt
@@ -11,9 +11,8 @@ import org.junit.rules.TemporaryFolder
 import java.io.File
 
 /**
- * End-to-end coverage for issue #439: after baseline dedup, unresolvable agent noise
- * (`kotlin.Any`, …) is reported by default and only removed under
- * `removeUnresolvable=true`, except types under exact-reachability packages.
+ * End-to-end coverage for issue #439: single disposition table, report-by-default,
+ * opt-in remove, exact-package protection, dryRun, and proxy entries.
  */
 class CleanupGraalvmMetadataTaskTest {
     @get:Rule
@@ -25,7 +24,7 @@ class CleanupGraalvmMetadataTaskTest {
     }
 
     private fun classDirWith(fqcn: String): File {
-        val classes = tmp.newFolder("classes-${fqcn.hashCode()}")
+        val classes = tmp.newFolder("classes-${fqcn.hashCode()}-${System.nanoTime()}")
         val path = fqcn.replace('.', '/') + ".class"
         val file = File(classes, path)
         file.parentFile.mkdirs()
@@ -40,12 +39,12 @@ class CleanupGraalvmMetadataTaskTest {
         dryRun: Boolean = false,
         exactPackages: List<String> = emptyList(),
     ): CleanupGraalvmMetadataTask {
-        val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+        val project = ProjectBuilder.builder().withProjectDir(tmp.newFolder()).build()
         return project.tasks
             .register("cleanupGraalvmMetadata", CleanupGraalvmMetadataTask::class.java) { task ->
                 task.runtimeClasspath.from(classpath)
                 task.platformName.set("linux")
-                // Leave mainClass blank so the fixture types are not deduped as "main entry".
+                // Leave mainClass blank so fixture types are not deduped as "main entry".
                 task.mainClass.set("")
                 task.configDir.set(configDir)
                 task.removeUnresolvable.set(removeUnresolvable)
@@ -64,10 +63,7 @@ class CleanupGraalvmMetadataTaskTest {
     }
 
     /**
-     * Real app class on the fake classpath, plus agent-mapped kotlin.* noise and an optional
-     * probe type that only exists as a Class.forName string (no .class file).
-     * Package `acme.app` is intentionally outside every L1/L3 baseline so only the
-     * resolvability pass acts (L3 ships `java.lang.String` and would otherwise dedup it).
+     * Package `acme.app` stays outside L1/L3 baselines so only the resolvability pass acts.
      */
     private val fixtureJson =
         """
@@ -77,7 +73,8 @@ class CleanupGraalvmMetadataTaskTest {
             { "type": "kotlin.Any" },
             { "type": "kotlin.Int" },
             { "type": "kotlin.collections.List" },
-            { "type": "acme.app.OptionalProbe" }
+            { "type": "acme.app.OptionalProbe" },
+            { "type": { "proxy": ["acme.app.RealClass", "acme.app.MissingIface"] } }
           ],
           "serialization": [
             { "type": "kotlin.Boolean" },
@@ -87,7 +84,7 @@ class CleanupGraalvmMetadataTaskTest {
         """.trimIndent()
 
     @Test
-    fun `default mode reports unresolvable but does not rewrite them away`() {
+    fun `default mode reports unresolvable once and does not rewrite them away`() {
         val configDir = tmp.newFolder("graalvm-default")
         val metadata = writeMetadata(configDir, fixtureJson)
         val before = metadata.readText()
@@ -107,7 +104,7 @@ class CleanupGraalvmMetadataTaskTest {
     }
 
     @Test
-    fun `removeUnresolvable drops agent noise but keeps resolvable classpath types`() {
+    fun `removeUnresolvable drops agent noise and partial proxies, keeps resolvable types`() {
         val configDir = tmp.newFolder("graalvm-remove")
         val metadata = writeMetadata(configDir, fixtureJson)
 
@@ -127,12 +124,20 @@ class CleanupGraalvmMetadataTaskTest {
         assertFalse(reflection.contains("kotlin.collections.List"))
         assertFalse(reflection.contains("acme.app.OptionalProbe"))
 
+        // Partial proxy (MissingIface) must be gone.
+        @Suppress("UNCHECKED_CAST")
+        val root = JsonSlurper().parseText(metadata.readText()) as Map<String, Any?>
+
+        @Suppress("UNCHECKED_CAST")
+        val entries = root["reflection"] as List<Map<String, Any?>>
+        assertTrue(entries.none { proxyInterfaceNames(it).isNotEmpty() })
+
         assertFalse(serialization.contains("kotlin.Boolean"))
         assertTrue(serialization.contains("acme.app.RealClass"))
     }
 
     @Test
-    fun `exact reachability packages protect unresolvable probes under scope`() {
+    fun `exact reachability packages protect unresolvable probes and proxies under scope`() {
         val configDir = tmp.newFolder("graalvm-exact")
         val metadata = writeMetadata(configDir, fixtureJson)
 
@@ -144,12 +149,18 @@ class CleanupGraalvmMetadataTaskTest {
         ).cleanup()
 
         val reflection = typeNames(metadata, "reflection")
-        // Under exact mode, optional Class.forName probes in app packages stay.
         assertTrue(reflection.contains("acme.app.OptionalProbe"))
         assertTrue(reflection.contains("acme.app.RealClass"))
-        // Mapped Kotlin types are outside the scope → removed.
         assertFalse(reflection.contains("kotlin.Any"))
         assertFalse(reflection.contains("kotlin.Int"))
+
+        // Proxy with any interface under acme.app is protected.
+        @Suppress("UNCHECKED_CAST")
+        val root = JsonSlurper().parseText(metadata.readText()) as Map<String, Any?>
+
+        @Suppress("UNCHECKED_CAST")
+        val entries = root["reflection"] as List<Map<String, Any?>>
+        assertTrue(entries.any { proxyInterfaceNames(it).contains("acme.app.MissingIface") })
     }
 
     @Test
@@ -176,5 +187,25 @@ class CleanupGraalvmMetadataTaskTest {
             classpath = emptyList(),
         ).cleanup()
         assertFalse(File(configDir, "reachability-metadata.json").exists())
+    }
+
+    @Test
+    fun `default mode does not claim already clean when unresolvable remain`() {
+        val configDir = tmp.newFolder("graalvm-msg")
+        writeMetadata(configDir, fixtureJson)
+        val task =
+            createTask(
+                configDir = configDir,
+                classpath = listOf(classDirWith("acme.app.RealClass")),
+                removeUnresolvable = false,
+            )
+
+        // Drive the action; assert on post-condition that is independent of logger wiring:
+        // file still has unresolvable entries, so the task's success path for "already clean"
+        // must not have rewritten. Message content is covered by classify + e2e gradle log.
+        task.cleanup()
+        assertTrue(typeNames(File(configDir, "reachability-metadata.json")).contains("kotlin.Int"))
+        // Kept resolvable + unresolvable still present — not "clean" by deletion.
+        assertEquals(5, typeNames(File(configDir, "reachability-metadata.json")).size)
     }
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvabilityTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvabilityTest.kt
@@ -100,6 +100,10 @@ class GraalvmMetadataResolvabilityTest {
         assertTrue(index.contains("org.lib.Helper"))
         assertFalse(isTypeResolvable("kotlin.Int", index))
         assertTrue(isTypeResolvable("com.example.App", index))
+
+        val packages = buildClasspathPackageIndex(listOf(classDir, jarFile))
+        assertTrue(packages.contains("com.example"))
+        assertTrue(packages.contains("org.lib"))
     }
 
     @Test
@@ -126,6 +130,7 @@ class GraalvmMetadataResolvabilityTest {
             )
         assertTrue(isEntryResolvable(full, index))
         assertFalse(isEntryResolvable(partial, index))
+        assertEquals("com.example.A,com.example.B", proxyKey(full))
         assertEquals(
             "proxy[com.example.A,com.example.B]",
             entryDisplayName(full),
@@ -133,24 +138,56 @@ class GraalvmMetadataResolvabilityTest {
     }
 
     @Test
-    fun `entry protected when any proxy interface is under exact packages`() {
-        val packages = listOf("com.example")
-        val entry =
+    fun `classifyUnresolvableEntry pure policy matrix`() {
+        val index = setOf("acme.app.Real")
+        val real = mapOf<String, Any?>("type" to "acme.app.Real")
+        val noise = mapOf<String, Any?>("type" to "kotlin.Int")
+        val probe = mapOf<String, Any?>("type" to "acme.app.Optional")
+        val proxyMissing =
             mapOf<String, Any?>(
-                "type" to mapOf("proxy" to listOf("kotlin.Function2", "com.example.Optional")),
+                "type" to mapOf("proxy" to listOf("acme.app.Real", "acme.app.Missing")),
             )
-        assertTrue(isEntryProtectedByExactReachability(entry, packages))
-        assertFalse(
-            isEntryProtectedByExactReachability(
-                mapOf("type" to "kotlin.Int"),
-                packages,
-            ),
+        val proxyExact =
+            mapOf<String, Any?>(
+                "type" to mapOf("proxy" to listOf("kotlin.Function2", "acme.app.Optional")),
+            )
+
+        assertEquals(
+            UnresolvableDisposition.RESOLVABLE,
+            classifyUnresolvableEntry(real, index, emptyList(), removeUnresolvable = true),
         )
-        assertTrue(
-            isEntryProtectedByExactReachability(
-                mapOf("type" to "com.example.OptionalFeature"),
-                packages,
-            ),
+        assertEquals(
+            UnresolvableDisposition.REPORT,
+            classifyUnresolvableEntry(noise, index, emptyList(), removeUnresolvable = false),
+        )
+        assertEquals(
+            UnresolvableDisposition.REMOVE,
+            classifyUnresolvableEntry(noise, index, emptyList(), removeUnresolvable = true),
+        )
+        assertEquals(
+            UnresolvableDisposition.PROTECT,
+            classifyUnresolvableEntry(probe, index, listOf("acme.app"), removeUnresolvable = true),
+        )
+        assertEquals(
+            UnresolvableDisposition.REMOVE,
+            classifyUnresolvableEntry(probe, index, emptyList(), removeUnresolvable = true),
+        )
+        assertEquals(
+            UnresolvableDisposition.REMOVE,
+            classifyUnresolvableEntry(proxyMissing, index, emptyList(), removeUnresolvable = true),
+        )
+        assertEquals(
+            UnresolvableDisposition.PROTECT,
+            classifyUnresolvableEntry(proxyExact, index, listOf("acme.app"), removeUnresolvable = true),
+        )
+    }
+
+    @Test
+    fun `formatDispositionLine is single-tag stable`() {
+        val entry = mapOf<String, Any?>("type" to "kotlin.Int")
+        assertEquals(
+            "  [unresolvable/kept] [reflection] kotlin.Int",
+            formatDispositionLine("unresolvable/kept", "reflection", entry),
         )
     }
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvabilityTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvabilityTest.kt
@@ -1,0 +1,156 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+
+class GraalvmMetadataResolvabilityTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun `classNameFromClassPath handles nested and multi-release paths`() {
+        assertEquals(
+            "com.example.Foo\$Companion",
+            classNameFromClassPath("com/example/Foo\$Companion.class"),
+        )
+        assertEquals(
+            "com.example.Bar",
+            classNameFromClassPath("META-INF/versions/11/com/example/Bar.class"),
+        )
+        assertNull(classNameFromClassPath("module-info.class"))
+        assertNull(classNameFromClassPath("META-INF/versions/11/module-info.class"))
+        assertNull(classNameFromClassPath("readme.txt"))
+    }
+
+    @Test
+    fun `normalizeTypeForLookup strips Java and JVM array forms`() {
+        assertEquals("java.lang.String", normalizeTypeForLookup("java.lang.String[]"))
+        assertEquals(
+            "java.lang.foreign.Linker\$Option",
+            normalizeTypeForLookup("java.lang.foreign.Linker\$Option[]"),
+        )
+        assertEquals("com.example.Foo", normalizeTypeForLookup("com.example.Foo[][]"))
+        assertNull(normalizeTypeForLookup("[B"))
+        assertNull(normalizeTypeForLookup("[[I"))
+        assertEquals("java.lang.String", normalizeTypeForLookup("[Ljava.lang.String;"))
+        assertEquals("java.lang.String", normalizeTypeForLookup("[[Ljava.lang.String;"))
+    }
+
+    @Test
+    fun `JDK prefixes and primitives are always resolvable`() {
+        val empty = emptySet<String>()
+        assertTrue(isTypeResolvable("java.lang.String", empty))
+        assertTrue(isTypeResolvable("javax.swing.JFrame", empty))
+        assertTrue(isTypeResolvable("jdk.internal.misc.Unsafe", empty))
+        assertTrue(isTypeResolvable("sun.misc.Unsafe", empty))
+        assertTrue(isTypeResolvable("com.sun.media.sound.PortMixerProvider", empty))
+        assertTrue(isTypeResolvable("java.lang.String[]", empty))
+        assertTrue(isTypeResolvable("[B", empty))
+        assertTrue(isTypeResolvable("int", empty))
+    }
+
+    @Test
+    fun `mapped kotlin types are unresolvable without a class file`() {
+        val empty = emptySet<String>()
+        for (type in listOf(
+            "kotlin.Any",
+            "kotlin.Int",
+            "kotlin.Boolean",
+            "kotlin.Long",
+            "kotlin.Cloneable",
+            "kotlin.Throwable",
+            "kotlin.Function2",
+            "kotlin.Function3",
+            "kotlin.collections.List",
+            "kotlin.collections.Map",
+        )) {
+            assertFalse("$type should be unresolvable", isTypeResolvable(type, empty))
+        }
+    }
+
+    @Test
+    fun `buildClasspathClassIndex reads jars and class dirs`() {
+        val classDir = tmp.newFolder("classes")
+        val packageDir = File(classDir, "com/example")
+        packageDir.mkdirs()
+        File(packageDir, "App.class").writeBytes(byteArrayOf(0xCA.toByte(), 0xFE.toByte()))
+        File(packageDir, "App\$Companion.class").writeBytes(byteArrayOf(0xCA.toByte(), 0xFE.toByte()))
+
+        val jarFile = tmp.newFile("lib.jar")
+        JarOutputStream(jarFile.outputStream()).use { jos ->
+            jos.putNextEntry(JarEntry("org/lib/Helper.class"))
+            jos.write(byteArrayOf(0xCA.toByte(), 0xFE.toByte()))
+            jos.closeEntry()
+            jos.putNextEntry(JarEntry("META-INF/versions/17/org/lib/Helper.class"))
+            jos.write(byteArrayOf(0xCA.toByte(), 0xFE.toByte()))
+            jos.closeEntry()
+        }
+
+        val index = buildClasspathClassIndex(listOf(classDir, jarFile))
+        assertTrue(index.contains("com.example.App"))
+        assertTrue(index.contains("com.example.App\$Companion"))
+        assertTrue(index.contains("org.lib.Helper"))
+        assertFalse(isTypeResolvable("kotlin.Int", index))
+        assertTrue(isTypeResolvable("com.example.App", index))
+    }
+
+    @Test
+    fun `exact package protection matches prefix semantics`() {
+        val packages = listOf("com.example.app", "io.acme")
+        assertTrue(isUnderExactReachabilityPackages("com.example.app.Optional", packages))
+        assertTrue(isUnderExactReachabilityPackages("com.example.app", packages))
+        assertTrue(isUnderExactReachabilityPackages("io.acme.dep.Missing", packages))
+        assertFalse(isUnderExactReachabilityPackages("com.example.other.Foo", packages))
+        assertFalse(isUnderExactReachabilityPackages("kotlin.Int", packages))
+        assertFalse(isUnderExactReachabilityPackages("kotlin.Int", emptyList()))
+    }
+
+    @Test
+    fun `proxy entry resolvability requires every interface`() {
+        val index = setOf("com.example.A", "com.example.B")
+        val full =
+            mapOf<String, Any?>(
+                "type" to mapOf("proxy" to listOf("com.example.A", "com.example.B")),
+            )
+        val partial =
+            mapOf<String, Any?>(
+                "type" to mapOf("proxy" to listOf("com.example.A", "com.example.Missing")),
+            )
+        assertTrue(isEntryResolvable(full, index))
+        assertFalse(isEntryResolvable(partial, index))
+        assertEquals(
+            "proxy[com.example.A,com.example.B]",
+            entryDisplayName(full),
+        )
+    }
+
+    @Test
+    fun `entry protected when any proxy interface is under exact packages`() {
+        val packages = listOf("com.example")
+        val entry =
+            mapOf<String, Any?>(
+                "type" to mapOf("proxy" to listOf("kotlin.Function2", "com.example.Optional")),
+            )
+        assertTrue(isEntryProtectedByExactReachability(entry, packages))
+        assertFalse(
+            isEntryProtectedByExactReachability(
+                mapOf("type" to "kotlin.Int"),
+                packages,
+            ),
+        )
+        assertTrue(
+            isEntryProtectedByExactReachability(
+                mapOf("type" to "com.example.OptionalFeature"),
+                packages,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- After baseline dedup, `cleanupGraalvmMetadata` now scans the runtime classpath for `.class` files and reports entries whose types resolve nowhere (typical tracing-agent noise: `kotlin.Any`, `kotlin.Int`, `kotlin.collections.List`, …).
- **Default is report-only** so exact-mode optional probes stay safe. Removal is opt-in via `-Pnucleus.graalvm.cleanup.removeUnresolvable=true`.
- Types under the configured `exactReachabilityMetadata` packages are never removed (registration for a missing class is what restores `ClassNotFoundException` under exact mode).
- `-Pnucleus.graalvm.cleanup.dryRun=true` analyzes without rewriting the file.
- Remaining manual entries are listed as `kept — not covered by any managed source`.

Closes #439

## Test plan

- [x] `GraalvmMetadataResolvabilityTest` — normalize arrays, JDK prefixes, classpath index, exact package protection, proxies
- [x] `CleanupGraalvmMetadataTaskTest` (ProjectBuilder) — default keep / remove / exact protect / dryRun / missing file
- [x] E2E on `:examples:system-info-demo:cleanupGraalvmMetadata` dry-run reports all `kotlin.*` noise
- [x] E2E with `-Pnucleus.graalvm.cleanup.removeUnresolvable=true` removes kotlin noise and protects `systeminfodemo.*` under APP_PACKAGES