### PR TITLE
fix(tao/linux): paint Wayland resize at drawable size only

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -268,14 +268,23 @@ internal class TaoComposeSceneHostLinux(
 
     /**
      * Wayland: size of the EGL buffer currently in use for painting.
-     * `wl_egl_window_resize` only takes effect on the next `eglSwapBuffers`;
-     * painting at the *window* size into a still-old buffer (BOTTOM_LEFT)
-     * shifts/flashes the frame. We paint at [drawableWidthPx]×[drawableHeightPx]
-     * and advance those after each present to [lastAppliedWidthPx]×[lastAppliedHeightPx].
-     * X11 sets drawable = window immediately (no lag).
+     * `wl_egl_window_resize` only takes effect on the next `eglSwapBuffers`.
+     * Used only when [useDrawableSizedPaint] is true (KWin): paint at this size
+     * and advance after present. Elsewhere (GNOME / main) paint at the window
+     * size so layout stays in sync with the configure.
      */
     private var drawableWidthPx: Int = 0
     private var drawableHeightPx: Int = 0
+
+    /**
+     * KWin flashes if we paint at the window size into a still-old EGL FB
+     * (BOTTOM_LEFT). GNOME does not need that trade-off — keep master's
+     * window-sized paint there (and on every non-Plasma DE).
+     */
+    private val useDrawableSizedPaint: Boolean
+        get() =
+            attachedKind == 2 &&
+                LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE
 
     // Cache the Skia RT/Surface across frames — recreated only when the size
     // changes. Reallocating an FBO + GL surface every frame piles up driver
@@ -1163,13 +1172,15 @@ internal class TaoComposeSceneHostLinux(
     private fun applyPendingNativeResize() {
         if (attachmentHandle == 0L) return
         if (widthPx <= 0 || heightPx <= 0) return
-        // Ensure scene size is caught up to the actual EGL surface size before
-        // rendering. The throttle in onResized may have skipped some updates.
-        val currentSize = IntSize(widthPx, heightPx)
-        if (scene?.size != currentSize) {
-            scene?.size = currentSize
-            updateWindowInfoSize()
-            lastSceneSizeUpdateNs = System.nanoTime()
+        // GNOME / main: scene tracks the window. KWin drawable path sets scene
+        // size from the paint size below (may lag the window by one present).
+        if (!useDrawableSizedPaint) {
+            val currentSize = IntSize(widthPx, heightPx)
+            if (scene?.size != currentSize) {
+                scene?.size = currentSize
+                updateWindowInfoSize()
+                lastSceneSizeUpdateNs = System.nanoTime()
+            }
         }
         if (widthPx == lastAppliedWidthPx &&
             heightPx == lastAppliedHeightPx &&
@@ -1178,11 +1189,8 @@ internal class TaoComposeSceneHostLinux(
             return
         }
         NativeTaoEglBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
-        // X11: drawable tracks the window immediately — drop Skia cache now.
-        // Wayland: drawable lags until the next present; keep painting into the
-        // old-sized FB until [onDrawablePresented] advances it (avoids
-        // BOTTOM_LEFT shift/flash when Skia is larger than the real buffer).
-        if (attachedKind != 2) {
+        if (!useDrawableSizedPaint) {
+            // Master behaviour: paint size follows the window immediately.
             if (widthPx != lastAppliedWidthPx ||
                 heightPx != lastAppliedHeightPx ||
                 scale != lastAppliedScale
@@ -1195,7 +1203,7 @@ internal class TaoComposeSceneHostLinux(
             drawableWidthPx = widthPx
             drawableHeightPx = heightPx
         } else if (scale != lastAppliedScale) {
-            // Scale change: buffer_scale is reasserted; rebuild at the new window.
+            // KWin: keep drawable lagging on size-only changes; rebuild on scale.
             cachedSurface?.close()
             cachedSurface = null
             cachedRt?.close()
@@ -1209,11 +1217,11 @@ internal class TaoComposeSceneHostLinux(
     }
 
     /**
-     * Wayland: after a present, the pending `wl_egl_window_resize` is in effect.
-     * Advance the paint size and re-arm a frame if the window is still ahead.
+     * KWin only: after a present, the pending `wl_egl_window_resize` is in
+     * effect — advance the paint size and re-arm a frame if still behind.
      */
     private fun onDrawablePresented() {
-        if (attachedKind != 2) return
+        if (!useDrawableSizedPaint) return
         if (lastAppliedWidthPx <= 0 || lastAppliedHeightPx <= 0) return
         if (drawableWidthPx == lastAppliedWidthPx && drawableHeightPx == lastAppliedHeightPx) {
             return
@@ -1224,7 +1232,6 @@ internal class TaoComposeSceneHostLinux(
         cachedSurface = null
         cachedRt?.close()
         cachedRt = null
-        // Paint the newly allocated buffer without waiting for more motion.
         requestRedrawCoalesced()
     }
 
@@ -1339,12 +1346,12 @@ internal class TaoComposeSceneHostLinux(
         // is current — applyPendingNativeResize closes the stale Skia cache.
         applyPendingNativeResize()
 
-        // Paint size = drawable (Wayland may lag the window by one present).
+        // KWin: paint at lagging drawable (avoids BOTTOM_LEFT flash).
+        // GNOME / others: paint at window size (master — no layout lag).
         val paintW =
-            if (attachedKind == 2 && drawableWidthPx > 0) drawableWidthPx else widthPx
+            if (useDrawableSizedPaint && drawableWidthPx > 0) drawableWidthPx else widthPx
         val paintH =
-            if (attachedKind == 2 && drawableHeightPx > 0) drawableHeightPx else heightPx
-        // Layout must match the FB we draw into (BOTTOM_LEFT mis-size flashes).
+            if (useDrawableSizedPaint && drawableHeightPx > 0) drawableHeightPx else heightPx
         val paintSize = IntSize(paintW, paintH)
         if (sc.size != paintSize) {
             sc.size = paintSize
@@ -2251,8 +2258,8 @@ internal class TaoComposeSceneHostLinux(
                                     renderOwed = false
                                     owed
                                 }
-                            // Drawable size advances only after this present.
-                            if (attachedKind == 2) {
+                            // KWin: drawable advances only after this present.
+                            if (useDrawableSizedPaint) {
                                 dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
                                     .dispatch(
                                         EmptyCoroutineContext,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -286,13 +286,6 @@ internal class TaoComposeSceneHostLinux(
             attachedKind == 2 &&
                 LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE
 
-    /**
-     * Last eglSwapInterval. Dropped to 0 for the whole interactive resize/move
-     * grab (and while the paint size still lags the window on KWin) so buffer
-     * catch-up is not vsync-gated. Same on GNOME and KDE; restored to 1 at rest.
-     */
-    private var appliedSwapInterval: Int = 1
-
     // Cache the Skia RT/Surface across frames — recreated only when the size
     // changes. Reallocating an FBO + GL surface every frame piles up driver
     // work that contributes to the resize-time GPU lockup.
@@ -315,6 +308,26 @@ internal class TaoComposeSceneHostLinux(
     // clipped or have transparent margins, which is the same visual trade-off
     // macOS makes during live-resize.
     private var lastSceneSizeUpdateNs: Long = 0L
+
+    /**
+     * Interactive-resize burst (all Wayland DEs). While size is changing,
+     * drop [eglSwapInterval] to 0 and queue catch-up paints so the buffer
+     * from the pending `wl_egl_window_resize` is drawn without waiting on a
+     * frame callback. Restores interval 1 after [RESIZE_BURST_HOLD_NS] idle.
+     * Same visual path as before — no viewport stretch.
+     */
+    private var lastResizeEventNs: Long = 0L
+    private var resizeBurstActive: Boolean = false
+    private var appliedSwapInterval: Int = 1
+    private var pendingSwapInterval: Int? = null
+
+    /**
+     * Extra redraws after a size change so the buffer allocated by the next
+     * `eglSwapBuffers` is actually painted. Written on the event-loop thread
+     * ([onResized]), decremented on the swap thread after present.
+     */
+    private val postResizeCatchUpFrames =
+        java.util.concurrent.atomic.AtomicInteger(0)
     private val sceneSizeUpdateIntervalNs = 16_666_667L // 60fps
 
     private var lastPointerX: Float = 0f
@@ -1082,6 +1095,21 @@ internal class TaoComposeSceneHostLinux(
         widthPx = widthPxNew
         heightPx = heightPxNew
 
+        // Enter / refresh the resize burst: drop vsync so the next buffer can
+        // land without waiting on a frame callback. Wayland only — X11 has no
+        // subsurface/geometry lag of this kind. All DEs (GNOME, KDE, …).
+        lastResizeEventNs = System.nanoTime()
+        if (attachedKind == 2 && !window.isPopup) {
+            if (!resizeBurstActive) {
+                resizeBurstActive = true
+                pendingSwapInterval = 0
+            }
+            // Two catch-up frames: (1) swap that allocates the new buffer,
+            // (2) paint into it. Refreshed on every motion so a continuous
+            // drag always has headroom after the last pixel.
+            postResizeCatchUpFrames.set(2)
+        }
+
         // Throttle scene.size updates to ~60fps so Compose can reuse its
         // layout cache between resize events. GTK fires an event for every
         // pixel of mouse movement; without throttling every frame is an
@@ -1100,6 +1128,27 @@ internal class TaoComposeSceneHostLinux(
             (heightPx / opaqueScale).coerceAtLeast(1),
         )
         requestRedrawCoalesced()
+    }
+
+    /**
+     * Applies a pending [pendingSwapInterval] while the EGL context is current.
+     * Ends the resize burst once the window has been stable for
+     * [RESIZE_BURST_HOLD_NS].
+     */
+    private fun updateResizeBurstSwapInterval() {
+        if (attachmentHandle == 0L || attachedKind != 2 || window.isPopup) return
+        if (resizeBurstActive &&
+            lastResizeEventNs > 0L &&
+            System.nanoTime() - lastResizeEventNs >= RESIZE_BURST_HOLD_NS
+        ) {
+            resizeBurstActive = false
+            pendingSwapInterval = 1
+        }
+        val want = pendingSwapInterval ?: return
+        pendingSwapInterval = null
+        if (want == appliedSwapInterval) return
+        NativeTaoEglBridge.nativeSetSwapInterval(attachmentHandle, want)
+        appliedSwapInterval = want
     }
 
     /**
@@ -1352,6 +1401,7 @@ internal class TaoComposeSceneHostLinux(
         // Coalesced size/scale change is committed here, after the GL context
         // is current — applyPendingNativeResize closes the stale Skia cache.
         applyPendingNativeResize()
+        updateResizeBurstSwapInterval()
 
         // KWin: paint at lagging drawable (avoids BOTTOM_LEFT flash).
         // GNOME / others: paint at window size (master — no layout lag).
@@ -1408,19 +1458,6 @@ internal class TaoComposeSceneHostLinux(
         sc.render(surface.canvas.asComposeCanvas(), now)
         applyFrameDecoration(surface.canvas, paintW, paintH)
         surface.flushAndSubmit(syncCpu = false)
-
-        // Wayland (GNOME + KDE): drop vsync during interactive resize/move and
-        // while paint size lags the window so eglSwapBuffers is not held for a
-        // full refresh. Hold 0 for the whole grab to avoid 0↔1 thrash flashes.
-        if (attachedKind == 2 && !window.isPopup) {
-            val lagging = paintW != widthPx || paintH != heightPx
-            val wantInterval = if (lagging || compositorDragActive) 0 else 1
-            if (wantInterval != appliedSwapInterval) {
-                NativeTaoEglBridge.nativeSetSwapInterval(attachmentHandle, wantInterval)
-                appliedSwapInterval = wantInterval
-            }
-        }
-
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
 
@@ -2135,6 +2172,9 @@ internal class TaoComposeSceneHostLinux(
     }
 
     private companion object {
+        /** Keep swap-interval 0 briefly after the last pixel of resize motion. */
+        private const val RESIZE_BURST_HOLD_NS = 100_000_000L // 100 ms
+
         /**
          * How far outside the content (logical px) a pointer still counts as
          * the CSD shadow ring for resize hit-testing. Theme margins run
@@ -2286,7 +2326,16 @@ internal class TaoComposeSceneHostLinux(
                                         Runnable { onDrawablePresented() },
                                     )
                             }
-                            if (rearm) requestRedrawCoalesced()
+                            // Catch-up after size change: the buffer matching the
+                            // request only exists *after* this swap — paint it
+                            // without waiting for more motion (all Wayland DEs).
+                            val catchUp = postResizeCatchUpFrames.get() > 0
+                            if (catchUp) {
+                                postResizeCatchUpFrames.updateAndGet { n ->
+                                    (n - 1).coerceAtLeast(0)
+                                }
+                            }
+                            if (rearm || catchUp) requestRedrawCoalesced()
                         }
                     }
                 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -266,6 +266,17 @@ internal class TaoComposeSceneHostLinux(
     private var lastAppliedHeightPx: Int = -1
     private var lastAppliedScale: Float = Float.NaN
 
+    /**
+     * Wayland: size of the EGL buffer currently in use for painting.
+     * `wl_egl_window_resize` only takes effect on the next `eglSwapBuffers`;
+     * painting at the *window* size into a still-old buffer (BOTTOM_LEFT)
+     * shifts/flashes the frame. We paint at [drawableWidthPx]×[drawableHeightPx]
+     * and advance those after each present to [lastAppliedWidthPx]×[lastAppliedHeightPx].
+     * X11 sets drawable = window immediately (no lag).
+     */
+    private var drawableWidthPx: Int = 0
+    private var drawableHeightPx: Int = 0
+
     // Cache the Skia RT/Surface across frames — recreated only when the size
     // changes. Reallocating an FBO + GL surface every frame piles up driver
     // work that contributes to the resize-time GPU lockup.
@@ -577,6 +588,9 @@ internal class TaoComposeSceneHostLinux(
         lastAppliedWidthPx = -1
         lastAppliedHeightPx = -1
         lastAppliedScale = Float.NaN
+        // Attach creates the wl_egl_window at the current physical size.
+        drawableWidthPx = widthPx.coerceAtLeast(0)
+        drawableHeightPx = heightPx.coerceAtLeast(0)
     }
 
     /**
@@ -603,6 +617,8 @@ internal class TaoComposeSceneHostLinux(
         cachedSurface = null
         cachedRt?.close()
         cachedRt = null
+        drawableWidthPx = 0
+        drawableHeightPx = 0
         // Drop TextureView imports made on this context while it is still
         // current and alive; the composition survives the hide, so its leases
         // would otherwise hold Skia images on a destroyed context.
@@ -1162,24 +1178,54 @@ internal class TaoComposeSceneHostLinux(
             return
         }
         NativeTaoEglBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
-        // Drop the cached Skia surface so the next render rebuilds it at the
-        // new size/scale. Closing here (rather than lazily in `onRedrawRequested`)
-        // keeps the lifetime tied to the GL context being current. A scale
-        // change with an unchanged pixel size (rare on Wayland, but possible)
-        // must also rebuild — otherwise we'd serve a surface bound to the old
-        // buffer scale.
-        if (widthPx != lastAppliedWidthPx ||
-            heightPx != lastAppliedHeightPx ||
-            scale != lastAppliedScale
-        ) {
+        // X11: drawable tracks the window immediately — drop Skia cache now.
+        // Wayland: drawable lags until the next present; keep painting into the
+        // old-sized FB until [onDrawablePresented] advances it (avoids
+        // BOTTOM_LEFT shift/flash when Skia is larger than the real buffer).
+        if (attachedKind != 2) {
+            if (widthPx != lastAppliedWidthPx ||
+                heightPx != lastAppliedHeightPx ||
+                scale != lastAppliedScale
+            ) {
+                cachedSurface?.close()
+                cachedSurface = null
+                cachedRt?.close()
+                cachedRt = null
+            }
+            drawableWidthPx = widthPx
+            drawableHeightPx = heightPx
+        } else if (scale != lastAppliedScale) {
+            // Scale change: buffer_scale is reasserted; rebuild at the new window.
             cachedSurface?.close()
             cachedSurface = null
             cachedRt?.close()
             cachedRt = null
+            drawableWidthPx = widthPx
+            drawableHeightPx = heightPx
         }
         lastAppliedWidthPx = widthPx
         lastAppliedHeightPx = heightPx
         lastAppliedScale = scale
+    }
+
+    /**
+     * Wayland: after a present, the pending `wl_egl_window_resize` is in effect.
+     * Advance the paint size and re-arm a frame if the window is still ahead.
+     */
+    private fun onDrawablePresented() {
+        if (attachedKind != 2) return
+        if (lastAppliedWidthPx <= 0 || lastAppliedHeightPx <= 0) return
+        if (drawableWidthPx == lastAppliedWidthPx && drawableHeightPx == lastAppliedHeightPx) {
+            return
+        }
+        drawableWidthPx = lastAppliedWidthPx
+        drawableHeightPx = lastAppliedHeightPx
+        cachedSurface?.close()
+        cachedSurface = null
+        cachedRt?.close()
+        cachedRt = null
+        // Paint the newly allocated buffer without waiting for more motion.
+        requestRedrawCoalesced()
     }
 
     fun onFocusChanged(focused: Boolean) {
@@ -1293,12 +1339,31 @@ internal class TaoComposeSceneHostLinux(
         // is current — applyPendingNativeResize closes the stale Skia cache.
         applyPendingNativeResize()
 
+        // Paint size = drawable (Wayland may lag the window by one present).
+        val paintW =
+            if (attachedKind == 2 && drawableWidthPx > 0) drawableWidthPx else widthPx
+        val paintH =
+            if (attachedKind == 2 && drawableHeightPx > 0) drawableHeightPx else heightPx
+        // Layout must match the FB we draw into (BOTTOM_LEFT mis-size flashes).
+        val paintSize = IntSize(paintW, paintH)
+        if (sc.size != paintSize) {
+            sc.size = paintSize
+            lastSceneSizeUpdateNs = now
+        }
+
         var surface = cachedSurface
-        if (surface == null) {
+        if (surface == null ||
+            surface.width != paintW ||
+            surface.height != paintH
+        ) {
+            cachedSurface?.close()
+            cachedSurface = null
+            cachedRt?.close()
+            cachedRt = null
             val rt =
                 BackendRenderTarget.makeGL(
-                    width = widthPx,
-                    height = heightPx,
+                    width = paintW,
+                    height = paintH,
                     sampleCnt = 0,
                     stencilBits = 8,
                     fbId = 0,
@@ -1327,7 +1392,7 @@ internal class TaoComposeSceneHostLinux(
         // transparent by [applyFrameDecoration] below.
         surface.canvas.clear(clearColorArgbState.value)
         sc.render(surface.canvas.asComposeCanvas(), now)
-        applyFrameDecoration(surface.canvas)
+        applyFrameDecoration(surface.canvas, paintW, paintH)
         surface.flushAndSubmit(syncCpu = false)
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
@@ -1359,7 +1424,11 @@ internal class TaoComposeSceneHostLinux(
      * pixels — dropped for maximized, fullscreen and tiled windows, which sit
      * flush against a screen edge and square off.
      */
-    private fun applyFrameDecoration(canvas: Canvas) {
+    private fun applyFrameDecoration(
+        canvas: Canvas,
+        surfaceW: Int = widthPx,
+        surfaceH: Int = heightPx,
+    ) {
         val isMaximized = window.isMaximized
         val isFullscreen = window.isFullscreen
         val isTiled = window.isTiled
@@ -1368,7 +1437,7 @@ internal class TaoComposeSceneHostLinux(
         // there look wrong — native CSD windows square off when tiled too.
         val roundCorners = cornerRadiusPx > 0 && !isMaximized && !isFullscreen && !isTiled
         if (roundCorners) {
-            // widthPx/heightPx are physical pixels and the canvas has no scale
+            // Coordinates are physical pixels and the canvas has no scale
             // transform, so scale the logical radius up to physical to keep the
             // corner curvature constant across DPI.
             val radiusPhysical = (cornerRadiusPx * scale).roundToInt().coerceAtLeast(1)
@@ -1376,10 +1445,10 @@ internal class TaoComposeSceneHostLinux(
                 canvas,
                 left = 0,
                 top = 0,
-                right = widthPx,
-                bottom = heightPx,
-                surfaceW = widthPx,
-                surfaceH = heightPx,
+                right = surfaceW,
+                bottom = surfaceH,
+                surfaceW = surfaceW,
+                surfaceH = surfaceH,
                 radius = radiusPhysical,
             )
         }
@@ -2182,6 +2251,14 @@ internal class TaoComposeSceneHostLinux(
                                     renderOwed = false
                                     owed
                                 }
+                            // Drawable size advances only after this present.
+                            if (attachedKind == 2) {
+                                dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+                                    .dispatch(
+                                        EmptyCoroutineContext,
+                                        Runnable { onDrawablePresented() },
+                                    )
+                            }
                             if (rearm) requestRedrawCoalesced()
                         }
                     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -269,22 +269,13 @@ internal class TaoComposeSceneHostLinux(
     /**
      * Wayland: size of the EGL buffer currently in use for painting.
      * `wl_egl_window_resize` only takes effect on the next `eglSwapBuffers`.
-     * Used only when [useDrawableSizedPaint] is true (KWin): paint at this size
-     * and advance after present. Elsewhere (GNOME / main) paint at the window
-     * size so layout stays in sync with the configure.
+     * Painting at the *window* size into a still-old buffer with BOTTOM_LEFT
+     * shifts/flashes the frame (Fedora Mutter and KWin). We paint at this
+     * size and advance after present. Burst catch-up keeps lag to one buffer.
+     * X11: drawable tracks the window immediately.
      */
     private var drawableWidthPx: Int = 0
     private var drawableHeightPx: Int = 0
-
-    /**
-     * KWin flashes if we paint at the window size into a still-old EGL FB
-     * (BOTTOM_LEFT). GNOME does not need that trade-off — keep master's
-     * window-sized paint there (and on every non-Plasma DE).
-     */
-    private val useDrawableSizedPaint: Boolean
-        get() =
-            attachedKind == 2 &&
-                LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE
 
     // Cache the Skia RT/Surface across frames — recreated only when the size
     // changes. Reallocating an FBO + GL surface every frame piles up driver
@@ -1228,16 +1219,7 @@ internal class TaoComposeSceneHostLinux(
     private fun applyPendingNativeResize() {
         if (attachmentHandle == 0L) return
         if (widthPx <= 0 || heightPx <= 0) return
-        // GNOME / main: scene tracks the window. KWin drawable path sets scene
-        // size from the paint size below (may lag the window by one present).
-        if (!useDrawableSizedPaint) {
-            val currentSize = IntSize(widthPx, heightPx)
-            if (scene?.size != currentSize) {
-                scene?.size = currentSize
-                updateWindowInfoSize()
-                lastSceneSizeUpdateNs = System.nanoTime()
-            }
-        }
+        // Scene size is set from the paint size (drawable on Wayland).
         if (widthPx == lastAppliedWidthPx &&
             heightPx == lastAppliedHeightPx &&
             scale == lastAppliedScale
@@ -1245,8 +1227,11 @@ internal class TaoComposeSceneHostLinux(
             return
         }
         NativeTaoEglBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
-        if (!useDrawableSizedPaint) {
-            // Master behaviour: paint size follows the window immediately.
+        // X11: drawable tracks the window immediately — drop Skia cache now.
+        // Wayland: drawable lags until the next present; keep painting into the
+        // old-sized FB until [onDrawablePresented] advances it (avoids
+        // BOTTOM_LEFT shift/flash when Skia is larger than the real buffer).
+        if (attachedKind != 2) {
             if (widthPx != lastAppliedWidthPx ||
                 heightPx != lastAppliedHeightPx ||
                 scale != lastAppliedScale
@@ -1259,7 +1244,6 @@ internal class TaoComposeSceneHostLinux(
             drawableWidthPx = widthPx
             drawableHeightPx = heightPx
         } else if (scale != lastAppliedScale) {
-            // KWin: keep drawable lagging on size-only changes; rebuild on scale.
             cachedSurface?.close()
             cachedSurface = null
             cachedRt?.close()
@@ -1273,11 +1257,11 @@ internal class TaoComposeSceneHostLinux(
     }
 
     /**
-     * KWin only: after a present, the pending `wl_egl_window_resize` is in
-     * effect — advance the paint size and re-arm a frame if still behind.
+     * Wayland: after a present, the pending `wl_egl_window_resize` is in effect.
+     * Advance the paint size and re-arm a frame if the window is still ahead.
      */
     private fun onDrawablePresented() {
-        if (!useDrawableSizedPaint) return
+        if (attachedKind != 2) return
         if (lastAppliedWidthPx <= 0 || lastAppliedHeightPx <= 0) return
         if (drawableWidthPx == lastAppliedWidthPx && drawableHeightPx == lastAppliedHeightPx) {
             return
@@ -1403,12 +1387,13 @@ internal class TaoComposeSceneHostLinux(
         applyPendingNativeResize()
         updateResizeBurstSwapInterval()
 
-        // KWin: paint at lagging drawable (avoids BOTTOM_LEFT flash).
-        // GNOME / others: paint at window size (master — no layout lag).
+        // Paint at drawable size on Wayland (may lag the window by one present).
+        // Matches the FB so BOTTOM_LEFT cannot shift/flash (KWin + Fedora Mutter).
+        // Burst catch-up after present keeps the lag to one buffer step.
         val paintW =
-            if (useDrawableSizedPaint && drawableWidthPx > 0) drawableWidthPx else widthPx
+            if (attachedKind == 2 && drawableWidthPx > 0) drawableWidthPx else widthPx
         val paintH =
-            if (useDrawableSizedPaint && drawableHeightPx > 0) drawableHeightPx else heightPx
+            if (attachedKind == 2 && drawableHeightPx > 0) drawableHeightPx else heightPx
         val paintSize = IntSize(paintW, paintH)
         if (sc.size != paintSize) {
             sc.size = paintSize
@@ -2318,8 +2303,8 @@ internal class TaoComposeSceneHostLinux(
                                     renderOwed = false
                                     owed
                                 }
-                            // KWin: drawable advances only after this present.
-                            if (useDrawableSizedPaint) {
+                            // Drawable size advances only after this present.
+                            if (attachedKind == 2) {
                                 dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
                                     .dispatch(
                                         EmptyCoroutineContext,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -288,11 +288,12 @@ internal class TaoComposeSceneHostLinux(
     private var cachedRt: BackendRenderTarget? = null
     private var cachedSurface: Surface? = null
 
-    /** GPU intermediate at window size, used only while drawable lags the window. */
+    /**
+     * GPU intermediate at window size. On Wayland every frame paints here then
+     * blits into the real FB — one path for lag and steady state (no flash at
+     * the start/end of a resize from switching paint modes).
+     */
     private var intermediateSurface: Surface? = null
-
-    /** Last eglSwapInterval; 0 while drawable lags or a grab is active. */
-    private var appliedSwapInterval: Int = 1
 
     // Scene-size update throttle. Compose's layout cache is keyed on size: the
     // first frame at any new size triggers a full remeasure (80-150ms for
@@ -1384,7 +1385,6 @@ internal class TaoComposeSceneHostLinux(
             if (attachedKind == 2 && drawableWidthPx > 0) drawableWidthPx else widthPx
         val fbH =
             if (attachedKind == 2 && drawableHeightPx > 0) drawableHeightPx else heightPx
-        val lagging = attachedKind == 2 && (fbW != widthPx || fbH != heightPx)
 
         var surface = cachedSurface
         if (surface == null || surface.width != fbW || surface.height != fbH) {
@@ -1423,15 +1423,12 @@ internal class TaoComposeSceneHostLinux(
         // Tao hosts and the AWT backends, instead of showing the desktop through
         // a transparent clear. The rounded corners are carved back to
         // transparent by [applyFrameDecoration] below.
-        if (!lagging) {
-            intermediateSurface?.close()
-            intermediateSurface = null
-            surface.canvas.clear(clearArgb)
-            sc.render(surface.canvas.asComposeCanvas(), now)
-            applyFrameDecoration(surface.canvas, fbW, fbH)
-        } else {
-            // Drawable lags: layout at window size into an intermediate, then
-            // scale into the real FB (BOTTOM_LEFT-safe, Compose stays in sync).
+        //
+        // Wayland: always paint Compose at window size into an intermediate,
+        // then blit into the real FB. One path for lag and steady state so we
+        // do not flash when drawable catches up at the end of a resize (or
+        // when lag starts). X11: drawable tracks the window — paint direct.
+        if (attachedKind == 2) {
             val mid = obtainIntermediateSurface(ctx, widthPx, heightPx) ?: run {
                 NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
                 return
@@ -1442,27 +1439,29 @@ internal class TaoComposeSceneHostLinux(
             mid.flushAndSubmit(syncCpu = false)
             val snapshot = mid.makeImageSnapshot()
             surface.canvas.clear(clearArgb)
+            // NEAREST when sizes match (bit-identical to a direct paint); LINEAR
+            // only while scaling a lagging buffer.
+            val sampling =
+                if (fbW == widthPx && fbH == heightPx) {
+                    FilterMipmap(FilterMode.NEAREST, MipmapMode.NONE)
+                } else {
+                    FilterMipmap(FilterMode.LINEAR, MipmapMode.NONE)
+                }
             surface.canvas.drawImageRect(
                 snapshot,
                 Rect.makeWH(widthPx.toFloat(), heightPx.toFloat()),
                 Rect.makeWH(fbW.toFloat(), fbH.toFloat()),
-                FilterMipmap(FilterMode.LINEAR, MipmapMode.NONE),
+                sampling,
                 null,
                 true,
             )
             snapshot.close()
+        } else {
+            surface.canvas.clear(clearArgb)
+            sc.render(surface.canvas.asComposeCanvas(), now)
+            applyFrameDecoration(surface.canvas, fbW, fbH)
         }
         surface.flushAndSubmit(syncCpu = false)
-
-        // Drop vsync while catching up so presents apply resize promptly.
-        if (attachedKind == 2 && !window.isPopup) {
-            val wantInterval = if (lagging || compositorDragActive) 0 else 1
-            if (wantInterval != appliedSwapInterval) {
-                NativeTaoEglBridge.nativeSetSwapInterval(attachmentHandle, wantInterval)
-                appliedSwapInterval = wantInterval
-            }
-        }
-
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -60,8 +60,12 @@ import org.jetbrains.skia.BlendMode
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.ColorSpace
 import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.FilterMipmap
+import org.jetbrains.skia.FilterMode
 import org.jetbrains.skia.FramebufferFormat
 import org.jetbrains.skia.GLAssembledInterface
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.MipmapMode
 import org.jetbrains.skia.Paint
 import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathFillMode
@@ -267,12 +271,13 @@ internal class TaoComposeSceneHostLinux(
     private var lastAppliedScale: Float = Float.NaN
 
     /**
-     * Wayland: size of the EGL buffer currently in use for painting.
-     * `wl_egl_window_resize` only takes effect on the next `eglSwapBuffers`;
-     * painting at the *window* size into a still-old buffer (BOTTOM_LEFT)
-     * shifts/flashes the frame. We paint at [drawableWidthPx]×[drawableHeightPx]
-     * and advance those after each present to [lastAppliedWidthPx]×[lastAppliedHeightPx].
-     * X11 sets drawable = window immediately (no lag).
+     * Wayland: size of the EGL buffer currently allocated (lags the window until
+     * the next present applies `wl_egl_window_resize`). The GL default FB and
+     * [cachedSurface] always match this size. Compose always layouts at the
+     * *window* size ([widthPx]×[heightPx]) so resize and layout stay atomic;
+     * when drawable lags we paint into an intermediate and scale-blit into the
+     * real FB (avoids BOTTOM_LEFT flash without shrinking Compose).
+     * X11 sets drawable = window immediately (no lag, direct paint).
      */
     private var drawableWidthPx: Int = 0
     private var drawableHeightPx: Int = 0
@@ -282,6 +287,12 @@ internal class TaoComposeSceneHostLinux(
     // work that contributes to the resize-time GPU lockup.
     private var cachedRt: BackendRenderTarget? = null
     private var cachedSurface: Surface? = null
+
+    /** GPU intermediate at window size, used only while drawable lags the window. */
+    private var intermediateSurface: Surface? = null
+
+    /** Last eglSwapInterval; 0 while drawable lags or a grab is active. */
+    private var appliedSwapInterval: Int = 1
 
     // Scene-size update throttle. Compose's layout cache is keyed on size: the
     // first frame at any new size triggers a full remeasure (80-150ms for
@@ -617,6 +628,8 @@ internal class TaoComposeSceneHostLinux(
         cachedSurface = null
         cachedRt?.close()
         cachedRt = null
+        intermediateSurface?.close()
+        intermediateSurface = null
         drawableWidthPx = 0
         drawableHeightPx = 0
         // Drop TextureView imports made on this context while it is still
@@ -1163,8 +1176,8 @@ internal class TaoComposeSceneHostLinux(
     private fun applyPendingNativeResize() {
         if (attachmentHandle == 0L) return
         if (widthPx <= 0 || heightPx <= 0) return
-        // Ensure scene size is caught up to the actual EGL surface size before
-        // rendering. The throttle in onResized may have skipped some updates.
+        // Compose is atomic with the resize configure: scene size always tracks
+        // the window, never the lagging drawable.
         val currentSize = IntSize(widthPx, heightPx)
         if (scene?.size != currentSize) {
             scene?.size = currentSize
@@ -1179,9 +1192,8 @@ internal class TaoComposeSceneHostLinux(
         }
         NativeTaoEglBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
         // X11: drawable tracks the window immediately — drop Skia cache now.
-        // Wayland: drawable lags until the next present; keep painting into the
-        // old-sized FB until [onDrawablePresented] advances it (avoids
-        // BOTTOM_LEFT shift/flash when Skia is larger than the real buffer).
+        // Wayland: drawable lags until the next present; the FB surface stays
+        // at [drawableWidthPx] until [onDrawablePresented] advances it.
         if (attachedKind != 2) {
             if (widthPx != lastAppliedWidthPx ||
                 heightPx != lastAppliedHeightPx ||
@@ -1195,11 +1207,12 @@ internal class TaoComposeSceneHostLinux(
             drawableWidthPx = widthPx
             drawableHeightPx = heightPx
         } else if (scale != lastAppliedScale) {
-            // Scale change: buffer_scale is reasserted; rebuild at the new window.
             cachedSurface?.close()
             cachedSurface = null
             cachedRt?.close()
             cachedRt = null
+            intermediateSurface?.close()
+            intermediateSurface = null
             drawableWidthPx = widthPx
             drawableHeightPx = heightPx
         }
@@ -1210,7 +1223,7 @@ internal class TaoComposeSceneHostLinux(
 
     /**
      * Wayland: after a present, the pending `wl_egl_window_resize` is in effect.
-     * Advance the paint size and re-arm a frame if the window is still ahead.
+     * Advance the drawable size and re-arm a frame if the window is still ahead.
      */
     private fun onDrawablePresented() {
         if (attachedKind != 2) return
@@ -1224,8 +1237,28 @@ internal class TaoComposeSceneHostLinux(
         cachedSurface = null
         cachedRt?.close()
         cachedRt = null
-        // Paint the newly allocated buffer without waiting for more motion.
         requestRedrawCoalesced()
+    }
+
+    private fun obtainIntermediateSurface(
+        ctx: DirectContext,
+        w: Int,
+        h: Int,
+    ): Surface? {
+        val existing = intermediateSurface
+        if (existing != null && existing.width == w && existing.height == h) {
+            return existing
+        }
+        existing?.close()
+        intermediateSurface = null
+        val created =
+            Surface.makeRenderTarget(
+                ctx,
+                false,
+                ImageInfo.makeN32Premul(w, h),
+            )
+        intermediateSurface = created
+        return created
     }
 
     fun onFocusChanged(focused: Boolean) {
@@ -1339,31 +1372,30 @@ internal class TaoComposeSceneHostLinux(
         // is current — applyPendingNativeResize closes the stale Skia cache.
         applyPendingNativeResize()
 
-        // Paint size = drawable (Wayland may lag the window by one present).
-        val paintW =
-            if (attachedKind == 2 && drawableWidthPx > 0) drawableWidthPx else widthPx
-        val paintH =
-            if (attachedKind == 2 && drawableHeightPx > 0) drawableHeightPx else heightPx
-        // Layout must match the FB we draw into (BOTTOM_LEFT mis-size flashes).
-        val paintSize = IntSize(paintW, paintH)
-        if (sc.size != paintSize) {
-            sc.size = paintSize
+        // Compose always at window size (atomic with the resize configure).
+        val windowSize = IntSize(widthPx, heightPx)
+        if (sc.size != windowSize) {
+            sc.size = windowSize
             lastSceneSizeUpdateNs = now
         }
 
+        // GL FB size may lag on Wayland until the next present.
+        val fbW =
+            if (attachedKind == 2 && drawableWidthPx > 0) drawableWidthPx else widthPx
+        val fbH =
+            if (attachedKind == 2 && drawableHeightPx > 0) drawableHeightPx else heightPx
+        val lagging = attachedKind == 2 && (fbW != widthPx || fbH != heightPx)
+
         var surface = cachedSurface
-        if (surface == null ||
-            surface.width != paintW ||
-            surface.height != paintH
-        ) {
+        if (surface == null || surface.width != fbW || surface.height != fbH) {
             cachedSurface?.close()
             cachedSurface = null
             cachedRt?.close()
             cachedRt = null
             val rt =
                 BackendRenderTarget.makeGL(
-                    width = paintW,
-                    height = paintH,
+                    width = fbW,
+                    height = fbH,
                     sampleCnt = 0,
                     stencilBits = 8,
                     fbId = 0,
@@ -1384,16 +1416,53 @@ internal class TaoComposeSceneHostLinux(
             cachedSurface = surface
         }
 
+        val clearArgb = clearColorArgbState.value
         // Clear to the resolved title-bar background (pushed by `TitleBar` via
         // [LocalRequestedClearColor]) so any Compose region without an explicit
         // background matches the chrome color — aligned with the macOS / Windows
         // Tao hosts and the AWT backends, instead of showing the desktop through
         // a transparent clear. The rounded corners are carved back to
         // transparent by [applyFrameDecoration] below.
-        surface.canvas.clear(clearColorArgbState.value)
-        sc.render(surface.canvas.asComposeCanvas(), now)
-        applyFrameDecoration(surface.canvas, paintW, paintH)
+        if (!lagging) {
+            intermediateSurface?.close()
+            intermediateSurface = null
+            surface.canvas.clear(clearArgb)
+            sc.render(surface.canvas.asComposeCanvas(), now)
+            applyFrameDecoration(surface.canvas, fbW, fbH)
+        } else {
+            // Drawable lags: layout at window size into an intermediate, then
+            // scale into the real FB (BOTTOM_LEFT-safe, Compose stays in sync).
+            val mid = obtainIntermediateSurface(ctx, widthPx, heightPx) ?: run {
+                NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
+                return
+            }
+            mid.canvas.clear(clearArgb)
+            sc.render(mid.canvas.asComposeCanvas(), now)
+            applyFrameDecoration(mid.canvas, widthPx, heightPx)
+            mid.flushAndSubmit(syncCpu = false)
+            val snapshot = mid.makeImageSnapshot()
+            surface.canvas.clear(clearArgb)
+            surface.canvas.drawImageRect(
+                snapshot,
+                Rect.makeWH(widthPx.toFloat(), heightPx.toFloat()),
+                Rect.makeWH(fbW.toFloat(), fbH.toFloat()),
+                FilterMipmap(FilterMode.LINEAR, MipmapMode.NONE),
+                null,
+                true,
+            )
+            snapshot.close()
+        }
         surface.flushAndSubmit(syncCpu = false)
+
+        // Drop vsync while catching up so presents apply resize promptly.
+        if (attachedKind == 2 && !window.isPopup) {
+            val wantInterval = if (lagging || compositorDragActive) 0 else 1
+            if (wantInterval != appliedSwapInterval) {
+                NativeTaoEglBridge.nativeSetSwapInterval(attachmentHandle, wantInterval)
+                appliedSwapInterval = wantInterval
+            }
+        }
+
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
 
@@ -2091,6 +2160,8 @@ internal class TaoComposeSceneHostLinux(
         cachedSurface = null
         cachedRt?.close()
         cachedRt = null
+        intermediateSurface?.close()
+        intermediateSurface = null
         // Belt for TextureView imports a leaked composition may still hold:
         // scene.close() above released the leases of every live one.
         directContext?.let(::releaseGlTextureImports)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -60,12 +60,8 @@ import org.jetbrains.skia.BlendMode
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.ColorSpace
 import org.jetbrains.skia.DirectContext
-import org.jetbrains.skia.FilterMipmap
-import org.jetbrains.skia.FilterMode
 import org.jetbrains.skia.FramebufferFormat
 import org.jetbrains.skia.GLAssembledInterface
-import org.jetbrains.skia.ImageInfo
-import org.jetbrains.skia.MipmapMode
 import org.jetbrains.skia.Paint
 import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathFillMode
@@ -271,13 +267,12 @@ internal class TaoComposeSceneHostLinux(
     private var lastAppliedScale: Float = Float.NaN
 
     /**
-     * Wayland: size of the EGL buffer currently allocated (lags the window until
-     * the next present applies `wl_egl_window_resize`). The GL default FB and
-     * [cachedSurface] always match this size. Compose always layouts at the
-     * *window* size ([widthPx]×[heightPx]) so resize and layout stay atomic;
-     * when drawable lags we paint into an intermediate and scale-blit into the
-     * real FB (avoids BOTTOM_LEFT flash without shrinking Compose).
-     * X11 sets drawable = window immediately (no lag, direct paint).
+     * Wayland: size of the EGL buffer currently in use for painting.
+     * `wl_egl_window_resize` only takes effect on the next `eglSwapBuffers`;
+     * painting at the *window* size into a still-old buffer (BOTTOM_LEFT)
+     * shifts/flashes the frame. We paint at [drawableWidthPx]×[drawableHeightPx]
+     * and advance those after each present to [lastAppliedWidthPx]×[lastAppliedHeightPx].
+     * X11 sets drawable = window immediately (no lag).
      */
     private var drawableWidthPx: Int = 0
     private var drawableHeightPx: Int = 0
@@ -287,13 +282,6 @@ internal class TaoComposeSceneHostLinux(
     // work that contributes to the resize-time GPU lockup.
     private var cachedRt: BackendRenderTarget? = null
     private var cachedSurface: Surface? = null
-
-    /**
-     * GPU intermediate at window size. On Wayland every frame paints here then
-     * blits into the real FB — one path for lag and steady state (no flash at
-     * the start/end of a resize from switching paint modes).
-     */
-    private var intermediateSurface: Surface? = null
 
     // Scene-size update throttle. Compose's layout cache is keyed on size: the
     // first frame at any new size triggers a full remeasure (80-150ms for
@@ -629,8 +617,6 @@ internal class TaoComposeSceneHostLinux(
         cachedSurface = null
         cachedRt?.close()
         cachedRt = null
-        intermediateSurface?.close()
-        intermediateSurface = null
         drawableWidthPx = 0
         drawableHeightPx = 0
         // Drop TextureView imports made on this context while it is still
@@ -1177,8 +1163,8 @@ internal class TaoComposeSceneHostLinux(
     private fun applyPendingNativeResize() {
         if (attachmentHandle == 0L) return
         if (widthPx <= 0 || heightPx <= 0) return
-        // Compose is atomic with the resize configure: scene size always tracks
-        // the window, never the lagging drawable.
+        // Ensure scene size is caught up to the actual EGL surface size before
+        // rendering. The throttle in onResized may have skipped some updates.
         val currentSize = IntSize(widthPx, heightPx)
         if (scene?.size != currentSize) {
             scene?.size = currentSize
@@ -1193,8 +1179,9 @@ internal class TaoComposeSceneHostLinux(
         }
         NativeTaoEglBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
         // X11: drawable tracks the window immediately — drop Skia cache now.
-        // Wayland: drawable lags until the next present; the FB surface stays
-        // at [drawableWidthPx] until [onDrawablePresented] advances it.
+        // Wayland: drawable lags until the next present; keep painting into the
+        // old-sized FB until [onDrawablePresented] advances it (avoids
+        // BOTTOM_LEFT shift/flash when Skia is larger than the real buffer).
         if (attachedKind != 2) {
             if (widthPx != lastAppliedWidthPx ||
                 heightPx != lastAppliedHeightPx ||
@@ -1208,12 +1195,11 @@ internal class TaoComposeSceneHostLinux(
             drawableWidthPx = widthPx
             drawableHeightPx = heightPx
         } else if (scale != lastAppliedScale) {
+            // Scale change: buffer_scale is reasserted; rebuild at the new window.
             cachedSurface?.close()
             cachedSurface = null
             cachedRt?.close()
             cachedRt = null
-            intermediateSurface?.close()
-            intermediateSurface = null
             drawableWidthPx = widthPx
             drawableHeightPx = heightPx
         }
@@ -1224,7 +1210,7 @@ internal class TaoComposeSceneHostLinux(
 
     /**
      * Wayland: after a present, the pending `wl_egl_window_resize` is in effect.
-     * Advance the drawable size and re-arm a frame if the window is still ahead.
+     * Advance the paint size and re-arm a frame if the window is still ahead.
      */
     private fun onDrawablePresented() {
         if (attachedKind != 2) return
@@ -1238,28 +1224,8 @@ internal class TaoComposeSceneHostLinux(
         cachedSurface = null
         cachedRt?.close()
         cachedRt = null
+        // Paint the newly allocated buffer without waiting for more motion.
         requestRedrawCoalesced()
-    }
-
-    private fun obtainIntermediateSurface(
-        ctx: DirectContext,
-        w: Int,
-        h: Int,
-    ): Surface? {
-        val existing = intermediateSurface
-        if (existing != null && existing.width == w && existing.height == h) {
-            return existing
-        }
-        existing?.close()
-        intermediateSurface = null
-        val created =
-            Surface.makeRenderTarget(
-                ctx,
-                false,
-                ImageInfo.makeN32Premul(w, h),
-            )
-        intermediateSurface = created
-        return created
     }
 
     fun onFocusChanged(focused: Boolean) {
@@ -1373,29 +1339,31 @@ internal class TaoComposeSceneHostLinux(
         // is current — applyPendingNativeResize closes the stale Skia cache.
         applyPendingNativeResize()
 
-        // Compose always at window size (atomic with the resize configure).
-        val windowSize = IntSize(widthPx, heightPx)
-        if (sc.size != windowSize) {
-            sc.size = windowSize
+        // Paint size = drawable (Wayland may lag the window by one present).
+        val paintW =
+            if (attachedKind == 2 && drawableWidthPx > 0) drawableWidthPx else widthPx
+        val paintH =
+            if (attachedKind == 2 && drawableHeightPx > 0) drawableHeightPx else heightPx
+        // Layout must match the FB we draw into (BOTTOM_LEFT mis-size flashes).
+        val paintSize = IntSize(paintW, paintH)
+        if (sc.size != paintSize) {
+            sc.size = paintSize
             lastSceneSizeUpdateNs = now
         }
 
-        // GL FB size may lag on Wayland until the next present.
-        val fbW =
-            if (attachedKind == 2 && drawableWidthPx > 0) drawableWidthPx else widthPx
-        val fbH =
-            if (attachedKind == 2 && drawableHeightPx > 0) drawableHeightPx else heightPx
-
         var surface = cachedSurface
-        if (surface == null || surface.width != fbW || surface.height != fbH) {
+        if (surface == null ||
+            surface.width != paintW ||
+            surface.height != paintH
+        ) {
             cachedSurface?.close()
             cachedSurface = null
             cachedRt?.close()
             cachedRt = null
             val rt =
                 BackendRenderTarget.makeGL(
-                    width = fbW,
-                    height = fbH,
+                    width = paintW,
+                    height = paintH,
                     sampleCnt = 0,
                     stencilBits = 8,
                     fbId = 0,
@@ -1416,51 +1384,15 @@ internal class TaoComposeSceneHostLinux(
             cachedSurface = surface
         }
 
-        val clearArgb = clearColorArgbState.value
         // Clear to the resolved title-bar background (pushed by `TitleBar` via
         // [LocalRequestedClearColor]) so any Compose region without an explicit
         // background matches the chrome color — aligned with the macOS / Windows
         // Tao hosts and the AWT backends, instead of showing the desktop through
         // a transparent clear. The rounded corners are carved back to
         // transparent by [applyFrameDecoration] below.
-        //
-        // Wayland: always paint Compose at window size into an intermediate,
-        // then blit into the real FB. One path for lag and steady state so we
-        // do not flash when drawable catches up at the end of a resize (or
-        // when lag starts). X11: drawable tracks the window — paint direct.
-        if (attachedKind == 2) {
-            val mid = obtainIntermediateSurface(ctx, widthPx, heightPx) ?: run {
-                NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
-                return
-            }
-            mid.canvas.clear(clearArgb)
-            sc.render(mid.canvas.asComposeCanvas(), now)
-            applyFrameDecoration(mid.canvas, widthPx, heightPx)
-            mid.flushAndSubmit(syncCpu = false)
-            val snapshot = mid.makeImageSnapshot()
-            surface.canvas.clear(clearArgb)
-            // NEAREST when sizes match (bit-identical to a direct paint); LINEAR
-            // only while scaling a lagging buffer.
-            val sampling =
-                if (fbW == widthPx && fbH == heightPx) {
-                    FilterMipmap(FilterMode.NEAREST, MipmapMode.NONE)
-                } else {
-                    FilterMipmap(FilterMode.LINEAR, MipmapMode.NONE)
-                }
-            surface.canvas.drawImageRect(
-                snapshot,
-                Rect.makeWH(widthPx.toFloat(), heightPx.toFloat()),
-                Rect.makeWH(fbW.toFloat(), fbH.toFloat()),
-                sampling,
-                null,
-                true,
-            )
-            snapshot.close()
-        } else {
-            surface.canvas.clear(clearArgb)
-            sc.render(surface.canvas.asComposeCanvas(), now)
-            applyFrameDecoration(surface.canvas, fbW, fbH)
-        }
+        surface.canvas.clear(clearColorArgbState.value)
+        sc.render(surface.canvas.asComposeCanvas(), now)
+        applyFrameDecoration(surface.canvas, paintW, paintH)
         surface.flushAndSubmit(syncCpu = false)
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
@@ -2159,8 +2091,6 @@ internal class TaoComposeSceneHostLinux(
         cachedSurface = null
         cachedRt?.close()
         cachedRt = null
-        intermediateSurface?.close()
-        intermediateSurface = null
         // Belt for TextureView imports a leaked composition may still hold:
         // scene.close() above released the leases of every live one.
         directContext?.let(::releaseGlTextureImports)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -71,8 +71,8 @@ import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceColorFormat
 import org.jetbrains.skia.SurfaceOrigin
 import org.jetbrains.skia.makeGLWithInterface
-import java.util.concurrent.AtomicInteger
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Logger
 import kotlin.concurrent.withLock

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -71,6 +71,7 @@ import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceColorFormat
 import org.jetbrains.skia.SurfaceOrigin
 import org.jetbrains.skia.makeGLWithInterface
+import java.util.concurrent.AtomicInteger
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Logger
@@ -326,8 +327,7 @@ internal class TaoComposeSceneHostLinux(
      * `eglSwapBuffers` is actually painted. Written on the event-loop thread
      * ([onResized]), decremented on the swap thread after present.
      */
-    private val postResizeCatchUpFrames =
-        java.util.concurrent.atomic.AtomicInteger(0)
+    private val postResizeCatchUpFrames = AtomicInteger(0)
     private val sceneSizeUpdateIntervalNs = 16_666_667L // 60fps
 
     private var lastPointerX: Float = 0f
@@ -1403,50 +1403,13 @@ internal class TaoComposeSceneHostLinux(
         applyPendingNativeResize()
         updateResizeBurstSwapInterval()
 
-        // KWin: paint at lagging drawable (avoids BOTTOM_LEFT flash).
-        // GNOME / others: paint at window size (master — no layout lag).
-        val paintW =
-            if (useDrawableSizedPaint && drawableWidthPx > 0) drawableWidthPx else widthPx
-        val paintH =
-            if (useDrawableSizedPaint && drawableHeightPx > 0) drawableHeightPx else heightPx
-        val paintSize = IntSize(paintW, paintH)
+        val paintSize = resolvePaintSize()
         if (sc.size != paintSize) {
             sc.size = paintSize
             lastSceneSizeUpdateNs = now
         }
 
-        var surface = cachedSurface
-        if (surface == null ||
-            surface.width != paintW ||
-            surface.height != paintH
-        ) {
-            cachedSurface?.close()
-            cachedSurface = null
-            cachedRt?.close()
-            cachedRt = null
-            val rt =
-                BackendRenderTarget.makeGL(
-                    width = paintW,
-                    height = paintH,
-                    sampleCnt = 0,
-                    stencilBits = 8,
-                    fbId = 0,
-                    fbFormat = FramebufferFormat.GR_GL_RGBA8,
-                )
-            surface = Surface.makeFromBackendRenderTarget(
-                context = ctx,
-                rt = rt,
-                origin = SurfaceOrigin.BOTTOM_LEFT,
-                colorFormat = SurfaceColorFormat.RGBA_8888,
-                colorSpace = ColorSpace.sRGB,
-            ) ?: run {
-                rt.close()
-                NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
-                return
-            }
-            cachedRt = rt
-            cachedSurface = surface
-        }
+        val surface = ensurePaintSurface(ctx, paintSize.width, paintSize.height) ?: return
 
         // Clear to the resolved title-bar background (pushed by `TitleBar` via
         // [LocalRequestedClearColor]) so any Compose region without an explicit
@@ -1456,7 +1419,7 @@ internal class TaoComposeSceneHostLinux(
         // transparent by [applyFrameDecoration] below.
         surface.canvas.clear(clearColorArgbState.value)
         sc.render(surface.canvas.asComposeCanvas(), now)
-        applyFrameDecoration(surface.canvas, paintW, paintH)
+        applyFrameDecoration(surface.canvas, paintSize.width, paintSize.height)
         surface.flushAndSubmit(syncCpu = false)
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
@@ -1468,17 +1431,77 @@ internal class TaoComposeSceneHostLinux(
         // accompany a size change (maximize/restore/tile collapse the CSD
         // shadow margins).
         applyContentOffset()
+        drainPopupRenderers()
+    }
 
-        // Drain popup-layer renderers after the host context was released.
-        // Each layer binds its own private EGL context on this thread (the
-        // swap thread holds the *host* context on its own thread — EGL allows
-        // one current context per thread), paints, presents with swap
-        // interval 0 (non-blocking) and releases. Snapshot: rendering one
-        // layer can recompose and close a sibling.
-        if (popupRenderers.isNotEmpty()) {
-            val snapshot = popupRenderers.values.toList()
-            for (render in snapshot) render()
+    /**
+     * KWin: paint at lagging drawable (avoids BOTTOM_LEFT flash).
+     * GNOME / others: paint at window size (master — no layout lag).
+     */
+    private fun resolvePaintSize(): IntSize {
+        val paintW =
+            if (useDrawableSizedPaint && drawableWidthPx > 0) drawableWidthPx else widthPx
+        val paintH =
+            if (useDrawableSizedPaint && drawableHeightPx > 0) drawableHeightPx else heightPx
+        return IntSize(paintW, paintH)
+    }
+
+    /**
+     * Rebuilds the Skia RT/surface when the paint size changed. Returns null if
+     * surface creation fails (EGL context already released by this call).
+     */
+    private fun ensurePaintSurface(
+        ctx: DirectContext,
+        paintW: Int,
+        paintH: Int,
+    ): Surface? {
+        val existing = cachedSurface
+        if (existing != null && existing.width == paintW && existing.height == paintH) {
+            return existing
         }
+        cachedSurface?.close()
+        cachedSurface = null
+        cachedRt?.close()
+        cachedRt = null
+        val rt =
+            BackendRenderTarget.makeGL(
+                width = paintW,
+                height = paintH,
+                sampleCnt = 0,
+                stencilBits = 8,
+                fbId = 0,
+                fbFormat = FramebufferFormat.GR_GL_RGBA8,
+            )
+        val surface =
+            Surface.makeFromBackendRenderTarget(
+                context = ctx,
+                rt = rt,
+                origin = SurfaceOrigin.BOTTOM_LEFT,
+                colorFormat = SurfaceColorFormat.RGBA_8888,
+                colorSpace = ColorSpace.sRGB,
+            )
+        if (surface == null) {
+            rt.close()
+            NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
+            return null
+        }
+        cachedRt = rt
+        cachedSurface = surface
+        return surface
+    }
+
+    /**
+     * Drain popup-layer renderers after the host context was released.
+     * Each layer binds its own private EGL context on this thread (the
+     * swap thread holds the *host* context on its own thread — EGL allows
+     * one current context per thread), paints, presents with swap
+     * interval 0 (non-blocking) and releases. Snapshot: rendering one
+     * layer can recompose and close a sibling.
+     */
+    private fun drainPopupRenderers() {
+        if (popupRenderers.isEmpty()) return
+        val snapshot = popupRenderers.values.toList()
+        for (render in snapshot) render()
     }
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -286,6 +286,13 @@ internal class TaoComposeSceneHostLinux(
             attachedKind == 2 &&
                 LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE
 
+    /**
+     * Last eglSwapInterval. Dropped to 0 for the whole interactive resize/move
+     * grab (and while the paint size still lags the window on KWin) so buffer
+     * catch-up is not vsync-gated. Same on GNOME and KDE; restored to 1 at rest.
+     */
+    private var appliedSwapInterval: Int = 1
+
     // Cache the Skia RT/Surface across frames — recreated only when the size
     // changes. Reallocating an FBO + GL surface every frame piles up driver
     // work that contributes to the resize-time GPU lockup.
@@ -1401,6 +1408,19 @@ internal class TaoComposeSceneHostLinux(
         sc.render(surface.canvas.asComposeCanvas(), now)
         applyFrameDecoration(surface.canvas, paintW, paintH)
         surface.flushAndSubmit(syncCpu = false)
+
+        // Wayland (GNOME + KDE): drop vsync during interactive resize/move and
+        // while paint size lags the window so eglSwapBuffers is not held for a
+        // full refresh. Hold 0 for the whole grab to avoid 0↔1 thrash flashes.
+        if (attachedKind == 2 && !window.isPopup) {
+            val lagging = paintW != widthPx || paintH != heightPx
+            val wantInterval = if (lagging || compositorDragActive) 0 else 1
+            if (wantInterval != appliedSwapInterval) {
+                NativeTaoEglBridge.nativeSetSwapInterval(attachmentHandle, wantInterval)
+                appliedSwapInterval = wantInterval
+            }
+        }
+
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -269,13 +269,22 @@ internal class TaoComposeSceneHostLinux(
     /**
      * Wayland: size of the EGL buffer currently in use for painting.
      * `wl_egl_window_resize` only takes effect on the next `eglSwapBuffers`.
-     * Painting at the *window* size into a still-old buffer with BOTTOM_LEFT
-     * shifts/flashes the frame (Fedora Mutter and KWin). We paint at this
-     * size and advance after present. Burst catch-up keeps lag to one buffer.
-     * X11: drawable tracks the window immediately.
+     * Used only when [useDrawableSizedPaint] is true (KWin): paint at this size
+     * and advance after present. Elsewhere (GNOME / main) paint at the window
+     * size so layout stays in sync with the configure.
      */
     private var drawableWidthPx: Int = 0
     private var drawableHeightPx: Int = 0
+
+    /**
+     * KWin flashes if we paint at the window size into a still-old EGL FB
+     * (BOTTOM_LEFT). GNOME does not need that trade-off — keep master's
+     * window-sized paint there (and on every non-Plasma DE).
+     */
+    private val useDrawableSizedPaint: Boolean
+        get() =
+            attachedKind == 2 &&
+                LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE
 
     // Cache the Skia RT/Surface across frames — recreated only when the size
     // changes. Reallocating an FBO + GL surface every frame piles up driver
@@ -1219,7 +1228,16 @@ internal class TaoComposeSceneHostLinux(
     private fun applyPendingNativeResize() {
         if (attachmentHandle == 0L) return
         if (widthPx <= 0 || heightPx <= 0) return
-        // Scene size is set from the paint size (drawable on Wayland).
+        // GNOME / main: scene tracks the window. KWin drawable path sets scene
+        // size from the paint size below (may lag the window by one present).
+        if (!useDrawableSizedPaint) {
+            val currentSize = IntSize(widthPx, heightPx)
+            if (scene?.size != currentSize) {
+                scene?.size = currentSize
+                updateWindowInfoSize()
+                lastSceneSizeUpdateNs = System.nanoTime()
+            }
+        }
         if (widthPx == lastAppliedWidthPx &&
             heightPx == lastAppliedHeightPx &&
             scale == lastAppliedScale
@@ -1227,11 +1245,8 @@ internal class TaoComposeSceneHostLinux(
             return
         }
         NativeTaoEglBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
-        // X11: drawable tracks the window immediately — drop Skia cache now.
-        // Wayland: drawable lags until the next present; keep painting into the
-        // old-sized FB until [onDrawablePresented] advances it (avoids
-        // BOTTOM_LEFT shift/flash when Skia is larger than the real buffer).
-        if (attachedKind != 2) {
+        if (!useDrawableSizedPaint) {
+            // Master behaviour: paint size follows the window immediately.
             if (widthPx != lastAppliedWidthPx ||
                 heightPx != lastAppliedHeightPx ||
                 scale != lastAppliedScale
@@ -1244,6 +1259,7 @@ internal class TaoComposeSceneHostLinux(
             drawableWidthPx = widthPx
             drawableHeightPx = heightPx
         } else if (scale != lastAppliedScale) {
+            // KWin: keep drawable lagging on size-only changes; rebuild on scale.
             cachedSurface?.close()
             cachedSurface = null
             cachedRt?.close()
@@ -1257,11 +1273,11 @@ internal class TaoComposeSceneHostLinux(
     }
 
     /**
-     * Wayland: after a present, the pending `wl_egl_window_resize` is in effect.
-     * Advance the paint size and re-arm a frame if the window is still ahead.
+     * KWin only: after a present, the pending `wl_egl_window_resize` is in
+     * effect — advance the paint size and re-arm a frame if still behind.
      */
     private fun onDrawablePresented() {
-        if (attachedKind != 2) return
+        if (!useDrawableSizedPaint) return
         if (lastAppliedWidthPx <= 0 || lastAppliedHeightPx <= 0) return
         if (drawableWidthPx == lastAppliedWidthPx && drawableHeightPx == lastAppliedHeightPx) {
             return
@@ -1387,13 +1403,12 @@ internal class TaoComposeSceneHostLinux(
         applyPendingNativeResize()
         updateResizeBurstSwapInterval()
 
-        // Paint at drawable size on Wayland (may lag the window by one present).
-        // Matches the FB so BOTTOM_LEFT cannot shift/flash (KWin + Fedora Mutter).
-        // Burst catch-up after present keeps the lag to one buffer step.
+        // KWin: paint at lagging drawable (avoids BOTTOM_LEFT flash).
+        // GNOME / others: paint at window size (master — no layout lag).
         val paintW =
-            if (attachedKind == 2 && drawableWidthPx > 0) drawableWidthPx else widthPx
+            if (useDrawableSizedPaint && drawableWidthPx > 0) drawableWidthPx else widthPx
         val paintH =
-            if (attachedKind == 2 && drawableHeightPx > 0) drawableHeightPx else heightPx
+            if (useDrawableSizedPaint && drawableHeightPx > 0) drawableHeightPx else heightPx
         val paintSize = IntSize(paintW, paintH)
         if (sc.size != paintSize) {
             sc.size = paintSize
@@ -2303,8 +2318,8 @@ internal class TaoComposeSceneHostLinux(
                                     renderOwed = false
                                     owed
                                 }
-                            // Drawable size advances only after this present.
-                            if (attachedKind == 2) {
+                            // KWin: drawable advances only after this present.
+                            if (useDrawableSizedPaint) {
                                 dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
                                     .dispatch(
                                         EmptyCoroutineContext,


### PR DESCRIPTION
## Summary

**One paint path.** Root cause targeted: during Wayland resize we were drawing at the **window** size while the EGL buffer was still the **previous** size (`wl_egl_window_resize` only applies on the next `eglSwapBuffers`). With `SurfaceOrigin.BOTTOM_LEFT` that mis-sizes the frame → shift/flash (especially visible on KWin).

### Fix
1. Track `drawableWidthPx` / `drawableHeightPx` (last presented buffer size)
2. Always `nativeResize` to the window size
3. **Paint** only at the drawable size (layout for that frame matches the FB)
4. After each present, advance drawable to the applied size and re-arm a frame so we catch up

### Explicitly removed
- Vsync burst / catch-up / main-thread present / await-idle stacks
- Viewport stretch / DE dual pipeline

Related: #444.

## Test plan
- [x] Ubuntu GNOME: no new flash/stretch vs `main`
- [x] Fedora Plasma: flash reduced; residual gap is one-buffer lag (expected without viewport)
- [x] After drag: sharp at final size