### PR TITLE
fix(tao/linux): position popupOf windows in CSD content space

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -314,7 +314,14 @@ public fun ApplicationScope.DecoratedWindow(
         if (pos == applied.position) return@LaunchedEffect
         when (pos) {
             is WindowPosition.Absolute -> {
-                window.setOuterPosition(pos.x.value.toDouble(), pos.y.value.toDouble())
+                // Drag ghosts (and similar Absolute-driven popup overlays) build
+                // their position as parentOuter + content-relative pointer. On
+                // native Wayland setOuterPosition expects content-area coords
+                // (it adds the CSD content origin itself) — strip the parent
+                // outer origin so the ghost tracks the cursor instead of
+                // landing up/left by the decoration inset + outer offset.
+                val (xDp, yDp) = absolutePositionForPopup(window, pos)
+                window.setOuterPosition(xDp, yDp)
                 applied.position = pos
             }
             is WindowPosition.Aligned -> {
@@ -548,6 +555,43 @@ private fun WindowState.inflateToMinimumSize(minimumSize: DpSize?) {
             }
         }
     }
+}
+
+/**
+ * Converts an Absolute position for a Linux popup overlay into the coordinate
+ * space [TaoWindow.setOuterPosition] expects on native Wayland: parent
+ * **content-area** logical pixels. Apps (tab-drag ghosts) typically build
+ * Absolute as `parent.boundsOnScreen + contentPointer`; strip the parent outer
+ * origin so only the content-relative part remains. No-op on X11 (screen
+ * coords) and for non-popup windows.
+ */
+private fun absolutePositionForPopup(
+    window: TaoWindow,
+    pos: WindowPosition.Absolute,
+): Pair<Double, Double> {
+    var x = pos.x.value.toDouble()
+    var y = pos.y.value.toDouble()
+    // Only native Wayland maps popups as subsurfaces of the parent; X11 uses
+    // override-redirect root coordinates and must keep Absolute as-is.
+    // Prefer the parent surface's backend: the popup may not be realised yet
+    // on the first Absolute write, while the parent already has handles.
+    val parent = if (window.isPopup) window.popupParent else null
+    val offset = parent?.let { parentOuterOriginLogical(it) }
+    if (offset != null) {
+        x -= offset.first
+        y -= offset.second
+    }
+    return x to y
+}
+
+/** Parent outer origin in logical dp when [parent] is a native Wayland surface. */
+private fun parentOuterOriginLogical(parent: TaoWindow): Pair<Double, Double>? {
+    val handles = NativeTaoBridge.nativeLinuxHandles(parent.handle) ?: return null
+    if (handles.isEmpty() || handles[0] != 2L) return null
+    val rect = parent.outerBoundsPx() ?: return null
+    if (rect.size < 2) return null
+    val scale = parent.scaleFactor.takeIf { it > 0f } ?: 1f
+    return (rect[0] / scale) to (rect[1] / scale)
 }
 
 /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -591,7 +591,7 @@ private fun parentOuterOriginLogical(parent: TaoWindow): Pair<Double, Double>? {
     val rect = parent.outerBoundsPx() ?: return null
     if (rect.size < 2) return null
     val scale = parent.scaleFactor.takeIf { it > 0f } ?: 1f
-    return (rect[0] / scale) to (rect[1] / scale)
+    return (rect[0] / scale).toDouble() to (rect[1] / scale).toDouble()
 }
 
 /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -92,7 +92,13 @@ public object TaoApplication {
         undecoratedShadow: Boolean = true,
     ): TaoWindow {
         val handle = handleSeq.getAndIncrement()
-        val window = TaoWindow(handle, isResizable = resizable, isPopup = popupOf != null)
+        val window =
+            TaoWindow(
+                handle,
+                isResizable = resizable,
+                isPopup = popupOf != null,
+                popupParentHandle = popupOf?.handle ?: 0L,
+            )
         windows[handle] = window
         NativeTaoBridge.nativeCreateWindow(
             handle,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -34,6 +34,12 @@ public class TaoWindow internal constructor(
      * "Commit already has timestamp" protocol error.
      */
     public val isPopup: Boolean = false,
+    /**
+     * Handle of the [popupOf] parent when [isPopup] is true (Linux only).
+     * Used to resolve the parent's CSD content origin when positioning this
+     * window as a Wayland `wl_subsurface`.
+     */
+    internal val popupParentHandle: Long = 0L,
 ) {
     // Snapshot-backed so Compose consumers (WindowControls*, resize hit-test
     // gating) recompose when resizability changes at runtime — the AWT
@@ -658,13 +664,50 @@ public class TaoWindow internal constructor(
         NativeTaoBridge.nativeSetInnerSize(handle, widthDp, heightDp)
     }
 
-    /** Logical pixels. Top-left of the outer (decoration-inclusive) window. */
+    /**
+     * Logical pixels. Top-left of the outer (decoration-inclusive) window.
+     *
+     * **Linux popup overlays** (`isPopup`, `openWindow(popupOf = …)`):
+     * - On **X11** the coordinates are root/screen space (override-redirect).
+     * - On **native Wayland** they are **parent content-area** coordinates.
+     *   The hidden-titlebar CSD puts the parent surface origin at the theme
+     *   shadow margin while Compose's content (and content-relative pointer
+     *   samples) live at GTK's content origin. This method adds that content
+     *   origin before `wl_subsurface.set_position`, so callers — drag ghosts,
+     *   in-scene popup layers — can keep working in content space. Zero once
+     *   GTK collapses the margins (maximized / fullscreen / tiled).
+     */
     public fun setOuterPosition(
         xDp: Double,
         yDp: Double,
     ) {
-        NativeTaoBridge.nativeSetOuterPosition(handle, xDp, yDp)
+        var x = xDp
+        var y = yDp
+        // Wayland popup subsurface: content-area → parent-surface coords.
+        // Detect the parent's backend (not env vars) so XWayland stays clean.
+        if (isPopup && popupParentHandle != 0L && parentIsNativeWayland()) {
+            val packed = NativeTaoBridge.nativeLinuxContentOrigin(popupParentHandle)
+            // Packed as (x << 32) | (y & 0xffff_ffff) in logical GTK units.
+            x += (packed shr 32).toInt()
+            y += packed.toInt()
+        }
+        NativeTaoBridge.nativeSetOuterPosition(handle, x, y)
     }
+
+    /** `true` when the popup parent is a native Wayland surface (kind == 2). */
+    private fun parentIsNativeWayland(): Boolean {
+        val handles = NativeTaoBridge.nativeLinuxHandles(popupParentHandle) ?: return false
+        return handles.isNotEmpty() && handles[0] == WAYLAND_HANDLE_KIND
+    }
+
+    /**
+     * Parent window when this is a Linux popup overlay, or `null`. Used by
+     * [DecoratedWindow] Absolute positioning to convert screen-style coords
+     * (parent outer + content-relative) into the content-area space
+     * [setOuterPosition] expects on Wayland.
+     */
+    internal val popupParent: TaoWindow?
+        get() = if (popupParentHandle != 0L) TaoApplication.lookup(popupParentHandle) else null
 
     /** Multi-cast: fires on every native window move. [xPx]/[yPx] are physical pixels. */
     public fun onMoved(block: (xPx: Int, yPx: Int) -> Unit) {
@@ -966,6 +1009,9 @@ public class TaoWindow internal constructor(
                     Platform.Linux -> LINUX_AWT_SCROLL_AMOUNT_DEFAULT
                     else -> MACOS_AWT_SCROLL_AMOUNT
                 }
+
+        /** `nativeLinuxHandles` slot 0: 1 = Xlib, 2 = Wayland. */
+        const val WAYLAND_HANDLE_KIND: Long = 2L
     }
 }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostLinux.kt
@@ -56,6 +56,10 @@ internal interface TaoPopupHostLinux {
      * Offset added to a popup's `boundsInWindow` before positioning the
      * popup window. Non-zero when the popup originates from a nested
      * scene whose origin is not at the host window's top-left.
+     *
+     * The hidden-titlebar CSD content origin is **not** reported here —
+     * [TaoWindow.setOuterPosition] applies it for every Linux `popupOf`
+     * window so drag ghosts and in-scene layers share one code path.
      */
     val coordinateOffset: IntOffset get() = IntOffset.Zero
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
@@ -385,8 +385,10 @@ internal class TaoPopupSceneLayerLinux(
      * Pushes `boundsInWindow` to the popup window. GTK positions in
      * *logical* pixels: X11 popups in root coordinates (parent screen
      * origin + window-relative bounds), Wayland subsurfaces relative to
-     * the parent surface ([TaoPopupHostLinux.parentScreenOriginPx] is
-     * zero there).
+     * the parent **content** area — [TaoWindow.setOuterPosition] adds the
+     * CSD content origin for `popupOf` windows, so we pass content-space
+     * coords here ([TaoPopupHostLinux.parentScreenOriginPx] is zero on
+     * Wayland).
      */
     private fun updateNativeFrame() {
         if (_bounds == IntRect.Zero || released) return

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -1932,26 +1932,13 @@ internal class TaoComposeSceneHostLinux(
                 }
 
             /**
-             * Wayland: the toplevel is decorated with a hidden header bar so GTK
-             * draws the theme drop shadow, which means the parent **surface**
-             * starts at the shadow margin while the content subsurface sits at
-             * GTK's content-area origin (see [applyContentOffset]). A popup is a
-             * subsurface of that same parent surface, so it has to carry the very
-             * offset the content does — otherwise every popup lands up and left
-             * of its anchor by the decoration inset. Zero once GTK collapses the
-             * margins (maximized, fullscreen, tiled) and on X11, which keeps the
-             * flat undecorated presentation.
+             * Nested-scene origin only. The hidden-titlebar CSD content origin
+             * used to live here, but [TaoWindow.setOuterPosition] now applies it
+             * for every Linux popup overlay (`popupOf`) — including in-scene
+             * layers and app-level drag ghosts — so callers can stay in parent
+             * **content** coordinates. Adding it again would double-offset.
              */
-            override val coordinateOffset: IntOffset get() =
-                if (outer.attachedKind != 2 || outer.window.handle == 0L) {
-                    IntOffset.Zero
-                } else {
-                    val packed = NativeTaoBridge.nativeLinuxContentOrigin(outer.window.handle)
-                    IntOffset(
-                        ((packed shr 32).toInt() * outer.scale).roundToInt(),
-                        (packed.toInt() * outer.scale).roundToInt(),
-                    )
-                }
+            override val coordinateOffset: IntOffset get() = IntOffset.Zero
 
             override val sceneCoroutineContext: CoroutineContext
                 get() = outer.coroutineContext + outer.frameClock + outer.flushingDispatcher


### PR DESCRIPTION
## Summary

- Wayland `popupOf` overlays (`wl_subsurface`) were positioned relative to the parent **surface** origin (theme shadow margin) while apps and in-scene layers pass **content-area** coordinates after the hidden-titlebar CSD stack.
- `TaoWindow.setOuterPosition` now adds the parent CSD content origin for popup windows on native Wayland so callers stay in content space.
- Absolute positions on `DecoratedWindow(popupFor=…)` strip the parent outer origin (tab-drag ghosts typically build `outer + contentPointer`).
- In-scene popup layers no longer apply the same offset via `coordinateOffset`, avoiding a double offset.

## Test plan

- [x] Tab drag ghost follows the cursor outside the strip on native Wayland (no CSD inset drift)
- [ ] In-scene Compose popups (menus, tooltips) still anchor correctly under hidden-titlebar CSD
- [ ] X11 / XWayland Absolute popup positioning unchanged
- [x] ktlint + detekt clean on `decorated-window-tao`