### PR TITLE
fix(decorated-window-tao): stop macOS live-resize trembling

### DIFF
--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -2019,7 +2019,12 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeResize(
         //   origin.y unchanged -> bottom edge fixed (else top edge fixed)
         NSString *gravity = kCAGravityResize;
         NSWindow *win = att->view.window;
-        if (att->view.inLiveResize && win != nil &&
+        // Never anchor during an AppKit fullscreen transition: the #327
+        // snapshot ramp depends on Resize gravity for the whole animation,
+        // and AppKit may report inLiveResize while it animates the frame.
+        BOOL liveResize = att->view.inLiveResize &&
+                          atomic_load(&att->in_transition) == 0;
+        if (liveResize && win != nil &&
             !isnan(att->prev_origin_x) && !isnan(att->prev_origin_y)) {
             NSRect fr = win.frame;
             BOOL leftFixed   = fabs(fr.origin.x - att->prev_origin_x) < 0.5;
@@ -2029,7 +2034,7 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeResize(
             } else {
                 gravity = bottomFixed ? kCAGravityBottomRight : kCAGravityTopRight;
             }
-        } else if (att->view.inLiveResize) {
+        } else if (liveResize) {
             // First tick of the drag: no prior origin to diff against. Pin
             // top-left — the common bottom/right case — and let the next
             // tick self-correct to the proper fixed corner.

--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -22,6 +22,7 @@
 #import <stdatomic.h>
 #import <stdio.h>
 #include <stdint.h>
+#include <math.h>
 #import <jni.h>
 
 // Diagnostic logging for the title-bar / fullscreen / menu-bar paths. Off by
@@ -293,6 +294,13 @@ typedef struct {
     // (see willExitFS / #327). Zero until the first fullscreen entry.
     double windowed_w_points;
     double windowed_h_points;
+    // Previous NSWindow frame origin (bottom-left screen coords), used by
+    // nativeResize to pick a live-resize contentsGravity that anchors the
+    // stale drawable to the window's *fixed* corner instead of letting
+    // Core Animation rubber-band it around the layer centre. NAN until the
+    // first resize.
+    double prev_origin_x;
+    double prev_origin_y;
 } NucleusTaoMetalAttachment;
 
 #define HANDLE_OF(ptr) ((NucleusTaoMetalAttachment *)(uintptr_t)(ptr))
@@ -1143,6 +1151,8 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeAttach(
     att->device = device;
     att->queue  = [device newCommandQueue];
     att->view   = view;
+    att->prev_origin_x = NAN;
+    att->prev_origin_y = NAN;
 
     // Install fullscreen observer so the CAMetalLayer wiring survives an
     // AppKit toggleFullScreen: transition. We hang the attachment pointer
@@ -1225,6 +1235,8 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeAttachOverlay(
     att->device = device;
     att->queue  = [device newCommandQueue];
     att->view   = view;
+    att->prev_origin_x = NAN;
+    att->prev_origin_y = NAN;
     return (jlong)(uintptr_t)att;
 }
 
@@ -1991,6 +2003,43 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeResize(
         att->layer.contentsScale = scale;
         att->layer.drawableSize  = CGSizeMake(widthPx, heightPx);
         att->layer.frame         = att->view.bounds;
+        // During an interactive live-resize the present always lags the
+        // bounds by one frame (the Resized event is queued and processed on
+        // a later runloop turn than the AppKit layout commit). With the
+        // default `kCAGravityResize`, Core Animation stretches the stale
+        // last drawable to the new — oscillating — bounds, which reads as
+        // the whole window trembling when the pointer circles a corner.
+        // Instead anchor the stale drawable to the window's *fixed* corner
+        // for the duration of the drag so it stops rubber-banding around
+        // the layer centre; the render thread still presents crisp frames
+        // at the new size, and `kCAGravityResize` is restored on drag end.
+        // The fixed corner is inferred from the NSWindow frame origin delta
+        // (macOS reports the origin at the bottom-left corner):
+        //   origin.x unchanged -> left edge fixed   (else right edge fixed)
+        //   origin.y unchanged -> bottom edge fixed (else top edge fixed)
+        NSString *gravity = kCAGravityResize;
+        NSWindow *win = att->view.window;
+        if (att->view.inLiveResize && win != nil &&
+            !isnan(att->prev_origin_x) && !isnan(att->prev_origin_y)) {
+            NSRect fr = win.frame;
+            BOOL leftFixed   = fabs(fr.origin.x - att->prev_origin_x) < 0.5;
+            BOOL bottomFixed = fabs(fr.origin.y - att->prev_origin_y) < 0.5;
+            if (leftFixed) {
+                gravity = bottomFixed ? kCAGravityBottomLeft : kCAGravityTopLeft;
+            } else {
+                gravity = bottomFixed ? kCAGravityBottomRight : kCAGravityTopRight;
+            }
+        } else if (att->view.inLiveResize) {
+            // First tick of the drag: no prior origin to diff against. Pin
+            // top-left — the common bottom/right case — and let the next
+            // tick self-correct to the proper fixed corner.
+            gravity = kCAGravityTopLeft;
+        }
+        att->layer.contentsGravity = gravity;
+        if (win != nil) {
+            att->prev_origin_x = win.frame.origin.x;
+            att->prev_origin_y = win.frame.origin.y;
+        }
         [CATransaction commit];
     };
     if ([NSThread isMainThread]) resize();


### PR DESCRIPTION
## Summary

- On macOS, resizing the window (notably with circular pointer motion at a corner) made the whole window visibly tremble — a glitch unique to macOS; Windows and Linux are unaffected.
- Root cause: the vendored tao `window_delegate.rs` **queues** the `Resized` event (`AppState::queue_event`), so Kotlin `onResized` runs on a later runloop turn than the AppKit layout commit. The Metal present (async, VSync-paced on the render thread) therefore always lags the `NSView` bounds by ~1 frame. With the default `kCAGravityResize`, Core Animation stretches the stale last drawable across the new — and during circular motion, oscillating — bounds → the window trembles. (Windows presents **inline** on the event-loop thread inside `WM_SIZE`; Linux coalesces.)
- Fix: in `nativeResize`, while `NSView.inLiveResize`, anchor the stale drawable to the window’s **fixed** corner instead of stretching it. The fixed corner is inferred from the `NSWindow` frame origin delta (macOS bottom-left origin):
  - `origin.x` unchanged → left edge fixed, else right edge fixed
  - `origin.y` unchanged → bottom edge fixed, else top edge fixed
  - → `kCAGravityTopLeft / TopRight / BottomLeft / BottomRight`, correct for every edge/corner.
- The corner anchor is additionally gated on the attachment’s `in_transition == 0`: AppKit may report `inLiveResize` while animating a fullscreen transition, and the #327 snapshot ramp depends on `kCAGravityResize` for the whole animation — the fullscreen paths keep Resize gravity unconditionally.
- `kCAGravityResize` is restored as soon as the drag ends, so steady-state rendering and programmatic resizes are byte-for-byte unchanged; Windows/Linux paths untouched.

### Known trade-offs (all transient, ≤1 frame)
- Brief `layer.backgroundColor` strip on the dragged edge until the next present (~16 ms). Opaque windows show the themed bg color (clean); `transparent=true` windows show the desktop for one frame on the dragged edge.
- First tick of a drag uses a `topLeft` fallback (no prior origin to diff) → self-corrects on the next tick.
- After a titlebar move immediately followed by a resize, `prev_origin` is stale for one tick → self-corrects.
- Overlay/popup attachments also receive corner gravity during a window resize (edge detection uses the window origin, not the overlay frame) → possible brief gap on an overlay. Can be gated to the main attachment later if observed.

## Test plan
- [x] macOS: rebuild native (`cd decorated-window-tao/src/main/native/macos && bash build.sh`), run a Compose window, drag a corner with **circular** pointer motion — no trembling.
- [ ] macOS: drag each edge/corner linearly — content stays anchored to the fixed edge, no rubber-banding.
- [ ] macOS: programmatic resize / initial layout / fullscreen toggle — unchanged, no artifacts.
- [ ] macOS: `transparent=true` window — confirm the one-frame desktop strip on the dragged edge is acceptable.
- [x] Windows / Linux: resize behavior unchanged.
