### PR TITLE
fix(updater): relaunch AppImage after auto-update on Linux

### DIFF
--- a/updater-runtime/build.gradle.kts
+++ b/updater-runtime/build.gradle.kts
@@ -43,6 +43,22 @@ tasks.withType<Test>().configureEach {
     maxHeapSize = "2g"
 }
 
+/**
+ * Prints the exact production AppImage update script (used by
+ * `scripts/e2e-appimage-gui-restart.sh`).
+ *
+ * ```
+ * ./gradlew :updater-runtime:dumpLinuxAppImageUpdateScript \
+ *   --args="'/tmp/new.AppImage' '/tmp/old.AppImage' 12345 '/tmp/update.log' true"
+ * ```
+ */
+tasks.register<JavaExec>("dumpLinuxAppImageUpdateScript") {
+    group = "verification"
+    description = "Emit the production Linux AppImage update shell script to stdout"
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.nucleusframework.updater.DumpLinuxAppImageUpdateScriptKt")
+}
+
 mavenPublishing {
     coordinates("dev.nucleusframework", "nucleus.updater-runtime", publishVersion)
 

--- a/updater-runtime/scripts/e2e-appimage-gui-restart.sh
+++ b/updater-runtime/scripts/e2e-appimage-gui-restart.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Full GUI e2e for AppImage post-update restart (#178).
+#
+# 1. Install an old real nucleusdemo AppImage
+# 2. Launch it on the desktop (X11 via NUCLEUS_TAO_LINUX_RENDERER=x11 so xdotool works)
+# 3. Wait for the "Nucleus Demo" window
+# 4. Apply the production update path (in-place replace + generated script)
+# 5. Assert the old process dies, a new process appears, and the GUI window returns
+#
+# Usage:
+#   OLD=/path/to/old.AppImage NEW=/path/to/new.AppImage \
+#     ./updater-runtime/scripts/e2e-appimage-gui-restart.sh
+#
+# Requires: DISPLAY, xdotool, a working FUSE AppImage runtime.
+set -u
+
+OLD_ARTIFACT=${OLD:-/tmp/nucleus-e2e-appimage/v1-old.AppImage}
+NEW_ARTIFACT=${NEW:-/tmp/nucleus-e2e-appimage/v1.AppImage}
+WORKDIR=${WORKDIR:-/tmp/nucleus-e2e-gui}
+DISPLAY_VAL=${DISPLAY:-:0}
+export DISPLAY="$DISPLAY_VAL"
+# Prefer XWayland so xdotool can see the window (tao defaults to native Wayland).
+export NUCLEUS_TAO_LINUX_RENDERER=x11
+
+log() { printf '[e2e-gui] %s\n' "$*"; }
+die() { log "FAIL: $*"; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "missing command: $1"; }
+need xdotool
+need setsid
+[ -f "$OLD_ARTIFACT" ] || die "old AppImage not found: $OLD_ARTIFACT"
+[ -f "$NEW_ARTIFACT" ] || die "new AppImage not found: $NEW_ARTIFACT"
+[ -n "$DISPLAY" ] || die "DISPLAY is not set"
+
+rm -rf "$WORKDIR"
+mkdir -p "$WORKDIR"
+INSTALLED="$WORKDIR/NucleusDemo.AppImage"
+DOWNLOAD="$WORKDIR/NucleusDemo-new.AppImage"
+UPDATE_LOG="$WORKDIR/nucleus-update.log"
+SCRIPT="$WORKDIR/nucleus-update.sh"
+BEFORE_SHOT="$WORKDIR/before.png"
+AFTER_SHOT="$WORKDIR/after.png"
+APP_LOG="$WORKDIR/app-v1.log"
+APP_LOG_V2="$WORKDIR/app-v2.log"
+
+cp -a "$OLD_ARTIFACT" "$INSTALLED"
+cp -a "$NEW_ARTIFACT" "$DOWNLOAD"
+chmod +x "$INSTALLED" "$DOWNLOAD"
+OLD_SHA=$(sha256sum "$INSTALLED" | awk '{print $1}')
+NEW_SHA=$(sha256sum "$DOWNLOAD" | awk '{print $1}')
+[ "$OLD_SHA" != "$NEW_SHA" ] || die "old and new AppImages are identical (need two versions)"
+
+log "installed=$INSTALLED"
+log "old_sha=$OLD_SHA"
+log "new_sha=$NEW_SHA"
+
+# --- kill any leftover demo from a previous run (by absolute path only) ---
+kill_demo_tree() {
+  local pid cmd
+  for pid in $(pgrep -x NucleusDemo 2>/dev/null || true); do
+    cmd=$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null || true)
+    case "$cmd" in
+      *"$WORKDIR"*|*NucleusDemo*)
+        log "killing leftover pid=$pid ($cmd)"
+        kill "$pid" 2>/dev/null || true
+        ;;
+    esac
+  done
+  # AppImage outer process
+  for pid in $(pgrep -f "NucleusDemo\\.AppImage" 2>/dev/null || true); do
+    cmd=$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null || true)
+    case "$cmd" in
+      *"$WORKDIR"*)
+        log "killing leftover appimage pid=$pid"
+        kill "$pid" 2>/dev/null || true
+        ;;
+    esac
+  done
+}
+kill_demo_tree
+sleep 1
+
+# --- launch v1 GUI ---
+log "launching AppImage (X11 renderer)..."
+(
+  cd "$WORKDIR"
+  # shellcheck disable=SC2093
+  exec ./NucleusDemo.AppImage
+) >"$APP_LOG" 2>&1 &
+LAUNCHER_PID=$!
+log "launcher_pid=$LAUNCHER_PID"
+
+find_demo_window() {
+  # Return first window id whose name is exactly/contains "Nucleus Demo"
+  # and whose pid is related to our AppImage (not the Warp terminal title).
+  local id name pid cmd
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    name=$(xdotool getwindowname "$id" 2>/dev/null || true)
+    pid=$(xdotool getwindowpid "$id" 2>/dev/null || true)
+    [ -n "$pid" ] || continue
+    case "$name" in
+      "Nucleus Demo"|"NucleusDemo"|*"Nucleus Demo"*)
+        cmd=$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null || true)
+        case "$cmd" in
+          *NucleusDemo*|*mount_Nucleu*)
+            printf '%s\n' "$id"
+            return 0
+            ;;
+        esac
+        ;;
+    esac
+  done < <(xdotool search --onlyvisible --name 'Nucleus' 2>/dev/null || true)
+  return 1
+}
+
+wait_for_window() {
+  local timeout=${1:-120}
+  local i=0 id
+  while [ "$i" -lt "$timeout" ]; do
+    if id=$(find_demo_window); then
+      printf '%s\n' "$id"
+      return 0
+    fi
+    # also accept any window owned by NucleusDemo binary
+    for pid in $(pgrep -x NucleusDemo 2>/dev/null || true); do
+      id=$(xdotool search --pid "$pid" 2>/dev/null | head -1 || true)
+      if [ -n "$id" ]; then
+        printf '%s\n' "$id"
+        return 0
+      fi
+    done
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+log "waiting for GUI window..."
+WIN1=$(wait_for_window 120) || {
+  log "app log:"; tail -80 "$APP_LOG" || true
+  die "GUI window did not appear within 120s"
+}
+WIN1_PID=$(xdotool getwindowpid "$WIN1")
+WIN1_NAME=$(xdotool getwindowname "$WIN1")
+log "window_before id=$WIN1 pid=$WIN1_PID name=[$WIN1_NAME]"
+
+# Resolve the process PlatformInstaller would wait on: the JVM/native main
+# (ProcessHandle.current()), which is the NucleusDemo binary under the mount.
+APP_PID=$WIN1_PID
+APPIMAGE_ENV=$(tr '\0' '\n' <"/proc/$APP_PID/environ" 2>/dev/null | sed -n 's/^APPIMAGE=//p' | head -1)
+[ -n "$APPIMAGE_ENV" ] || APPIMAGE_ENV="$INSTALLED"
+log "app_pid=$APP_PID APPIMAGE=$APPIMAGE_ENV"
+
+# Screenshot before (best-effort)
+if command -v import >/dev/null 2>&1; then
+  import -window "$WIN1" "$BEFORE_SHOT" 2>/dev/null || import -window root "$BEFORE_SHOT" 2>/dev/null || true
+elif command -v scrot >/dev/null 2>&1; then
+  scrot -u "$BEFORE_SHOT" 2>/dev/null || scrot "$BEFORE_SHOT" 2>/dev/null || true
+fi
+[ -f "$BEFORE_SHOT" ] && log "screenshot_before=$BEFORE_SHOT"
+
+# --- production update path ---
+# 1) in-place replace while the app still holds the old inode open
+log "replacing AppImage in place (electron-updater pattern)..."
+rm -f "$APPIMAGE_ENV"
+mv -f "$DOWNLOAD" "$APPIMAGE_ENV"
+chmod +x "$APPIMAGE_ENV"
+POST_SHA=$(sha256sum "$APPIMAGE_ENV" | awk '{print $1}')
+[ "$POST_SHA" = "$NEW_SHA" ] || die "installed sha mismatch after replace (got $POST_SHA want $NEW_SHA)"
+log "replaced ok (sha=$POST_SHA); old process still alive? $(kill -0 "$APP_PID" 2>/dev/null && echo yes || echo no)"
+
+# 2) emit the *exact* production script from buildLinuxAppImageUpdateScript
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+log "generating production update script via Kotlin..."
+JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-21-openjdk-amd64}"
+RAW_SCRIPT="$WORKDIR/nucleus-update.raw.sh"
+if ! (
+  cd "$REPO_ROOT"
+  # --args paths are simple absolute /tmp paths (no spaces) so quoting is safe.
+  ./gradlew -q :updater-runtime:dumpLinuxAppImageUpdateScript \
+    --args="$DOWNLOAD $APPIMAGE_ENV $APP_PID $UPDATE_LOG true" \
+    >"$RAW_SCRIPT" 2>"$WORKDIR/dump.err"
+); then
+  log "dump.err:"; cat "$WORKDIR/dump.err" 2>/dev/null || true
+  die "failed to generate production update script"
+fi
+# Gradle plugins may chatter on stdout — keep only the shell script payload.
+if ! grep -q '^#!/usr/bin/env bash' "$RAW_SCRIPT"; then
+  log "dump.err:"; cat "$WORKDIR/dump.err" 2>/dev/null || true
+  log "raw dump head:"; head -20 "$RAW_SCRIPT" || true
+  die "generated output is not a shell script"
+fi
+# Drop any banner lines before the shebang.
+sed -n '/^#!\/usr\/bin\/env bash/,$p' "$RAW_SCRIPT" >"$SCRIPT"
+# DISPLAY / NUCLEUS_TAO_LINUX_RENDERER are inherited by setsid → relaunch (script only unsets AppImage vars).
+chmod +x "$SCRIPT"
+grep -q 'unset APPDIR APPIMAGE' "$SCRIPT" || die "generated script missing env cleanup"
+grep -q 'APPIMAGE_SILENT_INSTALL' "$SCRIPT" || die "generated script missing APPIMAGE_SILENT_INSTALL"
+log "production script written to $SCRIPT ($(wc -l <"$SCRIPT") lines)"
+
+log "starting update script via setsid..."
+setsid bash "$SCRIPT" >/dev/null 2>&1 &
+sleep 0.3
+
+# 3) quit the running app (PlatformInstaller does exitProcess after spawning the script)
+log "terminating app pid=$APP_PID (simulating exitProcess after installAndRestart)..."
+kill "$APP_PID" 2>/dev/null || true
+# also terminate sibling tree under the AppImage if needed
+if [ -n "${LAUNCHER_PID:-}" ]; then
+  kill "$LAUNCHER_PID" 2>/dev/null || true
+fi
+# Wait for death
+for i in $(seq 1 60); do
+  kill -0 "$APP_PID" 2>/dev/null || break
+  sleep 0.5
+done
+kill -0 "$APP_PID" 2>/dev/null && kill -9 "$APP_PID" 2>/dev/null || true
+log "old process gone"
+
+# --- wait for GUI relaunch ---
+log "waiting for relaunched GUI..."
+# give the script its sleep 1 + app cold start
+sleep 2
+WIN2=$(wait_for_window 120) || {
+  log "update log:"; cat "$UPDATE_LOG" 2>/dev/null || true
+  log "app log v1:"; tail -40 "$APP_LOG" 2>/dev/null || true
+  die "GUI did not reappear after update"
+}
+WIN2_PID=$(xdotool getwindowpid "$WIN2")
+WIN2_NAME=$(xdotool getwindowname "$WIN2")
+log "window_after id=$WIN2 pid=$WIN2_PID name=[$WIN2_NAME]"
+
+[ "$WIN2_PID" != "$APP_PID" ] || die "relaunch pid equals old pid (did not actually restart)"
+
+# Confirm new process still points at the installed AppImage path
+NEW_APPIMAGE=$(tr '\0' '\n' <"/proc/$WIN2_PID/environ" 2>/dev/null | sed -n 's/^APPIMAGE=//p' | head -1 || true)
+log "relaunch APPIMAGE=${NEW_APPIMAGE:-unknown}"
+INSTALLED_SHA=$(sha256sum "$APPIMAGE_ENV" | awk '{print $1}')
+[ "$INSTALLED_SHA" = "$NEW_SHA" ] || die "on-disk AppImage is not the new version after relaunch"
+
+if command -v import >/dev/null 2>&1; then
+  import -window "$WIN2" "$AFTER_SHOT" 2>/dev/null || import -window root "$AFTER_SHOT" 2>/dev/null || true
+elif command -v scrot >/dev/null 2>&1; then
+  scrot -u "$AFTER_SHOT" 2>/dev/null || scrot "$AFTER_SHOT" 2>/dev/null || true
+fi
+[ -f "$AFTER_SHOT" ] && log "screenshot_after=$AFTER_SHOT"
+
+log "update log:"
+cat "$UPDATE_LOG" || true
+
+log "PASS: full GUI AppImage update+restart verified"
+log "  before_window=$WIN1 (pid $APP_PID)"
+log "  after_window=$WIN2 (pid $WIN2_PID)"
+log "  artifact_sha=$INSTALLED_SHA"
+
+# Leave the relaunched app running so the user can see it; comment next lines to auto-quit.
+# kill "$WIN2_PID" 2>/dev/null || true
+exit 0

--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/LinuxAppImageUpdateScript.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/LinuxAppImageUpdateScript.kt
@@ -1,0 +1,117 @@
+package dev.nucleusframework.updater.internal
+
+/**
+ * Builds the shell script that finalises a Linux AppImage self-update and optionally relaunches.
+ *
+ * The downloaded AppImage is preferably swapped into place by [PlatformInstaller] *before* this
+ * script runs (while the old FUSE/loop mount still holds the previous inode open — the
+ * electron-updater pattern). The script then:
+ *
+ *  1. waits for the previous process to exit so [dev.nucleusframework.core.runtime.SingleInstanceManager]
+ *     releases its lock;
+ *  2. retries the file replace if the in-process swap could not complete;
+ *  3. relaunches with a clean environment — stale `APPDIR` / `LD_LIBRARY_PATH` values still point
+ *     into the unmounted squashfs of the previous instance and prevent the new process from
+ *     starting, which is the failure mode behind issue #178.
+ *
+ * Extracted from [PlatformInstaller] so the exact script can be exercised by tests.
+ */
+internal fun buildLinuxAppImageUpdateScript(
+    newFile: String,
+    oldFile: String,
+    appPid: Long,
+    logFile: String,
+    restart: Boolean,
+    /** When true the JVM already swapped [newFile] onto [oldFile]; the script only retries on miss. */
+    alreadyReplaced: Boolean,
+    selfDelete: Boolean = true,
+): String {
+    val restartFlag = if (restart) "1" else "0"
+    val alreadyFlag = if (alreadyReplaced) "1" else "0"
+    val selfDeleteCmd = if (selfDelete) "rm -f \"\$0\"" else "true"
+    return """
+        |#!/usr/bin/env bash
+        |# Intentionally no `set -e`: a failed intermediate step must not skip the relaunch —
+        |# the user would otherwise be left with an installed update and a dead process (#178).
+        |
+        |# Survive parent process exit (desktop session / terminal hangup).
+        |trap '' HUP
+        |
+        |NEW_FILE=${newFile.quoteForShell()}
+        |OLD_FILE=${oldFile.quoteForShell()}
+        |LOG_FILE=${logFile.quoteForShell()}
+        |APP_PID=$appPid
+        |RESTART=$restartFlag
+        |ALREADY_REPLACED=$alreadyFlag
+        |
+        |log() {
+        |    echo "${'$'}(date -Iseconds 2>/dev/null || date) ${'$'}*" >> "${'$'}LOG_FILE" 2>/dev/null || true
+        |}
+        |
+        |log "waiting for pid ${'$'}APP_PID (already_replaced=${'$'}ALREADY_REPLACED restart=${'$'}RESTART)"
+        |
+        |# Wait for the app process to fully exit.
+        |while kill -0 "${'$'}APP_PID" 2>/dev/null; do
+        |    sleep 0.5
+        |done
+        |log "pid ${'$'}APP_PID exited"
+        |
+        |# FUSE/loop unmount can lag the process exit by a moment.
+        |sleep 1
+        |
+        |replace_appimage() {
+        |    if [ -f "${'$'}NEW_FILE" ]; then
+        |        # Prefer atomic rename; fall back to rm+mv when crossing filesystems.
+        |        if mv -f "${'$'}NEW_FILE" "${'$'}OLD_FILE" 2>/dev/null; then
+        |            return 0
+        |        fi
+        |        rm -f "${'$'}OLD_FILE" 2>/dev/null || true
+        |        mv -f "${'$'}NEW_FILE" "${'$'}OLD_FILE"
+        |        return ${'$'}?
+        |    fi
+        |    # In-process swap already put the new bytes at OLD_FILE.
+        |    [ -f "${'$'}OLD_FILE" ] && [ -x "${'$'}OLD_FILE" ]
+        |}
+        |
+        |if [ "${'$'}ALREADY_REPLACED" != "1" ] || [ -f "${'$'}NEW_FILE" ]; then
+        |    attempts=0
+        |    until replace_appimage; do
+        |        attempts=${'$'}((attempts + 1))
+        |        if [ "${'$'}attempts" -ge 10 ]; then
+        |            log "ERROR: failed to install AppImage after ${'$'}attempts attempts"
+        |            $selfDeleteCmd
+        |            exit 1
+        |        fi
+        |        log "replace attempt ${'$'}attempts failed; retrying"
+        |        sleep 0.5
+        |    done
+        |    log "AppImage installed at ${'$'}OLD_FILE"
+        |else
+        |    log "using in-process install at ${'$'}OLD_FILE"
+        |fi
+        |
+        |chmod +x "${'$'}OLD_FILE" 2>/dev/null || true
+        |
+        |if [ "${'$'}RESTART" = "1" ]; then
+        |    # Drop FUSE/AppImage leftovers from the previous instance. Stale APPDIR and
+        |    # LD_LIBRARY_PATH point into the unmounted squashfs and break the new launch.
+        |    unset APPDIR APPIMAGE OWD ARGV0
+        |    unset LD_LIBRARY_PATH LD_PRELOAD
+        |    unset QT_PLUGIN_PATH GTK_PATH GIO_MODULE_DIR
+        |    # AppImage desktop-integration prompts must not block an unattended relaunch.
+        |    export APPIMAGE_SILENT_INSTALL=true
+        |    # CWD may still be the old mount point (ENOENT after unmount).
+        |    cd "${'$'}{HOME:-/}" 2>/dev/null || cd / || true
+        |    log "relaunching ${'$'}OLD_FILE"
+        |    nohup "${'$'}OLD_FILE" >> "${'$'}LOG_FILE" 2>&1 &
+        |    log "relaunch spawned (pid ${'$'}!)"
+        |else
+        |    log "relaunch skipped"
+        |fi
+        |
+        |$selfDeleteCmd
+        """.trimMargin()
+}
+
+/** Wraps a value in single quotes for safe interpolation into the generated shell script. */
+private fun String.quoteForShell(): String = "'" + replace("'", "'\\''") + "'"

--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/PlatformInstaller.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/PlatformInstaller.kt
@@ -81,51 +81,69 @@ internal object PlatformInstaller {
         val currentAppImage =
             System.getenv("APPIMAGE")
                 ?: error("APPIMAGE environment variable not set — update is only supported from a packaged AppImage")
+        val destination = File(currentAppImage)
 
-        val relaunchCmd =
-            if (restart) {
-                "\n# Relaunch in a fully detached process\nnohup \"\$OLD_FILE\" > /dev/null 2>&1 &\n"
-            } else {
-                ""
-            }
+        // electron-updater pattern: unlink + replace while the running mount still holds the
+        // previous inode open. Avoids racing the FUSE unmount that follows process exit.
+        val replacedInPlace = replaceAppImageInPlace(newAppImage, destination)
 
-        val script = File(System.getProperty("java.io.tmpdir"), "nucleus-update.sh")
+        val tmpDir = System.getProperty("java.io.tmpdir")
+        val script = File(tmpDir, "nucleus-update.sh")
+        val logFile = File(tmpDir, "nucleus-update.log")
         script.writeText(
-            """
-            |#!/usr/bin/env bash
-            |set -e
-            |
-            |# Ignore SIGHUP to survive parent process exit
-            |trap '' HUP
-            |
-            |NEW_FILE="${newAppImage.absolutePath}"
-            |OLD_FILE="$currentAppImage"
-            |APP_PID=$pid
-            |
-            |# Wait for the app process to fully exit
-            |while kill -0 "${'$'}APP_PID" 2>/dev/null; do
-            |    sleep 0.5
-            |done
-            |
-            |# Wait for the AppImage FUSE mount to fully clean up
-            |sleep 1
-            |
-            |# Replace the old AppImage with the new one
-            |mv -f "${'$'}NEW_FILE" "${'$'}OLD_FILE"
-            |chmod +x "${'$'}OLD_FILE"
-            |$relaunchCmd
-            |# Clean up this script
-            |rm -f "${'$'}{0}"
-            """.trimMargin(),
+            buildLinuxAppImageUpdateScript(
+                newFile = newAppImage.absolutePath,
+                oldFile = destination.absolutePath,
+                appPid = pid,
+                logFile = logFile.absolutePath,
+                restart = restart,
+                alreadyReplaced = replacedInPlace,
+            ),
         )
         script.setExecutable(true)
 
-        // Use setsid to start the script in a new session, fully detached
-        // from the current process tree
+        // New session, started from $HOME so a FUSE-mount CWD cannot poison the relaunch.
+        val home = File(System.getProperty("user.home") ?: tmpDir)
         ProcessBuilder("setsid", "bash", script.absolutePath)
+            .directory(home)
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
             .redirectError(ProcessBuilder.Redirect.DISCARD)
             .start()
+    }
+
+    /**
+     * Swaps [newAppImage] onto [destination] while this process is still running.
+     *
+     * Returns `true` when [destination] holds the new bytes (caller may leave [newAppImage]
+     * missing). Returns `false` when the swap could not be completed; the detached script
+     * will retry after this process exits.
+     */
+    internal fun replaceAppImageInPlace(
+        newAppImage: File,
+        destination: File,
+    ): Boolean {
+        if (!newAppImage.isFile) return false
+        return try {
+            // Unlink first so a busy destination (open as the loop/FUSE backend) does not block
+            // the subsequent rename the way a direct overwrite can on some kernels.
+            if (destination.exists() && !destination.delete() && destination.exists()) {
+                return false
+            }
+            val moved =
+                newAppImage.renameTo(destination) ||
+                    run {
+                        newAppImage.copyTo(destination, overwrite = true)
+                        newAppImage.delete()
+                        destination.isFile
+                    }
+            if (moved) {
+                // ownerOnly = false: match `chmod +x` so any user can relaunch the AppImage
+                destination.setExecutable(true, false)
+            }
+            moved && destination.isFile
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private fun installLinuxPackage(

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/DumpLinuxAppImageUpdateScript.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/DumpLinuxAppImageUpdateScript.kt
@@ -1,0 +1,24 @@
+package dev.nucleusframework.updater
+
+import dev.nucleusframework.updater.internal.buildLinuxAppImageUpdateScript
+
+/**
+ * CLI helper for the full-GUI e2e shell script: prints the exact production update script.
+ * Invoked as:
+ *   java -cp ... dev.nucleusframework.updater.DumpLinuxAppImageUpdateScriptKt \
+ *     <newFile> <oldFile> <pid> <logFile>
+ */
+fun main(args: Array<String>) {
+    require(args.size >= 4) { "usage: newFile oldFile pid logFile" }
+    print(
+        buildLinuxAppImageUpdateScript(
+            newFile = args[0],
+            oldFile = args[1],
+            appPid = args[2].toLong(),
+            logFile = args[3],
+            restart = true,
+            alreadyReplaced = args.getOrNull(4)?.toBooleanStrictOrNull() ?: true,
+            selfDelete = false,
+        ),
+    )
+}

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/LinuxAppImageUpdateScriptTest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/LinuxAppImageUpdateScriptTest.kt
@@ -1,0 +1,277 @@
+package dev.nucleusframework.updater
+
+import dev.nucleusframework.updater.internal.PlatformInstaller
+import dev.nucleusframework.updater.internal.buildLinuxAppImageUpdateScript
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Regression coverage for AppImage post-update restart (#178).
+ *
+ * The previous script used `set -e` and relaunched with the full parent environment: after the
+ * FUSE mount went away, stale `APPDIR` / `LD_LIBRARY_PATH` values prevented the new process from
+ * starting, so the update applied but the app never came back.
+ */
+class LinuxAppImageUpdateScriptTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var installDir: File
+    private lateinit var logFile: File
+
+    @Before
+    fun setUp() {
+        assumeTrue("Linux-only", System.getProperty("os.name").startsWith("Linux"))
+        installDir = tmp.newFolder("apps")
+        logFile = tmp.newFile("nucleus-update.log")
+    }
+
+    @Test
+    fun `script unsets AppImage env and relaunches after replace`() {
+        val oldApp = writeMarkerApp(installDir, "App.AppImage", marker = "v1")
+        val newApp = writeMarkerApp(tmp.newFolder("download"), "App-2.AppImage", marker = "v2")
+        val startedFlag = File(tmp.root, "started.flag")
+
+        // A short-lived "running" process the script will wait on.
+        val holder = ProcessBuilder("sleep", "30").start()
+        try {
+            val script =
+                writeScript(
+                    newFile = newApp,
+                    oldFile = oldApp,
+                    appPid = holder.pid(),
+                    restart = true,
+                    alreadyReplaced = false,
+                )
+
+            val runner =
+                ProcessBuilder("bash", script.absolutePath)
+                    .apply {
+                        // Simulate the environment a still-mounted AppImage leaves on the
+                        // process: after unmount these paths are dead and must not leak into
+                        // the relaunch (the #178 failure mode).
+                        environment()["APPDIR"] = "/tmp/.mount_stale_app"
+                        environment()["LD_LIBRARY_PATH"] = "/tmp/.mount_stale_app/usr/lib"
+                        environment()["APPIMAGE"] = oldApp.absolutePath
+                    }.start()
+            // Let the script enter its wait loop, then release it.
+            Thread.sleep(200)
+            holder.destroy()
+            holder.waitFor(5, TimeUnit.SECONDS)
+
+            assertTrue(
+                "update script must finish",
+                runner.waitFor(15, TimeUnit.SECONDS),
+            )
+            assertEquals(readLog(), 0, runner.exitValue())
+
+            assertTrue("app must have been relaunched", waitForFile(startedFlag, 10_000))
+            assertTrue("version flag must be written by relaunch", waitForFile(File(tmp.root, "version.flag"), 5_000))
+            assertEquals("v2", markerOf(oldApp))
+            assertFalse("download must be consumed", newApp.exists())
+            assertTrue(
+                "relaunch must clear APPDIR (stale FUSE path)",
+                startedFlag.readText().contains("APPDIR=unset"),
+            )
+            assertTrue(
+                "relaunch must clear LD_LIBRARY_PATH",
+                startedFlag.readText().contains("LD_LIBRARY_PATH=unset"),
+            )
+            assertTrue(
+                readLog().contains("relaunch spawned") || readLog().contains("relaunching"),
+            )
+        } finally {
+            holder.destroyForcibly()
+            // Kill anything the script may have started from our temp tree.
+            installDir.listFiles()?.forEach { /* marker apps exit on their own */ }
+        }
+    }
+
+    @Test
+    fun `restart=false installs without relaunch`() {
+        val oldApp = writeMarkerApp(installDir, "App.AppImage", marker = "v1", recordStart = false)
+        val newApp = writeMarkerApp(tmp.newFolder("download"), "App-2.AppImage", marker = "v2", recordStart = false)
+        val startedFlag = File(tmp.root, "started.flag")
+
+        val holder = ProcessBuilder("sleep", "30").start()
+        try {
+            val script =
+                writeScript(
+                    newFile = newApp,
+                    oldFile = oldApp,
+                    appPid = holder.pid(),
+                    restart = false,
+                    alreadyReplaced = false,
+                )
+            val runner = ProcessBuilder("bash", script.absolutePath).start()
+            Thread.sleep(200)
+            holder.destroy()
+            holder.waitFor(5, TimeUnit.SECONDS)
+
+            assertTrue(runner.waitFor(15, TimeUnit.SECONDS))
+            assertEquals(readLog(), 0, runner.exitValue())
+            // No relaunch, so the version flag is never written — the installed bytes are the proof.
+            assertTrue("installed AppImage must be the v2 payload", oldApp.readText().contains("v2"))
+            assertFalse("must not relaunch when restart=false", startedFlag.exists())
+            assertTrue(readLog().contains("relaunch skipped"))
+        } finally {
+            holder.destroyForcibly()
+        }
+    }
+
+    @Test
+    fun `in-process replace leaves the destination ready before the script runs`() {
+        val destination = File(installDir, "App.AppImage").apply { writeText("old") }
+        val incoming =
+            File(tmp.newFolder("download"), "App-new.AppImage").apply {
+                writeText("new-bytes")
+                setExecutable(true)
+            }
+
+        assertTrue(PlatformInstaller.replaceAppImageInPlace(incoming, destination))
+        assertEquals("new-bytes", destination.readText())
+        assertTrue(destination.canExecute())
+        assertFalse(incoming.exists())
+    }
+
+    @Test
+    fun `script resumes from an in-process replace when the download is already gone`() {
+        val oldApp = writeMarkerApp(installDir, "App.AppImage", marker = "v2")
+        // Simulate PlatformInstaller having already swapped the file.
+        val missingDownload = File(tmp.newFolder("download"), "gone.AppImage")
+        val startedFlag = File(tmp.root, "started.flag")
+
+        val holder = ProcessBuilder("sleep", "30").start()
+        try {
+            val script =
+                writeScript(
+                    newFile = missingDownload,
+                    oldFile = oldApp,
+                    appPid = holder.pid(),
+                    restart = true,
+                    alreadyReplaced = true,
+                )
+            val runner = ProcessBuilder("bash", script.absolutePath).start()
+            Thread.sleep(200)
+            holder.destroy()
+            holder.waitFor(5, TimeUnit.SECONDS)
+
+            assertTrue(runner.waitFor(15, TimeUnit.SECONDS))
+            assertEquals(readLog(), 0, runner.exitValue())
+            assertTrue("app must have been relaunched", waitForFile(startedFlag, 10_000))
+            assertTrue(readLog().contains("in-process install") || readLog().contains("relaunch"))
+        } finally {
+            holder.destroyForcibly()
+        }
+    }
+
+    @Test
+    fun `generated script quotes paths with spaces`() {
+        val script =
+            buildLinuxAppImageUpdateScript(
+                newFile = "/tmp/My App-2.0.0.AppImage",
+                oldFile = "/home/user/My Applications/My App.AppImage",
+                appPid = 42L,
+                logFile = "/tmp/nucleus update.log",
+                restart = true,
+                alreadyReplaced = false,
+                selfDelete = false,
+            )
+        assertTrue(script.contains("NEW_FILE='/tmp/My App-2.0.0.AppImage'"))
+        assertTrue(script.contains("OLD_FILE='/home/user/My Applications/My App.AppImage'"))
+        assertTrue(script.contains("unset APPDIR APPIMAGE OWD ARGV0"))
+        assertTrue(script.contains("unset LD_LIBRARY_PATH LD_PRELOAD"))
+        // Active errexit would abort before relaunch on a flaky mv; only the explanatory
+        // comment may mention `set -e`.
+        assertFalse(
+            "set -e would abort before relaunch on a flaky mv",
+            script.lines().any { it.trimStart().startsWith("set -e") },
+        )
+    }
+
+    private fun writeScript(
+        newFile: File,
+        oldFile: File,
+        appPid: Long,
+        restart: Boolean,
+        alreadyReplaced: Boolean,
+    ): File {
+        val scriptFile = tmp.newFile("nucleus-update.sh")
+        scriptFile.writeText(
+            buildLinuxAppImageUpdateScript(
+                newFile = newFile.absolutePath,
+                oldFile = oldFile.absolutePath,
+                appPid = appPid,
+                logFile = logFile.absolutePath,
+                restart = restart,
+                alreadyReplaced = alreadyReplaced,
+                selfDelete = false,
+            ),
+        )
+        scriptFile.setExecutable(true)
+        return scriptFile
+    }
+
+    /**
+     * Tiny stand-in for an AppImage: records that it was launched (and with which env) then exits.
+     *
+     * Marker / start-flag paths are absolute under [tmp] so they still resolve after the update
+     * script `mv`s the download onto the installed path (the shebang script body moves with the
+     * file, but must not hard-code the pre-mv location).
+     */
+    private fun writeMarkerApp(
+        dir: File,
+        name: String,
+        marker: String,
+        recordStart: Boolean = true,
+    ): File {
+        val file = File(dir, name)
+        val versionFlag = File(tmp.root, "version.flag")
+        val startedFlag = File(tmp.root, "started.flag")
+        val body =
+            if (recordStart) {
+                """
+                #!/usr/bin/env bash
+                echo "$marker" > "${versionFlag.absolutePath}"
+                {
+                  echo "APPDIR=${'$'}{APPDIR:-unset}"
+                  echo "LD_LIBRARY_PATH=${'$'}{LD_LIBRARY_PATH:-unset}"
+                } > "${startedFlag.absolutePath}"
+                """.trimIndent()
+            } else {
+                """
+                #!/usr/bin/env bash
+                echo "$marker" > "${versionFlag.absolutePath}"
+                """.trimIndent()
+            }
+        file.writeText(body + "\n")
+        file.setExecutable(true)
+        return file
+    }
+
+    private fun markerOf(
+        @Suppress("UNUSED_PARAMETER") app: File,
+    ): String = File(tmp.root, "version.flag").readText().trim()
+
+    private fun readLog(): String = if (logFile.isFile) logFile.readText() else ""
+
+    private fun waitForFile(
+        file: File,
+        timeoutMs: Long,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (file.isFile && file.length() > 0) return true
+            Thread.sleep(50)
+        }
+        return file.isFile && file.length() > 0
+    }
+}

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/RealAppImageRestartE2ETest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/RealAppImageRestartE2ETest.kt
@@ -1,0 +1,240 @@
+package dev.nucleusframework.updater
+
+import dev.nucleusframework.updater.internal.PlatformInstaller
+import dev.nucleusframework.updater.internal.buildLinuxAppImageUpdateScript
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end coverage for AppImage post-update restart (#178) against a *real* AppImage binary.
+ *
+ * Flow mirrors production [PlatformInstaller.installLinuxAppImage]:
+ *  1. hold the installed AppImage open via `--appimage-mount` (FUSE/loop, like a running app);
+ *  2. swap the new bytes in place while that mount still holds the old inode;
+ *  3. run the generated update script (wait for pid → clean-env relaunch);
+ *  4. assert the relaunch actually started the new AppImage.
+ *
+ * Supply the artifacts with:
+ * ```
+ * ./gradlew :updater-runtime:test --tests '*RealAppImageRestartE2ETest*' \
+ *   -Dnucleus.e2e.appimage.old=/path/to/v1.AppImage \
+ *   -Dnucleus.e2e.appimage.new=/path/to/v2.AppImage
+ * ```
+ * When the properties are absent the test is skipped (unit CI stays free of multi-dozen-MB downloads).
+ */
+class RealAppImageRestartE2ETest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var oldArtifact: File
+    private lateinit var newArtifact: File
+
+    @Before
+    fun setUp() {
+        assumeTrue("Linux-only", System.getProperty("os.name").startsWith("Linux"))
+        val oldPath = System.getProperty("nucleus.e2e.appimage.old")
+        val newPath = System.getProperty("nucleus.e2e.appimage.new")
+        assumeTrue(
+            "real AppImage artifacts not supplied " +
+                "(-Dnucleus.e2e.appimage.old / -Dnucleus.e2e.appimage.new)",
+            !oldPath.isNullOrBlank() && !newPath.isNullOrBlank(),
+        )
+        oldArtifact = File(oldPath!!)
+        newArtifact = File(newPath!!)
+        assumeTrue("old AppImage missing: $oldPath", oldArtifact.isFile)
+        assumeTrue("new AppImage missing: $newPath", newArtifact.isFile)
+        assumeTrue("fuse/AppImage runtime must respond", appImageRuntimeWorks(oldArtifact))
+    }
+
+    @Test
+    fun `real AppImage is replaced in-place and relaunched with a clean environment`() {
+        val installDir = tmp.newFolder("Applications")
+        val installed = File(installDir, "NucleusDemo.AppImage")
+        val download = File(tmp.newFolder("download"), "NucleusDemo-2.AppImage")
+        val relaunchLog = File(tmp.root, "relaunch.log")
+        val updateLog = File(tmp.root, "nucleus-update.log")
+
+        oldArtifact.copyTo(installed, overwrite = true)
+        installed.setExecutable(true, false)
+        newArtifact.copyTo(download, overwrite = true)
+        download.setExecutable(true, false)
+
+        val oldSha = sha256(installed)
+        val newSha = sha256(download)
+        assertTrue(
+            "e2e needs two distinct AppImage payloads (got identical sha256)",
+            oldSha != newSha || oldArtifact.absolutePath != newArtifact.absolutePath,
+        )
+
+        // Keep the installed AppImage open the way a running instance does (FUSE mount).
+        val mount =
+            ProcessBuilder(installed.absolutePath, "--appimage-mount")
+                .redirectErrorStream(true)
+                .start()
+        val mountPoint =
+            mount.inputStream
+                .bufferedReader()
+                .readLine()
+                ?.trim()
+        assertFalse("AppImage mount produced no mount point", mountPoint.isNullOrBlank())
+        assertTrue("mount point must exist: $mountPoint", File(mountPoint!!).isDirectory)
+
+        try {
+            // Production step 1: in-process swap while the previous inode is still open.
+            val replaced = PlatformInstaller.replaceAppImageInPlace(download, installed)
+            assertTrue("in-process replace must succeed against an open AppImage", replaced)
+            assertFalse("download consumed by in-process replace", download.exists())
+            assertTrue(installed.isFile)
+            assertTrue(installed.canExecute())
+            // Mount still alive (old inode) even though the directory entry was replaced.
+            assertTrue("FUSE mount must survive the replace", mount.isAlive)
+            assertTrue(File(mountPoint).isDirectory)
+
+            // Production step 2: detached script waits for the "app" pid, then relaunches.
+            // We wrap the relaunch target so a headless environment does not need a display —
+            // the wrapper records env + that the real AppImage runtime still works, then exits.
+            val wrapper = File(installDir, "NucleusDemo.AppImage")
+            // `installed` is already that path and now holds the *new* bytes. Build a recorder
+            // that execs those bytes with `--appimage-version` after logging env.
+            val realNew = File(installDir, "NucleusDemo.real.AppImage")
+            installed.copyTo(realNew, overwrite = true)
+            realNew.setExecutable(true, false)
+            writeRelaunchRecorder(wrapper, realNew, relaunchLog)
+
+            val scriptFile = tmp.newFile("nucleus-update.sh")
+            scriptFile.writeText(
+                buildLinuxAppImageUpdateScript(
+                    newFile = download.absolutePath, // already gone → alreadyReplaced path
+                    oldFile = wrapper.absolutePath,
+                    appPid = mount.pid(),
+                    logFile = updateLog.absolutePath,
+                    restart = true,
+                    alreadyReplaced = true,
+                    selfDelete = false,
+                ),
+            )
+            scriptFile.setExecutable(true)
+
+            val script =
+                ProcessBuilder("setsid", "bash", scriptFile.absolutePath)
+                    .directory(File(System.getProperty("user.home")))
+                    .apply {
+                        environment()["APPDIR"] = mountPoint
+                        environment()["APPIMAGE"] = wrapper.absolutePath
+                        environment()["LD_LIBRARY_PATH"] = "$mountPoint/usr/lib"
+                        environment()["OWD"] = mountPoint
+                    }.redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start()
+
+            // Release the mount → script proceeds past the pid wait and relaunches.
+            mount.destroy()
+            mount.waitFor(10, TimeUnit.SECONDS)
+            // Some runtimes ignore SIGTERM; force so the script cannot hang.
+            if (mount.isAlive) mount.destroyForcibly()
+
+            assertTrue("update script must finish", script.waitFor(30, TimeUnit.SECONDS))
+            assertEquals(
+                "update log:\n${updateLog.readText()}",
+                0,
+                script.exitValue(),
+            )
+
+            assertTrue(
+                "relaunch must have started (log missing). update log:\n${updateLog.readText()}",
+                waitForFile(relaunchLog, 15_000),
+            )
+            val relaunch = relaunchLog.readText()
+            assertTrue("stale APPDIR must be cleared:\n$relaunch", relaunch.contains("APPDIR=unset"))
+            assertTrue(
+                "stale LD_LIBRARY_PATH must be cleared:\n$relaunch",
+                relaunch.contains("LD_LIBRARY_PATH=unset"),
+            )
+            assertTrue(
+                "real AppImage runtime must accept the replaced payload:\n$relaunch",
+                relaunch.contains("runtime_ok=1"),
+            )
+            assertTrue(
+                updateLog.readText().contains("relaunch spawned") ||
+                    updateLog.readText().contains("relaunching"),
+            )
+        } finally {
+            if (mount.isAlive) mount.destroyForcibly()
+        }
+    }
+
+    /**
+     * Replaces [wrapper] with a small shell recorder that logs the inherited environment, probes
+     * the real AppImage at [realAppImage] with `--appimage-version`, then exits. This lets the e2e
+     * assert relaunch without requiring a working display for the full GUI app.
+     */
+    private fun writeRelaunchRecorder(
+        wrapper: File,
+        realAppImage: File,
+        relaunchLog: File,
+    ) {
+        wrapper.writeText(
+            """
+            #!/usr/bin/env bash
+            {
+              echo "APPDIR=${'$'}{APPDIR:-unset}"
+              echo "LD_LIBRARY_PATH=${'$'}{LD_LIBRARY_PATH:-unset}"
+              echo "APPIMAGE=${'$'}{APPIMAGE:-unset}"
+              if "${realAppImage.absolutePath}" --appimage-version >/dev/null 2>&1 \
+                || "${realAppImage.absolutePath}" --appimage-help >/dev/null 2>&1; then
+                echo "runtime_ok=1"
+              else
+                echo "runtime_ok=0"
+              fi
+            } > "${relaunchLog.absolutePath}"
+            """.trimIndent() + "\n",
+        )
+        wrapper.setExecutable(true, false)
+    }
+
+    private fun appImageRuntimeWorks(appImage: File): Boolean =
+        try {
+            val p =
+                ProcessBuilder(appImage.absolutePath, "--appimage-help")
+                    .redirectErrorStream(true)
+                    .start()
+            val finished = p.waitFor(15, TimeUnit.SECONDS)
+            finished && p.exitValue() == 0
+        } catch (_: Exception) {
+            false
+        }
+
+    private fun sha256(file: File): String {
+        val md = java.security.MessageDigest.getInstance("SHA-256")
+        Files.newInputStream(file.toPath()).use { input ->
+            val buf = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val n = input.read(buf)
+                if (n <= 0) break
+                md.update(buf, 0, n)
+            }
+        }
+        return md.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun waitForFile(
+        file: File,
+        timeoutMs: Long,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (file.isFile && file.length() > 0L) return true
+            Thread.sleep(50)
+        }
+        return file.isFile && file.length() > 0L
+    }
+}


### PR DESCRIPTION
## Summary

- Fix AppImage post-update restart on Linux (#178): the update applied but the app never came back because the relaunch inherited stale `APPDIR` / `LD_LIBRARY_PATH` from the unmounted FUSE squashfs, and `set -e` could abort the script before relaunch.
- Swap the new AppImage in place while the previous mount still holds the old inode (electron-updater pattern), then wait for the old process to exit so the single-instance lock is free.
- Relaunch with a cleaned environment (`unset APPDIR APPIMAGE OWD ARGV0 LD_LIBRARY_PATH …`, `APPIMAGE_SILENT_INSTALL=true`, safe `cd $HOME`), no `set -e`, and retries on replace.
- Extract `buildLinuxAppImageUpdateScript` for testability; add unit tests, real-artifact e2e (opt-in), and a full-GUI shell e2e script.

## Test plan

- [x] `./gradlew :updater-runtime:test --tests '*LinuxAppImageUpdateScriptTest*' :updater-runtime:ktlintCheck`
- [x] Real AppImage e2e with nucleusdemo 2.1.10 → 2.2.0:
  ```bash
  ./gradlew :updater-runtime:test --tests '*RealAppImageRestartE2ETest*' \
    -Dnucleus.e2e.appimage.old=/path/to/v1.AppImage \
    -Dnucleus.e2e.appimage.new=/path/to/v2.AppImage
  ```
- [x] Full GUI e2e on a desktop session:
  ```bash
  export DISPLAY=:0
  ./updater-runtime/scripts/e2e-appimage-gui-restart.sh
  ```
  Verified: window `NucleusDemo` before/after, new PID, on-disk SHA is the new artifact.

Closes #178