### PR TITLE
fix(application): re-provide scene window locals for secondary windows

### DIFF
--- a/decorated-window-tao/api/decorated-window-tao.api
+++ b/decorated-window-tao/api/decorated-window-tao.api
@@ -118,7 +118,9 @@ public final class dev/nucleusframework/window/WindowDoubleClickAction : java/la
 
 public final class dev/nucleusframework/window/WindowDragAreaKt {
 	public static final fun noWindowDrag (Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;
+	public static final fun windowDragArea (Landroidx/compose/ui/Modifier;Ldev/nucleusframework/window/tao/TaoWindow;Ldev/nucleusframework/window/WindowDoubleClickAction;)Landroidx/compose/ui/Modifier;
 	public static final fun windowDragArea (Landroidx/compose/ui/Modifier;ZLdev/nucleusframework/window/WindowDoubleClickAction;)Landroidx/compose/ui/Modifier;
+	public static synthetic fun windowDragArea$default (Landroidx/compose/ui/Modifier;Ldev/nucleusframework/window/tao/TaoWindow;Ldev/nucleusframework/window/WindowDoubleClickAction;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 	public static synthetic fun windowDragArea$default (Landroidx/compose/ui/Modifier;ZLdev/nucleusframework/window/WindowDoubleClickAction;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
@@ -278,11 +278,10 @@ public fun DecoratedWindowScope.BasicTitleBar(
             .let {
                 if (isMacOS) it.offset(y = menuBarOffset).zIndex(if (menuBarOffset > 0.dp) 1f else 0f) else it
             }.then(modifier)
-            // The whole bar drags the window, and a double-click toggles
-            // maximize; interactive children opt out by consuming the press.
-            // This is the same public modifier a custom `WindowScaffold` chrome
-            // uses, so the two can never drift apart.
-            .windowDragArea()
+            // Bind drag to [taoWindow] explicitly (not only LocalTaoWindow) so
+            // secondary windows stay movable when parent CompositionLocals are
+            // bridged into this scene and would otherwise clobber LocalTaoWindow.
+            .windowDragArea(window = taoWindow)
 
     val overlayHolder = LocalFullscreenTitleBarHolder.current
     val useOverlay =

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/WindowDragArea.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/WindowDragArea.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.IntSize
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.tao.LocalTaoWindow
+import dev.nucleusframework.window.tao.TaoWindow
 
 /**
  * Declares this component as a window drag region: an unconsumed primary
@@ -36,6 +37,11 @@ import dev.nucleusframework.window.tao.LocalTaoWindow
  *
  * Must be used inside a Tao `DecoratedWindow` content tree; outside of one
  * (no [LocalTaoWindow]) the modifier is a no-op.
+ *
+ * Prefer the overload that takes an explicit [TaoWindow] when composing
+ * chrome that already holds the window handle (e.g. [BasicTitleBar]) — that
+ * path does not depend on [LocalTaoWindow] and stays correct if parent-window
+ * CompositionLocals are bridged into a secondary scene.
  */
 @OptIn(ExperimentalComposeUiApi::class)
 public fun Modifier.windowDragArea(
@@ -45,6 +51,20 @@ public fun Modifier.windowDragArea(
     composed {
         val window = LocalTaoWindow.current
         if (!enabled || window == null) return@composed Modifier
+        windowDragArea(window = window, doubleClickAction = doubleClickAction)
+    }
+
+/**
+ * Same as [windowDragArea] but binds drag/maximize to the given [window]
+ * instead of [LocalTaoWindow]. Use from title-bar chrome that already
+ * resolves the window via [DecoratedWindowScope].
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+public fun Modifier.windowDragArea(
+    window: TaoWindow,
+    doubleClickAction: WindowDoubleClickAction = WindowDoubleClickAction.ToggleMaximize,
+): Modifier =
+    composed {
         val viewConfig = LocalViewConfiguration.current
         var lastPress by remember { mutableLongStateOf(0L) }
         Modifier

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -19,6 +19,8 @@ import dev.nucleusframework.application.ObserveSingleInstanceRestore
 import dev.nucleusframework.application.TaoNucleusApplicationScope
 import dev.nucleusframework.application.TaoNucleusWindow
 import dev.nucleusframework.window.DecoratedWindowState
+import dev.nucleusframework.window.LocalTitleBarInfo
+import dev.nucleusframework.window.tao.LocalTaoWindow
 import dev.nucleusframework.window.tao.TaoDecoratedWindowScope
 import dev.nucleusframework.window.tao.render.LocalTaoTextSelectionA11yPublisher
 import dev.nucleusframework.window.tao.render.TaoTextSelectionAccessibility
@@ -91,14 +93,22 @@ internal object TaoDecoratedWindowAdapter {
                         TaoNucleusDecoratedWindowScope(taoScope, nucleusWindow)
                     }
                 ObserveSingleInstanceRestore(nucleusWindow)
-                // outerLocals were captured in the OUTER application composition
-                // (NoOpApplier with GlobalDensity = Density(1f)). Blindly applying
-                // them inside the scene would override LocalDensity with the
-                // platform-incorrect 1.0 (the scene's own owner.density mirrors
-                // the screen's backing scale and is what Compose layout expects).
-                // Snapshot the scene's density BEFORE applying outerLocals so we
-                // can re-provide it inside. LocalLayoutDirection is intentionally
-                // left to outerLocals so an app-level RTL override propagates here.
+                // outerLocals were captured in the OUTER composition. Blindly
+                // applying them inside this scene would override:
+                //  - LocalDensity with the application root's Density(1f)
+                //  - LocalTaoWindow / LocalTitleBarInfo with the *parent*
+                //    window's values, when this window is opened from inside
+                //    another DecoratedWindow (secondary windows, demos, apps
+                //    that open windows from a navigation destination).
+                // Snapshot scene-owned locals BEFORE applying outerLocals and
+                // re-provide them below so title-bar drag, system controls, and
+                // title/icon state bind to *this* window on every platform
+                // (Windows / macOS / Linux). Without re-providing LocalTaoWindow,
+                // windowDragArea() and WindowControlsWindows would call
+                // dragWindow() / minimize / maximize on the parent window —
+                // the secondary window appears immovable.
+                // LocalLayoutDirection is intentionally left to outerLocals so
+                // an app-level RTL override propagates here.
                 val sceneDensity = LocalDensity.current
                 // outerLocals carries the app theme's own LocalTextContextMenu
                 // (e.g. Jewel's). Applying it here shadows the scene's selection
@@ -109,12 +119,16 @@ internal object TaoDecoratedWindowAdapter {
                 // publisher itself is reset by outerLocals, so snapshot + re-provide
                 // it, exactly like LocalDensity.
                 val scenePublisher = LocalTaoTextSelectionA11yPublisher.current
+                val sceneTaoWindow = LocalTaoWindow.current
+                val sceneTitleBarInfo = LocalTitleBarInfo.current
                 CompositionLocalProvider(outerLocals) {
                     CompositionLocalProvider(
                         LocalDensity provides sceneDensity,
                         LocalTaoTextSelectionA11yPublisher provides scenePublisher,
                         LocalNucleusBackend provides NucleusBackend.Tao,
                         LocalNucleusWindow provides nucleusWindow,
+                        LocalTaoWindow provides sceneTaoWindow,
+                        LocalTitleBarInfo provides sceneTitleBarInfo,
                     ) {
                         TaoTextSelectionAccessibility {
                             nucleusScope.content()


### PR DESCRIPTION
## Summary
- Re-provide `LocalTaoWindow` and `LocalTitleBarInfo` after applying `outerLocals` in `TaoDecoratedWindowAdapter`, so secondary windows keep their own handles when opened from inside another `DecoratedWindow`
- Add `Modifier.windowDragArea(window: TaoWindow)` and use it from `BasicTitleBar` so drag/maximize bind to the scope window even if parent CompositionLocals are bridged into the scene
- Without this, title-bar drag and system controls on secondary windows targeted the parent window (appeared immovable)

## Test plan
- [ ] Open a secondary `DecoratedWindow` from inside another window (e.g. demo / app navigation destination)
- [ ] Drag the secondary window title bar — window should move (Windows / macOS / Linux)
- [ ] Double-click title bar toggles maximize on the secondary window, not the parent
- [ ] Minimize / maximize / close controls operate on the secondary window
- [ ] Primary window title bar drag still works as before
- [ ] `./gradlew ktlintCheck detekt` (already green)