### PR TITLE
feat(plugin): per-format compression for AppImage and portable

### DIFF
--- a/examples/nucleus-demo/build.gradle.kts
+++ b/examples/nucleus-demo/build.gradle.kts
@@ -121,6 +121,8 @@ nucleus.application {
         homepage = "https://github.com/KdroidFilter/NucleusDemo"
 
         // --- Compression ---
+        // Ultra enables DEB xz -9e + DMG LZMA post-processing. AppImage/portable should stay
+        // lighter (FUSE/squashfs cold start and portable self-extract) via format overrides below.
         compressionLevel = CompressionLevel.Ultra
 
         // --- Artifact naming ---
@@ -185,6 +187,8 @@ nucleus.application {
                 category = AppImageCategory.Utility
                 genericName = "Nucleus Demo"
                 synopsis = "Demo app using Nucleus"
+                // Override root Ultra: maximum squashfs compression makes AppImage cold starts very slow.
+                compressionLevel = CompressionLevel.Normal
             }
 
             // --- Snap (NEW) ---
@@ -271,6 +275,12 @@ nucleus.application {
                 multiLanguageInstaller = true // Default: false
                 // Languages: "en_US", "fr_FR", "de_DE", "es_ES", "ja_JP", "zh_CN", etc.
                 installerLanguages = listOf("en_US", "fr_FR")
+            }
+
+            // --- Portable EXE ---
+            // Override root Ultra so self-extract stays reasonable while NSIS/DEB keep max packing.
+            portable {
+                compressionLevel = CompressionLevel.Normal
             }
 
             // --- AppX/Windows Store (NEW) ---

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/AppImageSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/AppImageSettings.kt
@@ -18,4 +18,14 @@ abstract class AppImageSettings {
 
     /** Additional desktop file entries (key=value) */
     var desktopEntries: Map<String, String> = emptyMap()
+
+    /**
+     * Archive compression for this AppImage only.
+     *
+     * Overrides the root [JvmApplicationDistributions.compressionLevel] when set.
+     * Prefer [CompressionLevel.Normal] or [CompressionLevel.Store]:
+     * [CompressionLevel.Maximum] / [CompressionLevel.Ultra] map to electron-builder
+     * `maximum` and can make cold starts very slow (squashfs/FUSE decompression).
+     */
+    var compressionLevel: CompressionLevel? = null
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/CompressionLevel.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/CompressionLevel.kt
@@ -5,7 +5,12 @@
 
 package dev.nucleusframework.desktop.application.dsl
 
-/** Archive compression level for electron-builder output. */
+/**
+ * Archive compression level for electron-builder output.
+ *
+ * Set globally via [JvmApplicationDistributions.compressionLevel], or per format via
+ * [AppImageSettings.compressionLevel] / [PortableSettings.compressionLevel].
+ */
 enum class CompressionLevel(
     internal val id: String,
 ) {
@@ -18,6 +23,8 @@ enum class CompressionLevel(
      * `"maximum"`), but additionally enables the plugin's post-processing recompression steps that
      * electron-builder's own `maximum` leaves on the table: LZMA (ULMO) for DMG and `xz -9e` for DEB.
      * These steps are slower and are therefore opt-in via this level rather than [Maximum].
+     *
+     * Not recommended for AppImage: use a format-local override to [Normal] or [Store] instead.
      */
     Ultra("maximum"),
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplicationDistributions.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplicationDistributions.kt
@@ -121,6 +121,16 @@ abstract class JvmApplicationDistributions : AbstractDistributions() {
 
     // --- Compression level for archive formats ---
 
+    /**
+     * Default archive compression for electron-builder packages.
+     *
+     * Per-format overrides take precedence when set:
+     * - AppImage: [LinuxPlatformSettings.appImage] → [AppImageSettings.compressionLevel]
+     * - Windows portable: [WindowsPlatformSettings.portable] → [PortableSettings.compressionLevel]
+     *
+     * [CompressionLevel.Maximum] / [CompressionLevel.Ultra] are not recommended for AppImage
+     * (slow FUSE/squashfs cold start); override that format to [CompressionLevel.Normal] instead.
+     */
     var compressionLevel: CompressionLevel? = null
 
     // --- Artifact name template (e.g., "\${name}-\${version}-\${arch}.\${ext}") ---

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/PlatformSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/PlatformSettings.kt
@@ -236,6 +236,12 @@ abstract class WindowsPlatformSettings : AbstractPlatformSettings() {
         fn.execute(appx)
     }
 
+    val portable: PortableSettings = objects.newInstance(PortableSettings::class.java)
+
+    fun portable(fn: Action<PortableSettings>) {
+        fn.execute(portable)
+    }
+
     val signing: WindowsSigningSettings = objects.newInstance(WindowsSigningSettings::class.java)
 
     fun signing(fn: Action<WindowsSigningSettings>) {

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/PortableSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/PortableSettings.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.dsl
+
+/**
+ * Settings for the Windows portable (self-extracting) package.
+ *
+ * ```kotlin
+ * nativeDistributions {
+ *     compressionLevel = CompressionLevel.Ultra
+ *     windows {
+ *         portable {
+ *             // Keep portable extraction snappy while DEB/DMG still use Ultra.
+ *             compressionLevel = CompressionLevel.Normal
+ *         }
+ *     }
+ * }
+ * ```
+ */
+@Suppress("AbstractClassCanBeConcreteClass") // Required abstract for Gradle ObjectFactory.newInstance()
+abstract class PortableSettings {
+    /**
+     * Archive compression for the portable EXE only.
+     *
+     * Overrides the root [JvmApplicationDistributions.compressionLevel] when set.
+     * Portable packages are self-extracting archives: higher levels shrink the download
+     * but slow first launch while the payload is unpacked.
+     */
+    var compressionLevel: CompressionLevel? = null
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -6,6 +6,7 @@
 package dev.nucleusframework.desktop.application.internal.electronbuilder
 
 import dev.nucleusframework.desktop.application.dsl.AppXSettings
+import dev.nucleusframework.desktop.application.dsl.CompressionLevel
 import dev.nucleusframework.desktop.application.dsl.DmgSettings
 import dev.nucleusframework.desktop.application.dsl.FileAssociation
 import dev.nucleusframework.desktop.application.dsl.FlatpakSettings
@@ -19,6 +20,24 @@ import dev.nucleusframework.internal.utils.Arch
 import dev.nucleusframework.internal.utils.OS
 import dev.nucleusframework.internal.utils.currentOS
 import java.io.File
+
+/**
+ * Effective electron-builder compression for [targetFormat].
+ *
+ * Format-local overrides ([AppImageSettings.compressionLevel], [PortableSettings.compressionLevel])
+ * win over the root [JvmApplicationDistributions.compressionLevel].
+ */
+internal fun resolveCompressionLevel(
+    distributions: JvmApplicationDistributions,
+    targetFormat: TargetFormat,
+): CompressionLevel? =
+    when (targetFormat) {
+        TargetFormat.AppImage ->
+            distributions.linux.appImage.compressionLevel ?: distributions.compressionLevel
+        TargetFormat.Portable ->
+            distributions.windows.portable.compressionLevel ?: distributions.compressionLevel
+        else -> distributions.compressionLevel
+    }
 
 /**
  * Generates an electron-builder YAML configuration from the Gradle DSL settings.
@@ -88,7 +107,7 @@ internal class ElectronBuilderConfigGenerator {
         yaml.appendLine("directories:")
         yaml.appendLine("  output: .")
 
-        appendIfNotNull(yaml, "compression", distributions.compressionLevel?.id)
+        appendIfNotNull(yaml, "compression", resolveCompressionLevel(distributions, targetFormat)?.id)
         yaml.appendLine("artifactName: ${withTargetSuffix(distributions.artifactName, targetFormat)}")
         generateFileAssociations(yaml, distributions, targetFormat)
 
@@ -298,7 +317,11 @@ internal class ElectronBuilderConfigGenerator {
                 yaml.appendLine("  perMachine: ${!distributions.windows.perUserInstall}")
             }
             TargetFormat.AppX -> generateAppXConfig(yaml, distributions.windows.appx)
-            TargetFormat.Portable -> yaml.appendLine("portable: {}")
+            TargetFormat.Portable -> {
+                // electron-builder only honors top-level `compression` for portable;
+                // the block is still required so the target is configured.
+                yaml.appendLine("portable: {}")
+            }
             else -> {}
         }
     }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -24,6 +24,7 @@ import dev.nucleusframework.desktop.application.internal.electronbuilder.Electro
 import dev.nucleusframework.desktop.application.internal.electronbuilder.ElectronBuilderInvocation
 import dev.nucleusframework.desktop.application.internal.electronbuilder.ElectronBuilderToolManager
 import dev.nucleusframework.desktop.application.internal.electronbuilder.NodeJsDetector
+import dev.nucleusframework.desktop.application.internal.electronbuilder.resolveCompressionLevel
 import dev.nucleusframework.desktop.application.internal.files.isDylibPath
 import dev.nucleusframework.desktop.application.internal.MACOS_DMG_TITLE_BAR_HEIGHT
 import dev.nucleusframework.desktop.application.internal.padDmgBackgroundForTitleBar
@@ -423,10 +424,15 @@ abstract class AbstractElectronBuilderPackageTask
             }
 
             // Both Maximum and Ultra map to electron-builder's "maximum"; warn for either.
-            if (targetFormat == TargetFormat.AppImage && distributions.compressionLevel?.id == "maximum") {
+            // Honor the AppImage-local override so Ultra globally + Normal on AppImage stays quiet.
+            val effectiveCompression =
+                resolveCompressionLevel(distributions, targetFormat)
+            if (targetFormat == TargetFormat.AppImage && effectiveCompression?.id == "maximum") {
                 logger.warn(
                     "AppImage with 'maximum' compression can cause extremely slow startup times (60s+) " +
-                        "due to squashfs/FUSE decompression overhead. Consider 'normal' or 'store' instead. " +
+                        "due to squashfs/FUSE decompression overhead. Prefer " +
+                        "linux { appImage { compressionLevel = CompressionLevel.Normal } } " +
+                        "(or Store), or lower the root compressionLevel. " +
                         "See https://github.com/electron-userland/electron-builder/issues/7483",
                 )
             }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/dsl/CompressionLevelIdsTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/dsl/CompressionLevelIdsTest.kt
@@ -9,5 +9,7 @@ class CompressionLevelIdsTest {
         assertEquals("store", CompressionLevel.Store.id)
         assertEquals("normal", CompressionLevel.Normal.id)
         assertEquals("maximum", CompressionLevel.Maximum.id)
+        // Ultra reuses electron-builder's maximum id; extra post-processing is plugin-side.
+        assertEquals("maximum", CompressionLevel.Ultra.id)
     }
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderCompressionConfigTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderCompressionConfigTest.kt
@@ -1,0 +1,98 @@
+package dev.nucleusframework.desktop.application.internal.electronbuilder
+
+import dev.nucleusframework.desktop.application.dsl.CompressionLevel
+import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
+import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import dev.nucleusframework.internal.utils.Arch
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * End-to-end check that the electron-builder YAML emits the effective compression for the
+ * format under build (AppImage override, portable override, global fallback).
+ *
+ * Full packaging is too heavy for unit tests; this validates the config that electron-builder
+ * actually receives.
+ */
+class ElectronBuilderCompressionConfigTest {
+    private fun distributions(): JvmApplicationDistributions =
+        ProjectBuilder
+            .builder()
+            .build()
+            .objects
+            .newInstance(JvmApplicationDistributions::class.java)
+            .also {
+                it.appName = "CompressionDemo"
+                it.packageName = "CompressionDemo"
+            }
+
+    private fun render(
+        distributions: JvmApplicationDistributions,
+        targetFormat: TargetFormat,
+    ): String {
+        // generateConfig branches on currentOS for platform blocks, but top-level `compression`
+        // is always written. Use formats that match the host when possible; AppImage/Portable
+        // still get the shared compression line either way.
+        return ElectronBuilderConfigGenerator().generateConfig(
+            distributions = distributions,
+            targetFormat = targetFormat,
+            appImageDir = java.io.File("."),
+            targetArch = Arch.X64,
+            executableName = "compressiondemo",
+        )
+    }
+
+    @Test
+    fun `appImage yaml uses format override not global Ultra`() {
+        val dist = distributions()
+        dist.compressionLevel = CompressionLevel.Ultra
+        dist.linux.appImage.compressionLevel = CompressionLevel.Normal
+
+        val yaml = render(dist, TargetFormat.AppImage)
+
+        assertTrue(yaml, yaml.contains("compression: \"normal\""))
+        assertFalse(yaml, yaml.contains("compression: \"maximum\""))
+    }
+
+    @Test
+    fun `portable yaml uses format override not global Ultra`() {
+        val dist = distributions()
+        dist.compressionLevel = CompressionLevel.Ultra
+        dist.windows.portable.compressionLevel = CompressionLevel.Store
+
+        val yaml = render(dist, TargetFormat.Portable)
+
+        assertTrue(yaml, yaml.contains("compression: \"store\""))
+        assertFalse(yaml, yaml.contains("compression: \"maximum\""))
+    }
+
+    @Test
+    fun `deb yaml keeps global Ultra when only appImage is overridden`() {
+        val dist = distributions()
+        dist.compressionLevel = CompressionLevel.Ultra
+        dist.linux.appImage.compressionLevel = CompressionLevel.Normal
+
+        val yaml = render(dist, TargetFormat.Deb)
+
+        assertTrue(yaml, yaml.contains("compression: \"maximum\""))
+    }
+
+    @Test
+    fun `nsis yaml keeps global Ultra when only portable is overridden`() {
+        val dist = distributions()
+        dist.compressionLevel = CompressionLevel.Ultra
+        dist.windows.portable.compressionLevel = CompressionLevel.Normal
+
+        val yaml = render(dist, TargetFormat.Nsis)
+
+        assertTrue(yaml, yaml.contains("compression: \"maximum\""))
+    }
+
+    @Test
+    fun `no compression line when unset`() {
+        val yaml = render(distributions(), TargetFormat.AppImage)
+        assertFalse(yaml, yaml.lines().any { it.startsWith("compression:") })
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ResolveCompressionLevelTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ResolveCompressionLevelTest.kt
@@ -1,0 +1,87 @@
+package dev.nucleusframework.desktop.application.internal.electronbuilder
+
+import dev.nucleusframework.desktop.application.dsl.CompressionLevel
+import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
+import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Per-format compression overrides for AppImage and Windows portable.
+ *
+ * Global [JvmApplicationDistributions.compressionLevel] stays the default; format-local
+ * settings win so apps can keep Ultra for DEB/DMG while packaging AppImage/portable lighter.
+ */
+class ResolveCompressionLevelTest {
+    private fun distributions(): JvmApplicationDistributions =
+        ProjectBuilder.builder().build().objects.newInstance(JvmApplicationDistributions::class.java)
+
+    @Test
+    fun `null global and no override yields null`() {
+        val dist = distributions()
+        assertNull(resolveCompressionLevel(dist, TargetFormat.AppImage))
+        assertNull(resolveCompressionLevel(dist, TargetFormat.Portable))
+        assertNull(resolveCompressionLevel(dist, TargetFormat.Deb))
+    }
+
+    @Test
+    fun `global level applies to every format without override`() {
+        val dist = distributions()
+        dist.compressionLevel = CompressionLevel.Ultra
+
+        assertEquals(CompressionLevel.Ultra, resolveCompressionLevel(dist, TargetFormat.AppImage))
+        assertEquals(CompressionLevel.Ultra, resolveCompressionLevel(dist, TargetFormat.Portable))
+        assertEquals(CompressionLevel.Ultra, resolveCompressionLevel(dist, TargetFormat.Deb))
+        assertEquals(CompressionLevel.Ultra, resolveCompressionLevel(dist, TargetFormat.Nsis))
+        assertEquals(CompressionLevel.Ultra, resolveCompressionLevel(dist, TargetFormat.Dmg))
+    }
+
+    @Test
+    fun `appImage override wins over global`() {
+        val dist = distributions()
+        dist.compressionLevel = CompressionLevel.Ultra
+        dist.linux.appImage.compressionLevel = CompressionLevel.Normal
+
+        assertEquals(CompressionLevel.Normal, resolveCompressionLevel(dist, TargetFormat.AppImage))
+        // Sibling Linux formats keep the global level.
+        assertEquals(CompressionLevel.Ultra, resolveCompressionLevel(dist, TargetFormat.Deb))
+        assertEquals(CompressionLevel.Ultra, resolveCompressionLevel(dist, TargetFormat.Rpm))
+    }
+
+    @Test
+    fun `portable override wins over global`() {
+        val dist = distributions()
+        dist.compressionLevel = CompressionLevel.Ultra
+        dist.windows.portable.compressionLevel = CompressionLevel.Store
+
+        assertEquals(CompressionLevel.Store, resolveCompressionLevel(dist, TargetFormat.Portable))
+        // Sibling Windows formats keep the global level.
+        assertEquals(CompressionLevel.Ultra, resolveCompressionLevel(dist, TargetFormat.Nsis))
+        assertEquals(CompressionLevel.Ultra, resolveCompressionLevel(dist, TargetFormat.Msi))
+    }
+
+    @Test
+    fun `format override without global is still used`() {
+        val dist = distributions()
+        dist.linux.appImage.compressionLevel = CompressionLevel.Store
+        dist.windows.portable.compressionLevel = CompressionLevel.Normal
+
+        assertEquals(CompressionLevel.Store, resolveCompressionLevel(dist, TargetFormat.AppImage))
+        assertEquals(CompressionLevel.Normal, resolveCompressionLevel(dist, TargetFormat.Portable))
+        assertNull(resolveCompressionLevel(dist, TargetFormat.Deb))
+    }
+
+    @Test
+    fun `appImage and portable overrides are independent`() {
+        val dist = distributions()
+        dist.compressionLevel = CompressionLevel.Maximum
+        dist.linux.appImage.compressionLevel = CompressionLevel.Normal
+        dist.windows.portable.compressionLevel = CompressionLevel.Store
+
+        assertEquals(CompressionLevel.Normal, resolveCompressionLevel(dist, TargetFormat.AppImage))
+        assertEquals(CompressionLevel.Store, resolveCompressionLevel(dist, TargetFormat.Portable))
+        assertEquals(CompressionLevel.Maximum, resolveCompressionLevel(dist, TargetFormat.Nsis))
+    }
+}


### PR DESCRIPTION
## Summary

- Add `linux { appImage { compressionLevel } }` and `windows { portable { compressionLevel } }` overrides over the root `nativeDistributions.compressionLevel`
- Resolve the effective level in electron-builder config so each package task gets the right `compression` value
- Silence the AppImage maximum-compression warning when an AppImage-local override is not maximum; point the warning at the format override DSL
- Document the pattern in nucleus-demo (Ultra global, Normal for AppImage and portable)

## Test plan

- [x] `:plugin:test` — `ResolveCompressionLevelTest`, `ElectronBuilderCompressionConfigTest`, `CompressionLevelIdsTest`
- [x] Configure `:examples:nucleus-demo` with the new DSL
- [ ] CI green on this PR