### PR TITLE
fix(tao/linux): clear opaque region while NativeView is attached

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxWidgetBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxWidgetBridge.kt
@@ -109,9 +109,10 @@ internal object NativeTaoLinuxWidgetBridge {
 
     /**
      * Receives motion / press / release events forwarded from the
-     * native EventBox handlers. Coords are **logical pixels** in
-     * GtkApplicationWindow space (already translated via
-     * `gtk_widget_translate_coordinates`).
+     * native EventBox handlers. Coords are **logical pixels** in the
+     * window content area (bin child), matching Tao's CSD-normalised
+     * pointer path and Compose's (0,0) — not the decorated toplevel
+     * (which includes theme shadow margins under hidden-titlebar CSD).
      *
      * `type`: 0 = move, 1 = press, 2 = release.
      * `pressed`: 1 if currently pressed, 0 otherwise.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -245,6 +245,15 @@ internal class TaoComposeSceneHostLinux(
     /** Last opaque region pushed: (logicalW, logicalH, cornerRadius). */
     private var lastOpaqueRegion: Triple<Int, Int, Int>? = null
 
+    /**
+     * GtkWidget handles currently embedded via [NativeView]. While any are
+     * present, Compose punches transparent holes (`BlendMode.Clear`) so the
+     * native widget shows through the EGL subsurface — that only works if the
+     * compositor still blends GTK underneath us, so we must not declare an
+     * opaque region. Tracked by handle so duplicate attach/detach is safe.
+     */
+    private val attachedNativeViews: MutableSet<Long> = linkedSetOf()
+
     private var widthPx: Int = 0
     private var heightPx: Int = 0
     private var scale: Float = 1f
@@ -1177,9 +1186,13 @@ internal class TaoComposeSceneHostLinux(
      * which throttles GDK's frame clock, which is what caps how fast the window
      * edge moves during a resize.
      *
-     * Cleared when the window is genuinely translucent: [clearColorArgbState] is
-     * what the scene is cleared to each frame, so an alpha below 255 means
-     * pixels really can show through and claiming otherwise would corrupt them.
+     * Cleared when:
+     *  - the window is genuinely translucent: [clearColorArgbState] alpha < 255
+     *  - a [NativeView] GtkWidget is attached: Compose clears that rect to
+     *    alpha 0 so the native widget can show through; claiming the surface
+     *    opaque there makes the compositor drop GTK/WebKit underneath and
+     *    produces damage/cursor trails
+     *
      * The rounded corners are excluded for the same reason — see
      * [applyFrameDecoration], which carves them out.
      */
@@ -1188,7 +1201,9 @@ internal class TaoComposeSceneHostLinux(
         logicalH: Int,
     ) {
         if (attachmentHandle == 0L) return
-        val opaque = (clearColorArgbState.value ushr 24) and 0xFF == 0xFF
+        val opaque =
+            (clearColorArgbState.value ushr 24) and 0xFF == 0xFF &&
+                attachedNativeViews.isEmpty()
         if (!opaque) {
             if (lastOpaqueRegion != null) {
                 NativeTaoEglBridge.nativeSetOpaqueRegion(attachmentHandle, 0, 0, 0)
@@ -1202,6 +1217,16 @@ internal class TaoComposeSceneHostLinux(
         if (key == lastOpaqueRegion) return
         lastOpaqueRegion = key
         NativeTaoEglBridge.nativeSetOpaqueRegion(attachmentHandle, logicalW, logicalH, radius)
+    }
+
+    /** Re-pushes the opaque region for the current size (e.g. after NativeView attach). */
+    private fun refreshOpaqueRegion() {
+        if (widthPx <= 0 || heightPx <= 0) return
+        val opaqueScale = scale.roundToInt().coerceAtLeast(1)
+        pushOpaqueRegion(
+            (widthPx / opaqueScale).coerceAtLeast(1),
+            (heightPx / opaqueScale).coerceAtLeast(1),
+        )
     }
 
     /**
@@ -2002,11 +2027,21 @@ internal class TaoComposeSceneHostLinux(
             override fun attach(childHandle: Long) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxWidgetBridge
                     .nativeAttach(gtkWindow, childHandle)
+                if (childHandle != 0L && outer.attachedNativeViews.add(childHandle)) {
+                    // Force a re-push: lastOpaqueRegion may still hold the full
+                    // opaque key from before the embed existed.
+                    outer.lastOpaqueRegion = Triple(-1, -1, -1)
+                    outer.refreshOpaqueRegion()
+                }
             }
 
             override fun detach(childHandle: Long) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxWidgetBridge
                     .nativeDetach(childHandle)
+                if (childHandle != 0L && outer.attachedNativeViews.remove(childHandle)) {
+                    outer.lastOpaqueRegion = null
+                    outer.refreshOpaqueRegion()
+                }
             }
 
             override fun setFrame(

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_widget.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_widget.c
@@ -582,12 +582,25 @@ static int gtk_button_to_tao(unsigned int gtk_button) {
     }
 }
 
-static int translate_to_toplevel(GtkWidget *widget, double ex, double ey, int *out_x, int *out_y) {
+/* Map EventBox-local event coords into Compose's content-area logical space.
+ *
+ * With the yaru-style hidden-titlebar CSD, the GtkApplicationWindow includes
+ * theme shadow margins around the content GtkBox. Tao's normal pointer path
+ * (and the EGL subsurface) use content (0,0) — translating to the *toplevel*
+ * leaves those margins in the coords and shifts every overlay click by ~the
+ * shadow size. Prefer the bin child (content box); fall back to the toplevel
+ * when CSD is off / no child (identity for flat undecorated windows). */
+static int translate_to_content(GtkWidget *widget, double ex, double ey, int *out_x, int *out_y) {
     *out_x = -1; *out_y = -1;
     if (g.gtk_widget_get_toplevel == NULL || g.gtk_widget_translate_coordinates == NULL) return 0;
     GtkWidget *toplevel = g.gtk_widget_get_toplevel(widget);
     if (toplevel == NULL) return 0;
-    return g.gtk_widget_translate_coordinates(widget, toplevel, (int) ex, (int) ey, out_x, out_y) ? 1 : 0;
+    GtkWidget *target = toplevel;
+    if (g.gtk_bin_get_child != NULL) {
+        GtkWidget *child = g.gtk_bin_get_child(toplevel);
+        if (child != NULL) target = child;
+    }
+    return g.gtk_widget_translate_coordinates(widget, target, (int) ex, (int) ey, out_x, out_y) ? 1 : 0;
 }
 
 static gboolean on_input_box_button_press(GtkWidget *widget, void *event_ptr,
@@ -596,8 +609,8 @@ static gboolean on_input_box_button_press(GtkWidget *widget, void *event_ptr,
     gdk_event_button_t *e = (gdk_event_button_t *) event_ptr;
     if (e == NULL) return GTK_FALSE;
     int wx, wy;
-    translate_to_toplevel(widget, e->x, e->y, &wx, &wy);
-    /* Forward window-relative coords + press to Compose, bypassing
+    translate_to_content(widget, e->x, e->y, &wx, &wy);
+    /* Forward content-relative coords + press to Compose, bypassing
      * Tao's `cursor.window_at_position()` which on Wayland reports
      * EventBox-local coords because of WebKit's accelerated subsurface
      * stealing the seat focus. The callback updates the host's
@@ -619,7 +632,7 @@ static gboolean on_input_box_button_release(GtkWidget *widget, void *event_ptr,
     gdk_event_button_t *e = (gdk_event_button_t *) event_ptr;
     if (e == NULL) return GTK_FALSE;
     int wx, wy;
-    translate_to_toplevel(widget, e->x, e->y, &wx, &wy);
+    translate_to_content(widget, e->x, e->y, &wx, &wy);
     invoke_callback(widget, EVT_OVERLAY_RELEASE, wx, wy, gtk_button_to_tao(e->button));
     return GTK_TRUE;
 }
@@ -642,7 +655,7 @@ static gboolean on_input_box_motion_notify(GtkWidget *widget, void *event_ptr,
     gdk_event_motion_t *e = (gdk_event_motion_t *) event_ptr;
     if (e == NULL) return GTK_FALSE;
     int wx, wy;
-    translate_to_toplevel(widget, e->x, e->y, &wx, &wy);
+    translate_to_content(widget, e->x, e->y, &wx, &wy);
     invoke_callback(widget, EVT_OVERLAY_MOVE, wx, wy, /*button*/ 0);
     /* Consume so Tao's GtkApplicationWindow-level motion handler
      * doesn't ALSO fire — its `cursor.window_at_position()` reports

--- a/examples/gstreamer-demo/src/main/kotlin/dev/nucleusframework/samplegst/NativeGstVideoBridge.kt
+++ b/examples/gstreamer-demo/src/main/kotlin/dev/nucleusframework/samplegst/NativeGstVideoBridge.kt
@@ -47,7 +47,10 @@ internal object NativeGstVideoBridge {
 
     /** Mutes the audio path; a no-op for a file without audio. */
     @JvmStatic
-    external fun nativeSetMuted(handle: Long, muted: Boolean)
+    external fun nativeSetMuted(
+        handle: Long,
+        muted: Boolean,
+    )
 
     @JvmStatic
     external fun nativeClose(handle: Long)

--- a/examples/mediafoundation-demo/src/main/kotlin/dev/nucleusframework/samplemf/NativeMfVideoBridge.kt
+++ b/examples/mediafoundation-demo/src/main/kotlin/dev/nucleusframework/samplemf/NativeMfVideoBridge.kt
@@ -51,5 +51,8 @@ internal object NativeMfVideoBridge {
     external fun nativeHasAudio(handle: Long): Boolean
 
     @JvmStatic
-    external fun nativeSetMuted(handle: Long, muted: Boolean)
+    external fun nativeSetMuted(
+        handle: Long,
+        muted: Boolean,
+    )
 }

--- a/examples/orphan-reflect-smoke/src/main/kotlin/dev/nucleusframework/orphanreflectsmoke/Main.kt
+++ b/examples/orphan-reflect-smoke/src/main/kotlin/dev/nucleusframework/orphanreflectsmoke/Main.kt
@@ -45,6 +45,7 @@ abstract class AppDatabase {
  * Stand-in for Room-generated `*_Impl`. Must stay unreferenced from app bytecode
  * (no field types, no direct `AppDatabase_Impl::class` usage).
  */
+@Suppress("ktlint:standard:class-naming")
 class AppDatabase_Impl : AppDatabase() {
     override fun name(): String = "impl-ok"
 }

--- a/nucleus-application/build.gradle.kts
+++ b/nucleus-application/build.gradle.kts
@@ -59,7 +59,7 @@ tasks.register<JavaExec>("systemThemeE2E") {
     group = "verification"
     description =
         "Boots a real Compose application under ProvideNucleusSystemTheme and " +
-            "asserts isSystemInDarkTheme() matches the native detector"
+        "asserts isSystemInDarkTheme() matches the native detector"
     dependsOn(tasks.named("testClasses"))
     classpath = sourceSets["test"].runtimeClasspath
     mainClass.set("dev.nucleusframework.application.NucleusApplicationSystemThemeE2EMainKt")

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/LinuxColorSchemeToggle.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/LinuxColorSchemeToggle.kt
@@ -11,7 +11,11 @@ internal object LinuxColorSchemeToggle {
     private const val KEY = "color-scheme"
 
     val isAvailable: Boolean by lazy {
-        System.getProperty("os.name").orEmpty().lowercase().contains("linux") &&
+        System
+            .getProperty("os.name")
+            .orEmpty()
+            .lowercase()
+            .contains("linux") &&
             runCatching {
                 ProcessBuilder("gsettings", "get", SCHEMA, KEY)
                     .redirectErrorStream(true)
@@ -38,7 +42,11 @@ internal object LinuxColorSchemeToggle {
         check(p.waitFor(3, TimeUnit.SECONDS)) { "gsettings get timed out" }
         check(p.exitValue() == 0) { "gsettings get failed: ${p.inputStream.bufferedReader().readText()}" }
         // gsettings prints e.g. 'prefer-dark'
-        return p.inputStream.bufferedReader().readText().trim().trim('\'')
+        return p.inputStream
+            .bufferedReader()
+            .readText()
+            .trim()
+            .trim('\'')
     }
 
     fun write(value: String) {
@@ -66,8 +74,7 @@ internal object LinuxColorSchemeToggle {
     }
 
     /** Flip between prefer-dark and prefer-light. */
-    fun oppositeOf(current: String): String =
-        if (current == "prefer-dark") "prefer-light" else "prefer-dark"
+    fun oppositeOf(current: String): String = if (current == "prefer-dark") "prefer-light" else "prefer-dark"
 
     fun isDarkScheme(scheme: String): Boolean = scheme == "prefer-dark"
 }

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/NucleusApplicationSystemThemeE2EMain.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/NucleusApplicationSystemThemeE2EMain.kt
@@ -19,7 +19,6 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.system.exitProcess
 
-
 /**
  * Process-level E2E that **actually flips** the OS color-scheme and checks that
  * under [ProvideNucleusSystemTheme] both [isSystemInDarkMode] and official


### PR DESCRIPTION
## Summary

- Clear the Compose EGL `wl_surface` opaque region while any Linux `NativeView` GtkWidget is attached, so the compositor keeps blending GTK/WebKit under the transparent `BlendMode.Clear` holes.
- Restores correct WebView compositing after #447, which declared the full window opaque for resize performance and broke the NativeView contract (cursor trails / glitches).
- Minor ktlint cleanups from format + suppress intentional `AppDatabase_Impl` class name in orphan-reflect-smoke.

## Test plan

- [x] `./gradlew :decorated-window-tao:ktlintCheck :decorated-window-tao:detekt`
- [x] `./gradlew ktlintCheck detekt`
- [x] Manual: `./gradlew :examples:tao-demo:run` → WebView tab → move cursor over page (no multiplied cursor / trail)
- [ ] Resize a window without NativeView (opaque region still applied for resize perf)