### PR TITLE
feat(application): HostedWindow/HostedDialog composition hosts

### DIFF
--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
@@ -13,8 +13,10 @@ import java.util.Locale
  *
  * Picks the window backend (AWT-based JBR/JNI or no-AWT Tao) and dispatches to
  * Compose Desktop's `application { … }` or Tao's `taoApplication { … }`.
- * Inside [content], use [DecoratedWindow] / [DecoratedDialog] — both work
- * uniformly across backends and expose a [NucleusWindow] handle.
+ * Inside [content], use [DecoratedWindow] / [DecoratedDialog], or
+ * [HostedWindow] / [HostedDialog] when libraries must not hard-code chrome.
+ * All open secondary windows/dialogs on the active backend (Tao or AWT) and
+ * expose a [NucleusWindow] handle.
  *
  * Compose's [androidx.compose.foundation.isSystemInDarkTheme] is bridged to
  * Nucleus's reactive OS detector (`darkmode-detector`), so official and library
@@ -97,6 +99,8 @@ fun nucleusApplication(
                     CompositionLocalProvider(
                         LocalNucleusBackend provides NucleusBackend.Awt,
                         LocalNucleusApplicationScope provides nucleusScope,
+                        LocalNucleusWindowHost provides DefaultNucleusWindowHost,
+                        LocalNucleusDialogHost provides DefaultNucleusDialogHost,
                     ) {
                         nucleusScope.content()
                     }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplicationScope.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplicationScope.kt
@@ -76,9 +76,16 @@ sealed interface NucleusApplicationScope : AwtApplicationScope {
  * For plain [DecoratedWindow] / [DecoratedDialog] the receiver-less overloads
  * already read this local, so no `with` is needed.
  *
+ * Libraries and navigation that must open a secondary window or dialog without
+ * hard-coding Material/Jewel chrome should use [LocalNucleusWindowHost] /
+ * [HostedWindow] and [LocalNucleusDialogHost] / [HostedDialog] instead of
+ * Compose Desktop's AWT `Window` / `Dialog` (unsupported on Tao). Apps may
+ * override either host to inject themed wrappers.
+ *
  * Provided by [nucleusApplication] on both backends. On Tao each window owns
  * its own `ComposeScene`, but the whole parent local context is bridged into
- * it, so the scope stays reachable from nested window content too.
+ * it, so the scope (and the window/dialog hosts) stay reachable from nested
+ * window content too.
  */
 val LocalNucleusApplicationScope =
     staticCompositionLocalOf<NucleusApplicationScope> {

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindowHost.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindowHost.kt
@@ -1,0 +1,295 @@
+package dev.nucleusframework.application
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.window.DialogState
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.rememberDialogState
+import androidx.compose.ui.window.rememberWindowState
+
+/**
+ * Opens secondary windows on the active Nucleus backend.
+ *
+ * Compose Desktop's `androidx.compose.ui.window.Window` is hard-wired to AWT
+ * and cannot run under the Tao event loop. Libraries and navigation layers
+ * must open windows through this host (or [DecoratedWindow] /
+ * [HostedWindow]) so Tao secondary scenes get a proper backend, scene-local
+ * re-provisioning, and optional app chrome.
+ *
+ * Provided by [nucleusApplication] as [DefaultNucleusWindowHost]
+ * ([DecoratedWindow]). Override when the app needs a themed wrapper
+ * (Material, Jewel, custom chrome):
+ *
+ * ```
+ * CompositionLocalProvider(
+ *     LocalNucleusWindowHost provides myMaterialHost,
+ * ) {
+ *     // navigation / library code
+ * }
+ *
+ * // library or WindowScene:
+ * HostedWindow(
+ *     onCloseRequest = onBack,
+ *     state = rememberWindowState(size = DpSize(1200.dp, 800.dp)),
+ *     title = "Deep search",
+ * ) {
+ *     TitleBar { Text(title) }
+ *     DeepSearchContent()
+ * }
+ * ```
+ *
+ * Parameter surface matches [DecoratedWindow] (including Tao-only knobs such
+ * as [popupFor], [nativePopupLayers], [hiddenFromDock]).
+ */
+fun interface NucleusWindowHost {
+    @Composable
+    fun Window(
+        onCloseRequest: () -> Unit,
+        state: WindowState,
+        visible: Boolean,
+        title: String,
+        icon: Painter?,
+        resizable: Boolean,
+        enabled: Boolean,
+        focusable: Boolean,
+        alwaysOnTop: Boolean,
+        undecorated: Boolean,
+        popupFor: NucleusWindow?,
+        nativePopupLayers: Boolean,
+        hiddenFromDock: Boolean,
+        minimumSize: DpSize?,
+        onPreviewKeyEvent: (KeyEvent) -> Boolean,
+        onKeyEvent: (KeyEvent) -> Boolean,
+        content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    )
+}
+
+/**
+ * Opens secondary dialogs on the active Nucleus backend.
+ *
+ * Same motivation as [NucleusWindowHost]: avoid Compose Desktop's AWT
+ * `Dialog` under Tao. Default is [DefaultNucleusDialogHost]
+ * ([DecoratedDialog]).
+ *
+ * Parameter surface matches [DecoratedDialog].
+ */
+fun interface NucleusDialogHost {
+    @Composable
+    fun Dialog(
+        onCloseRequest: () -> Unit,
+        state: DialogState,
+        visible: Boolean,
+        title: String,
+        icon: Painter?,
+        resizable: Boolean,
+        enabled: Boolean,
+        focusable: Boolean,
+        onPreviewKeyEvent: (KeyEvent) -> Boolean,
+        onKeyEvent: (KeyEvent) -> Boolean,
+        content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+    )
+}
+
+/**
+ * [NucleusWindowHost] of the surrounding [nucleusApplication].
+ *
+ * Default: [DefaultNucleusWindowHost] ([DecoratedWindow]). Override to inject
+ * Material / Jewel / app chrome without teaching every call site about the
+ * concrete window type.
+ */
+val LocalNucleusWindowHost =
+    staticCompositionLocalOf<NucleusWindowHost> {
+        error(
+            "LocalNucleusWindowHost not provided — use it inside a nucleusApplication { … } block, " +
+                "or call DecoratedWindow { … } directly.",
+        )
+    }
+
+/**
+ * [NucleusDialogHost] of the surrounding [nucleusApplication].
+ *
+ * Default: [DefaultNucleusDialogHost] ([DecoratedDialog]).
+ */
+val LocalNucleusDialogHost =
+    staticCompositionLocalOf<NucleusDialogHost> {
+        error(
+            "LocalNucleusDialogHost not provided — use it inside a nucleusApplication { … } block, " +
+                "or call DecoratedDialog { … } directly.",
+        )
+    }
+
+/**
+ * Default [NucleusWindowHost]: opens a backend-agnostic [DecoratedWindow].
+ * Does not draw a title bar — callers that need CSD chrome compose
+ * [dev.nucleusframework.window.TitleBar] (or a Material/Jewel title bar)
+ * inside [content], same as a top-level [DecoratedWindow].
+ */
+object DefaultNucleusWindowHost : NucleusWindowHost {
+    @Composable
+    override fun Window(
+        onCloseRequest: () -> Unit,
+        state: WindowState,
+        visible: Boolean,
+        title: String,
+        icon: Painter?,
+        resizable: Boolean,
+        enabled: Boolean,
+        focusable: Boolean,
+        alwaysOnTop: Boolean,
+        undecorated: Boolean,
+        popupFor: NucleusWindow?,
+        nativePopupLayers: Boolean,
+        hiddenFromDock: Boolean,
+        minimumSize: DpSize?,
+        onPreviewKeyEvent: (KeyEvent) -> Boolean,
+        onKeyEvent: (KeyEvent) -> Boolean,
+        content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    ) {
+        DecoratedWindow(
+            onCloseRequest = onCloseRequest,
+            state = state,
+            visible = visible,
+            title = title,
+            icon = icon,
+            resizable = resizable,
+            enabled = enabled,
+            focusable = focusable,
+            alwaysOnTop = alwaysOnTop,
+            undecorated = undecorated,
+            popupFor = popupFor,
+            nativePopupLayers = nativePopupLayers,
+            hiddenFromDock = hiddenFromDock,
+            minimumSize = minimumSize,
+            onPreviewKeyEvent = onPreviewKeyEvent,
+            onKeyEvent = onKeyEvent,
+            content = content,
+        )
+    }
+}
+
+/**
+ * Default [NucleusDialogHost]: opens a backend-agnostic [DecoratedDialog].
+ * Does not draw a title bar — same contract as [DefaultNucleusWindowHost].
+ */
+object DefaultNucleusDialogHost : NucleusDialogHost {
+    @Composable
+    override fun Dialog(
+        onCloseRequest: () -> Unit,
+        state: DialogState,
+        visible: Boolean,
+        title: String,
+        icon: Painter?,
+        resizable: Boolean,
+        enabled: Boolean,
+        focusable: Boolean,
+        onPreviewKeyEvent: (KeyEvent) -> Boolean,
+        onKeyEvent: (KeyEvent) -> Boolean,
+        content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+    ) {
+        DecoratedDialog(
+            onCloseRequest = onCloseRequest,
+            state = state,
+            visible = visible,
+            title = title,
+            icon = icon,
+            resizable = resizable,
+            enabled = enabled,
+            focusable = focusable,
+            onPreviewKeyEvent = onPreviewKeyEvent,
+            onKeyEvent = onKeyEvent,
+            content = content,
+        )
+    }
+}
+
+/**
+ * Opens a secondary window via [LocalNucleusWindowHost].
+ *
+ * Prefer this (or [DecoratedWindow]) over Compose Desktop's
+ * `androidx.compose.ui.window.Window` under [nucleusApplication], especially
+ * on the Tao backend.
+ *
+ * Defaults match [DecoratedWindow].
+ */
+@Suppress("FunctionNaming", "LongParameterList")
+@Composable
+fun HostedWindow(
+    onCloseRequest: () -> Unit,
+    state: WindowState = rememberWindowState(),
+    visible: Boolean = true,
+    title: String = "",
+    icon: Painter? = null,
+    resizable: Boolean = true,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    alwaysOnTop: Boolean = false,
+    undecorated: Boolean = false,
+    popupFor: NucleusWindow? = null,
+    nativePopupLayers: Boolean = false,
+    hiddenFromDock: Boolean = false,
+    minimumSize: DpSize? = null,
+    onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
+    onKeyEvent: (KeyEvent) -> Boolean = { false },
+    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+) {
+    LocalNucleusWindowHost.current.Window(
+        onCloseRequest = onCloseRequest,
+        state = state,
+        visible = visible,
+        title = title,
+        icon = icon,
+        resizable = resizable,
+        enabled = enabled,
+        focusable = focusable,
+        alwaysOnTop = alwaysOnTop,
+        undecorated = undecorated,
+        popupFor = popupFor,
+        nativePopupLayers = nativePopupLayers,
+        hiddenFromDock = hiddenFromDock,
+        minimumSize = minimumSize,
+        onPreviewKeyEvent = onPreviewKeyEvent,
+        onKeyEvent = onKeyEvent,
+        content = content,
+    )
+}
+
+/**
+ * Opens a secondary dialog via [LocalNucleusDialogHost].
+ *
+ * Prefer this (or [DecoratedDialog]) over Compose Desktop's AWT `Dialog`
+ * under [nucleusApplication], especially on the Tao backend.
+ *
+ * Defaults match [DecoratedDialog].
+ */
+@Suppress("FunctionNaming", "LongParameterList")
+@Composable
+fun HostedDialog(
+    onCloseRequest: () -> Unit,
+    state: DialogState = rememberDialogState(),
+    visible: Boolean = true,
+    title: String = "",
+    icon: Painter? = null,
+    resizable: Boolean = false,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
+    onKeyEvent: (KeyEvent) -> Boolean = { false },
+    content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+) {
+    LocalNucleusDialogHost.current.Dialog(
+        onCloseRequest = onCloseRequest,
+        state = state,
+        visible = visible,
+        title = title,
+        icon = icon,
+        resizable = resizable,
+        enabled = enabled,
+        focusable = focusable,
+        onPreviewKeyEvent = onPreviewKeyEvent,
+        onKeyEvent = onKeyEvent,
+        content = content,
+    )
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoLauncher.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoLauncher.kt
@@ -3,8 +3,12 @@ package dev.nucleusframework.application.internal
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import dev.nucleusframework.application.DefaultNucleusDialogHost
+import dev.nucleusframework.application.DefaultNucleusWindowHost
 import dev.nucleusframework.application.LocalNucleusApplicationScope
 import dev.nucleusframework.application.LocalNucleusBackend
+import dev.nucleusframework.application.LocalNucleusDialogHost
+import dev.nucleusframework.application.LocalNucleusWindowHost
 import dev.nucleusframework.application.NucleusApplicationScope
 import dev.nucleusframework.application.NucleusBackend
 import dev.nucleusframework.application.ProvideNucleusSystemTheme
@@ -35,6 +39,8 @@ internal object TaoLauncher {
                 CompositionLocalProvider(
                     LocalNucleusBackend provides NucleusBackend.Tao,
                     LocalNucleusApplicationScope provides scope,
+                    LocalNucleusWindowHost provides DefaultNucleusWindowHost,
+                    LocalNucleusDialogHost provides DefaultNucleusDialogHost,
                 ) {
                     // Apply the Dock-follows-windows opt-in on the Tao main thread
                     // (this composition) so a tray-only app drops out of the Dock at


### PR DESCRIPTION
## Summary

- Add `NucleusWindowHost` / `NucleusDialogHost` CompositionLocals so libraries and navigation can open secondary windows/dialogs without hard-coding Compose Desktop's AWT `Window`/`Dialog` (unsupported on Tao) or app chrome (Material/Jewel).
- Default hosts delegate to `DecoratedWindow` / `DecoratedDialog` (full parameter parity, including Tao knobs like `popupFor`, `nativePopupLayers`, `hiddenFromDock`).
- Convenience APIs: `HostedWindow` / `HostedDialog`.
- Provided automatically by `nucleusApplication` on Tao (`TaoLauncher`) and AWT.

## Test plan

- [ ] Compile `:nucleus-application`
- [ ] Under Tao, open a secondary window via `HostedWindow` and verify it works (title bar drag if using `TitleBar`)
- [ ] Override `LocalNucleusWindowHost` with a custom host and confirm library call sites pick it up
- [ ] Open a dialog via `HostedDialog` on Tao
- [ ] Optional: AWT path still provides the locals and defaults open windows