### PR TITLE
feat(tao): XDG portal dialog parents for Wayland and X11

### DIFF
--- a/decorated-window-tao/api/decorated-window-tao.api
+++ b/decorated-window-tao/api/decorated-window-tao.api
@@ -679,6 +679,7 @@ public final class dev/nucleusframework/window/tao/TaoWindow {
 	public final fun getHandle ()J
 	public final fun getNativeHandle ()J
 	public final fun getScaleFactor ()F
+	public final fun getX11PortalParent ()Ljava/lang/String;
 	public final fun getX11WindowId ()Ljava/lang/Long;
 	public final fun hide ()V
 	public final fun isFullscreen ()Z
@@ -724,6 +725,8 @@ public final class dev/nucleusframework/window/tao/TaoWindow {
 	public final fun setResizable (Z)V
 	public final fun setTitle (Ljava/lang/String;)V
 	public final fun show ()V
+	public final fun xdgPortalParent (J)Ldev/nucleusframework/window/tao/XdgPortalParent;
+	public static synthetic fun xdgPortalParent$default (Ldev/nucleusframework/window/tao/TaoWindow;JILjava/lang/Object;)Ldev/nucleusframework/window/tao/XdgPortalParent;
 }
 
 public abstract interface class dev/nucleusframework/window/tao/TaoWindow$KeyEventListener {
@@ -772,6 +775,35 @@ public final class dev/nucleusframework/window/tao/XdgForeignExport : java/lang/
 	public final fun getHandle ()Ljava/lang/String;
 	public final fun getPortalParent ()Ljava/lang/String;
 	public final fun isClosed ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class dev/nucleusframework/window/tao/XdgPortalParent {
+	public static final field $stable I
+	public static final field X11_XID_MAX J
+	public abstract fun getPortalParent ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/window/tao/XdgPortalParent$Wayland : dev/nucleusframework/window/tao/XdgPortalParent, java/lang/AutoCloseable {
+	public static final field $stable I
+	public fun <init> (Ldev/nucleusframework/window/tao/XdgForeignExport;)V
+	public fun close ()V
+	public final fun getExport ()Ldev/nucleusframework/window/tao/XdgForeignExport;
+	public final fun getHandle ()Ljava/lang/String;
+	public fun getPortalParent ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/window/tao/XdgPortalParent$X11 : dev/nucleusframework/window/tao/XdgPortalParent {
+	public static final field $stable I
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Ldev/nucleusframework/window/tao/XdgPortalParent$X11;
+	public static synthetic fun copy$default (Ldev/nucleusframework/window/tao/XdgPortalParent$X11;JILjava/lang/Object;)Ldev/nucleusframework/window/tao/XdgPortalParent$X11;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getPortalParent ()Ljava/lang/String;
+	public final fun getXid ()J
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/decorated-window-tao/api/decorated-window-tao.api
+++ b/decorated-window-tao/api/decorated-window-tao.api
@@ -673,10 +673,13 @@ public final class dev/nucleusframework/window/tao/TaoWindow {
 	public static final field SCROLL_FIXED_SCALE F
 	public static final field WINDOWS_TOUCH_DRAG_THRESHOLD_PX I
 	public final fun dragWindow ()V
+	public final fun exportXdgForeignHandle (J)Ldev/nucleusframework/window/tao/XdgForeignExport;
+	public static synthetic fun exportXdgForeignHandle$default (Ldev/nucleusframework/window/tao/TaoWindow;JILjava/lang/Object;)Ldev/nucleusframework/window/tao/XdgForeignExport;
 	public final fun focus ()V
 	public final fun getHandle ()J
 	public final fun getNativeHandle ()J
 	public final fun getScaleFactor ()F
+	public final fun getX11WindowId ()Ljava/lang/Long;
 	public final fun hide ()V
 	public final fun isFullscreen ()Z
 	public final fun isMaximized ()Z
@@ -761,6 +764,15 @@ public final class dev/nucleusframework/window/tao/TextureViewKt {
 }
 
 public abstract interface class dev/nucleusframework/window/tao/TextureViewSource {
+}
+
+public final class dev/nucleusframework/window/tao/XdgForeignExport : java/lang/AutoCloseable {
+	public static final field $stable I
+	public fun close ()V
+	public final fun getHandle ()Ljava/lang/String;
+	public final fun getPortalParent ()Ljava/lang/String;
+	public final fun isClosed ()Z
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/nucleusframework/window/tao/render/MetalFrame {

--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -173,11 +173,35 @@ val taoHeadfulTest by tasks.registering(JavaExec::class) {
     System.getProperty("nucleus.tao.headful.filter")?.let {
         systemProperty("nucleus.tao.headful.filter", it)
     }
+    // Honor a caller-forced Linux renderer (x11 / wayland) so portal parenting
+    // e2es can be launched against XWayland from a native Wayland session.
+    providers.environmentVariable("NUCLEUS_TAO_LINUX_RENDERER").orNull?.let {
+        environment("NUCLEUS_TAO_LINUX_RENDERER", it)
+    }
+    providers.environmentVariable("GDK_BACKEND").orNull?.let {
+        environment("GDK_BACKEND", it)
+    }
     // NO -XstartOnFirstThread here: taoApplication marshals to the AppKit main
     // thread itself (main_thread_dispatch.m), exactly like a normal `java`
     // launch — and the flag would deadlock the AWT classes the Compose host
     // touches. smokeStandalonePanelMac needs it only because it creates an
     // NSPanel directly, without the Tao loop machinery.
+}
+
+// X11 / XWayland portal parenting e2e: forces GDK onto X11 so Tao windows get
+// a real XID, then parents a session xdg-desktop-portal FileChooser with
+// `x11:<hex>`. Safe to run on a Wayland host (XWayland). Not part of `check`.
+val taoX11PortalE2E by tasks.registering(JavaExec::class) {
+    description = "E2E: X11 XID parents a real XDG portal FileChooser (forces XWayland)"
+    group = "verification"
+    onlyIf { Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) }
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass.set("dev.nucleusframework.window.tao.headful.TaoHeadfulTestSuiteMain")
+    systemProperty("nucleus.tao.headful.filter", "x11 XID")
+    System.getProperty("nucleus.tao.headful.watchdogMillis")?.let {
+        systemProperty("nucleus.tao.headful.watchdogMillis", it)
+    }
+    environment("NUCLEUS_TAO_LINUX_RENDERER", "x11")
 }
 
 val smokeStandalonePanelMac by tasks.registering(JavaExec::class) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -393,8 +393,9 @@ public class TaoWindow internal constructor(
      *  - Windows: HWND as a `Long` (0 if unavailable).
      *  - macOS: NSView pointer as a `Long` — the AppKit subview hosting the
      *    Compose surface. The owning NSWindow can be obtained via `[view window]`.
-     *  - Linux: returns 0 (use [NativeTaoBridge.nativeLinuxHandles] for the
-     *    full `[kind, display, nativeWindow]` triplet).
+     *  - Linux: returns 0. Prefer [x11WindowId] (X11 portal parent) or
+     *    [exportXdgForeignHandle] (Wayland portal parent) — a raw `wl_surface*`
+     *    is not a valid XDG Desktop Portal parent.
      *
      * Intended for cross-module integration (e.g. taskbar, notifications) that
      * need to address the OS window directly without going through Tao APIs.
@@ -406,6 +407,44 @@ public class TaoWindow internal constructor(
                 Platform.MacOS -> NativeTaoBridge.nativeNsViewHandle(handle)
                 else -> 0L
             }
+
+    /**
+     * Linux/X11 only: the window's XID for XDG Desktop Portal parenting
+     * (`x11:<hex>` / `FileKitDialogParent.x11`). `null` when not on X11, not
+     * yet realized, or the native bridge is unavailable.
+     */
+    public val x11WindowId: Long?
+        get() {
+            if (Platform.Current != Platform.Linux || !NativeTaoBridge.isLoaded) return null
+            val handles = NativeTaoBridge.nativeLinuxHandles(handle) ?: return null
+            // [kind, display, nativeWindow] — kind 1 = Xlib, slot 2 = XID.
+            if (handles.size < 3 || handles[0] != 1L) return null
+            return handles[2].takeIf { it != 0L }
+        }
+
+    /**
+     * Linux/Wayland only: export this window via `xdg_foreign` for XDG Desktop
+     * Portal dialog parenting (FileKit `FileKitDialogParent.wayland`, portal
+     * `parent_window = wayland:<handle>`).
+     *
+     * Blocks until the compositor issues the token or [timeoutMs] elapses.
+     * Returns `null` on X11, when the window is not realized, or on failure.
+     * The returned [XdgForeignExport] must stay open until portal dialogs that
+     * borrow [XdgForeignExport.handle] complete — close it afterward.
+     *
+     * Safe to call from a worker thread or the Tao main thread (the native
+     * side nests the GLib main context when already on the GTK thread).
+     */
+    public fun exportXdgForeignHandle(timeoutMs: Long = 5_000L): XdgForeignExport? {
+        if (Platform.Current != Platform.Linux || !NativeTaoBridge.isLoaded) return null
+        val token =
+            NativeTaoBridge.nativeLinuxExportXdgForeignHandle(
+                handle,
+                timeoutMs.coerceIn(1L, Int.MAX_VALUE.toLong()).toInt(),
+            ) ?: return null
+        if (token.isEmpty()) return null
+        return XdgForeignExport(token, handle)
+    }
 
     public val isMaximized: Boolean
         get() = NativeTaoBridge.nativeIsMaximized(handle)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -412,6 +412,9 @@ public class TaoWindow internal constructor(
      * Linux/X11 only: the window's XID for XDG Desktop Portal parenting
      * (`x11:<hex>` / `FileKitDialogParent.x11`). `null` when not on X11, not
      * yet realized, or the native bridge is unavailable.
+     *
+     * Prefer [xdgPortalParent] when the caller only needs a portal string and
+     * should work on both X11 and Wayland.
      */
     public val x11WindowId: Long?
         get() {
@@ -419,8 +422,16 @@ public class TaoWindow internal constructor(
             val handles = NativeTaoBridge.nativeLinuxHandles(handle) ?: return null
             // [kind, display, nativeWindow] — kind 1 = Xlib, slot 2 = XID.
             if (handles.size < 3 || handles[0] != 1L) return null
-            return handles[2].takeIf { it != 0L }
+            val xid = handles[2]
+            return xid.takeIf { it in 1L..0xffff_ffffL }
         }
+
+    /**
+     * Linux/X11 only: portal `parent_window` value `x11:<lowercase-hex-xid>`.
+     * `null` when [x11WindowId] is unavailable.
+     */
+    public val x11PortalParent: String?
+        get() = x11WindowId?.let { xid -> "x11:${xid.toString(radix = 16)}" }
 
     /**
      * Linux/Wayland only: export this window via `xdg_foreign` for XDG Desktop
@@ -431,6 +442,8 @@ public class TaoWindow internal constructor(
      * Returns `null` on X11, when the window is not realized, or on failure.
      * The returned [XdgForeignExport] must stay open until portal dialogs that
      * borrow [XdgForeignExport.handle] complete — close it afterward.
+     *
+     * Prefer [xdgPortalParent] for a backend-agnostic Linux parent.
      *
      * Safe to call from a worker thread or the Tao main thread (the native
      * side nests the GLib main context when already on the GTK thread).
@@ -444,6 +457,24 @@ public class TaoWindow internal constructor(
             ) ?: return null
         if (token.isEmpty()) return null
         return XdgForeignExport(token, handle)
+    }
+
+    /**
+     * Linux only: resolve the XDG Desktop Portal parent for this window.
+     *
+     * - **X11 / XWayland** → [XdgPortalParent.X11] with the live XID (no
+     *   lifetime object; valid while the window is mapped).
+     * - **Wayland** → [XdgPortalParent.Wayland] wrapping an [XdgForeignExport]
+     *   that must stay open until portal dialogs complete.
+     *
+     * Returns `null` when the window is not realized, the bridge is missing,
+     * or Wayland export times out. [timeoutMs] only applies to the Wayland path.
+     */
+    public fun xdgPortalParent(timeoutMs: Long = 5_000L): XdgPortalParent? {
+        if (Platform.Current != Platform.Linux || !NativeTaoBridge.isLoaded) return null
+        x11WindowId?.let { return XdgPortalParent.X11(it) }
+        val export = exportXdgForeignHandle(timeoutMs) ?: return null
+        return XdgPortalParent.Wayland(export)
     }
 
     public val isMaximized: Boolean

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/XdgForeignExport.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/XdgForeignExport.kt
@@ -1,0 +1,43 @@
+package dev.nucleusframework.window.tao
+
+import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Borrowed [xdg_foreign](https://wayland.app/protocols/xdg-foreign-unstable-v2)
+ * export of a Tao window's Wayland surface.
+ *
+ * The [handle] is the **unprefixed** opaque token issued by the compositor.
+ * XDG Desktop Portal (and FileKit) want it as `wayland:<handle>` — see
+ * [portalParent]. Keep this export open until every portal dialog that uses it
+ * has completed; [close] unexports the surface.
+ *
+ * Not a raw `wl_surface*` pointer and not a Tao event-loop identity.
+ */
+public class XdgForeignExport internal constructor(
+    /** Unprefixed opaque xdg_foreign token. */
+    public val handle: String,
+    private val windowHandle: Long,
+) : AutoCloseable {
+    private val closed = AtomicBoolean(false)
+
+    /**
+     * Full XDG Desktop Portal `parent_window` value:
+     * `wayland:<unprefixed-handle>`.
+     */
+    public val portalParent: String
+        get() = "wayland:$handle"
+
+    public val isClosed: Boolean
+        get() = closed.get()
+
+    override fun close() {
+        if (closed.compareAndSet(false, true)) {
+            if (NativeTaoBridge.isLoaded) {
+                NativeTaoBridge.nativeLinuxUnexportXdgForeignHandle(windowHandle)
+            }
+        }
+    }
+
+    override fun toString(): String = "XdgForeignExport(closed=$isClosed)"
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/XdgPortalParent.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/XdgPortalParent.kt
@@ -1,0 +1,60 @@
+package dev.nucleusframework.window.tao
+
+/**
+ * Linux window identity accepted by the XDG Desktop Portal `parent_window`
+ * argument (and by FileKit's `FileKitDialogParent.x11` / `.wayland`).
+ *
+ * Construct via [TaoWindow.xdgPortalParent] — it picks X11 or Wayland from the
+ * live GDK backend. On Wayland the [Wayland] variant owns an [XdgForeignExport]
+ * that must stay open until portal dialogs finish.
+ */
+public sealed class XdgPortalParent {
+    /** Full portal string: `x11:<hex>` or `wayland:<token>`. */
+    public abstract val portalParent: String
+
+    /**
+     * X11 window id (XID). [portalParent] is `x11:` plus the bare lowercase
+     * hexadecimal XID, matching the
+     * [portal window identifier](https://flatpak.github.io/xdg-desktop-portal/docs/window-identifiers.html)
+     * and FileKit's serialization.
+     */
+    public data class X11(
+        public val xid: Long,
+    ) : XdgPortalParent() {
+        init {
+            require(xid in 1L..X11_XID_MAX) {
+                "An X11 XID must be between 1 and 0xffffffff."
+            }
+        }
+
+        override val portalParent: String
+            get() = "x11:${xid.toString(radix = 16)}"
+
+        override fun toString(): String = "XdgPortalParent.X11"
+    }
+
+    /**
+     * Wayland `xdg_foreign` export. Keep [export] open (or call [close]) only
+     * after every portal dialog that borrowed [handle] has completed.
+     */
+    public class Wayland(
+        public val export: XdgForeignExport,
+    ) : XdgPortalParent(),
+        AutoCloseable {
+        public val handle: String
+            get() = export.handle
+
+        override val portalParent: String
+            get() = export.portalParent
+
+        override fun close() {
+            export.close()
+        }
+
+        override fun toString(): String = "XdgPortalParent.Wayland(closed=${export.isClosed})"
+    }
+
+    private companion object {
+        const val X11_XID_MAX: Long = 0xffff_ffffL
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -209,9 +209,36 @@ internal object NativeTaoBridge {
      * For Xlib, `display` is `Display*` and `nativeWindow` is the X11 `Window`
      * (XID). For Wayland, `display` is `wl_display*` and `nativeWindow` is
      * `wl_surface*`. Only resolvable on Linux.
+     *
+     * Prefer [TaoWindow.x11WindowId] / [TaoWindow.exportXdgForeignHandle] when
+     * the goal is XDG Desktop Portal dialog parenting rather than EGL.
      */
     @JvmStatic
     external fun nativeLinuxHandles(handle: Long): LongArray?
+
+    /**
+     * Linux/Wayland only: export this window's surface via `xdg_foreign` and
+     * return the **unprefixed** opaque handle string (for
+     * `FileKitDialogParent.wayland` / portal `wayland:<handle>`).
+     *
+     * Blocks until the compositor delivers the handle or [timeoutMs] elapses.
+     * Returns `null` on X11, when the window is not realized, or on failure.
+     * Pair with [nativeLinuxUnexportXdgForeignHandle] when the portal dialogs
+     * finish — FileKit borrows the handle and does not extend its lifetime.
+     */
+    @JvmStatic
+    external fun nativeLinuxExportXdgForeignHandle(
+        handle: Long,
+        timeoutMs: Int,
+    ): String?
+
+    /**
+     * Linux/Wayland only: drop the `xdg_foreign` export created by
+     * [nativeLinuxExportXdgForeignHandle]. No-op when never exported or not
+     * on Wayland.
+     */
+    @JvmStatic
+    external fun nativeLinuxUnexportXdgForeignHandle(handle: Long)
 
     /**
      * Linux only: returns the underlying `GtkApplicationWindow*` (cast

--- a/decorated-window-tao/src/main/native/Cargo.lock
+++ b/decorated-window-tao/src/main/native/Cargo.lock
@@ -1235,6 +1235,7 @@ dependencies = [
  "accesskit_unix",
  "accesskit_windows",
  "cc",
+ "gdkwayland-sys",
  "gdkx11-sys",
  "glib",
  "gtk",

--- a/decorated-window-tao/src/main/native/Cargo.toml
+++ b/decorated-window-tao/src/main/native/Cargo.toml
@@ -35,6 +35,10 @@ gtk = "0.18"
 # the context, drawable and display to all come from the same X connection,
 # so reusing GDK's is the only way the GLX bridge can render into the GTK XID.
 gdkx11-sys = "0.18"
+# Same for Wayland: `gdk_wayland_window_export_handle` / `unexport_handle` so
+# we can mint an xdg_foreign token for XDG Desktop Portal dialog parenting
+# (FileKit, etc.). Transitive via tao; explicit for the FFI symbols.
+gdkwayland-sys = "0.18"
 glib = "0.18"
 # AT-SPI2 accessibility provider via AccessKit. Pure-Rust D-Bus (zbus) so we
 # don't have to link libatspi / libatk / glib at runtime. We're an XWayland

--- a/decorated-window-tao/src/main/native/src/platform/linux/handles.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/handles.rs
@@ -198,3 +198,236 @@ fn gdk_x11_display_for_window(window: &Window) -> Option<jlong> {
         Some(xdisplay as jlong)
     }
 }
+
+// ── xdg_foreign export for XDG Desktop Portal parenting ─────────────────────
+//
+// FileKit / xdg-desktop-portal expect a Wayland parent as `wayland:<token>`,
+// where `<token>` is the opaque handle from `xdg_foreign` — NOT a raw
+// `wl_surface*`. GDK already owns the exporter (`gdk_wayland_window_export_handle`);
+// we surface that string to the JVM and require the caller to keep the export
+// alive until portal dialogs complete (`nativeLinuxUnexportXdgForeignHandle`).
+
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_void};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Holds the oneshot sender until the compositor delivers the exported handle
+/// (or until the export is torn down via [export_destroy]).
+struct ExportUserData {
+    tx: Mutex<Option<mpsc::Sender<Option<String>>>>,
+}
+
+unsafe extern "C" fn export_callback(
+    _window: *mut gdk_wayland_sys::GdkWaylandWindow,
+    handle: *const c_char,
+    user_data: *mut c_void,
+) {
+    let data = &*(user_data as *const ExportUserData);
+    let value = if handle.is_null() {
+        None
+    } else {
+        Some(CStr::from_ptr(handle).to_string_lossy().into_owned())
+    };
+    if let Ok(mut guard) = data.tx.lock() {
+        if let Some(tx) = guard.take() {
+            let _ = tx.send(value);
+        }
+    }
+}
+
+unsafe extern "C" fn export_destroy(user_data: *mut c_void) {
+    // Drop any leftover sender so a blocked waiter unblocks with RecvError.
+    drop(Box::from_raw(user_data as *mut ExportUserData));
+}
+
+/// Raw `GdkWindow*` for the Tao window, or null if unavailable / not realized.
+fn gdk_window_ptr_for_handle(handle: jlong) -> *mut gtk::gdk::ffi::GdkWindow {
+    use gtk::prelude::{DisplayExtManual, WidgetExt};
+    use tao::platform::unix::WindowExtUnix;
+
+    let Ok(guard) = WINDOWS.lock() else {
+        return std::ptr::null_mut();
+    };
+    let Some(map) = guard.as_ref() else {
+        return std::ptr::null_mut();
+    };
+    let Some(window) = map.get(&(handle as u64)) else {
+        return std::ptr::null_mut();
+    };
+    let gtk_window = window.gtk_window();
+    // Only Wayland has xdg_foreign; X11 uses the XID path instead.
+    if !gtk_window.display().backend().is_wayland() {
+        return std::ptr::null_mut();
+    }
+    match WidgetExt::window(gtk_window) {
+        Some(gw) => {
+            glib::translate::ToGlibPtr::<*mut gtk::gdk::ffi::GdkWindow>::to_glib_none(&gw).0
+        }
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Starts `gdk_wayland_window_export_handle` on [gdk_ptr]. Returns whether GDK
+/// accepted the export request. On `false`, [user_data_ptr] is still owned by
+/// the caller and must be freed; on `true`, ownership moved to GDK (freed by
+/// [export_destroy] on unexport / window destroy).
+unsafe fn start_export(
+    gdk_ptr: *mut gtk::gdk::ffi::GdkWindow,
+    user_data_ptr: *mut ExportUserData,
+) -> bool {
+    if gdk_ptr.is_null() {
+        return false;
+    }
+    let ok = gdk_wayland_sys::gdk_wayland_window_export_handle(
+        gdk_ptr as *mut gdk_wayland_sys::GdkWaylandWindow,
+        Some(export_callback),
+        user_data_ptr as *mut c_void,
+        Some(export_destroy),
+    );
+    ok != glib::ffi::GFALSE
+}
+
+/// Blocks until the compositor returns an xdg_foreign handle (or [timeout_ms]
+/// elapses). Safe from the Tao/GTK main thread (nested main-context iteration)
+/// and from worker threads (`MainContext::invoke` + channel wait).
+///
+/// Returns a JVM string with the **unprefixed** opaque handle, or null on
+/// failure / timeout / non-Wayland.
+#[no_mangle]
+pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_nativeLinuxExportXdgForeignHandle(
+    env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+    timeout_ms: jint,
+) -> jni::sys::jstring {
+    let timeout = Duration::from_millis(timeout_ms.max(1) as u64);
+    let (tx, rx) = mpsc::channel::<Option<String>>();
+
+    let started_ok = Arc::new(AtomicBool::new(false));
+    let invoke_done = Arc::new(AtomicBool::new(false));
+
+    // Allocate ExportUserData inside the main-context closure so we never need
+    // to Send a raw pointer across threads (MainContext::invoke requires Send).
+    let run_export = {
+        let started_ok = started_ok.clone();
+        let invoke_done = invoke_done.clone();
+        move || {
+            let user_data = Box::new(ExportUserData {
+                tx: Mutex::new(Some(tx)),
+            });
+            let user_data_ptr = Box::into_raw(user_data);
+            let gdk_ptr = gdk_window_ptr_for_handle(handle);
+            let ok = unsafe { start_export(gdk_ptr, user_data_ptr) };
+            if !ok {
+                // GDK rejected the export — reclaim user_data and unblock.
+                let data = unsafe { Box::from_raw(user_data_ptr) };
+                if let Ok(mut guard) = data.tx.lock() {
+                    if let Some(tx) = guard.take() {
+                        let _ = tx.send(None);
+                    }
+                }
+                drop(data);
+            }
+            started_ok.store(ok, Ordering::SeqCst);
+            invoke_done.store(true, Ordering::SeqCst);
+        }
+    };
+
+    let ctx = glib::MainContext::default();
+    if ctx.is_owner() {
+        // Already on the GTK thread: run inline, then nest-iterate until the
+        // wayland handle event arrives (callback) or we time out.
+        run_export();
+    } else {
+        ctx.invoke(run_export);
+    }
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        // Nested iteration when we own the main context so the export's
+        // wayland round-trip can complete without deadlocking.
+        if ctx.is_owner() {
+            while ctx.iteration(false) {}
+        }
+        match rx.try_recv() {
+            Ok(Some(token)) if !token.is_empty() => {
+                return match env.new_string(token) {
+                    Ok(js) => js.into_raw(),
+                    Err(_) => std::ptr::null_mut(),
+                };
+            }
+            Ok(_) => {
+                // Empty / explicit failure.
+                return std::ptr::null_mut();
+            }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                return std::ptr::null_mut();
+            }
+            Err(mpsc::TryRecvError::Empty) => {
+                if Instant::now() >= deadline {
+                    // Timed out: drop a pending export so we don't leave the
+                    // surface exported without a Kotlin owner.
+                    if started_ok.load(Ordering::SeqCst) {
+                        let unexport = move || {
+                            let gdk_ptr = gdk_window_ptr_for_handle(handle);
+                            if !gdk_ptr.is_null() {
+                                unsafe {
+                                    gdk_wayland_sys::gdk_wayland_window_unexport_handle(
+                                        gdk_ptr as *mut gdk_wayland_sys::GdkWaylandWindow,
+                                    );
+                                }
+                            }
+                        };
+                        if ctx.is_owner() {
+                            unexport();
+                        } else {
+                            ctx.invoke(unexport);
+                        }
+                    }
+                    return std::ptr::null_mut();
+                }
+                // Worker thread: yield so the main loop can run. Main thread:
+                // iteration(false) above already drained; brief sleep avoids
+                // a hot spin when no events are pending yet.
+                if !ctx.is_owner() {
+                    std::thread::sleep(Duration::from_millis(2));
+                } else {
+                    // Block briefly for the next glib source (wayland fd).
+                    let _ = ctx.iteration(true);
+                }
+            }
+        }
+    }
+}
+
+/// Drops the xdg_foreign export for [handle]. No-op when the window is gone,
+/// not on Wayland, or was never exported. Safe from any thread.
+#[no_mangle]
+pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_nativeLinuxUnexportXdgForeignHandle(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+) {
+    let ctx = glib::MainContext::default();
+    let do_unexport = move || {
+        let gdk_ptr = gdk_window_ptr_for_handle(handle);
+        if gdk_ptr.is_null() {
+            return;
+        }
+        unsafe {
+            gdk_wayland_sys::gdk_wayland_window_unexport_handle(
+                gdk_ptr as *mut gdk_wayland_sys::GdkWaylandWindow,
+            );
+        }
+    };
+    if ctx.is_owner() {
+        do_unexport();
+    } else {
+        // Fire-and-forget: unexport does not need a reply. Using `invoke` keeps
+        // GDK calls on the GTK thread.
+        ctx.invoke(do_unexport);
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import dev.nucleusframework.window.tao.DecoratedWindow
+import dev.nucleusframework.window.tao.XdgPortalParent
 import dev.nucleusframework.window.tao.taoApplication
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -146,16 +147,10 @@ public object TaoHeadfulTestSuiteMain {
                     if (!isLinux) {
                         "Linux only"
                     } else {
-                        val backend = System.getenv("GDK_BACKEND")?.split(',')?.firstOrNull()
-                        val forcedX11 =
-                            backend == "x11" ||
-                                System
-                                    .getenv("NUCLEUS_TAO_LINUX_RENDERER")
-                                    .orEmpty()
-                                    .equals("x11", ignoreCase = true)
-                        val wayland = System.getenv("WAYLAND_DISPLAY") != null && !forcedX11
                         when {
-                            !wayland -> "requires native Wayland (WAYLAND_DISPLAY)"
+                            forcedX11Backend -> "Wayland-only (forced X11 backend)"
+                            System.getenv("WAYLAND_DISPLAY") == null ->
+                                "requires native Wayland (WAYLAND_DISPLAY)"
                             !XdgPortalFileChooser.gdbusAvailable() -> "gdbus not on PATH"
                             !XdgPortalFileChooser.portalAvailable() ->
                                 "xdg-desktop-portal FileChooser unavailable"
@@ -166,24 +161,28 @@ public object TaoHeadfulTestSuiteMain {
             ) {
                 awaitUntil("window mapped") { bounds() != null }
                 settle()
-                // Export on the Tao main thread (nested GLib iteration is OK).
-                val export =
-                    checkNotNull(window.exportXdgForeignHandle(timeoutMs = 8_000L)) {
-                        "exportXdgForeignHandle returned null on a realized Wayland window"
+                val parent =
+                    checkNotNull(window.xdgPortalParent(timeoutMs = 8_000L)) {
+                        "xdgPortalParent returned null on a realized Wayland window"
                     }
+                check(parent is XdgPortalParent.Wayland) {
+                    "expected Wayland portal parent, got $parent"
+                }
                 try {
+                    val export = parent.export
                     check(export.handle.isNotEmpty()) { "empty xdg_foreign handle" }
                     check('\u0000' !in export.handle) { "handle contains NUL" }
                     check(!export.handle.startsWith("wayland:")) {
                         "handle must be unprefixed; got ${export.handle.take(32)}"
                     }
-                    check(export.portalParent == "wayland:${export.handle}")
+                    check(parent.portalParent == "wayland:${export.handle}")
+                    check(window.x11WindowId == null) { "XID must be null on native Wayland" }
+                    check(window.x11PortalParent == null)
 
-                    // Portal IPC is blocking; park it off the event loop.
                     val open =
                         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
                             XdgPortalFileChooser.openFile(
-                                parentWindow = export.portalParent,
+                                parentWindow = parent.portalParent,
                                 title = "Nucleus xdg_foreign e2e",
                             )
                         }
@@ -192,14 +191,12 @@ public object TaoHeadfulTestSuiteMain {
                     }
                     println(
                         "xdg_foreign e2e: handle=${export.handle.take(12)}… " +
-                            "portalParent=${export.portalParent.take(24)}… " +
+                            "portalParent=${parent.portalParent.take(24)}… " +
                             "request=${open.requestPath}",
                     )
                     kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
                         open.close()
                     }
-                    // Second export while the first is still live must still
-                    // yield a usable token (GDK reuses the active export).
                     val again =
                         checkNotNull(window.exportXdgForeignHandle(timeoutMs = 5_000L)) {
                             "re-export while live failed"
@@ -207,8 +204,84 @@ public object TaoHeadfulTestSuiteMain {
                     check(again.handle.isNotEmpty())
                     again.close()
                 } finally {
-                    export.close()
-                    check(export.isClosed)
+                    parent.close()
+                    check(parent.export.isClosed)
+                }
+            },
+            // X11 / XWayland e2e: resolve the live XID and parent a real portal
+            // FileChooser with `x11:<hex>`. Run the suite with
+            // NUCLEUS_TAO_LINUX_RENDERER=x11 (or GDK_BACKEND=x11) on a Wayland
+            // host to force XWayland; also runs on native X11 sessions.
+            TaoWindowTestCase(
+                name = "x11 XID parents a real XDG portal FileChooser",
+                timeoutMillis = 45_000L,
+                skip = {
+                    if (!isLinux) {
+                        "Linux only"
+                    } else {
+                        when {
+                            !isX11Backend ->
+                                "requires X11/XWayland (set NUCLEUS_TAO_LINUX_RENDERER=x11)"
+                            !XdgPortalFileChooser.gdbusAvailable() -> "gdbus not on PATH"
+                            !XdgPortalFileChooser.portalAvailable() ->
+                                "xdg-desktop-portal FileChooser unavailable"
+                            else -> null
+                        }
+                    }
+                },
+            ) {
+                awaitUntil("window mapped") { bounds() != null }
+                settle()
+
+                val xid =
+                    checkNotNull(window.x11WindowId) {
+                        "x11WindowId null under X11 backend " +
+                            "(GDK_BACKEND=${System.getenv("GDK_BACKEND")}, " +
+                            "NUCLEUS_TAO_LINUX_RENDERER=${System.getenv("NUCLEUS_TAO_LINUX_RENDERER")})"
+                    }
+                check(xid in 1L..0xffff_ffffL) { "XID out of range: $xid" }
+
+                val portalFromProp =
+                    checkNotNull(window.x11PortalParent) { "x11PortalParent null while XID is set" }
+                check(portalFromProp == "x11:${xid.toString(16)}") {
+                    "x11PortalParent mismatch: $portalFromProp vs xid=$xid"
+                }
+                // FileKit canonical form: lowercase bare hex, no 0x prefix.
+                check(portalFromProp == portalFromProp.lowercase()) {
+                    "portal parent must be lowercase: $portalFromProp"
+                }
+                check(!portalFromProp.contains("0x")) { "unexpected 0x in $portalFromProp" }
+
+                val parent =
+                    checkNotNull(window.xdgPortalParent()) {
+                        "xdgPortalParent returned null under X11"
+                    }
+                check(parent is XdgPortalParent.X11) {
+                    "expected X11 portal parent, got $parent"
+                }
+                check(parent.xid == xid)
+                check(parent.portalParent == portalFromProp)
+                // Wayland export must not succeed on the X11 backend.
+                check(window.exportXdgForeignHandle(timeoutMs = 500L) == null) {
+                    "exportXdgForeignHandle must be null on X11"
+                }
+
+                val open =
+                    kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                        XdgPortalFileChooser.openFile(
+                            parentWindow = parent.portalParent,
+                            title = "Nucleus x11 portal e2e",
+                        )
+                    }
+                check(open.requestPath.startsWith("/org/freedesktop/portal/desktop/request/")) {
+                    "unexpected request path: ${open.requestPath}"
+                }
+                println(
+                    "x11 portal e2e: xid=$xid (0x${xid.toString(16)}) " +
+                        "portalParent=$portalFromProp request=${open.requestPath}",
+                )
+                kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                    open.close()
                 }
             },
         ) + ChromeReviewHeadfulCases.all() + DisplayScaleHeadfulCases.all() + FramePacingHeadfulCases.all()
@@ -351,6 +424,30 @@ public object TaoHeadfulTestSuiteMain {
     private val isLinux: Boolean =
         System.getProperty("os.name", "").lowercase().let { os ->
             !os.contains("win") && !os.contains("mac") && !os.contains("darwin")
+        }
+
+    /**
+     * True when the process was launched with an X11-forcing env var. The native
+     * loop also setenvs `GDK_BACKEND=x11` from `NUCLEUS_TAO_LINUX_RENDERER`, but
+     * that is too late for the JVM's env snapshot — honor both signals here.
+     */
+    private val forcedX11Backend: Boolean
+        get() {
+            val backend = System.getenv("GDK_BACKEND")?.split(',')?.firstOrNull()
+            return backend == "x11" ||
+                System.getenv("NUCLEUS_TAO_LINUX_RENDERER").orEmpty().equals("x11", ignoreCase = true)
+        }
+
+    /**
+     * X11 session or forced XWayland. Native Wayland (no force) is false even
+     * when `DISPLAY` is set for XWayland compatibility.
+     */
+    private val isX11Backend: Boolean
+        get() {
+            if (forcedX11Backend) return true
+            // Pure X11 desktop: DISPLAY set, no WAYLAND_DISPLAY.
+            return !System.getenv("DISPLAY").isNullOrEmpty() &&
+                System.getenv("WAYLAND_DISPLAY").isNullOrEmpty()
         }
 
     private const val WINDOW_PUBLISH_TIMEOUT_MILLIS = 15_000L

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -135,6 +135,82 @@ public object TaoHeadfulTestSuiteMain {
                 settle()
                 check(bounds() != null) { "window must survive a handled close request" }
             },
+            // Real Wayland session e2e (not a synthetic unit test): export the
+            // live surface via xdg_foreign, hand the token to the session
+            // xdg-desktop-portal FileChooser as parent_window, then Close the
+            // Request so no modal sticks around. Proves FileKit-style parenting.
+            TaoWindowTestCase(
+                name = "xdg_foreign export parents a real XDG portal FileChooser",
+                timeoutMillis = 45_000L,
+                skip = {
+                    if (!isLinux) {
+                        "Linux only"
+                    } else {
+                        val backend = System.getenv("GDK_BACKEND")?.split(',')?.firstOrNull()
+                        val forcedX11 =
+                            backend == "x11" ||
+                                System
+                                    .getenv("NUCLEUS_TAO_LINUX_RENDERER")
+                                    .orEmpty()
+                                    .equals("x11", ignoreCase = true)
+                        val wayland = System.getenv("WAYLAND_DISPLAY") != null && !forcedX11
+                        when {
+                            !wayland -> "requires native Wayland (WAYLAND_DISPLAY)"
+                            !XdgPortalFileChooser.gdbusAvailable() -> "gdbus not on PATH"
+                            !XdgPortalFileChooser.portalAvailable() ->
+                                "xdg-desktop-portal FileChooser unavailable"
+                            else -> null
+                        }
+                    }
+                },
+            ) {
+                awaitUntil("window mapped") { bounds() != null }
+                settle()
+                // Export on the Tao main thread (nested GLib iteration is OK).
+                val export =
+                    checkNotNull(window.exportXdgForeignHandle(timeoutMs = 8_000L)) {
+                        "exportXdgForeignHandle returned null on a realized Wayland window"
+                    }
+                try {
+                    check(export.handle.isNotEmpty()) { "empty xdg_foreign handle" }
+                    check('\u0000' !in export.handle) { "handle contains NUL" }
+                    check(!export.handle.startsWith("wayland:")) {
+                        "handle must be unprefixed; got ${export.handle.take(32)}"
+                    }
+                    check(export.portalParent == "wayland:${export.handle}")
+
+                    // Portal IPC is blocking; park it off the event loop.
+                    val open =
+                        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                            XdgPortalFileChooser.openFile(
+                                parentWindow = export.portalParent,
+                                title = "Nucleus xdg_foreign e2e",
+                            )
+                        }
+                    check(open.requestPath.startsWith("/org/freedesktop/portal/desktop/request/")) {
+                        "unexpected request path: ${open.requestPath}"
+                    }
+                    println(
+                        "xdg_foreign e2e: handle=${export.handle.take(12)}… " +
+                            "portalParent=${export.portalParent.take(24)}… " +
+                            "request=${open.requestPath}",
+                    )
+                    kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                        open.close()
+                    }
+                    // Second export while the first is still live must still
+                    // yield a usable token (GDK reuses the active export).
+                    val again =
+                        checkNotNull(window.exportXdgForeignHandle(timeoutMs = 5_000L)) {
+                            "re-export while live failed"
+                        }
+                    check(again.handle.isNotEmpty())
+                    again.close()
+                } finally {
+                    export.close()
+                    check(export.isClosed)
+                }
+            },
         ) + ChromeReviewHeadfulCases.all() + DisplayScaleHeadfulCases.all() + FramePacingHeadfulCases.all()
 
     private val cases: List<TaoWindowTestCase> =

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/XdgPortalFileChooser.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/XdgPortalFileChooser.kt
@@ -1,0 +1,129 @@
+package dev.nucleusframework.window.tao.headful
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Thin shell around `gdbus` for the session [xdg-desktop-portal] FileChooser.
+ * Used by the Wayland `xdg_foreign` headful e2e so we exercise a real portal
+ * round-trip (not a mocked D-Bus transport).
+ */
+internal object XdgPortalFileChooser {
+    fun gdbusAvailable(): Boolean =
+        runCatching {
+            val p =
+                ProcessBuilder("gdbus", "--help")
+                    .redirectErrorStream(true)
+                    .start()
+            p.waitFor(3, TimeUnit.SECONDS) && p.exitValue() == 0
+        }.getOrDefault(false)
+
+    fun portalAvailable(): Boolean =
+        runCatching {
+            val output =
+                gdbus(
+                    "call",
+                    "--session",
+                    "--dest",
+                    "org.freedesktop.portal.Desktop",
+                    "--object-path",
+                    "/org/freedesktop/portal/desktop",
+                    "--method",
+                    "org.freedesktop.DBus.Properties.Get",
+                    "org.freedesktop.portal.FileChooser",
+                    "version",
+                    timeoutSec = 5,
+                )
+            output.contains("uint32") || output.contains("<uint32")
+        }.getOrDefault(false)
+
+    /**
+     * Calls `FileChooser.OpenFile` with [parentWindow] (e.g. `wayland:…` or
+     * `x11:…` or `""`) and returns the Request object path. The dialog may
+     * flash briefly; callers should [PortalRequest.close] immediately.
+     */
+    fun openFile(
+        parentWindow: String,
+        title: String,
+    ): PortalRequest {
+        // Stable handle_token so the request object path is predictable and
+        // still alive when we Close it (empty options let the portal pick a
+        // one-char token that can vanish before we parse the reply).
+        val token = "nucleus" + System.nanoTime().toString(16)
+        val options = "{'handle_token': <'$token'>}"
+        // gdbus prints: (objectpath '/org/freedesktop/portal/desktop/request/…',)
+        val output =
+            gdbus(
+                "call",
+                "--session",
+                "--dest",
+                "org.freedesktop.portal.Desktop",
+                "--object-path",
+                "/org/freedesktop/portal/desktop",
+                "--method",
+                "org.freedesktop.portal.FileChooser.OpenFile",
+                parentWindow,
+                title,
+                options,
+                timeoutSec = 15,
+            )
+        val path =
+            OBJECTPATH_REGEX.find(output)?.groupValues?.get(1)
+                ?: error("OpenFile did not return a request path:\n$output")
+        check(token in path) {
+            "request path does not contain our handle_token ($token): $path\n$output"
+        }
+        return PortalRequest(path)
+    }
+
+    class PortalRequest(
+        val requestPath: String,
+    ) {
+        /**
+         * Best-effort [Request.Close]. On several desktop portals (notably
+         * xdg-desktop-portal-gnome) the Request object path returned by
+         * OpenFile is not long-lived enough for a follow-up Close — the dialog
+         * is still parented; the object simply isn't exported under that path
+         * by the time a second call runs. Ignoring the failure keeps the e2e
+         * focused on the parenting contract we care about (export + accepted
+         * `parent_window`).
+         */
+        fun close() {
+            runCatching {
+                gdbus(
+                    "call",
+                    "--session",
+                    "--dest",
+                    "org.freedesktop.portal.Desktop",
+                    "--object-path",
+                    requestPath,
+                    "--method",
+                    "org.freedesktop.portal.Request.Close",
+                    timeoutSec = 5,
+                )
+            }
+        }
+    }
+
+    private fun gdbus(
+        vararg args: String,
+        timeoutSec: Long,
+    ): String {
+        val process =
+            ProcessBuilder(listOf("gdbus") + args)
+                .redirectErrorStream(true)
+                .start()
+        val finished = process.waitFor(timeoutSec, TimeUnit.SECONDS)
+        val text = process.inputStream.bufferedReader().readText()
+        if (!finished) {
+            process.destroyForcibly()
+            error("gdbus timed out after ${timeoutSec}s: ${args.joinToString(" ")}\n$text")
+        }
+        if (process.exitValue() != 0) {
+            error("gdbus exit ${process.exitValue()}: ${args.joinToString(" ")}\n$text")
+        }
+        return text
+    }
+
+    private val OBJECTPATH_REGEX =
+        Regex("""objectpath\s+'([^']+)'""")
+}


### PR DESCRIPTION
## Summary

- Expose Linux dialog-parent identities for XDG Desktop Portal / FileKit so Tao windows can own native file dialogs on both **Wayland** and **X11**
- **Wayland**: `TaoWindow.exportXdgForeignHandle()` → `XdgForeignExport` (unprefixed `xdg_foreign` token + `portalParent = wayland:…`); must stay open until pickers complete
- **X11**: `TaoWindow.x11WindowId` / `x11PortalParent` (`x11:<lowercase-hex>`)
- **Unified**: `TaoWindow.xdgPortalParent()` → sealed `XdgPortalParent.X11` | `XdgPortalParent.Wayland`
- Document that Linux `nativeHandle` stays `0` — a raw `wl_surface*` is not a portal parent

## Context

[FileKit #629](https://github.com/vinceglb/FileKit/pull/629) added typed JVM dialog parents (`windows` / `x11` / `wayland`) and a Nucleus sample, but Tao parenting only worked on Windows. Nucleus now exposes portal-ready Linux identifiers.

### FileKit adapter sketch

```kotlin
when (val parent = taoWindow.xdgPortalParent()) {
    is XdgPortalParent.X11 ->
        FileKitDialogParent.x11(parent.xid)
    is XdgPortalParent.Wayland -> {
        try {
            // settings.parent = FileKitDialogParent.wayland(parent.handle)
        } finally {
            parent.close()
        }
    }
    null -> { /* unparented */ }
}
```

## Test plan

- [x] `./gradlew :decorated-window-tao:apiCheck`
- [x] Live **Wayland** e2e (GNOME): `./gradlew :decorated-window-tao:taoHeadfulTest -Dnucleus.tao.headful.filter=xdg_foreign`
  - Real Tao window → `xdgPortalParent()` → session portal `FileChooser.OpenFile` with `parent_window=wayland:<token>` → PASS
- [x] Live **X11/XWayland** e2e: `./gradlew :decorated-window-tao:taoX11PortalE2E`
  - Forces `NUCLEUS_TAO_LINUX_RENDERER=x11` → XID `x11:<hex>` → portal OpenFile → PASS
- [ ] Manual: FileKit open/save with `FileKitDialogParent.wayland` / `.x11` while holding the export on Wayland
- [x] CI pre-merge green