### PR TITLE
Align MSI and NSIS install-scope DSL: add windows.msi block

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/MsiSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/MsiSettings.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.dsl
+
+abstract class MsiSettings {
+    /**
+     * Install per-machine (Program Files, all users). Default: true.
+     * Mirrors [NsisSettings.perMachine] (maps 1:1 to electron-builder `msi.perMachine`).
+     */
+    var perMachine: Boolean
+        get() = explicitPerMachine ?: true
+        set(value) {
+            explicitPerMachine = value
+        }
+
+    // Tracks whether the user set the value explicitly, so the deprecated
+    // windows.perUserInstall flag can still take effect when this one is untouched.
+    internal var explicitPerMachine: Boolean? = null
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/PlatformSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/PlatformSettings.kt
@@ -215,6 +215,11 @@ abstract class WindowsPlatformSettings : AbstractPlatformSettings() {
     var packageName: String? = null
     var console: Boolean = false
     var dirChooser: Boolean = true
+
+    @Deprecated(
+        "Use msi { perMachine = ... } instead. Note the inverted meaning: " +
+            "perUserInstall = true is equivalent to msi.perMachine = false.",
+    )
     var perUserInstall: Boolean = false
     var shortcut: Boolean = false
     var menu: Boolean = false
@@ -228,6 +233,12 @@ abstract class WindowsPlatformSettings : AbstractPlatformSettings() {
 
     fun nsis(fn: Action<NsisSettings>) {
         fn.execute(nsis)
+    }
+
+    val msi: MsiSettings = objects.newInstance(MsiSettings::class.java)
+
+    fun msi(fn: Action<MsiSettings>) {
+        fn.execute(msi)
     }
 
     val appx: AppXSettings = objects.newInstance(AppXSettings::class.java)

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -314,7 +314,10 @@ internal class ElectronBuilderConfigGenerator {
             TargetFormat.Msi -> {
                 yaml.appendLine("msi:")
                 appendIfNotNull(yaml, "  upgradeCode", distributions.windows.upgradeUuid)
-                yaml.appendLine("  perMachine: ${!distributions.windows.perUserInstall}")
+                @Suppress("DEPRECATION")
+                val perMachine = distributions.windows.msi.explicitPerMachine
+                    ?: !distributions.windows.perUserInstall
+                yaml.appendLine("  perMachine: $perMachine")
             }
             TargetFormat.AppX -> generateAppXConfig(yaml, distributions.windows.appx)
             TargetFormat.Portable -> {

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/dsl/MsiSettingsTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/dsl/MsiSettingsTest.kt
@@ -1,0 +1,30 @@
+package dev.nucleusframework.desktop.application.dsl
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MsiSettingsTest {
+    private fun msiSettings(): MsiSettings = object : MsiSettings() {}
+
+    @Test
+    fun `defaults to per-machine without marking the value as explicit`() {
+        val msi = msiSettings()
+        assertTrue(msi.perMachine)
+        assertNull(msi.explicitPerMachine)
+    }
+
+    @Test
+    fun `explicit value is tracked and returned`() {
+        val msi = msiSettings()
+        msi.perMachine = false
+        assertFalse(msi.perMachine)
+        assertEquals(false, msi.explicitPerMachine)
+
+        msi.perMachine = true
+        assertTrue(msi.perMachine)
+        assertEquals(true, msi.explicitPerMachine)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a `msi { }` sub-block to `windows { }` with `perMachine`, mirroring `nsis { perMachine }` — maps 1:1 to electron-builder `msi.perMachine`, no inverted boolean
- Deprecate `windows.perUserInstall` with a message explaining the inversion (`perUserInstall = true` ≡ `msi.perMachine = false`); it keeps working while `msi.perMachine` is untouched, so existing builds are unaffected
- Defaults unchanged: MSI still installs per-machine by default
- `MsiSettings` tracks whether `perMachine` was set explicitly (internal nullable backing), letting the generator resolve `msi.perMachine` first, then fall back to `!perUserInstall`

## Test plan
- [x] `:plugin:compileKotlin` passes
- [x] New `MsiSettingsTest` covers the per-machine default and explicit-value tracking
- [x] ktlint/detekt: no violations in changed files

Closes #225