### PR TITLE
fix(graalvm): resolve project class dirs for KMP named JVM targets

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationRuntimeFiles.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationRuntimeFiles.kt
@@ -35,6 +35,25 @@ internal class JvmApplicationRuntimeFiles(
 internal sealed class JvmApplicationRuntimeFilesProvider {
     abstract fun jvmApplicationRuntimeFiles(project: Project): JvmApplicationRuntimeFiles
 
+    /**
+     * Class directories produced by this app's own compilation (Kotlin + Java).
+     * Fed to the GraalVM orphan / project-class detectors (#441).
+     *
+     * Must resolve the **application's** JVM target output — including KMP named
+     * targets such as `jvm("desktop")` → `build/classes/kotlin/desktop/main` —
+     * not a hardcoded `jvm/main` path.
+     *
+     * Empty for [Custom] / `fromFiles` setups where the plugin does not own compilation.
+     */
+    open fun projectClassDirs(project: Project): FileCollection = project.files()
+
+    /**
+     * Tasks that produce [projectClassDirs] (e.g. `desktopMainClasses`, `classes`).
+     * [AnalyzeStaticMetadataTask] depends on these so Room/KSP outputs are on disk
+     * before the orphan detector walks the project class dirs.
+     */
+    open fun projectClassTaskDependencies(project: Project): Array<Any> = emptyArray()
+
     abstract class GradleJvmApplicationRuntimeFilesProvider : JvmApplicationRuntimeFilesProvider() {
         protected abstract val jarTaskName: String
         protected abstract val runtimeFiles: FileCollection
@@ -59,6 +78,11 @@ internal sealed class JvmApplicationRuntimeFilesProvider {
 
         override val runtimeFiles: FileCollection
             get() = sourceSet.runtimeClasspath
+
+        override fun projectClassDirs(project: Project): FileCollection = sourceSet.output.classesDirs
+
+        override fun projectClassTaskDependencies(project: Project): Array<Any> =
+            arrayOf(sourceSet.classesTaskName)
     }
 
     class FromKotlinMppTarget(
@@ -69,6 +93,16 @@ internal sealed class JvmApplicationRuntimeFilesProvider {
 
         override val runtimeFiles: FileCollection
             get() = target.compilations.getByName("main").runtimeDependencyFiles
+
+        override fun projectClassDirs(project: Project): FileCollection =
+            target.compilations.getByName("main").output.classesDirs
+
+        /**
+         * `compileAllTaskName` is target-aware (`desktopMainClasses`, `jvmMainClasses`, …)
+         * and already depends on compileKotlin + compileJava for that compilation.
+         */
+        override fun projectClassTaskDependencies(project: Project): Array<Any> =
+            arrayOf(target.compilations.getByName("main").compileAllTaskName)
     }
 
     class Custom(

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/analyzer/BytecodeAnalyzer.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/analyzer/BytecodeAnalyzer.kt
@@ -228,7 +228,13 @@ internal object BytecodeAnalyzer {
 
                         analyzeClassBytes(classBytes, reflectionEntries, resourcePatterns)
                         if (collectReferences) {
-                            referencedTypes.addAll(ClassReferenceCollector.collect(classBytes))
+                            // Nest-internal edges (Outer$Nested → Outer) must not hide Room
+                            // orphans; see OrphanProjectClassDetector.addExternalReferences.
+                            OrphanProjectClassDetector.addExternalReferences(
+                                sourceFqcn = internalName.replace('/', '.'),
+                                refs = ClassReferenceCollector.collect(classBytes),
+                                into = referencedTypes,
+                            )
                         }
                     } catch (_: IllegalArgumentException) {
                         // ASM does not support this class file version (e.g. JDK 25+) — skip
@@ -325,7 +331,11 @@ internal object BytecodeAnalyzer {
 
                     analyzeClassBytes(classBytes, reflectionEntries, resourcePatterns)
                     if (collectReferences) {
-                        referencedTypes.addAll(ClassReferenceCollector.collect(classBytes))
+                        OrphanProjectClassDetector.addExternalReferences(
+                            sourceFqcn = relativePath.replace('/', '.'),
+                            refs = ClassReferenceCollector.collect(classBytes),
+                            into = referencedTypes,
+                        )
                     }
                     if (collectProjectFacts) {
                         OrphanProjectClassDetector.inspect(classBytes)?.let { projectFacts.add(it) }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/analyzer/detectors/OrphanProjectClassDetector.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/analyzer/detectors/OrphanProjectClassDetector.kt
@@ -102,7 +102,8 @@ internal object OrphanProjectClassDetector {
     /**
      * @param projectFacts facts for the project's own compiled classes only
      * @param classpathReferencedTypes FQCNs referenced by any class on the full runtime
-     *   classpath (excluding self-references)
+     *   classpath (excluding self-references and nest-internal edges — see
+     *   [addExternalReferences])
      * @param appReferencedTypes FQCNs referenced by project class files only
      */
     fun detect(
@@ -119,6 +120,35 @@ internal object OrphanProjectClassDetector {
             entries.add(ReflectionEntry(type = fact.type, methods = setOf(NO_ARG_INIT)))
         }
         return entries
+    }
+
+    /**
+     * True when [source] is [outer] or a nested class of [outer] (JVM binary `$` nesting).
+     *
+     * Room (and similar generators) emit `AppDatabase_Impl$…` nested types that always
+     * use-site-reference the outer `_Impl`. Those edges must not disqualify the outer
+     * class as an orphan — it is still only reached via `Class.forName(… + "_Impl")`.
+     */
+    fun isNestMemberOf(
+        source: String,
+        outer: String,
+    ): Boolean = source == outer || source.startsWith("$outer$")
+
+    /**
+     * Adds [refs] collected from class [sourceFqcn] into [into], dropping edges from a
+     * nest member to its outer type(s). Self-references are already stripped by
+     * [ClassReferenceCollector].
+     */
+    fun addExternalReferences(
+        sourceFqcn: String,
+        refs: Set<String>,
+        into: MutableSet<String>,
+    ) {
+        for (ref in refs) {
+            if (!isNestMemberOf(sourceFqcn, ref)) {
+                into.add(ref)
+            }
+        }
     }
 
     /**

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -661,27 +661,11 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                     if (runtimeCfg != null) {
                         task.runtimeClasspath.from(runtimeCfg)
                     }
-                    // Include the project's own compiled classes (not just dependency JARs)
-                    // KMP projects use jvmMainClasses, standard JVM uses main sourceSet
-                    val jvmMainClasses =
-                        project.tasks.findByName("jvmMainClasses")
-                            ?: project.tasks.findByName("compileKotlinJvm")
-                            ?: project.tasks.findByName("compileKotlin")
-                    if (jvmMainClasses != null) {
-                        task.dependsOn(jvmMainClasses)
-                    }
-                    project.tasks.findByName("compileJava")?.let { task.dependsOn(it) }
-                    // Add class output directories
-                    for (dirPath in listOf(
-                        "classes/kotlin/jvm/main",
-                        "classes/kotlin/main",
-                        "classes/java/main",
-                    )) {
-                        val classDir = project.layout.buildDirectory.dir(dirPath)
-                        task.runtimeClasspath.from(classDir)
-                        // Separate collection for the orphan / project-class detectors (#441)
-                        task.projectClassDirs.from(classDir)
-                    }
+                    // Project class dirs for orphan / project-class detectors (#441).
+                    // Resolve from the application target's compilation output so KMP
+                    // named targets (jvm("desktop") → classes/kotlin/desktop/main) work;
+                    // hardcoding jvm/main misses Room *_Impl and friends on those apps.
+                    wireProjectClassOutputs(task)
                 }
             }
 
@@ -2309,6 +2293,107 @@ private fun JvmApplicationContext.collectNativeBuildTasks(runtimeConfigName: Str
     collectProjectResourceProjects(runtimeConfigName).map { p ->
         p.tasks.matching { it.name.startsWith("buildNative") }
     }
+
+/**
+ * Wires the app's own compilation class directories into [AnalyzeStaticMetadataTask]
+ * for orphan / project-class detection (#441).
+ *
+ * Prefers [JvmApplicationRuntimeFilesProvider.projectClassDirs] (target-aware:
+ * `jvm("desktop")`, default `jvm`, Kotlin/JVM `main`, Java `main`). Falls back to
+ * discovering every JVM main compilation when the app was configured via
+ * `fromFiles` / custom jars without a provider.
+ */
+private fun JvmApplicationContext.wireProjectClassOutputs(task: AnalyzeStaticMetadataTask) {
+    val provider = app.jvmApplicationRuntimeFilesProvider
+    val classDirs: FileCollection
+    val taskDeps: Array<Any>
+    if (provider != null) {
+        classDirs = provider.projectClassDirs(project)
+        taskDeps = provider.projectClassTaskDependencies(project)
+    } else {
+        classDirs = project.files(discoverProjectClassDirCollections(project))
+        taskDeps = discoverProjectClassTaskDependencies(project)
+    }
+    task.runtimeClasspath.from(classDirs)
+    task.projectClassDirs.from(classDirs)
+    if (taskDeps.isNotEmpty()) {
+        task.dependsOn(*taskDeps)
+    }
+}
+
+/**
+ * Fallback: class-output collections for every JVM `main` compilation in the project
+ * (KMP named targets, Kotlin/JVM, plain Java). Used when no runtime-files provider
+ * is configured.
+ */
+internal fun discoverProjectClassDirCollections(project: Project): List<FileCollection> {
+    val collections = mutableListOf<FileCollection>()
+
+    runCatching {
+        project.mppExtOrNull
+            ?.targets
+            ?.filter { it.platformType == KotlinPlatformType.jvm }
+            ?.forEach { target ->
+                target.compilations.findByName("main")?.output?.classesDirs?.let(collections::add)
+            }
+    }
+
+    runCatching {
+        project.kotlinJvmExtOrNull
+            ?.target
+            ?.compilations
+            ?.findByName("main")
+            ?.output
+            ?.classesDirs
+            ?.let(collections::add)
+    }
+
+    runCatching {
+        project.extensions
+            .findByType(JavaPluginExtension::class.java)
+            ?.sourceSets
+            ?.findByName("main")
+            ?.output
+            ?.classesDirs
+            ?.let(collections::add)
+    }
+
+    return collections
+}
+
+/** Task names that produce [discoverProjectClassDirCollections] outputs. */
+internal fun discoverProjectClassTaskDependencies(project: Project): Array<Any> {
+    val deps = mutableListOf<Any>()
+
+    runCatching {
+        project.mppExtOrNull
+            ?.targets
+            ?.filter { it.platformType == KotlinPlatformType.jvm }
+            ?.forEach { target ->
+                target.compilations.findByName("main")?.compileAllTaskName?.let(deps::add)
+            }
+    }
+
+    runCatching {
+        project.kotlinJvmExtOrNull
+            ?.target
+            ?.compilations
+            ?.findByName("main")
+            ?.compileAllTaskName
+            ?.let(deps::add)
+    }
+
+    runCatching {
+        project.extensions
+            .findByType(JavaPluginExtension::class.java)
+            ?.sourceSets
+            ?.findByName("main")
+            ?.classesTaskName
+            ?.let(deps::add)
+    }
+
+    return deps.toTypedArray()
+}
 
 /** Resource source directory collections declared by a project, across KMP JVM, Kotlin/JVM and plain Java. */
 private fun resourceSrcDirsOf(p: Project): List<FileCollection> {

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ProjectClassOutputsTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ProjectClassOutputsTest.kt
@@ -1,0 +1,69 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Regression for KMP named JVM targets (`jvm("desktop")`) and plain Java/Kotlin JVM:
+ * orphan / project-class detection (#441) must resolve compilation class dirs from the
+ * application target — not hard-coded `classes/kotlin/jvm/main` paths that miss
+ * `classes/kotlin/desktop/main`.
+ */
+class ProjectClassOutputsTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun fromGradleSourceSet_exposesClassesDirsAndClassesTask() {
+        val project = ProjectBuilder.builder().withProjectDir(tmp.newFolder()).build()
+        project.plugins.apply("java")
+        val sourceSet =
+            project.extensions
+                .getByType(JavaPluginExtension::class.java)
+                .sourceSets
+                .getByName("main")
+
+        val provider = JvmApplicationRuntimeFilesProvider.FromGradleSourceSet(sourceSet)
+
+        assertEquals(sourceSet.output.classesDirs, provider.projectClassDirs(project))
+        assertArrayEquals(arrayOf(sourceSet.classesTaskName), provider.projectClassTaskDependencies(project))
+    }
+
+    @Test
+    fun customProvider_hasNoProjectClassOutputs() {
+        val project = ProjectBuilder.builder().withProjectDir(tmp.newFolder()).build()
+        val provider =
+            JvmApplicationRuntimeFilesProvider.Custom(
+                runtimeJarFiles = project.files(),
+                mainJar = project.objects.fileProperty(),
+                taskDependencies = emptyArray(),
+            )
+
+        assertTrue(provider.projectClassDirs(project).isEmpty)
+        assertArrayEquals(emptyArray<Any>(), provider.projectClassTaskDependencies(project))
+    }
+
+    @Test
+    fun discoverFallback_usesJavaMainClassesWhenOnlyJavaPluginApplied() {
+        val project = ProjectBuilder.builder().withProjectDir(tmp.newFolder()).build()
+        project.plugins.apply("java")
+        val sourceSet =
+            project.extensions
+                .getByType(JavaPluginExtension::class.java)
+                .sourceSets
+                .getByName("main")
+
+        val dirs = discoverProjectClassDirCollections(project)
+        val deps = discoverProjectClassTaskDependencies(project)
+
+        assertEquals(1, dirs.size)
+        assertEquals(sourceSet.output.classesDirs, dirs.single())
+        assertArrayEquals(arrayOf(sourceSet.classesTaskName), deps)
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/analyzer/OrphanProjectClassDetectorTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/analyzer/OrphanProjectClassDetectorTest.kt
@@ -343,6 +343,91 @@ class OrphanProjectClassDetectorTest {
     }
 
     @Test
+    fun `nested class use-site of outer does not hide Room-shaped orphan`() {
+        // Real Room AppDatabase_Impl emits nested types (e.g. createOpenDelegate lambdas)
+        // that reference the outer _Impl. Those nest-internal edges must not disqualify it.
+        val root = Files.createTempDirectory("orphan-nested").toFile()
+        try {
+            val projectDir = File(root, "project").also { it.mkdirs() }
+            writeClass(projectDir, "com/example/AppDatabase", publicClass("com/example/AppDatabase", abstract = true))
+            writeClass(
+                projectDir,
+                "com/example/AppDatabase_Impl",
+                publicClass(
+                    "com/example/AppDatabase_Impl",
+                    superName = "com/example/AppDatabase",
+                    publicNoArgCtor = true,
+                ),
+            )
+            // Nested class with a field of the outer type — the classic false-negative shape.
+            writeClass(
+                projectDir,
+                "com/example/AppDatabase_Impl\$createOpenDelegate\$1",
+                publicClass(
+                    "com/example/AppDatabase_Impl\$createOpenDelegate\$1",
+                    superName = "java/lang/Object",
+                    publicNoArgCtor = true,
+                    referencedTypes = listOf("com/example/AppDatabase_Impl"),
+                ),
+            )
+            writeClass(
+                projectDir,
+                "com/example/App",
+                publicClass(
+                    "com/example/App",
+                    publicNoArgCtor = true,
+                    referencedTypes = listOf("com/example/AppDatabase"),
+                ),
+            )
+
+            val result =
+                BytecodeAnalyzer.analyzeClasspath(
+                    files = listOf(projectDir),
+                    projectClassDirs = listOf(projectDir),
+                    detectOrphanProjectClasses = true,
+                    reflectionForProjectClasses = false,
+                )
+
+            assertTrue(
+                "AppDatabase_Impl must stay an orphan despite nested-class references: " +
+                    result.projectClassEntries.map { it.type },
+                result.projectClassEntries.any { it.type == "com.example.AppDatabase_Impl" },
+            )
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `isNestMemberOf recognizes JVM binary nesting`() {
+        assertTrue(OrphanProjectClassDetector.isNestMemberOf("com.example.Outer", "com.example.Outer"))
+        assertTrue(
+            OrphanProjectClassDetector.isNestMemberOf(
+                "com.example.Outer\$Nested",
+                "com.example.Outer",
+            ),
+        )
+        assertTrue(
+            OrphanProjectClassDetector.isNestMemberOf(
+                "com.example.Outer\$Nested\$Deeper",
+                "com.example.Outer",
+            ),
+        )
+        assertFalse(
+            OrphanProjectClassDetector.isNestMemberOf(
+                "com.example.OuterImpl",
+                "com.example.Outer",
+            ),
+        )
+        assertFalse(
+            OrphanProjectClassDetector.isNestMemberOf(
+                "com.example.Other",
+                "com.example.Outer",
+            ),
+        )
+    }
+
+    @Test
     fun `inspect returns concretePublicNoArg for valid class`() {
         val bytes =
             publicClass("com/example/Ok", superName = "java/lang/Object", publicNoArgCtor = true)


### PR DESCRIPTION
## Summary

- Resolve GraalVM orphan / project-class detection class dirs from the application target’s compilation outputs (`desktopMainClasses`, `jvmMainClasses`, Java `classes`) instead of hardcoded `classes/kotlin/jvm/main` paths — fixes KMP apps using `jvm("desktop")` (e.g. Flocon) where Room `*_Impl` was never scanned.
- Ignore nest-internal use-site edges (`Outer$Nested` → `Outer`) so real Room-generated `AppDatabase_Impl` classes with nested types stay orphans (the smoke sample without nested types already worked).
- Fallback discovery for `fromFiles` / custom setups; unit tests for provider wiring and nested-class Room shape.

## Test plan

- [x] `:plugin:test` — `ProjectClassOutputsTest`, `OrphanProjectClassDetectorTest`
- [x] `:plugin:ktlintCheck`
- [x] Flocon composite includeBuild: `analyzeGraalvmStaticMetadata` logs `[orphan] …AppDatabase_Impl` (was 0)
- [x] Flocon `cleanupGraalvmMetadata` dry-run removes `AppDatabase_Impl` as baseline
- [ ] CI on PR