### PR TITLE
Tao: expose the scene's GPU render context (Skia DirectContext + native device) as public API

### DIFF
--- a/decorated-window-tao/api/decorated-window-tao.api
+++ b/decorated-window-tao/api/decorated-window-tao.api
@@ -599,6 +599,16 @@ public final class dev/nucleusframework/window/tao/TaoEventCode {
 	public static final field WINDOW_READY I
 }
 
+public abstract interface class dev/nucleusframework/window/tao/TaoGpuRenderContext {
+	public abstract fun getBackend ()Ldev/nucleusframework/window/tao/TaoRenderBackend;
+	public abstract fun getSkiaContext ()Lorg/jetbrains/skia/DirectContext;
+	public abstract fun runOnGpuThread (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class dev/nucleusframework/window/tao/TaoGpuRenderContextKt {
+	public static final fun rememberTaoGpuRenderContext (Landroidx/compose/runtime/Composer;I)Ldev/nucleusframework/window/tao/TaoGpuRenderContext;
+}
+
 public final class dev/nucleusframework/window/tao/TaoKeyLocation {
 	public static final field $stable I
 	public static final field INSTANCE Ldev/nucleusframework/window/tao/TaoKeyLocation;
@@ -606,6 +616,10 @@ public final class dev/nucleusframework/window/tao/TaoKeyLocation {
 	public static final field NUMPAD I
 	public static final field RIGHT I
 	public static final field STANDARD I
+}
+
+public abstract interface class dev/nucleusframework/window/tao/TaoMetalRenderContext : dev/nucleusframework/window/tao/TaoGpuRenderContext {
+	public abstract fun getMetalDevicePtr ()J
 }
 
 public final class dev/nucleusframework/window/tao/TaoModifierMask {
@@ -624,6 +638,18 @@ public final class dev/nucleusframework/window/tao/TaoMouseButton {
 	public static final field MIDDLE I
 	public static final field OTHER I
 	public static final field RIGHT I
+}
+
+public abstract interface class dev/nucleusframework/window/tao/TaoOpenGlRenderContext : dev/nucleusframework/window/tao/TaoGpuRenderContext {
+	public abstract fun withContextCurrent (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class dev/nucleusframework/window/tao/TaoRenderBackend : java/lang/Enum {
+	public static final field METAL Ldev/nucleusframework/window/tao/TaoRenderBackend;
+	public static final field OPENGL Ldev/nucleusframework/window/tao/TaoRenderBackend;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/nucleusframework/window/tao/TaoRenderBackend;
+	public static fun values ()[Ldev/nucleusframework/window/tao/TaoRenderBackend;
 }
 
 public final class dev/nucleusframework/window/tao/TaoScreenGeometry {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoGpuRenderContext.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoGpuRenderContext.kt
@@ -1,0 +1,247 @@
+package dev.nucleusframework.window.tao
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import dev.nucleusframework.window.tao.scene.LocalTaoGlTextureHost
+import dev.nucleusframework.window.tao.scene.LocalTaoMetalTextureHost
+import dev.nucleusframework.window.tao.scene.LocalTaoWindowsTextureHost
+import dev.nucleusframework.window.tao.scene.TaoGlTextureHost
+import dev.nucleusframework.window.tao.scene.TaoMetalTextureHost
+import dev.nucleusframework.window.tao.scene.TaoWindowsTextureHost
+import org.jetbrains.skia.DirectContext
+
+/**
+ * The graphics backend a [TaoGpuRenderContext] draws with.
+ */
+public enum class TaoRenderBackend {
+    /** Metal — macOS. */
+    METAL,
+
+    /**
+     * OpenGL (ES) — Linux (native EGL/GLES) and Windows (ANGLE-on-Direct3D-11
+     * GLES). On Windows the context is *not* a desktop OpenGL context: it is
+     * ANGLE's ES 3 context translated to D3D11, and its entry points must be
+     * resolved through ANGLE's `eglGetProcAddress` (the same way the scene's
+     * own Skia interface is assembled).
+     */
+    OPENGL,
+}
+
+/**
+ * The GPU render context of the enclosing Compose surface: the Skia
+ * [DirectContext] the scene is drawn with plus, per backend, the native device
+ * it renders on — published so an in-process renderer (a map engine, a 3D
+ * viewport, a charting engine) can allocate its render target **on the
+ * window's own device** and let Compose sample it directly: no second GPU
+ * device, no shareable allocation, no per-frame cross-device copy.
+ *
+ * This is the complement of `TextureView`'s import sources, not a replacement:
+ * `TextureView` remains the contract for **foreign** producers (out-of-process
+ * renderers, hardware video decoders on their own device), while this API is
+ * for renderers willing to create their Skia/GPU objects on the very context
+ * that paints the scene.
+ *
+ * Obtain it with [rememberTaoGpuRenderContext]; the concrete subtype
+ * ([TaoMetalRenderContext] or [TaoOpenGlRenderContext]) tells the backend
+ * apart, as does [backend].
+ *
+ * ### Ownership and lifetime
+ *
+ * Every handle exposed here is **borrowed**. Consumers must never retain,
+ * release or free them, and must stop using them the moment the surface
+ * publishes a different context (or none). [rememberTaoGpuRenderContext]
+ * returns a **new instance** whenever the underlying context is rebuilt —
+ * window detach, a Wayland hide/show cycle (which rebuilds the whole EGL
+ * stack), popup or tray-panel teardown — so keying on the instance
+ * (`remember(renderContext) { ... }`) is the intended way to rebuild
+ * renderer-side state, and a `DisposableEffect(renderContext)` the intended
+ * place to free it (inside [runOnGpuThread] / `withContextCurrent`).
+ *
+ * ### Threading
+ *
+ * Every member must be called from the thread the composition runs on (the Tao
+ * event-loop thread; on macOS, the process main thread). GPU work goes through
+ * [runOnGpuThread] — see its contract.
+ */
+@Stable
+public sealed interface TaoGpuRenderContext {
+    /** Which backend this context draws with. Matches the runtime subtype. */
+    public val backend: TaoRenderBackend
+
+    /**
+     * The Skia context the enclosing surface is drawn with. GPU resources
+     * created against it (a `BackendRenderTarget`, an adopted texture) are
+     * sampled by the scene with no import step. Only touch it from
+     * [runOnGpuThread] (Metal) or `withContextCurrent` (OpenGL).
+     */
+    public val skiaContext: DirectContext
+
+    /**
+     * Runs [action] **synchronously** with exclusive access to [skiaContext]
+     * — never overlapping the scene replaying a frame — and returns its
+     * result, propagating whatever it throws.
+     *
+     * Must be called from the composition thread. On macOS the action hops to
+     * the render thread that owns the Skia Metal context and blocks until it
+     * returns; that is safe from composition, layout/draw and disposal because
+     * the render thread is idle at those points. On Linux and Windows
+     * everything already runs on the event-loop thread, so the action runs
+     * inline (after the same thread check).
+     */
+    public fun <T> runOnGpuThread(action: () -> T): T
+}
+
+/**
+ * The Metal render context of a macOS surface.
+ *
+ * [metalDevicePtr] is the `id<MTLDevice>` the scene renders with; a renderer
+ * allocates its textures and command queues on it and hands Skia wrappers of
+ * them to [skiaContext][TaoGpuRenderContext.skiaContext]. Borrowed — never
+ * retain or release it (no ARC bridging that transfers ownership).
+ */
+@Stable
+public sealed interface TaoMetalRenderContext : TaoGpuRenderContext {
+    /** Raw `id<MTLDevice>` pointer the scene's Skia context renders with. */
+    public val metalDevicePtr: Long
+}
+
+/**
+ * The OpenGL (ES) render context of a Linux or Windows surface.
+ *
+ * GL state is bound to whichever context is current on the calling thread, so
+ * instead of a raw context handle this carries [withContextCurrent].
+ */
+@Stable
+public sealed interface TaoOpenGlRenderContext : TaoGpuRenderContext {
+    /**
+     * Runs [action] with this surface's GL context current on the calling
+     * thread and returns its result — or `null` when the context could not be
+     * bound (the surface is being torn down). Safe to nest, and safe to call
+     * from composition, layout/draw and disposal; must be called from the
+     * composition thread.
+     *
+     * Whatever was current before is put back afterwards, so a disposal
+     * running inside *another* surface's render pass cannot corrupt that
+     * surface's frame. After [action] returns, Skia's GL state cache is
+     * invalidated (`resetGLAll`) — the action's GL calls happened behind
+     * Skia's back — so consumers don't need to.
+     */
+    public fun <T> withContextCurrent(action: () -> T): T?
+}
+
+/**
+ * The [TaoGpuRenderContext] of the enclosing Compose surface, or `null` while
+ * the surface's GPU context does not exist (bring-up, teardown, or a
+ * non-hardware environment).
+ *
+ * Resolved per surface: inside a `DecoratedWindow` this is the window scene's
+ * context; inside a native popup layer, a `NativeView` overlay or a
+ * `TaoStandalonePopup` tray panel it is that surface's own context on
+ * platforms where surfaces own private contexts (macOS, Linux), and the shared
+ * window context on Windows.
+ *
+ * The returned instance is **identity-stable** for the lifetime of the
+ * underlying GPU context and is replaced (a fresh instance, triggering
+ * recomposition) whenever that context is rebuilt — see the lifetime contract
+ * on [TaoGpuRenderContext].
+ */
+@Composable
+public fun rememberTaoGpuRenderContext(): TaoGpuRenderContext? {
+    val metalHost = LocalTaoMetalTextureHost.current
+    val glHost = LocalTaoGlTextureHost.current
+    val windowsHost = LocalTaoWindowsTextureHost.current
+    return remember(metalHost, glHost, windowsHost) {
+        when {
+            metalHost != null -> MetalRenderContext(metalHost)
+            glHost != null -> LinuxOpenGlRenderContext(glHost)
+            windowsHost != null -> WindowsOpenGlRenderContext(windowsHost)
+            else -> null
+        }
+    }
+}
+
+/**
+ * Base of the concrete contexts: pins the thread the context was created on
+ * (the composition thread of its surface) and rejects calls from any other —
+ * a dispatch would be unsafe to fake (the event loop may be blocked on the
+ * caller), so misuse fails fast instead of deadlocking or racing.
+ */
+private abstract class ThreadPinnedRenderContext : TaoGpuRenderContext {
+    private val owningThread: Thread = Thread.currentThread()
+
+    protected fun checkThread() {
+        check(Thread.currentThread() === owningThread) {
+            "TaoGpuRenderContext used from thread '${Thread.currentThread().name}', " +
+                "but it belongs to '${owningThread.name}' (the surface's composition thread)"
+        }
+    }
+}
+
+private class MetalRenderContext(
+    private val host: TaoMetalTextureHost,
+) : ThreadPinnedRenderContext(),
+    TaoMetalRenderContext {
+    override val backend: TaoRenderBackend get() = TaoRenderBackend.METAL
+    override val skiaContext: DirectContext get() = host.directContext
+    override val metalDevicePtr: Long get() = host.metalDevicePtr
+
+    override fun <T> runOnGpuThread(action: () -> T): T {
+        checkThread()
+        return host.runOnRenderThread(action)
+    }
+}
+
+private class LinuxOpenGlRenderContext(
+    private val host: TaoGlTextureHost,
+) : ThreadPinnedRenderContext(),
+    TaoOpenGlRenderContext {
+    override val backend: TaoRenderBackend get() = TaoRenderBackend.OPENGL
+    override val skiaContext: DirectContext get() = host.directContext
+
+    override fun <T> runOnGpuThread(action: () -> T): T {
+        checkThread()
+        return action()
+    }
+
+    override fun <T> withContextCurrent(action: () -> T): T? {
+        checkThread()
+        return host.withContextCurrent {
+            try {
+                action()
+            } finally {
+                // The action's GL calls changed state behind Skia's back; the
+                // reset must land before this surface's next flushAndSubmit.
+                host.directContext.resetGLAll()
+            }
+        }
+    }
+}
+
+private class WindowsOpenGlRenderContext(
+    private val host: TaoWindowsTextureHost,
+) : ThreadPinnedRenderContext(),
+    TaoOpenGlRenderContext {
+    override val backend: TaoRenderBackend get() = TaoRenderBackend.OPENGL
+    override val skiaContext: DirectContext get() = host.directContext
+
+    override fun <T> runOnGpuThread(action: () -> T): T {
+        checkThread()
+        return action()
+    }
+
+    override fun <T> withContextCurrent(action: () -> T): T? {
+        checkThread()
+        return host.withContextCurrent {
+            try {
+                action()
+            } finally {
+                // Same protocol as the TextureView import path: reset now, not
+                // at the next frame entry, because this can run from inside
+                // ComposeScene.render() and the stale cache would be consumed
+                // by this very frame's flushAndSubmit.
+                host.markGlStateDirtied()
+            }
+        }
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -204,6 +204,22 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
                 override val directContext: DirectContext = ctx
 
                 override fun requestRedraw() = outer.scheduleRender()
+
+                override fun <T> withContextCurrent(block: () -> T): T? {
+                    // Read live: 0 after dispose, which keeps a late caller off
+                    // a freed panel. During the panel's own render pass the
+                    // enclosing preservingAngleBinding makes the inner save a
+                    // no-op and the re-make-current idempotent.
+                    val panelHandle = outer.panel
+                    if (panelHandle == 0L) return null
+                    return preservingAngleBinding {
+                        if (!PopupNativeBridgeWindows.nativeMakeCurrent(panelHandle)) {
+                            null
+                        } else {
+                            block()
+                        }
+                    }
+                }
             }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -1371,6 +1371,17 @@ internal class TaoComposeSceneHostWindows(
                 override val directContext: DirectContext = ctx
 
                 override fun requestRedraw() = outer.window.requestRedraw()
+
+                override fun <T> withContextCurrent(block: () -> T): T? {
+                    // Read live: 0 once the host detached, which keeps a late
+                    // caller off a freed attachment (the Linux twin's rule).
+                    val handle = outer.attachmentHandle
+                    if (handle == 0L) return null
+                    return preservingAngleBinding {
+                        NativeTaoGlBridge.nativeMakeCurrent(handle)
+                        block()
+                    }
+                }
             }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoWindowsTextureHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoWindowsTextureHost.kt
@@ -45,6 +45,22 @@ internal interface TaoWindowsTextureHost {
     fun requestRedraw()
 
     /**
+     * Runs [block] with this surface's ANGLE context current on the calling
+     * thread and returns its result — or null when the surface has no live
+     * context (torn down, or never came up). The Windows face of
+     * [TaoGlTextureHost.withContextCurrent], backing the public
+     * `TaoOpenGlRenderContext`; `TextureView` itself never needs it (the
+     * native import resolves the right EGL trio from [hostHwnd]).
+     *
+     * Implementations bind through [preservingAngleBinding], so whatever was
+     * current beforehand is put back — and when a snapshot is already
+     * outstanding on this thread (a tray panel's render pass wraps the whole
+     * frame in one), the block simply runs with the re-bound context, which
+     * the enclosing scope's restore covers.
+     */
+    fun <T> withContextCurrent(block: () -> T): T?
+
+    /**
      * Announces that GL state on *this surface's* EGL context just changed
      * behind Skia's back: importing a texture binds the producer's pbuffer
      * current and `eglBindTexImage`s onto a fresh texture id, destroying it

--- a/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/GpuContextSection.kt
+++ b/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/GpuContextSection.kt
@@ -1,0 +1,182 @@
+package dev.nucleusframework.sampletao
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.nucleusframework.window.tao.TaoGpuRenderContext
+import dev.nucleusframework.window.tao.TaoOpenGlRenderContext
+import dev.nucleusframework.window.tao.rememberTaoGpuRenderContext
+import kotlinx.coroutines.isActive
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Paint
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.Surface
+
+private const val RT_W = 320
+private const val RT_H = 240
+
+/**
+ * `TaoGpuRenderContext` demo (issue #478): the opposite ownership direction of
+ * `TextureView`. Instead of a foreign producer importing a shareable buffer,
+ * an in-process renderer allocates its render target **on the scene's own
+ * Skia context** ([Surface.makeRenderTarget] against `skiaContext`), draws
+ * into it under the published access scope (`runOnGpuThread` on Metal,
+ * `withContextCurrent` on OpenGL), and the scene samples the snapshot with no
+ * shared handle, no second GPU device, and no per-frame copy — the contract
+ * external engines such as MapLibre Compose build on.
+ */
+@Suppress("FunctionNaming", "MagicNumber")
+@Composable
+fun GpuContextSection(label: TextStyle) {
+    val renderContext = rememberTaoGpuRenderContext()
+
+    BasicText(
+        text = "GPU render context — in-process renderer on the scene's own device:",
+        style = label,
+    )
+    if (renderContext == null) {
+        BasicText("rememberTaoGpuRenderContext() → null (surface not up)", style = label)
+        return
+    }
+    BasicText(
+        text =
+            "backend=${renderContext.backend} · " +
+                "skiaContext@${Integer.toHexString(System.identityHashCode(renderContext.skiaContext))} · " +
+                "${RT_W}x$RT_H private render target, snapshot sampled zero-copy",
+        style = label,
+    )
+
+    // Keyed on the context instance: a rebuilt context (window detach, Wayland
+    // hide/show) publishes a new instance, which recreates the renderer — the
+    // invalidation contract of [TaoGpuRenderContext].
+    val renderer = remember(renderContext) { SceneContextRenderer(renderContext) }
+    var frame by remember(renderContext) { mutableStateOf<Image?>(null) }
+    DisposableEffect(renderer) {
+        onDispose { renderer.close() }
+    }
+    LaunchedEffect(renderer) {
+        var tick = 0
+        while (isActive) {
+            withFrameNanos { }
+            val next = renderer.renderFrame(tick) ?: continue
+            frame?.let(renderer::retire)
+            frame = next
+            tick++
+        }
+    }
+
+    Canvas(
+        Modifier
+            .size(320.dp, 240.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color(0xFF1F2630)),
+    ) {
+        val image = frame ?: return@Canvas
+        drawIntoCanvas { canvas ->
+            canvas.nativeCanvas.drawImageRect(
+                image,
+                Rect.makeWH(size.width, size.height),
+            )
+        }
+    }
+    BasicText(
+        text = "animated by Skia draws issued through the published context",
+        style = TextStyle(color = Color(0xFF6E7480), fontSize = 10.sp),
+    )
+}
+
+/**
+ * A miniature in-process renderer: one persistent GPU render target allocated
+ * on the scene's Skia context, one snapshot per frame.
+ *
+ * Snapshot lifetime: the image handed out for frame N may still be referenced
+ * by an in-flight recorded frame (macOS records on the main thread and replays
+ * on the render thread), so retired snapshots are closed inside a *later*
+ * frame's GPU access scope — by then the render thread has serially moved past
+ * every draw that referenced them.
+ */
+@Suppress("MagicNumber")
+private class SceneContextRenderer(
+    private val renderContext: TaoGpuRenderContext,
+) : AutoCloseable {
+    private var surface: Surface? = null
+    private val retired = ArrayDeque<Image>()
+    private val paint = Paint()
+
+    /**
+     * Runs [action] with safe access to the scene's GPU context: under the
+     * bound GL context on OpenGL backends, on the Skia context's render
+     * thread on Metal.
+     */
+    private fun <T> withGpuAccess(action: () -> T): T? =
+        when (renderContext) {
+            is TaoOpenGlRenderContext -> renderContext.withContextCurrent(action)
+            else -> renderContext.runOnGpuThread(action)
+        }
+
+    /** Draws one frame into the private target and returns its snapshot. */
+    fun renderFrame(tick: Int): Image? =
+        withGpuAccess {
+            val target =
+                surface ?: Surface
+                    .makeRenderTarget(
+                        renderContext.skiaContext,
+                        false,
+                        ImageInfo.makeN32Premul(RT_W, RT_H),
+                    ).also { surface = it }
+
+            val canvas = target.canvas
+            val hue = (tick % 360).toFloat()
+            canvas.clear(
+                androidx.compose.ui.graphics.Color
+                    .hsv(hue, 0.55f, 0.35f)
+                    .toArgb(),
+            )
+            paint.color = 0xFFFFFFFF.toInt()
+            val cx = RT_W / 2f + (RT_W / 3f) * kotlin.math.cos(tick / 30.0).toFloat()
+            val cy = RT_H / 2f + (RT_H / 3f) * kotlin.math.sin(tick / 30.0).toFloat()
+            canvas.drawCircle(cx, cy, 24f, paint)
+            paint.color = 0x80FFFFFF.toInt()
+            canvas.drawRect(Rect.makeXYWH((tick * 3f) % RT_W, 0f, 12f, RT_H.toFloat()), paint)
+            target.flushAndSubmit()
+
+            val snapshot = target.makeImageSnapshot()
+            // Two frames is enough headroom: frame N-2's replay finished before
+            // this scope could run.
+            while (retired.size > 2) retired.removeFirst().close()
+            snapshot
+        }
+
+    fun retire(image: Image) {
+        retired.addLast(image)
+    }
+
+    override fun close() {
+        withGpuAccess {
+            while (retired.isNotEmpty()) retired.removeFirst().close()
+            surface?.close()
+            surface = null
+        }
+        paint.close()
+    }
+}

--- a/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/GpuContextSection.kt
+++ b/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/GpuContextSection.kt
@@ -47,22 +47,30 @@ private const val RT_H = 240
  */
 @Suppress("FunctionNaming", "MagicNumber")
 @Composable
-fun GpuContextSection(label: TextStyle) {
+fun GpuContextSection(
+    label: TextStyle,
+    compact: Boolean = false,
+) {
     val renderContext = rememberTaoGpuRenderContext()
 
-    BasicText(
-        text = "GPU render context — in-process renderer on the scene's own device:",
-        style = label,
-    )
+    if (!compact) {
+        BasicText(
+            text = "GPU render context — in-process renderer on the scene's own device:",
+            style = label,
+        )
+    }
     if (renderContext == null) {
         BasicText("rememberTaoGpuRenderContext() → null (surface not up)", style = label)
         return
     }
+    // The skiaContext identity is the interesting bit in compact mode: a tray
+    // panel owns a private context on macOS/Linux (different id than the
+    // window's), while Windows shares one per surface owner.
     BasicText(
         text =
             "backend=${renderContext.backend} · " +
-                "skiaContext@${Integer.toHexString(System.identityHashCode(renderContext.skiaContext))} · " +
-                "${RT_W}x$RT_H private render target, snapshot sampled zero-copy",
+                "skiaContext@${Integer.toHexString(System.identityHashCode(renderContext.skiaContext))}" +
+                if (compact) "" else " · ${RT_W}x$RT_H private render target, snapshot sampled zero-copy",
         style = label,
     )
 
@@ -87,7 +95,7 @@ fun GpuContextSection(label: TextStyle) {
 
     Canvas(
         Modifier
-            .size(320.dp, 240.dp)
+            .size(if (compact) 160.dp else 320.dp, if (compact) 120.dp else 240.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(Color(0xFF1F2630)),
     ) {
@@ -99,10 +107,12 @@ fun GpuContextSection(label: TextStyle) {
             )
         }
     }
-    BasicText(
-        text = "animated by Skia draws issued through the published context",
-        style = TextStyle(color = Color(0xFF6E7480), fontSize = 10.sp),
-    )
+    if (!compact) {
+        BasicText(
+            text = "animated by Skia draws issued through the published context",
+            style = TextStyle(color = Color(0xFF6E7480), fontSize = 10.sp),
+        )
+    }
 }
 
 /**

--- a/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/TextureTab.kt
+++ b/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/TextureTab.kt
@@ -297,6 +297,11 @@ fun TextureTab(modifier: Modifier = Modifier) {
             }
             BasicText("standalone panel — its own Skia context", style = label)
         }
+        // The complementary API to everything above: an in-process renderer
+        // drawing on the scene's OWN context instead of importing a foreign
+        // buffer. See GpuContextSection.
+        GpuContextSection(label)
+
         if (isTaoStandalonePopupAvailable()) {
             TaoStandalonePopup(
                 visible = panelVisible,

--- a/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/TextureTab.kt
+++ b/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/TextureTab.kt
@@ -306,7 +306,7 @@ fun TextureTab(modifier: Modifier = Modifier) {
             TaoStandalonePopup(
                 visible = panelVisible,
                 position = WindowPosition.Absolute(40.dp, 40.dp),
-                size = DpSize(220.dp, 200.dp),
+                size = DpSize(220.dp, 380.dp),
                 focusable = false,
                 onOutsideClick = { panelVisible = false },
             ) {
@@ -324,6 +324,11 @@ fun TextureTab(modifier: Modifier = Modifier) {
                         modifier = demoBox(160.dp, 120.dp),
                         contentScale = ContentScale.FillBounds,
                     )
+                    // Same in-process-renderer demo, resolved against THIS
+                    // surface: on macOS/Linux the panel owns a private Skia
+                    // context (different skiaContext@ id than the window's),
+                    // on Windows it shares the headless one.
+                    GpuContextSection(label, compact = true)
                 }
             }
         }


### PR DESCRIPTION
Closes #478.

## What

Publishes the render context of every Tao surface so an **in-process** GPU renderer (MapLibre Compose, 3D viewports, charting engines) can allocate its render target on the window's own device and let Compose sample it directly — no second GPU device, no shareable allocation, no per-frame cross-device copy. `TextureView` stays the contract for foreign/out-of-process producers; the two APIs are complementary.

## API (decorated-window-tao)

- `TaoGpuRenderContext` (sealed): `backend`, `skiaContext: DirectContext`, `runOnGpuThread(action)` — synchronous, exclusive access to the Skia context, never overlapping frame replay.
- `TaoMetalRenderContext` (macOS): + `metalDevicePtr` (`id<MTLDevice>`, borrowed). `runOnGpuThread` hops to the render thread owning the Skia Metal context.
- `TaoOpenGlRenderContext` (Linux native EGL/GLES, Windows ANGLE-on-D3D11 GLES): + scoped `withContextCurrent(action)` — safe to nest, restores whatever binding it displaced, and `resetGLAll`s afterwards so consumer GL can't desync Skia's state cache.
- `rememberTaoGpuRenderContext()`: resolves the context of the **enclosing surface** (window scene, native popup layer, `NativeView` overlay, tray panel) by wrapping the existing internal per-surface texture hosts.

This maps one-to-one onto MapLibre Compose's `ComposeGpuContext` consumer contract (`MetalComposeGpuContext` / `OpenGlComposeGpuContext` + `runOnGpuThread`), without any Skiko reflection.

## Answers to the issue's open questions

1. **Windows backend**: Tao renders through ANGLE/GLES, so Windows publishes a `TaoOpenGlRenderContext` documented as ANGLE ES3-on-D3D11 (entry points via `eglGetProcAddress`) — not the `ID3D12Device` MapLibre pairs with Windows. For MapLibre specifically, `TextureView` + D3D11 shared handle remains the Windows bridge; the published GL context still serves generic in-process renderers (and Skia-level renderers fully, see the demo).
2. **Invalidation**: composition-driven replacement. The instance is identity-stable for the lifetime of the underlying context and a *new* instance is published on rebuild (window detach, Wayland hide/show EGL rebuild, popup/panel teardown) — `remember(renderContext)` keying works as MapLibre expects. Handles are documented borrowed, never retained/released.
3. **Scope**: every surface that provides an internal texture host — window scene, macOS/Linux popup layers, macOS `NativeView` overlays, tray panels (Windows/Linux/macOS). Windows overlay/popup layers inherit the window scene's shared context, matching the internal split.
4. **GraalVM**: raw handles are plain `Long`s; no new reachability metadata needed.

## Implementation notes

- Pure Kotlin promotion over the existing internal hosts (`TaoMetalTextureHost`, `TaoGlTextureHost`, `TaoWindowsTextureHost`); internals stay free to change. No native changes.
- Windows gains an internal `TaoWindowsTextureHost.withContextCurrent`, built from the existing `preservingAngleBinding` + `nativeMakeCurrent` (window scene attachment; tray panel headless context via `PopupNativeBridgeWindows`). Attachment/panel handles are read live so a late call after teardown degrades to `null` instead of touching a freed attachment.
- Contexts are thread-pinned to their surface's composition thread and fail fast on misuse (a dispatch could deadlock — the event loop may be blocked on the caller).
- `apiDump` committed; ktlint/detekt clean.

## Demo / verification

`examples/tao-demo` → Texture tab gains a **GPU render context** section: a persistent Skia render target allocated on the scene's own `DirectContext`, animated through `runOnGpuThread`/`withContextCurrent`, snapshot drawn by Compose zero-copy. Snapshot retirement is deferred two frames so macOS's record/replay split can't close an image a recorded frame still references.

Verified on Windows 11 (ANGLE/D3D11): section reports `backend=OPENGL`, animates at display rate alongside the existing `TextureView` producers, window close clean. macOS/Linux paths reuse the already-exercised internal hosts one-to-one (`runOnRenderThread`, `withEglContextCurrent`) — please give the demo a spin there before merge.

## Known issue surfaced while testing (left unfixed, out of scope)

Testing the demo's animating content exposed a pre-existing host problem on Windows, introduced by #477: **during the OS modal resize/move loop, frame-clock-driven content (animations, `withFrameNanos` producers) renders in a free-running loop (~1300 fps observed)**. #477 drops VSync (`eglSwapInterval(0)`) for the whole WM_ENTERSIZEMOVE session so per-WM_SIZE inline presents don't park the WndProc on VBlank — but with the pacer gone, every scene invalidation re-renders at event-pump speed, including during pure window *moves* where no WM_SIZE present ever happens.

Four fixes were attempted on this branch and reverted — recorded here so the next attempt doesn't retry them blind:

1. **Time-based demo animation** (phase from the `withFrameNanos` timestamp instead of a tick counter). Fixes the *apparent* animation speed-up but not the render rate — the host still renders per pump event.
2. **8 ms floor on animation frames** (gate in `onRedrawRequested` for `resizeLoopActive && !pendingResizeApply`, one in-flight delayed `requestRedraw` re-arm through a scheduled executor; WM_SIZE paints always unpaced). Capped move at ~125 fps but the reporter measured ~180-240 and it **reintroduced resize trembling** — the leading theory: a paced animation present can land inside `SetWindowPos` (tao defers WM_SIZE there, see #413) carrying the previous size, and at 8 ms pacing that stale-size frame stays composited long enough to be visible, recreating the very geometry/content mismatch #477 killed.
3. **Lazy VSync drop** — keep VSync on at WM_ENTERSIZEMOVE (it fires for moves too), only drop it at the first real WM_SIZE, restore on exit. Resize keeps the exact #477 regime; moves were expected to be vsync-paced. **In practice the fps still ran away during moves**, i.e. `eglSwapInterval(1)` does not reliably throttle ANGLE presents issued from inside the nested move pump.
4. **Display-refresh floor + quiet window** — native `nativeDisplayRefreshHz` (MonitorFromWindow + EnumDisplaySettings) resolved at loop entry; animation frames capped to one per refresh interval, and during an active resize additionally held until two quiet intervals after the last WM_SIZE render (to avoid the stale-size present of attempt 2). Still not right in testing.

Takeaways for a future fix: WM_SIZE paints must never be skipped or delayed (that is the #477/#476 trembling); any *presented* animation frame between WM_SIZEs risks a stale-size composite; VSync cannot be relied on as the pacer inside the modal loop, in either direction. This wants its own issue/PR — it reproduces on main with any animating window content, without this API.
