### PR TITLE
fix(graalvm): expand L1 metadata and always drop Kotlin agent noise

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTask.kt
@@ -29,6 +29,7 @@ import java.io.File
  * After baseline dedup, a **resolvability** pass scans the runtime classpath for
  * `.class` files and classifies each remaining type entry once:
  * - `removed [baseline]` — covered by L1/L2/L3/static (or main class)
+ * - `removed [agent-noise]` — Kotlin mapped-type phantoms (`kotlin.Any`, `kotlin.Int`, …); always
  * - `removed [unresolvable]` — opt-in prune (`-Pnucleus.graalvm.cleanup.removeUnresolvable=true`)
  * - `unresolvable (kept)` — missing type, default report-only
  * - `unresolvable (exact-protected)` — missing type under [exactReachabilityPackages]
@@ -379,16 +380,20 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
         // ── Resolvability pass ──
         // Agent-recorded negative Class.forName lookups (kotlin.Any, kotlin.Int, …) and
         // typos/stale renames never match a baseline. Classify each survivor once.
+        // Kotlin mapped-type phantoms are always removed (AGENT_NOISE); other missing
+        // types stay report-only unless removeUnresolvable is on.
         val classIndex = buildClasspathClassIndex(runtimeClasspath.files)
         logger.lifecycle("Classpath class index: ${classIndex.size} types")
 
         // Track which survivors were already classified as unresolvable so the final
         // "kept" pass does not re-list them.
         val classifiedUnresolvableKeys = mutableSetOf<String>()
+        var agentNoiseRemoved = 0
         for (section in listOf("reflection", "jni", "serialization")) {
             @Suppress("UNCHECKED_CAST")
             val targetArray = targetRoot[section] as? MutableList<Map<String, Any?>> ?: continue
             val before = targetArray.size
+            var sectionAgentNoise = 0
             targetArray.removeAll { projectEntry ->
                 when (
                     classifyUnresolvableEntry(
@@ -399,6 +404,11 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
                     )
                 ) {
                     UnresolvableDisposition.RESOLVABLE -> false
+                    UnresolvableDisposition.AGENT_NOISE -> {
+                        report.add(formatDispositionLine("removed/agent-noise", section, projectEntry))
+                        sectionAgentNoise++
+                        true
+                    }
                     UnresolvableDisposition.REMOVE -> {
                         report.add(formatDispositionLine("removed/unresolvable", section, projectEntry))
                         true
@@ -417,7 +427,9 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
                     }
                 }
             }
-            unresolvableRemoved += before - targetArray.size
+            val removedHere = before - targetArray.size
+            agentNoiseRemoved += sectionAgentNoise
+            unresolvableRemoved += removedHere - sectionAgentNoise
         }
 
         // Resolvable leftovers not covered by any managed baseline — worth a human look.
@@ -441,7 +453,7 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
             keptResolvable++
         }
 
-        val totalRemoved = baselineRemoved + unresolvableRemoved
+        val totalRemoved = baselineRemoved + unresolvableRemoved + agentNoiseRemoved
         if (totalRemoved > 0) {
             for (section in listOf("reflection", "jni", "resources", "bundles", "serialization")) {
                 @Suppress("UNCHECKED_CAST")
@@ -460,7 +472,8 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
             totalRemoved > 0 ->
                 logger.lifecycle(
                     "$verb $totalRemoved entr${if (totalRemoved == 1) "y" else "ies"} " +
-                        "(baseline=$baselineRemoved, unresolvable=$unresolvableRemoved) from $targetFile",
+                        "(baseline=$baselineRemoved, unresolvable=$unresolvableRemoved, " +
+                        "agent-noise=$agentNoiseRemoved) from $targetFile",
                 )
             unresolvableReported > 0 || unresolvableProtected > 0 ->
                 logger.lifecycle(
@@ -483,7 +496,8 @@ abstract class CleanupGraalvmMetadataTask : DefaultTask() {
         }
         logger.lifecycle(
             "Summary: removed=$totalRemoved " +
-                "(baseline=$baselineRemoved, unresolvable=$unresolvableRemoved), " +
+                "(baseline=$baselineRemoved, unresolvable=$unresolvableRemoved, " +
+                "agent-noise=$agentNoiseRemoved), " +
                 "unresolvable/kept=$unresolvableReported, " +
                 "unresolvable/exact-protected=$unresolvableProtected, " +
                 "kept=$keptResolvable",

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvability.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvability.kt
@@ -44,6 +44,82 @@ internal enum class UnresolvableDisposition {
 
     /** Missing type, opt-in prune is on, not under exact packages — drop. */
     REMOVE,
+
+    /**
+     * Tracing-agent phantom for a Kotlin mapped type (`kotlin.Any`, `kotlin.Int`, …).
+     * Always drop — these never exist as `.class` files and are never load-bearing.
+     */
+    AGENT_NOISE,
+}
+
+/**
+ * Kotlin language types the GraalVM tracing agent records via negative `Class.forName`
+ * of mapped types / collection interfaces. None of these have a `.class` on the
+ * classpath (`kotlin.Int` → `int`/`Integer`, `kotlin.collections.List` → `java.util.List`).
+ */
+private val KOTLIN_AGENT_NOISE_EXACT =
+    setOf(
+        "kotlin.Any",
+        "kotlin.Nothing",
+        "kotlin.Boolean",
+        "kotlin.Byte",
+        "kotlin.Char",
+        "kotlin.Short",
+        "kotlin.Int",
+        "kotlin.Long",
+        "kotlin.Float",
+        "kotlin.Double",
+        "kotlin.Cloneable",
+        "kotlin.Comparable",
+        "kotlin.Annotation",
+        "kotlin.Enum",
+        "kotlin.Number",
+        "kotlin.CharSequence",
+        "kotlin.String",
+        "kotlin.Throwable",
+    )
+
+/** Mapped `kotlin.collections.*` interfaces with no dedicated class file. */
+private val KOTLIN_COLLECTIONS_AGENT_NOISE =
+    setOf(
+        "Collection",
+        "List",
+        "Map",
+        "Set",
+        "Iterable",
+        "Iterator",
+        "MutableCollection",
+        "MutableList",
+        "MutableMap",
+        "MutableSet",
+        "MutableIterable",
+        "MutableIterator",
+    )
+
+/**
+ * True when [typeName] is a known tracing-agent phantom for a Kotlin mapped type.
+ * Only meaningful for types that already failed [isTypeResolvable] — real stdlib
+ * classes (`kotlin.Unit`, `kotlin.coroutines.*`, …) resolve via the classpath.
+ */
+internal fun isKotlinAgentNoiseType(typeName: String): Boolean {
+    val normalized = normalizeTypeForLookup(typeName) ?: return false
+    if (normalized in KOTLIN_AGENT_NOISE_EXACT) return true
+    if (normalized.startsWith("kotlin.Function")) {
+        val suffix = normalized.removePrefix("kotlin.Function")
+        if (suffix.isNotEmpty() && suffix.all { it.isDigit() }) return true
+    }
+    if (normalized.startsWith("kotlin.collections.")) {
+        val simple = normalized.removePrefix("kotlin.collections.")
+        if (simple in KOTLIN_COLLECTIONS_AGENT_NOISE) return true
+    }
+    return false
+}
+
+/** True when every type on [entry] is agent noise (proxies never are). */
+internal fun isKotlinAgentNoiseEntry(entry: Map<String, Any?>): Boolean {
+    if (proxyInterfaceNames(entry).isNotEmpty()) return false
+    val typeName = typeNameOfEntry(entry) ?: return false
+    return isKotlinAgentNoiseType(typeName)
 }
 
 /**
@@ -53,6 +129,9 @@ internal enum class UnresolvableDisposition {
  * “was this image built with exact mode”. Protection follows the configured scope so
  * cleanup never strips load-bearing negative lookups for apps that use exact mode on
  * the dev loop.
+ *
+ * Kotlin agent phantoms (`kotlin.Any`, …) always return [UnresolvableDisposition.AGENT_NOISE]
+ * — they are never exact-protected and do not require `-P…removeUnresolvable`.
  */
 internal fun classifyUnresolvableEntry(
     entry: Map<String, Any?>,
@@ -61,6 +140,7 @@ internal fun classifyUnresolvableEntry(
     removeUnresolvable: Boolean,
 ): UnresolvableDisposition {
     if (isEntryResolvable(entry, classIndex)) return UnresolvableDisposition.RESOLVABLE
+    if (isKotlinAgentNoiseEntry(entry)) return UnresolvableDisposition.AGENT_NOISE
     if (isEntryProtectedByExactReachability(entry, exactPackages)) {
         return UnresolvableDisposition.PROTECT
     }

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/androidx-sqlite-bundled.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/androidx-sqlite-bundled.json
@@ -1,0 +1,22 @@
+{
+    "_meta": {
+        "description": "AndroidX SQLite bundled driver (FFM/JNI bridges used by Room on desktop)",
+        "matchPackages": [
+            "androidx.sqlite"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "androidx.sqlite.driver.bundled.BundledSQLiteConnectionKt",
+            "jniAccessible": true
+        },
+        {
+            "type": "androidx.sqlite.driver.bundled.BundledSQLiteDriverKt",
+            "jniAccessible": true
+        },
+        {
+            "type": "androidx.sqlite.driver.bundled.BundledSQLiteStatementKt",
+            "jniAccessible": true
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/index.txt
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/index.txt
@@ -1,4 +1,5 @@
 android-compat.json
+androidx-sqlite-bundled.json
 coil.json
 compose-mediaplayer.json
 compose-ui.json

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jdk-core.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jdk-core.json
@@ -84,6 +84,9 @@
             "type": "java.io.Reader"
         },
         {
+            "type": "java.io.Serializable"
+        },
+        {
             "type": "java.lang.Boolean",
             "jniAccessible": true,
             "methods": [
@@ -151,6 +154,14 @@
             "methods": [
                 {
                     "name": "getComponentType",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "getModule",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "isSealed",
                     "parameterTypes": []
                 }
             ]
@@ -355,19 +366,177 @@
             ]
         },
         {
+            "type": "java.lang.Module",
+            "methods": [
+                {
+                    "name": "isNativeAccessEnabled",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "java.lang.foreign.FunctionDescriptor",
+            "methods": [
+                {
+                    "name": "of",
+                    "parameterTypes": [
+                        "java.lang.foreign.MemoryLayout",
+                        "java.lang.foreign.MemoryLayout[]"
+                    ]
+                },
+                {
+                    "name": "ofVoid",
+                    "parameterTypes": [
+                        "java.lang.foreign.MemoryLayout[]"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "java.lang.foreign.Linker",
+            "methods": [
+                {
+                    "name": "defaultLookup",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "downcallHandle",
+                    "parameterTypes": [
+                        "java.lang.foreign.MemorySegment",
+                        "java.lang.foreign.FunctionDescriptor",
+                        "java.lang.foreign.Linker$Option[]"
+                    ]
+                },
+                {
+                    "name": "nativeLinker",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "java.lang.foreign.Linker$Option[]"
+        },
+        {
+            "type": "java.lang.foreign.MemoryLayout",
+            "methods": [
+                {
+                    "name": "byteSize",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "java.lang.foreign.MemoryLayout[]"
+        },
+        {
+            "type": "java.lang.foreign.MemorySegment",
+            "methods": [
+                {
+                    "name": "address",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "asByteBuffer",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "ofAddress",
+                    "parameterTypes": [
+                        "long"
+                    ]
+                },
+                {
+                    "name": "ofBuffer",
+                    "parameterTypes": [
+                        "java.nio.Buffer"
+                    ]
+                },
+                {
+                    "name": "reinterpret",
+                    "parameterTypes": [
+                        "long"
+                    ]
+                }
+            ]
+        },
+        {
             "type": "java.lang.foreign.MemorySegment[]"
+        },
+        {
+            "type": "java.lang.foreign.SymbolLookup",
+            "methods": [
+                {
+                    "name": "findOrThrow",
+                    "parameterTypes": [
+                        "java.lang.String"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "java.lang.foreign.ValueLayout",
+            "fields": [
+                {
+                    "name": "ADDRESS"
+                },
+                {
+                    "name": "JAVA_LONG"
+                }
+            ]
         },
         {
             "type": "java.lang.invoke.MethodHandle"
         },
         {
-            "type": "java.lang.invoke.MethodHandles"
+            "type": "java.lang.invoke.MethodHandles",
+            "methods": [
+                {
+                    "name": "byteArrayViewVarHandle",
+                    "parameterTypes": [
+                        "java.lang.Class",
+                        "java.nio.ByteOrder"
+                    ]
+                },
+                {
+                    "name": "byteBufferViewVarHandle",
+                    "parameterTypes": [
+                        "java.lang.Class",
+                        "java.nio.ByteOrder"
+                    ]
+                },
+                {
+                    "name": "privateLookupIn",
+                    "parameterTypes": [
+                        "java.lang.Class",
+                        "java.lang.invoke.MethodHandles$Lookup"
+                    ]
+                }
+            ]
         },
         {
-            "type": "java.lang.invoke.MethodHandles$Lookup"
+            "type": "java.lang.invoke.MethodHandles$Lookup",
+            "methods": [
+                {
+                    "name": "findVarHandle",
+                    "parameterTypes": [
+                        "java.lang.Class",
+                        "java.lang.String",
+                        "java.lang.Class"
+                    ]
+                }
+            ]
         },
         {
             "type": "java.lang.invoke.MethodType"
+        },
+        {
+            "type": "java.lang.invoke.VarHandle",
+            "methods": [
+                {
+                    "name": "acquireFence",
+                    "parameterTypes": []
+                }
+            ]
         },
         {
             "type": "java.lang.reflect.Method",
@@ -408,12 +577,43 @@
             "jniAccessible": true,
             "methods": [
                 {
+                    "name": "alignedSlice",
+                    "parameterTypes": [
+                        "int"
+                    ]
+                },
+                {
                     "name": "array",
                     "parameterTypes": []
                 },
                 {
                     "name": "arrayOffset",
                     "parameterTypes": []
+                },
+                {
+                    "name": "put",
+                    "parameterTypes": [
+                        "int",
+                        "java.nio.ByteBuffer",
+                        "int",
+                        "int"
+                    ]
+                },
+                {
+                    "name": "put",
+                    "parameterTypes": [
+                        "int",
+                        "byte[]",
+                        "int",
+                        "int"
+                    ]
+                },
+                {
+                    "name": "slice",
+                    "parameterTypes": [
+                        "int",
+                        "int"
+                    ]
                 }
             ]
         },

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/kotlin-coroutines.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/kotlin-coroutines.json
@@ -7,7 +7,13 @@
             "type": "kotlin.SafePublicationLazyImpl"
         },
         {
+            "type": "kotlinx.atomicfu.AtomicInt"
+        },
+        {
             "type": "kotlinx.atomicfu.AtomicLong"
+        },
+        {
+            "type": "kotlinx.atomicfu.AtomicRef"
         },
         {
             "type": "kotlin.coroutines.SafeContinuation"
@@ -126,6 +132,11 @@
                     "parameterTypes": []
                 }
             ]
+        }
+    ],
+    "resources": [
+        {
+            "glob": "kotlin/kotlin.kotlin_builtins"
         }
     ]
 }

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/ktor.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/ktor.json
@@ -1,6 +1,6 @@
 {
     "_meta": {
-        "description": "Ktor HTTP client and networking types",
+        "description": "Ktor HTTP client/server, plugins, websockets, and networking types",
         "matchPackages": [
             "io.ktor"
         ]
@@ -10,13 +10,64 @@
             "type": "io.ktor.client.HttpClient"
         },
         {
+            "type": "io.ktor.client.HttpClientConfig"
+        },
+        {
             "type": "io.ktor.client.call.HttpClientCall"
+        },
+        {
+            "type": "io.ktor.client.content.ProgressListener"
         },
         {
             "type": "io.ktor.client.engine.HttpClientEngineBase"
         },
         {
+            "type": "io.ktor.client.engine.HttpClientEngineCapability"
+        },
+        {
+            "type": "io.ktor.client.engine.HttpClientEngineConfig"
+        },
+        {
             "type": "io.ktor.client.engine.cio.Endpoint"
+        },
+        {
+            "type": "io.ktor.client.plugins.HttpRetryDelayContext"
+        },
+        {
+            "type": "io.ktor.client.plugins.HttpRetryModifyRequestContext"
+        },
+        {
+            "type": "io.ktor.client.plugins.HttpRetryShouldRetryContext"
+        },
+        {
+            "type": "io.ktor.client.plugins.HttpSend"
+        },
+        {
+            "type": "io.ktor.client.plugins.api.ClientPluginImpl"
+        },
+        {
+            "type": "io.ktor.client.plugins.api.ClientPluginInstance"
+        },
+        {
+            "type": "io.ktor.client.plugins.logging.HttpClientCallLogger"
+        },
+        {
+            "type": "io.ktor.client.request.HttpRequest"
+        },
+        {
+            "type": "io.ktor.client.request.HttpRequestBuilder"
+        },
+        {
+            "type": "io.ktor.client.request.ResponseAdapter"
+        },
+        {
+            "type": "io.ktor.client.statement.HttpResponse"
+        },
+        {
+            "type": "io.ktor.http.ContentType"
+        },
+        {
+            "type": "io.ktor.http.HttpStatusCode"
         },
         {
             "type": "io.ktor.network.selector.InterestSuspensionsMap",
@@ -41,7 +92,22 @@
             "type": "io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider"
         },
         {
+            "type": "io.ktor.server.engine.BaseApplicationResponse"
+        },
+        {
+            "type": "io.ktor.server.routing.RoutingCall"
+        },
+        {
+            "type": "io.ktor.server.routing.RoutingRoot"
+        },
+        {
+            "type": "io.ktor.server.websocket.WebSockets"
+        },
+        {
             "type": "io.ktor.util.collections.CopyOnWriteHashMap"
+        },
+        {
+            "type": "io.ktor.util.reflect.TypeInfo"
         },
         {
             "type": "io.ktor.utils.io.ByteChannel"
@@ -50,7 +116,7 @@
             "type": "io.ktor.utils.io.pool.DefaultPool"
         },
         {
-            "type": "io.ktor.client.plugins.logging.HttpClientCallLogger"
+            "type": "io.ktor.websocket.WebSocketExtension"
         }
     ]
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTaskTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/CleanupGraalvmMetadataTaskTest.kt
@@ -84,10 +84,9 @@ class CleanupGraalvmMetadataTaskTest {
         """.trimIndent()
 
     @Test
-    fun `default mode reports unresolvable once and does not rewrite them away`() {
+    fun `default mode drops agent noise but keeps other unresolvable probes`() {
         val configDir = tmp.newFolder("graalvm-default")
         val metadata = writeMetadata(configDir, fixtureJson)
-        val before = metadata.readText()
 
         createTask(
             configDir = configDir,
@@ -95,12 +94,16 @@ class CleanupGraalvmMetadataTaskTest {
             removeUnresolvable = false,
         ).cleanup()
 
-        assertEquals("file must not drop unresolvable types by default", before, metadata.readText())
         val types = typeNames(metadata)
-        assertTrue(types.contains("kotlin.Any"))
-        assertTrue(types.contains("kotlin.Int"))
+        // Kotlin mapped-type phantoms are always stripped (no removeUnresolvable flag).
+        assertFalse(types.contains("kotlin.Any"))
+        assertFalse(types.contains("kotlin.Int"))
+        assertFalse(types.contains("kotlin.collections.List"))
+        // Real app probes stay unless removeUnresolvable is on.
         assertTrue(types.contains("acme.app.RealClass"))
         assertTrue(types.contains("acme.app.OptionalProbe"))
+        assertFalse(typeNames(metadata, "serialization").contains("kotlin.Boolean"))
+        assertTrue(typeNames(metadata, "serialization").contains("acme.app.RealClass"))
     }
 
     @Test
@@ -190,7 +193,7 @@ class CleanupGraalvmMetadataTaskTest {
     }
 
     @Test
-    fun `default mode does not claim already clean when unresolvable remain`() {
+    fun `default mode keeps app probes while stripping agent noise`() {
         val configDir = tmp.newFolder("graalvm-msg")
         writeMetadata(configDir, fixtureJson)
         val task =
@@ -200,12 +203,13 @@ class CleanupGraalvmMetadataTaskTest {
                 removeUnresolvable = false,
             )
 
-        // Drive the action; assert on post-condition that is independent of logger wiring:
-        // file still has unresolvable entries, so the task's success path for "already clean"
-        // must not have rewritten. Message content is covered by classify + e2e gradle log.
         task.cleanup()
-        assertTrue(typeNames(File(configDir, "reachability-metadata.json")).contains("kotlin.Int"))
-        // Kept resolvable + unresolvable still present — not "clean" by deletion.
-        assertEquals(5, typeNames(File(configDir, "reachability-metadata.json")).size)
+        val types = typeNames(File(configDir, "reachability-metadata.json"))
+        // App-level unresolvable probes stay (report-only without removeUnresolvable).
+        assertTrue(types.contains("acme.app.OptionalProbe"))
+        assertTrue(types.contains("acme.app.RealClass"))
+        // Agent phantoms are always gone.
+        assertFalse(types.contains("kotlin.Int"))
+        assertFalse(types.contains("kotlin.Any"))
     }
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvabilityTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/GraalvmMetadataResolvabilityTest.kt
@@ -156,12 +156,13 @@ class GraalvmMetadataResolvabilityTest {
             UnresolvableDisposition.RESOLVABLE,
             classifyUnresolvableEntry(real, index, emptyList(), removeUnresolvable = true),
         )
+        // Kotlin mapped-type phantoms are always AGENT_NOISE (no removeUnresolvable flag needed).
         assertEquals(
-            UnresolvableDisposition.REPORT,
+            UnresolvableDisposition.AGENT_NOISE,
             classifyUnresolvableEntry(noise, index, emptyList(), removeUnresolvable = false),
         )
         assertEquals(
-            UnresolvableDisposition.REMOVE,
+            UnresolvableDisposition.AGENT_NOISE,
             classifyUnresolvableEntry(noise, index, emptyList(), removeUnresolvable = true),
         )
         assertEquals(
@@ -180,6 +181,11 @@ class GraalvmMetadataResolvabilityTest {
             UnresolvableDisposition.PROTECT,
             classifyUnresolvableEntry(proxyExact, index, listOf("acme.app"), removeUnresolvable = true),
         )
+        assertTrue(isKotlinAgentNoiseType("kotlin.Any"))
+        assertTrue(isKotlinAgentNoiseType("kotlin.Function2"))
+        assertTrue(isKotlinAgentNoiseType("kotlin.collections.List"))
+        assertFalse(isKotlinAgentNoiseType("kotlin.Unit"))
+        assertFalse(isKotlinAgentNoiseType("acme.app.Optional"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Cleanup:** always remove Kotlin tracing-agent phantoms (`kotlin.Any`, `kotlin.Int`, `kotlin.FunctionN`, mapped `kotlin.collections.*`) as `removed/agent-noise` — no `-PremoveUnresolvable` required.
- **L1 Ktor:** expand `ktor.json` with client plugin/context types, request/response, server routing, websockets (Flocon-shaped).
- **L1 SQLite bundled:** new `androidx-sqlite-bundled.json` (`BundledSQLite*Kt` JNI bridges).
- **L1 JDK/Kotlin:** FFM + VarHandle/Module/ByteBuffer methods in `jdk-core`; `AtomicInt`/`AtomicRef` + `kotlin/kotlin.kotlin_builtins` in `kotlin-coroutines`.

## Flocon dry-run (includeBuild)

```
Would remove 55 entries (baseline=45, unresolvable=0, agent-noise=10)
```

Remaining manual (~15): Netty internals + one Tao synthetic type (+ Room `_Impl` until #467 lands).

## Test plan

- [x] `:plugin:test` — `CleanupGraalvmMetadataTaskTest`, `GraalvmMetadataResolvabilityTest`
- [x] `:plugin:ktlintCheck`
- [x] Flocon `cleanupGraalvmMetadata` dry-run via composite plugin
- [ ] CI on PR