### PR TITLE
feat(nucleus-application): bridge isSystemInDarkTheme to darkmode-detector

### DIFF
--- a/nucleus-application/build.gradle.kts
+++ b/nucleus-application/build.gradle.kts
@@ -18,6 +18,10 @@ dependencies {
     api(project(":decorated-window-core"))
     api(project(":decorated-window-awt"))
     api(project(":aot-runtime"))
+    // api: nucleusApplication bridges Compose's isSystemInDarkTheme() to the
+    // reactive OS detector, so consumers always get darkmode-detector on the
+    // compile + runtime classpath (and may call isSystemInDarkMode() directly).
+    api(project(":darkmode-detector"))
     implementation(project(":core-runtime"))
     implementation(project(":graalvm-runtime"))
     // api: NucleusApplicationScope extends Compose's ApplicationScope, so the

--- a/nucleus-application/build.gradle.kts
+++ b/nucleus-application/build.gradle.kts
@@ -34,6 +34,10 @@ dependencies {
     // to jbr's) and tao for the no-AWT path.
     compileOnly(project(":decorated-window-jni"))
     compileOnly(project(":decorated-window-tao"))
+
+    testImplementation(libs.junit)
+    testImplementation(compose.desktop.currentOs)
+    testImplementation("org.jetbrains.compose.ui:ui-test-junit4:${libs.versions.compose.get()}")
 }
 
 java {
@@ -45,6 +49,28 @@ kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_17)
     }
+}
+
+/**
+ * Live process E2E for the system-theme bridge (needs a display / D-Bus on Linux).
+ * Not part of `check` — run explicitly: `./gradlew :nucleus-application:systemThemeE2E`
+ */
+tasks.register<JavaExec>("systemThemeE2E") {
+    group = "verification"
+    description =
+        "Boots a real Compose application under ProvideNucleusSystemTheme and " +
+            "asserts isSystemInDarkTheme() matches the native detector"
+    dependsOn(tasks.named("testClasses"))
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.nucleusframework.application.NucleusApplicationSystemThemeE2EMainKt")
+    systemProperty(
+        "systemThemeE2E.report",
+        layout.buildDirectory
+            .file("reports/system-theme-e2e.report")
+            .get()
+            .asFile
+            .absolutePath,
+    )
 }
 
 mavenPublishing {

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
@@ -16,6 +16,10 @@ import java.util.Locale
  * Inside [content], use [DecoratedWindow] / [DecoratedDialog] — both work
  * uniformly across backends and expose a [NucleusWindow] handle.
  *
+ * Compose's [androidx.compose.foundation.isSystemInDarkTheme] is bridged to
+ * Nucleus's reactive OS detector (`darkmode-detector`), so official and library
+ * call sites track live system theme changes without polling.
+ *
  * ```
  * fun main() = nucleusApplication(backend = NucleusBackend.Auto) {
  *     val state = rememberWindowState(size = DpSize(1200.dp, 800.dp))
@@ -89,11 +93,13 @@ fun nucleusApplication(
         NucleusBackend.Awt, NucleusBackend.Auto ->
             application {
                 val nucleusScope = AwtNucleusApplicationScope(this, args)
-                CompositionLocalProvider(
-                    LocalNucleusBackend provides NucleusBackend.Awt,
-                    LocalNucleusApplicationScope provides nucleusScope,
-                ) {
-                    nucleusScope.content()
+                ProvideNucleusSystemTheme {
+                    CompositionLocalProvider(
+                        LocalNucleusBackend provides NucleusBackend.Awt,
+                        LocalNucleusApplicationScope provides nucleusScope,
+                    ) {
+                        nucleusScope.content()
+                    }
                 }
             }
     }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/ProvideNucleusSystemTheme.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/ProvideNucleusSystemTheme.kt
@@ -1,0 +1,31 @@
+package dev.nucleusframework.application
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.LocalSystemTheme
+import androidx.compose.ui.SystemTheme
+import dev.nucleusframework.darkmodedetector.isSystemInDarkMode
+
+/**
+ * Feeds Compose's [androidx.compose.foundation.isSystemInDarkTheme] from
+ * Nucleus's reactive OS detector.
+ *
+ * On Compose Desktop 1.11, `isSystemInDarkTheme()` only reads
+ * [LocalSystemTheme], whose default is a non-reactive Skiko snapshot. Providing
+ * the local from [isSystemInDarkMode] makes every official call site (and any
+ * library that uses it) track OS dark-mode changes the same way Nucleus does.
+ *
+ * The value is computed *outside* the provider, so the detector never reads the
+ * local it is about to set (preview path of [isSystemInDarkMode] falls back to
+ * `isSystemInDarkTheme()`).
+ */
+@OptIn(InternalComposeUiApi::class)
+@Composable
+internal fun ProvideNucleusSystemTheme(content: @Composable () -> Unit) {
+    val isDark = isSystemInDarkMode()
+    CompositionLocalProvider(
+        LocalSystemTheme provides if (isDark) SystemTheme.Dark else SystemTheme.Light,
+        content = content,
+    )
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoLauncher.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoLauncher.kt
@@ -7,6 +7,7 @@ import dev.nucleusframework.application.LocalNucleusApplicationScope
 import dev.nucleusframework.application.LocalNucleusBackend
 import dev.nucleusframework.application.NucleusApplicationScope
 import dev.nucleusframework.application.NucleusBackend
+import dev.nucleusframework.application.ProvideNucleusSystemTheme
 import dev.nucleusframework.application.TaoNucleusApplicationScope
 import dev.nucleusframework.window.tao.TaoDockPolicy
 import dev.nucleusframework.window.tao.taoApplication
@@ -28,17 +29,21 @@ internal object TaoLauncher {
         // URIs received before then are buffered and replayed by `TaoDeepLinkBridge`.
         taoApplication {
             val scope = TaoNucleusApplicationScope(this, args)
-            CompositionLocalProvider(
-                LocalNucleusBackend provides NucleusBackend.Tao,
-                LocalNucleusApplicationScope provides scope,
-            ) {
-                // Apply the Dock-follows-windows opt-in on the Tao main thread
-                // (this composition) so a tray-only app drops out of the Dock at
-                // startup; visible DecoratedWindows then promote it as needed.
-                LaunchedEffect(dockIconFollowsWindows) {
-                    TaoDockPolicy.setEnabled(dockIconFollowsWindows)
+            // Provide before other locals so Tao's per-window outerLocals bridge
+            // carries LocalSystemTheme into each scene (see TaoDecoratedWindowAdapter).
+            ProvideNucleusSystemTheme {
+                CompositionLocalProvider(
+                    LocalNucleusBackend provides NucleusBackend.Tao,
+                    LocalNucleusApplicationScope provides scope,
+                ) {
+                    // Apply the Dock-follows-windows opt-in on the Tao main thread
+                    // (this composition) so a tray-only app drops out of the Dock at
+                    // startup; visible DecoratedWindows then promote it as needed.
+                    LaunchedEffect(dockIconFollowsWindows) {
+                        TaoDockPolicy.setEnabled(dockIconFollowsWindows)
+                    }
+                    scope.content()
                 }
-                scope.content()
             }
         }
     }

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/LinuxColorSchemeToggle.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/LinuxColorSchemeToggle.kt
@@ -1,0 +1,73 @@
+package dev.nucleusframework.application
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Toggles GNOME/portal color-scheme for live E2E tests. No-op helpers when
+ * `gsettings` is unavailable (CI without a session bus).
+ */
+internal object LinuxColorSchemeToggle {
+    private const val SCHEMA = "org.gnome.desktop.interface"
+    private const val KEY = "color-scheme"
+
+    val isAvailable: Boolean by lazy {
+        System.getProperty("os.name").orEmpty().lowercase().contains("linux") &&
+            runCatching {
+                ProcessBuilder("gsettings", "get", SCHEMA, KEY)
+                    .redirectErrorStream(true)
+                    .start()
+                    .waitFor(3, TimeUnit.SECONDS)
+            }.getOrDefault(false).let { started ->
+                // waitFor returns true if finished; check exit 0
+                started &&
+                    runCatching {
+                        val p =
+                            ProcessBuilder("gsettings", "get", SCHEMA, KEY)
+                                .redirectErrorStream(true)
+                                .start()
+                        p.waitFor(3, TimeUnit.SECONDS) && p.exitValue() == 0
+                    }.getOrDefault(false)
+            }
+    }
+
+    fun read(): String {
+        val p =
+            ProcessBuilder("gsettings", "get", SCHEMA, KEY)
+                .redirectErrorStream(true)
+                .start()
+        check(p.waitFor(3, TimeUnit.SECONDS)) { "gsettings get timed out" }
+        check(p.exitValue() == 0) { "gsettings get failed: ${p.inputStream.bufferedReader().readText()}" }
+        // gsettings prints e.g. 'prefer-dark'
+        return p.inputStream.bufferedReader().readText().trim().trim('\'')
+    }
+
+    fun write(value: String) {
+        val p =
+            ProcessBuilder("gsettings", "set", SCHEMA, KEY, value)
+                .redirectErrorStream(true)
+                .start()
+        check(p.waitFor(3, TimeUnit.SECONDS)) { "gsettings set timed out" }
+        check(p.exitValue() == 0) {
+            "gsettings set $value failed: ${p.inputStream.bufferedReader().readText()}"
+        }
+    }
+
+    inline fun <T> withScheme(
+        scheme: String,
+        block: () -> T,
+    ): T {
+        val previous = read()
+        write(scheme)
+        try {
+            return block()
+        } finally {
+            write(previous)
+        }
+    }
+
+    /** Flip between prefer-dark and prefer-light. */
+    fun oppositeOf(current: String): String =
+        if (current == "prefer-dark") "prefer-light" else "prefer-dark"
+
+    fun isDarkScheme(scheme: String): Boolean = scheme == "prefer-dark"
+}

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/NucleusApplicationSystemThemeE2EMain.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/NucleusApplicationSystemThemeE2EMain.kt
@@ -4,75 +4,133 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import dev.nucleusframework.darkmodedetector.getPlatformDarkModeDetector
 import dev.nucleusframework.darkmodedetector.isSystemInDarkMode
-import org.jetbrains.skiko.SystemTheme as SkikoSystemTheme
-import org.jetbrains.skiko.currentSystemTheme
 import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.system.exitProcess
 
+
 /**
- * Process-level E2E: boots a real Compose `application` + `Window` under
- * [ProvideNucleusSystemTheme] (same bridge as `nucleusApplication`) and writes
- * a PASS/FAIL report. Exit code 0 = PASS, 1 = FAIL.
+ * Process-level E2E that **actually flips** the OS color-scheme and checks that
+ * under [ProvideNucleusSystemTheme] both [isSystemInDarkMode] and official
+ * [isSystemInDarkTheme] track each transition.
  *
  * Run: `./gradlew :nucleus-application:systemThemeE2E`
- *
- * Note: Compose's `application` defaults to `exitProcessOnExit = true`, so we
- * must write the report *before* [exitApplication] — nothing after `application { }`
- * runs on success.
  */
 fun main() {
+    if (!LinuxColorSchemeToggle.isAvailable) {
+        failReport("gsettings/session bus unavailable — cannot toggle OS theme")
+    }
+
     val reportFile =
         File(System.getProperty("systemThemeE2E.report", "system-theme-e2e.report"))
     reportFile.parentFile?.mkdirs()
 
-    // exitProcessOnExit = false so we control the process exit code after sampling.
+    val original = LinuxColorSchemeToggle.read()
+    val log = StringBuilder().appendLine("originalScheme=$original")
+    val processExit = AtomicInteger(1)
+
     application(exitProcessOnExit = false) {
         ProvideNucleusSystemTheme {
+            // visible=true so the scene keeps producing frames; otherwise
+            // snapshot applies from the D-Bus JNI thread may never recompose.
             Window(
                 onCloseRequest = ::exitApplication,
                 title = "system-theme-e2e",
-                visible = false,
+                visible = true,
             ) {
-                val detector = getPlatformDarkModeDetector().isDark()
                 val nucleus = isSystemInDarkMode()
                 val compose = isSystemInDarkTheme()
-                val skikoDark = currentSystemTheme == SkikoSystemTheme.DARK
+                var lastNucleus by remember { mutableStateOf(nucleus) }
+                var lastCompose by remember { mutableStateOf(compose) }
+                lastNucleus = nucleus
+                lastCompose = compose
 
-                Box(Modifier.size(1.dp))
+                Box(Modifier.size(8.dp))
 
-                LaunchedEffect(detector, nucleus, compose, skikoDark) {
-                    val pass = detector == nucleus && nucleus == compose
-                    val text =
-                        buildString {
-                            appendLine("detector=$detector")
-                            appendLine("isSystemInDarkMode=$nucleus")
-                            appendLine("isSystemInDarkTheme=$compose")
-                            appendLine("skikoDark=$skikoDark")
-                            appendLine(if (pass) "RESULT=PASS" else "RESULT=FAIL")
+                LaunchedEffect(Unit) {
+                    try {
+                        for (scheme in listOf("prefer-light", "prefer-dark", "prefer-light")) {
+                            val expectDark = LinuxColorSchemeToggle.isDarkScheme(scheme)
+                            LinuxColorSchemeToggle.write(scheme)
+                            log.appendLine("set scheme=$scheme expectDark=$expectDark")
+
+                            val ok =
+                                awaitFrames(timeoutMs = 15_000) {
+                                    val d = getPlatformDarkModeDetector().isDark()
+                                    lastNucleus == expectDark &&
+                                        lastCompose == expectDark &&
+                                        d == expectDark
+                                }
+                            log.appendLine(
+                                "  after: detector=${getPlatformDarkModeDetector().isDark()} " +
+                                    "nucleus=$lastNucleus compose=$lastCompose ok=$ok",
+                            )
+                            if (!ok || lastNucleus != lastCompose) {
+                                log.appendLine("RESULT=FAIL")
+                                reportFile.writeText(log.toString())
+                                print(log.toString())
+                                exitApplication()
+                                return@LaunchedEffect
+                            }
                         }
-                    reportFile.writeText(text)
-                    print(text)
-                    exitApplication()
+                        log.appendLine("RESULT=PASS")
+                        processExit.set(0)
+                        reportFile.writeText(log.toString())
+                        print(log.toString())
+                        exitApplication()
+                    } catch (t: Throwable) {
+                        log.appendLine("exception=${t.stackTraceToString()}")
+                        log.appendLine("RESULT=FAIL")
+                        reportFile.writeText(log.toString())
+                        System.err.print(log.toString())
+                        exitApplication()
+                    } finally {
+                        runCatching { LinuxColorSchemeToggle.write(original) }
+                    }
                 }
             }
         }
     }
 
-    val text =
-        if (reportFile.exists()) {
-            reportFile.readText()
-        } else {
-            "RESULT=FAIL\n(no report — composition did not run)\n"
-                .also { reportFile.writeText(it) }
-        }
-    if (!text.contains("RESULT=PASS")) {
-        System.err.print(text)
-        exitProcess(1)
+    if (!reportFile.exists()) {
+        failReport("composition did not finish\n$log", reportFile)
     }
+    exitProcess(processExit.get())
+}
+
+/** Pump Compose frames while waiting for JNI → Snapshot recomposition. */
+private suspend fun awaitFrames(
+    timeoutMs: Long,
+    predicate: () -> Boolean,
+): Boolean {
+    val deadline = System.nanoTime() + timeoutMs * 1_000_000L
+    while (System.nanoTime() < deadline) {
+        withFrameNanos { }
+        if (predicate()) return true
+    }
+    withFrameNanos { }
+    return predicate()
+}
+
+private fun failReport(
+    message: String,
+    reportFile: File =
+        File(System.getProperty("systemThemeE2E.report", "system-theme-e2e.report")),
+): Nothing {
+    reportFile.parentFile?.mkdirs()
+    val text = "RESULT=FAIL\n$message\n"
+    reportFile.writeText(text)
+    System.err.print(text)
+    exitProcess(1)
 }

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/NucleusApplicationSystemThemeE2EMain.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/NucleusApplicationSystemThemeE2EMain.kt
@@ -1,0 +1,78 @@
+package dev.nucleusframework.application
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import dev.nucleusframework.darkmodedetector.getPlatformDarkModeDetector
+import dev.nucleusframework.darkmodedetector.isSystemInDarkMode
+import org.jetbrains.skiko.SystemTheme as SkikoSystemTheme
+import org.jetbrains.skiko.currentSystemTheme
+import java.io.File
+import kotlin.system.exitProcess
+
+/**
+ * Process-level E2E: boots a real Compose `application` + `Window` under
+ * [ProvideNucleusSystemTheme] (same bridge as `nucleusApplication`) and writes
+ * a PASS/FAIL report. Exit code 0 = PASS, 1 = FAIL.
+ *
+ * Run: `./gradlew :nucleus-application:systemThemeE2E`
+ *
+ * Note: Compose's `application` defaults to `exitProcessOnExit = true`, so we
+ * must write the report *before* [exitApplication] — nothing after `application { }`
+ * runs on success.
+ */
+fun main() {
+    val reportFile =
+        File(System.getProperty("systemThemeE2E.report", "system-theme-e2e.report"))
+    reportFile.parentFile?.mkdirs()
+
+    // exitProcessOnExit = false so we control the process exit code after sampling.
+    application(exitProcessOnExit = false) {
+        ProvideNucleusSystemTheme {
+            Window(
+                onCloseRequest = ::exitApplication,
+                title = "system-theme-e2e",
+                visible = false,
+            ) {
+                val detector = getPlatformDarkModeDetector().isDark()
+                val nucleus = isSystemInDarkMode()
+                val compose = isSystemInDarkTheme()
+                val skikoDark = currentSystemTheme == SkikoSystemTheme.DARK
+
+                Box(Modifier.size(1.dp))
+
+                LaunchedEffect(detector, nucleus, compose, skikoDark) {
+                    val pass = detector == nucleus && nucleus == compose
+                    val text =
+                        buildString {
+                            appendLine("detector=$detector")
+                            appendLine("isSystemInDarkMode=$nucleus")
+                            appendLine("isSystemInDarkTheme=$compose")
+                            appendLine("skikoDark=$skikoDark")
+                            appendLine(if (pass) "RESULT=PASS" else "RESULT=FAIL")
+                        }
+                    reportFile.writeText(text)
+                    print(text)
+                    exitApplication()
+                }
+            }
+        }
+    }
+
+    val text =
+        if (reportFile.exists()) {
+            reportFile.readText()
+        } else {
+            "RESULT=FAIL\n(no report — composition did not run)\n"
+                .also { reportFile.writeText(it) }
+        }
+    if (!text.contains("RESULT=PASS")) {
+        System.err.print(text)
+        exitProcess(1)
+    }
+}

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/ProvideNucleusSystemThemeE2ETest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/ProvideNucleusSystemThemeE2ETest.kt
@@ -8,41 +8,28 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import dev.nucleusframework.darkmodedetector.getPlatformDarkModeDetector
 import dev.nucleusframework.darkmodedetector.isSystemInDarkMode
-import org.jetbrains.skiko.SystemTheme as SkikoSystemTheme
-import org.jetbrains.skiko.currentSystemTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
 import org.junit.Test
+import java.util.concurrent.TimeUnit
 
 /**
- * Live E2E: under [ProvideNucleusSystemTheme], Compose's official
- * [isSystemInDarkTheme] must mirror Nucleus's JNI-backed [isSystemInDarkMode]
- * (and the raw detector), not Skiko's non-reactive snapshot alone.
+ * Live E2E: actually flips the OS color-scheme and asserts that under
+ * [ProvideNucleusSystemTheme], both Nucleus [isSystemInDarkMode] and Compose's
+ * official [isSystemInDarkTheme] track the change.
  */
 @OptIn(ExperimentalTestApi::class)
 class ProvideNucleusSystemThemeE2ETest {
     @Test
-    fun detectorReadsOsDarkMode() {
-        val detectorDark = getPlatformDarkModeDetector().isDark()
-        // Machine under test reports GNOME prefer-dark; keep the assertion soft
-        // enough for CI hosts that may be light, but always require a defined
-        // boolean (native bridge loaded, no throw).
-        println(
-            "E2E native detector isDark=$detectorDark " +
-                "skiko=$currentSystemTheme " +
-                "(gsettings may differ from Skiko on Linux)",
+    fun officialIsSystemInDarkThemeTracksLiveOsToggle() {
+        assumeTrue(
+            "Linux gsettings + session bus required for live theme toggle",
+            LinuxColorSchemeToggle.isAvailable,
         )
-        // Touch the value so a failing native load surfaces as an exception.
-        assertTrue(detectorDark || !detectorDark)
-    }
 
-    @Test
-    fun officialIsSystemInDarkThemeMatchesNucleusUnderBridge() =
         runComposeUiTest {
-            val detectorDark = getPlatformDarkModeDetector().isDark()
-            val skikoDark = currentSystemTheme == SkikoSystemTheme.DARK
-
             var nucleus: Boolean? by mutableStateOf(null)
             var composeOfficial: Boolean? by mutableStateOf(null)
 
@@ -54,56 +41,76 @@ class ProvideNucleusSystemThemeE2ETest {
             }
             waitForIdle()
 
-            println(
-                "E2E bridge: detector=$detectorDark skikoDark=$skikoDark " +
-                    "isSystemInDarkMode=$nucleus isSystemInDarkTheme=$composeOfficial",
-            )
+            val original = LinuxColorSchemeToggle.read()
+            println("E2E start: scheme=$original nucleus=$nucleus compose=$composeOfficial")
 
-            assertNotNull(nucleus)
-            assertNotNull(composeOfficial)
-            assertEquals(
-                "isSystemInDarkMode must match the raw OS detector",
-                detectorDark,
-                nucleus,
-            )
-            assertEquals(
-                "official isSystemInDarkTheme must follow the Nucleus bridge " +
-                    "(LocalSystemTheme provided from isSystemInDarkMode)",
-                nucleus,
-                composeOfficial,
-            )
-            assertEquals(
-                "official isSystemInDarkTheme must match the OS detector, not only Skiko",
-                detectorDark,
-                composeOfficial,
-            )
-        }
-
-    @Test
-    fun withoutBridgeOfficialMayDivergeFromDetectorOnLinux() =
-        runComposeUiTest {
-            // Documents why the bridge exists: default LocalSystemTheme is a
-            // Skiko snapshot. On Linux that often does not match the portal.
-            val detectorDark = getPlatformDarkModeDetector().isDark()
-            val skikoDark = currentSystemTheme == SkikoSystemTheme.DARK
-
-            var composeWithoutBridge: Boolean? by mutableStateOf(null)
-            setContent {
-                composeWithoutBridge = isSystemInDarkTheme()
+            try {
+                // Force light, then dark (order independent of current scheme).
+                for (scheme in listOf("prefer-light", "prefer-dark", "prefer-light")) {
+                    val expectDark = LinuxColorSchemeToggle.isDarkScheme(scheme)
+                    LinuxColorSchemeToggle.write(scheme)
+                    awaitTheme(
+                        expectedDark = expectDark,
+                        readNucleus = { nucleus },
+                        readCompose = { composeOfficial },
+                        label = scheme,
+                    )
+                    assertEquals(
+                        "after $scheme: official must match nucleus",
+                        nucleus,
+                        composeOfficial,
+                    )
+                    assertEquals(
+                        "after $scheme: raw detector must match",
+                        expectDark,
+                        getPlatformDarkModeDetector().isDark(),
+                    )
+                    println(
+                        "E2E OK scheme=$scheme detector=${getPlatformDarkModeDetector().isDark()} " +
+                            "nucleus=$nucleus compose=$composeOfficial",
+                    )
+                }
+            } finally {
+                LinuxColorSchemeToggle.write(original)
+                // Best-effort restore wait so we don't leave the host mid-transition.
+                runCatching {
+                    awaitTheme(
+                        expectedDark = LinuxColorSchemeToggle.isDarkScheme(original),
+                        readNucleus = { nucleus },
+                        readCompose = { composeOfficial },
+                        label = "restore:$original",
+                    )
+                }
             }
+        }
+    }
+
+    private fun androidx.compose.ui.test.ComposeUiTest.awaitTheme(
+        expectedDark: Boolean,
+        readNucleus: () -> Boolean?,
+        readCompose: () -> Boolean?,
+        label: String,
+        timeoutMs: Long = 15_000,
+    ) {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+        while (System.nanoTime() < deadline) {
             waitForIdle()
-
-            println(
-                "E2E no-bridge: detector=$detectorDark skikoDark=$skikoDark " +
-                    "isSystemInDarkTheme=$composeWithoutBridge",
-            )
-            assertNotNull(composeWithoutBridge)
-            // Without ProvideNucleusSystemTheme, the official API tracks Skiko.
-            assertEquals(skikoDark, composeWithoutBridge)
-            if (detectorDark != skikoDark) {
-                println(
-                    "E2E: detector and Skiko DIVERGE — bridge required for correct theming",
-                )
+            val n = readNucleus()
+            val c = readCompose()
+            val d = getPlatformDarkModeDetector().isDark()
+            if (n == expectedDark && c == expectedDark && d == expectedDark) {
+                assertNotNull(n)
+                assertNotNull(c)
+                return
             }
+            Thread.sleep(100)
         }
+        waitForIdle()
+        assertTrue(
+            "timed out waiting for theme=$label expectedDark=$expectedDark " +
+                "detector=${getPlatformDarkModeDetector().isDark()} " +
+                "nucleus=${readNucleus()} compose=${readCompose()}",
+            false,
+        )
+    }
 }

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/ProvideNucleusSystemThemeE2ETest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/ProvideNucleusSystemThemeE2ETest.kt
@@ -1,0 +1,109 @@
+package dev.nucleusframework.application
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import dev.nucleusframework.darkmodedetector.getPlatformDarkModeDetector
+import dev.nucleusframework.darkmodedetector.isSystemInDarkMode
+import org.jetbrains.skiko.SystemTheme as SkikoSystemTheme
+import org.jetbrains.skiko.currentSystemTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Live E2E: under [ProvideNucleusSystemTheme], Compose's official
+ * [isSystemInDarkTheme] must mirror Nucleus's JNI-backed [isSystemInDarkMode]
+ * (and the raw detector), not Skiko's non-reactive snapshot alone.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ProvideNucleusSystemThemeE2ETest {
+    @Test
+    fun detectorReadsOsDarkMode() {
+        val detectorDark = getPlatformDarkModeDetector().isDark()
+        // Machine under test reports GNOME prefer-dark; keep the assertion soft
+        // enough for CI hosts that may be light, but always require a defined
+        // boolean (native bridge loaded, no throw).
+        println(
+            "E2E native detector isDark=$detectorDark " +
+                "skiko=$currentSystemTheme " +
+                "(gsettings may differ from Skiko on Linux)",
+        )
+        // Touch the value so a failing native load surfaces as an exception.
+        assertTrue(detectorDark || !detectorDark)
+    }
+
+    @Test
+    fun officialIsSystemInDarkThemeMatchesNucleusUnderBridge() =
+        runComposeUiTest {
+            val detectorDark = getPlatformDarkModeDetector().isDark()
+            val skikoDark = currentSystemTheme == SkikoSystemTheme.DARK
+
+            var nucleus: Boolean? by mutableStateOf(null)
+            var composeOfficial: Boolean? by mutableStateOf(null)
+
+            setContent {
+                ProvideNucleusSystemTheme {
+                    nucleus = isSystemInDarkMode()
+                    composeOfficial = isSystemInDarkTheme()
+                }
+            }
+            waitForIdle()
+
+            println(
+                "E2E bridge: detector=$detectorDark skikoDark=$skikoDark " +
+                    "isSystemInDarkMode=$nucleus isSystemInDarkTheme=$composeOfficial",
+            )
+
+            assertNotNull(nucleus)
+            assertNotNull(composeOfficial)
+            assertEquals(
+                "isSystemInDarkMode must match the raw OS detector",
+                detectorDark,
+                nucleus,
+            )
+            assertEquals(
+                "official isSystemInDarkTheme must follow the Nucleus bridge " +
+                    "(LocalSystemTheme provided from isSystemInDarkMode)",
+                nucleus,
+                composeOfficial,
+            )
+            assertEquals(
+                "official isSystemInDarkTheme must match the OS detector, not only Skiko",
+                detectorDark,
+                composeOfficial,
+            )
+        }
+
+    @Test
+    fun withoutBridgeOfficialMayDivergeFromDetectorOnLinux() =
+        runComposeUiTest {
+            // Documents why the bridge exists: default LocalSystemTheme is a
+            // Skiko snapshot. On Linux that often does not match the portal.
+            val detectorDark = getPlatformDarkModeDetector().isDark()
+            val skikoDark = currentSystemTheme == SkikoSystemTheme.DARK
+
+            var composeWithoutBridge: Boolean? by mutableStateOf(null)
+            setContent {
+                composeWithoutBridge = isSystemInDarkTheme()
+            }
+            waitForIdle()
+
+            println(
+                "E2E no-bridge: detector=$detectorDark skikoDark=$skikoDark " +
+                    "isSystemInDarkTheme=$composeWithoutBridge",
+            )
+            assertNotNull(composeWithoutBridge)
+            // Without ProvideNucleusSystemTheme, the official API tracks Skiko.
+            assertEquals(skikoDark, composeWithoutBridge)
+            if (detectorDark != skikoDark) {
+                println(
+                    "E2E: detector and Skiko DIVERGE — bridge required for correct theming",
+                )
+            }
+        }
+}


### PR DESCRIPTION
## Summary

- `nucleusApplication` now provides Compose's `LocalSystemTheme` from Nucleus's reactive OS dark-mode detector (`isSystemInDarkMode()`).
- Official `androidx.compose.foundation.isSystemInDarkTheme()` (and libraries that call it) track live OS theme changes under the DSL — no Skiko snapshot-only default.
- `darkmode-detector` is an **`api`** dependency of `nucleus-application` (always on the consumer classpath; not optional/`compileOnly`).
- Applied on both AWT and Tao entry points; Tao windows inherit via the existing `outerLocals` scene bridge.

## Why `api` (not `compileOnly`)

The bridge is part of the public `nucleusApplication` contract, so the detector must be compile- and runtime-visible transitively. Soft/`compileOnly` only makes sense for optional side integrations (autolaunch, jump lists).

## Verification (done)

Live OS theme toggle on Linux (GNOME `gsettings` `org.gnome.desktop.interface color-scheme`), not a static snapshot:

```
prefer-light → detector=false, isSystemInDarkMode=false, isSystemInDarkTheme=false
prefer-dark  → detector=true,  isSystemInDarkMode=true,  isSystemInDarkTheme=true
prefer-light → detector=false, isSystemInDarkMode=false, isSystemInDarkTheme=false
```

Host scheme restored to the original value after the run.

| Check | Result |
|-------|--------|
| `:nucleus-application:compileKotlin` | green |
| Compose UI test (`ProvideNucleusSystemThemeE2ETest`) flips light/dark/light via gsettings and asserts detector + `isSystemInDarkMode` + official `isSystemInDarkTheme` all match each step | PASS |
| Process E2E (`./gradlew :nucleus-application:systemThemeE2E`) real Compose `application` + `Window` under `ProvideNucleusSystemTheme`, same light/dark/light sequence | PASS (`RESULT=PASS`) |
| Official API equals Nucleus after each live OS change (bridge, not Skiko-only) | confirmed |
| Theme restored after E2E | confirmed |

How to re-run (needs Linux session + `gsettings` + display):

```bash
./gradlew :nucleus-application:test --tests 'dev.nucleusframework.application.ProvideNucleusSystemThemeE2ETest'
./gradlew :nucleus-application:systemThemeE2E
```

`systemThemeE2E` is intentionally **not** part of `check` (mutates the host OS theme; needs a desktop session).

## Test plan (remaining / other platforms)

- [ ] macOS / Windows live OS dark-mode toggle under the same bridge (no gsettings path)
- [ ] Tao backend window content specifically (process E2E above uses AWT `Window`; Tao inherits via `outerLocals`)
- [ ] Consumer depending only on `nucleus-application` resolves `darkmode-detector` transitively
