### PR TITLE
feat(tao): NSWindow dialog parent for macOS

### DIFF
--- a/decorated-window-tao/api/decorated-window-tao.api
+++ b/decorated-window-tao/api/decorated-window-tao.api
@@ -678,6 +678,7 @@ public final class dev/nucleusframework/window/tao/TaoWindow {
 	public final fun focus ()V
 	public final fun getHandle ()J
 	public final fun getNativeHandle ()J
+	public final fun getNsWindowHandle ()Ljava/lang/Long;
 	public final fun getScaleFactor ()F
 	public final fun getX11PortalParent ()Ljava/lang/String;
 	public final fun getX11WindowId ()Ljava/lang/Long;

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -390,9 +390,11 @@ public class TaoWindow internal constructor(
 
     /**
      * Returns the underlying native window handle for the current platform:
-     *  - Windows: HWND as a `Long` (0 if unavailable).
+     *  - Windows: HWND as a `Long` (0 if unavailable). Suitable for
+     *    `FileKitDialogParent.windows`.
      *  - macOS: NSView pointer as a `Long` — the AppKit subview hosting the
-     *    Compose surface. The owning NSWindow can be obtained via `[view window]`.
+     *    Compose surface. For dialog/sheet parenting use [nsWindowHandle]
+     *    instead; an NSView is not a valid `beginSheetModalForWindow:` parent.
      *  - Linux: returns 0. Prefer [x11WindowId] (X11 portal parent) or
      *    [exportXdgForeignHandle] (Wayland portal parent) — a raw `wl_surface*`
      *    is not a valid XDG Desktop Portal parent.
@@ -407,6 +409,28 @@ public class TaoWindow internal constructor(
                 Platform.MacOS -> NativeTaoBridge.nativeNsViewHandle(handle)
                 else -> 0L
             }
+
+    /**
+     * macOS only: the owning `NSWindow*` for native dialog parenting
+     * (`beginSheetModalForWindow:`, future FileKit sheet parents).
+     * `null` when not on macOS, not yet realized, or the native bridge is
+     * unavailable.
+     *
+     * Distinct from [nativeHandle], which is the Compose host `NSView*` on
+     * macOS. Borrow the pointer for the duration of the picker call only —
+     * FileKit-style adapters do not extend its lifetime.
+     *
+     * ### Adapter sketch
+     * ```kotlin
+     * // Once FileKit accepts an NSWindow parent:
+     * // window.nsWindowHandle?.let { FileKitDialogParent.macos(it) }
+     * ```
+     */
+    public val nsWindowHandle: Long?
+        get() {
+            if (Platform.Current != Platform.MacOS || !NativeTaoBridge.isLoaded) return null
+            return NativeTaoBridge.nativeNsWindowHandle(handle).takeIf { it != 0L }
+        }
 
     /**
      * Linux/X11 only: the window's XID for XDG Desktop Portal parenting

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -191,9 +191,36 @@ internal object NativeTaoBridge {
      * be called on the macOS main thread. Returns 0 if the window does not
      * exist (yet) or has been closed. Only resolvable on macOS — calling on
      * other platforms throws `UnsatisfiedLinkError`.
+     *
+     * Prefer [nativeNsWindowHandle] / [TaoWindow.nsWindowHandle] when the goal
+     * is dialog parenting (sheets) rather than rendering into the view.
      */
     @JvmStatic
     external fun nativeNsViewHandle(handle: Long): Long
+
+    /**
+     * macOS only: returns the owning `NSWindow*` for [handle] (cast to
+     * `Long`), or 0 if the window is unknown / not yet realized.
+     *
+     * Intended for native dialog parenting (`beginSheetModalForWindow:`,
+     * future FileKit `FileKitDialogParent.macos`). Distinct from
+     * [nativeNsViewHandle] — an NSView is not a valid sheet parent.
+     */
+    @JvmStatic
+    external fun nativeNsWindowHandle(handle: Long): Long
+
+    /**
+     * macOS only, headful e2e: present a real `NSOpenPanel` as a sheet on
+     * [nsWindow], confirm attachment (and that [nsView] is in that window's
+     * hierarchy), then cancel. Return codes:
+     * `1` ok, `0` window not found, `-1` view not in hierarchy,
+     * `-2` sheet did not attach, `-3` sheet did not dismiss cleanly.
+     */
+    @JvmStatic
+    external fun nativeMacOsProbeSheetParent(
+        nsWindow: Long,
+        nsView: Long,
+    ): Int
 
     /**
      * Windows counterpart of [nativeNsViewHandle]: returns the HWND so the JVM

--- a/decorated-window-tao/src/main/native/build.rs
+++ b/decorated-window-tao/src/main/native/build.rs
@@ -5,6 +5,7 @@ fn main() {
             .file("macos/a11y.m")
             .file("macos/window_drag.m")
             .file("macos/touchpad_gestures.m")
+            .file("macos/dialog_parent.m")
             .flag("-fobjc-arc")
             .flag("-mmacosx-version-min=10.15")
             .compile("nucleus_tao_objc_helpers");
@@ -13,5 +14,6 @@ fn main() {
         println!("cargo:rerun-if-changed=macos/a11y.m");
         println!("cargo:rerun-if-changed=macos/window_drag.m");
         println!("cargo:rerun-if-changed=macos/touchpad_gestures.m");
+        println!("cargo:rerun-if-changed=macos/dialog_parent.m");
     }
 }

--- a/decorated-window-tao/src/main/native/macos/dialog_parent.m
+++ b/decorated-window-tao/src/main/native/macos/dialog_parent.m
@@ -1,0 +1,158 @@
+// dialog_parent.m
+//
+// Headful e2e helper: prove a Tao-exported NSWindow* can own an NSOpenPanel
+// sheet (FileKit-style dialog parenting via beginSheetModalForWindow:).
+// Not used by the product path — only by the taoHeadfulTest suite.
+
+#import <Cocoa/Cocoa.h>
+#include <stdint.h>
+
+/// Pointer equality walk — never messages [target]; safe for any bit pattern.
+static BOOL view_tree_contains_ptr(NSView *root, void *target) {
+    if (root == nil || target == NULL) {
+        return NO;
+    }
+    if ((__bridge void *)root == target) {
+        return YES;
+    }
+    for (NSView *child in root.subviews) {
+        if (view_tree_contains_ptr(child, target)) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static NSWindow *find_window_by_ptr(void *raw) {
+    if (raw == NULL) {
+        return nil;
+    }
+    for (NSWindow *win in NSApp.windows) {
+        if ((__bridge void *)win == raw) {
+            return win;
+        }
+    }
+    return nil;
+}
+
+static void pump_main_runloop(NSTimeInterval seconds) {
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:seconds];
+    while ([deadline timeIntervalSinceNow] > 0) {
+        BOOL more = [[NSRunLoop currentRunLoop]
+            runMode:NSDefaultRunLoopMode
+            beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.02]];
+        if (!more) {
+            // No sources ready — still wait out a slice so timers/async work.
+            [NSThread sleepForTimeInterval:0.005];
+        }
+    }
+}
+
+/**
+ * Present an NSOpenPanel as a sheet on [ns_window_ptr], verify attachment,
+ * then cancel it. Optionally check that [ns_view_ptr] lives in that window's
+ * view tree (Tao nativeHandle is the Compose NSView).
+ *
+ * Return codes (mirrored by the Kotlin headful probe):
+ *   1  — sheet attached to the parent and dismissed cleanly
+ *   0  — ns_window_ptr not found among NSApp.windows
+ *  -1  — ns_view_ptr not in the parent's view hierarchy
+ *  -2  — beginSheetModalForWindow did not attach a sheet
+ *  -3  — sheet failed to dismiss / completion handler did not fire
+ */
+int nucleus_tao_probe_sheet_parent(int64_t ns_window_ptr, int64_t ns_view_ptr) {
+    __block int code = 0;
+
+    void (^work)(void) = ^{
+        @autoreleasepool {
+            NSWindow *parent = find_window_by_ptr((void *)(intptr_t)ns_window_ptr);
+            if (parent == nil) {
+                code = 0;
+                return;
+            }
+
+            if (ns_view_ptr != 0) {
+                void *viewPtr = (void *)(intptr_t)ns_view_ptr;
+                NSView *content = parent.contentView;
+                BOOL inTree = view_tree_contains_ptr(content, viewPtr);
+                // Tao may also place chrome outside contentView; check titlebar
+                // container when present (macOS 10.10+).
+                if (!inTree) {
+                    NSView *themeFrame = parent.contentView.superview;
+                    inTree = view_tree_contains_ptr(themeFrame, viewPtr);
+                }
+                if (!inTree) {
+                    code = -1;
+                    return;
+                }
+            }
+
+            NSOpenPanel *panel = [NSOpenPanel openPanel];
+            panel.message = @"Nucleus nsWindow sheet e2e";
+            panel.canChooseFiles = YES;
+            panel.canChooseDirectories = NO;
+            panel.allowsMultipleSelection = NO;
+            panel.prompt = @"E2E";
+
+            __block BOOL completed = NO;
+            [panel beginSheetModalForWindow:parent
+                          completionHandler:^(__unused NSModalResponse response) {
+                              completed = YES;
+                          }];
+
+            // Sheet attachment is async relative to beginSheet…; pump until
+            // AppKit wires attachedSheet / sheets, or time out.
+            NSDate *attachDeadline = [NSDate dateWithTimeIntervalSinceNow:3.0];
+            while (parent.attachedSheet == nil &&
+                   ![parent.sheets containsObject:panel] &&
+                   [attachDeadline timeIntervalSinceNow] > 0) {
+                [[NSRunLoop currentRunLoop]
+                    runMode:NSDefaultRunLoopMode
+                    beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.02]];
+            }
+
+            BOOL attached = (parent.attachedSheet == panel) ||
+                            [parent.sheets containsObject:panel] ||
+                            (panel.sheetParent == parent);
+            if (!attached) {
+                [panel orderOut:nil];
+                code = -2;
+                return;
+            }
+
+            [parent endSheet:panel returnCode:NSModalResponseCancel];
+
+            NSDate *endDeadline = [NSDate dateWithTimeIntervalSinceNow:3.0];
+            while ((!completed || parent.attachedSheet != nil) &&
+                   [endDeadline timeIntervalSinceNow] > 0) {
+                [[NSRunLoop currentRunLoop]
+                    runMode:NSDefaultRunLoopMode
+                    beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.02]];
+            }
+
+            if (parent.attachedSheet != nil || [parent.sheets containsObject:panel]) {
+                [panel orderOut:nil];
+                code = -3;
+                return;
+            }
+            if (!completed) {
+                // Sheet gone but completion never ran — still treat as soft
+                // failure so we notice AppKit lifecycle changes.
+                code = -3;
+                return;
+            }
+
+            // Drain a few more ticks so nothing from the sheet lingers into
+            // the next headful case.
+            pump_main_runloop(0.05);
+            code = 1;
+        }
+    };
+
+    if ([NSThread isMainThread]) {
+        work();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), work);
+    }
+    return code;
+}

--- a/decorated-window-tao/src/main/native/src/lib.rs
+++ b/decorated-window-tao/src/main/native/src/lib.rs
@@ -6,9 +6,10 @@
 //
 // Common responsibilities:
 //   - Owns the Tao event loop on the platform main thread.
-//   - Exposes the underlying native window handle (NSView on macOS, HWND on
-//     Windows, X11 / Wayland handles on Linux) so the JVM can attach a render
-//     surface and drive a Skiko/Compose render pipeline outside AWT.
+//   - Exposes the underlying native window handles (NSView + NSWindow on
+//     macOS, HWND on Windows, X11 / Wayland / xdg_foreign on Linux) so the JVM
+//     can attach a render surface, parent native dialogs, and drive a
+//     Skiko/Compose render pipeline outside AWT.
 //   - Dispatches pointer / mouse-button / keyboard events to Kotlin.
 //
 // Module layout (Rust idiomatic split):

--- a/decorated-window-tao/src/main/native/src/platform/macos/ffi.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/ffi.rs
@@ -41,6 +41,8 @@ extern "C" {
     pub(crate) fn nucleus_tao_a11y_note_pushed();
     pub(crate) fn nucleus_tao_install_drag_monitor();
     pub(crate) fn nucleus_tao_start_window_drag(ns_window_ptr: i64);
+    /// Headful e2e: beginSheetModalForWindow on [ns_window_ptr], cancel, report status.
+    pub(crate) fn nucleus_tao_probe_sheet_parent(ns_window_ptr: i64, ns_view_ptr: i64) -> i32;
     pub(crate) fn nucleus_tao_register_trackpad_gesture_callback(
         cb: extern "C" fn(
             ns_window_ptr: i64,

--- a/decorated-window-tao/src/main/native/src/platform/macos/handles.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/handles.rs
@@ -1,4 +1,8 @@
-// NSView pointer JNI export. The JVM uses this to attach a CAMetalLayer.
+// NSView / NSWindow pointer JNI exports.
+//
+// - NSView: JVM attaches a CAMetalLayer for Compose rendering.
+// - NSWindow: dialog parenting (FileKit sheets via beginSheetModalForWindow:).
+//   An NSView is not a valid sheet parent — callers must use the NSWindow.
 
 use jni::objects::JClass;
 use jni::sys::jlong;
@@ -23,4 +27,36 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_
     let Some(map) = guard.as_ref() else { return 0 };
     let Some(window) = map.get(&(handle as u64)) else { return 0 };
     window.ns_view() as jlong
+}
+
+/// Returns the underlying NSWindow pointer for dialog parenting (FileKit sheets,
+/// `beginSheetModalForWindow:`, etc.). Distinct from the NSView returned by
+/// [nativeNsViewHandle]. Safe while the Tao window is alive; 0 if unknown.
+#[no_mangle]
+pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_nativeNsWindowHandle(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+) -> jlong {
+    let guard = match WINDOWS.lock() {
+        Ok(g) => g,
+        Err(_) => return 0,
+    };
+    let Some(map) = guard.as_ref() else { return 0 };
+    let Some(window) = map.get(&(handle as u64)) else { return 0 };
+    window.ns_window() as jlong
+}
+
+/// Headful e2e only: present a real `NSOpenPanel` sheet on [ns_window], verify
+/// it attaches (and that [ns_view] lives in that window's hierarchy), then
+/// cancel. See `macos/dialog_parent.m` for return codes.
+#[no_mangle]
+pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_nativeMacOsProbeSheetParent(
+    _env: JNIEnv,
+    _class: JClass,
+    ns_window: jlong,
+    ns_view: jlong,
+) -> jni::sys::jint {
+    use crate::platform::macos::ffi::nucleus_tao_probe_sheet_parent;
+    unsafe { nucleus_tao_probe_sheet_parent(ns_window as i64, ns_view as i64) }
 }

--- a/decorated-window-tao/src/main/native/src/platform/macos/mod.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/mod.rs
@@ -5,7 +5,7 @@
 //                       Objective-C helpers compiled by `build.rs`.
 //   - `main_thread`   — JWM-style main-thread bouncing (NSApplication's event
 //                       loop must run on the OS main thread).
-//   - `handles`       — NSView pointer JNI export.
+//   - `handles`       — NSView + NSWindow pointer JNI exports.
 //   - `ime`           — caret rectangle / input-context activation.
 //   - `apple_events`  — `kAEGetURL` deep-link bridge.
 //   - `a11y`          — VoiceOver bridge (snapshot push + action callbacks).

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacOsSheetParentProbe.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacOsSheetParentProbe.kt
@@ -1,0 +1,31 @@
+package dev.nucleusframework.window.tao.headful
+
+import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+
+/**
+ * Thin wrapper around the macOS headful helper that parents a real
+ * [NSOpenPanel] sheet on a Tao [NSWindow] (mirrors [XdgPortalFileChooser] for
+ * the Linux portal path).
+ */
+internal object MacOsSheetParentProbe {
+    const val OK: Int = 1
+    const val WINDOW_NOT_FOUND: Int = 0
+    const val VIEW_NOT_IN_HIERARCHY: Int = -1
+    const val SHEET_DID_NOT_ATTACH: Int = -2
+    const val SHEET_DID_NOT_DISMISS: Int = -3
+
+    fun probe(
+        nsWindow: Long,
+        nsView: Long,
+    ): Int = NativeTaoBridge.nativeMacOsProbeSheetParent(nsWindow, nsView)
+
+    fun describe(code: Int): String =
+        when (code) {
+            OK -> "ok (sheet attached and cancelled)"
+            WINDOW_NOT_FOUND -> "NSWindow* not found in NSApp.windows"
+            VIEW_NOT_IN_HIERARCHY -> "NSView* not in parent window view hierarchy"
+            SHEET_DID_NOT_ATTACH -> "beginSheetModalForWindow did not attach a sheet"
+            SHEET_DID_NOT_DISMISS -> "sheet failed to dismiss / completion did not fire"
+            else -> "unknown code $code"
+        }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -284,6 +284,70 @@ public object TaoHeadfulTestSuiteMain {
                     open.close()
                 }
             },
+            // macOS dialog-parent e2e (real AppKit sheet, not a pointer smoke
+            // check): resolve the live NSWindow*, prove it is distinct from the
+            // Compose NSView, then parent a real NSOpenPanel via
+            // beginSheetModalForWindow: and cancel it. Mirrors the Linux portal
+            // FileChooser round-trips. FileKit's JVM picker still uses
+            // application-modal runModal() and has no .macos factory yet —
+            // this proves the Nucleus side of the sheet-parent contract.
+            TaoWindowTestCase(
+                name = "nsWindowHandle parents a real NSOpenPanel sheet",
+                timeoutMillis = 45_000L,
+                skip = { if (!isMac) "macOS only" else null },
+            ) {
+                awaitUntil("window mapped") { bounds() != null }
+                settle()
+
+                val nsView = window.nativeHandle
+                check(nsView != 0L) { "nativeHandle (NSView) must be non-zero on a mapped window" }
+
+                val nsWindow =
+                    checkNotNull(window.nsWindowHandle) {
+                        "nsWindowHandle null on a realized macOS window"
+                    }
+                check(nsWindow != 0L) { "nsWindowHandle must not be zero" }
+                // NSView* and NSWindow* are distinct AppKit objects.
+                check(nsWindow != nsView) {
+                    "nsWindowHandle must not equal nativeHandle (NSView); got both=$nsView"
+                }
+                // Stable while the window is alive (same pointer on re-read).
+                check(window.nsWindowHandle == nsWindow) {
+                    "nsWindowHandle must be stable across reads"
+                }
+                // Linux portal APIs must stay null on macOS.
+                check(window.x11WindowId == null)
+                check(window.x11PortalParent == null)
+                check(window.exportXdgForeignHandle(timeoutMs = 200L) == null)
+                check(window.xdgPortalParent(timeoutMs = 200L) == null)
+
+                // Negative: an NSView pointer is not a sheet parent — AppKit
+                // must not find it among NSApp.windows as an NSWindow.
+                val wrongParent =
+                    MacOsSheetParentProbe.probe(nsWindow = nsView, nsView = 0L)
+                check(wrongParent == MacOsSheetParentProbe.WINDOW_NOT_FOUND) {
+                    "NSView must not parent a sheet; got ${MacOsSheetParentProbe.describe(wrongParent)}"
+                }
+
+                // Positive: real beginSheetModalForWindow: + cancel.
+                val code = MacOsSheetParentProbe.probe(nsWindow = nsWindow, nsView = nsView)
+                check(code == MacOsSheetParentProbe.OK) {
+                    "sheet parent probe failed: ${MacOsSheetParentProbe.describe(code)} " +
+                        "(nsWindow=0x${nsWindow.toString(16)}, nsView=0x${nsView.toString(16)})"
+                }
+
+                // Window must still be alive after the nested runloop / sheet.
+                settle()
+                check(bounds() != null) { "window must survive sheet present + cancel" }
+                check(window.nsWindowHandle == nsWindow) {
+                    "nsWindowHandle must remain stable after sheet e2e"
+                }
+
+                println(
+                    "macOS sheet parent e2e: nsWindow=0x${nsWindow.toString(16)} " +
+                        "nsView=0x${nsView.toString(16)} probe=OK",
+                )
+            },
         ) + ChromeReviewHeadfulCases.all() + DisplayScaleHeadfulCases.all() + FramePacingHeadfulCases.all()
 
     private val cases: List<TaoWindowTestCase> =
@@ -420,6 +484,11 @@ public object TaoHeadfulTestSuiteMain {
         }
         exitProcess(if (failures > 0) 1 else 0)
     }
+
+    private val isMac: Boolean =
+        System.getProperty("os.name", "").lowercase().let { os ->
+            os.contains("mac") || os.contains("darwin")
+        }
 
     private val isLinux: Boolean =
         System.getProperty("os.name", "").lowercase().let { os ->


### PR DESCRIPTION
## Summary

- Expose macOS dialog-parent identity for FileKit / sheet dialogs: `TaoWindow.nsWindowHandle` → live `NSWindow*`
- Document that macOS `nativeHandle` stays the Compose host **NSView*** — not a valid `beginSheetModalForWindow:` parent
- Native bridge: `nativeNsWindowHandle` via Tao `WindowExtMacOS::ns_window()`
- Headful e2e: real `NSOpenPanel` sheet on the Tao window (attach + cancel), plus a negative check that an NSView pointer cannot parent a sheet

## Context

Follow-up to #466 (Linux XDG portal parents). FileKit’s typed JVM parents already cover Windows HWND and Linux X11/Wayland; macOS still needs an `NSWindow` for sheet modality. Nucleus now surfaces that pointer so adapters can use it once FileKit adds `FileKitDialogParent.macos`.

### Adapter sketch

```kotlin
when (Platform.Current) {
    Platform.Windows ->
        window.nativeHandle.takeIf { it != 0L }?.let(FileKitDialogParent::windows)
    Platform.Linux ->
        when (val parent = window.xdgPortalParent()) {
            is XdgPortalParent.X11 -> FileKitDialogParent.x11(parent.xid)
            is XdgPortalParent.Wayland -> FileKitDialogParent.wayland(parent.handle)
            null -> null
        }
    Platform.MacOS ->
        // Once FileKit accepts NSWindow:
        // window.nsWindowHandle?.let(FileKitDialogParent::macos)
        window.nsWindowHandle
    else -> null
}
```

## Test plan

- [x] `./gradlew :decorated-window-tao:apiCheck`
- [x] Live macOS e2e: `./gradlew :decorated-window-tao:taoHeadfulTest -Dnucleus.tao.headful.filter=nsWindowHandle`
  - Real Tao window → `nsWindowHandle` ≠ `nativeHandle` (NSView)
  - NSView as parent → `WINDOW_NOT_FOUND`
  - `beginSheetModalForWindow:` with `NSOpenPanel` → attach + cancel → **PASS**
- [ ] Manual: FileKit open/save sheet parenting once `FileKitDialogParent.macos` lands
- [ ] CI pre-merge green