### PR TITLE
fix(tao): defer DoDragDrop off the Compose pointer dispatch on Windows

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/dnd/TaoDragAndDropManager.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/dnd/TaoDragAndDropManager.kt
@@ -39,15 +39,29 @@ internal class TaoDragAndDropManager(
     /**
      * Per-platform implementation of the actual OS drag session. Receives the
      * extracted payload (already coerced from the user's [Transferable] into
-     * the cross-platform shape `files + text`) and returns the [DROPEFFECT]
-     * the destination accepted, or `null` if cancelled.
+     * the cross-platform shape `files + text`).
      *
-     * On Windows this maps to `DoDragDrop`. On macOS it will map to
-     * `[NSView beginDraggingSessionWithItems:event:source:]`. On Linux to
-     * `gtk_drag_begin_with_coordinates`.
+     * The contract is asynchronous because this is called from inside
+     * Compose's `sendPointerEvent` dispatch, and [startDragAndDropTransfer]
+     * must answer Compose before the OS session necessarily exists (#435):
+     * returns `true` if the session was — or will be — started, in which case
+     * [onCompleted] is invoked exactly once when the session ends, with the
+     * action the destination accepted or `null` if cancelled. Returns `false`
+     * without ever calling [onCompleted] when the session cannot start
+     * (native library missing, window gone).
+     *
+     * macOS (`beginDraggingSession`) and Linux (`gtk_drag_begin_with_coordinates`)
+     * run the session synchronously — their native calls cooperatively pump the
+     * platform run loop — and call [onCompleted] before returning. Windows
+     * defers `DoDragDrop` onto the main dispatcher so the modal session starts
+     * with no Compose dispatch below it, and calls [onCompleted] one event-loop
+     * iteration later, when `DoDragDrop` returns.
      */
     fun interface OutboundLauncher {
-        fun launch(request: OutboundRequest): DragAndDropTransferAction?
+        fun launch(
+            request: OutboundRequest,
+            onCompleted: (DragAndDropTransferAction?) -> Unit,
+        ): Boolean
     }
 
     class OutboundRequest internal constructor(
@@ -75,7 +89,7 @@ internal class TaoDragAndDropManager(
         TaoDnDDiagnostics.requests.intValue++
         TaoDnDDiagnostics.log("requestDragAndDropTransfer offset=$offset")
 
-        var started = false
+        var inProgress = false
         val scope =
             object : PlatformDragAndDropSource.StartTransferScope {
                 override fun startDragAndDropTransfer(
@@ -111,14 +125,22 @@ internal class TaoDragAndDropManager(
                             drawDragDecoration = drawDragDecoration,
                         )
                     TaoDnDDiagnostics.log("starting OS drag files=${files.size} text=${text != null}")
-                    val result = launcher.launch(request)
-                    TaoDnDDiagnostics.log("OS drag completed action=$result")
-                    transferData.onTransferCompleted?.invoke(result)
-                    started = result != null
+                    inProgress = true
+                    val launched =
+                        launcher.launch(request) { result ->
+                            TaoDnDDiagnostics.log("OS drag completed action=$result")
+                            inProgress = false
+                            transferData.onTransferCompleted?.invoke(result)
+                        }
+                    if (!launched) {
+                        inProgress = false
+                        TaoDnDDiagnostics.log("startDragAndDropTransfer skipped — launcher refused")
+                        return false
+                    }
                     return true
                 }
             }
-        with(source) { scope.startDragAndDropTransfer(offset) { started } }
+        with(source) { scope.startDragAndDropTransfer(offset) { inProgress } }
     }
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -405,29 +405,36 @@ internal class TaoComposeSceneHost(
     @OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
     private fun launchMacOsOutboundDrag(
         request: dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager.OutboundRequest,
-    ): androidx.compose.ui.draganddrop.DragAndDropTransferAction? {
-        if (!dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.isLoaded) return null
-        if (nsViewHandle == 0L) return null
-        return dev.nucleusframework.window.tao.dnd.TaoSceneDnD.launchOutboundDrag(
-            request = request,
-            dropEffectCopy = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_COPY,
-            dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_MOVE,
-            dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_LINK,
-        ) { files, text, allowedEffects ->
-            // No VSync dance and no post-drag `window.resetRedrawLatch()`, unlike
-            // the Windows counterpart. Nothing is consumed while tao's tick is
-            // suppressed: `AppState::cleared` returns early before it drains
-            // either the user-event channel (`RequestRedraw`) or the pending
-            // redraw list, so both survive the session and the latch un-wedges
-            // itself on the first tick after it.
-            dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.nativeStartDrag(
-                nsView = nsViewHandle,
-                files = files,
-                text = text,
-                allowedEffects = allowedEffects,
-                pump = OutboundDragPump(),
-            )
-        }
+        onCompleted: (androidx.compose.ui.draganddrop.DragAndDropTransferAction?) -> Unit,
+    ): Boolean {
+        if (!dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.isLoaded) return false
+        if (nsViewHandle == 0L) return false
+        // Synchronous path, unlike Windows (#435): `beginDraggingSession`
+        // cooperatively pumps the AppKit run loop, so the session completes
+        // before this returns and the result is reported inline.
+        val action: androidx.compose.ui.draganddrop.DragAndDropTransferAction? =
+            dev.nucleusframework.window.tao.dnd.TaoSceneDnD.launchOutboundDrag(
+                request = request,
+                dropEffectCopy = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_COPY,
+                dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_MOVE,
+                dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_LINK,
+            ) { files, text, allowedEffects ->
+                // No VSync dance and no post-drag `window.resetRedrawLatch()`, unlike
+                // the Windows counterpart. Nothing is consumed while tao's tick is
+                // suppressed: `AppState::cleared` returns early before it drains
+                // either the user-event channel (`RequestRedraw`) or the pending
+                // redraw list, so both survive the session and the latch un-wedges
+                // itself on the first tick after it.
+                dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.nativeStartDrag(
+                    nsView = nsViewHandle,
+                    files = files,
+                    text = text,
+                    allowedEffects = allowedEffects,
+                    pump = OutboundDragPump(),
+                )
+            }
+        onCompleted(action)
+        return true
     }
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -689,28 +689,35 @@ internal class TaoComposeSceneHostLinux(
     @OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
     private fun launchLinuxOutboundDrag(
         request: dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager.OutboundRequest,
-    ): androidx.compose.ui.draganddrop.DragAndDropTransferAction? {
-        if (!dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.isLoaded) return null
-        if (window.handle == 0L) return null
-        return dev.nucleusframework.window.tao.dnd.TaoSceneDnD.launchOutboundDrag(
-            request = request,
-            dropEffectCopy = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_COPY,
-            dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_MOVE,
-            dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_LINK,
-        ) { files, text, allowedEffects ->
-            // No VSync dance and no post-drag `window.resetRedrawLatch()`,
-            // unlike the Windows counterpart: the session's GTK pump consumes
-            // no tao event, so the `REDRAW_REQUESTED` matching a latched
-            // `redrawPending` still sits in tao's draw channel when the drag
-            // ends and the latch un-wedges itself on delivery.
-            dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.nativeStartDrag(
-                handle = window.handle,
-                files = files,
-                text = text,
-                allowedEffects = allowedEffects,
-                pump = OutboundDragPump(),
-            )
-        }
+        onCompleted: (androidx.compose.ui.draganddrop.DragAndDropTransferAction?) -> Unit,
+    ): Boolean {
+        if (!dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.isLoaded) return false
+        if (window.handle == 0L) return false
+        // Synchronous path, unlike Windows (#435): the session cooperatively
+        // pumps the GTK main loop, so it completes before this returns and
+        // the result is reported inline.
+        val action: androidx.compose.ui.draganddrop.DragAndDropTransferAction? =
+            dev.nucleusframework.window.tao.dnd.TaoSceneDnD.launchOutboundDrag(
+                request = request,
+                dropEffectCopy = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_COPY,
+                dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_MOVE,
+                dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_LINK,
+            ) { files, text, allowedEffects ->
+                // No VSync dance and no post-drag `window.resetRedrawLatch()`,
+                // unlike the Windows counterpart: the session's GTK pump consumes
+                // no tao event, so the `REDRAW_REQUESTED` matching a latched
+                // `redrawPending` still sits in tao's draw channel when the drag
+                // ends and the latch un-wedges itself on delivery.
+                dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.nativeStartDrag(
+                    handle = window.handle,
+                    files = files,
+                    text = text,
+                    allowedEffects = allowedEffects,
+                    pump = OutboundDragPump(),
+                )
+            }
+        onCompleted(action)
+        return true
     }
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -654,7 +654,34 @@ internal class TaoComposeSceneHostWindows(
     @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
     private fun launchWindowsOutboundDrag(
         request: dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager.OutboundRequest,
+        onCompleted: (androidx.compose.ui.draganddrop.DragAndDropTransferAction?) -> Unit,
+    ): Boolean {
+        if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.isLoaded) return false
+        if (hwnd == 0L) return false
+        // Defer DoDragDrop by one event-loop iteration (#435). Compose calls
+        // this launcher from inside `sendPointerEvent`; entering the modal
+        // session here would make every frame painted by [OutboundDragPump]
+        // re-enter the scene while that pointer dispatch is still on the
+        // stack — a recomposition applied mid-dispatch can detach the node
+        // whose pointer-input handler is suspended underneath. Started from
+        // the dispatcher's pump instead, the session has no Compose dispatch
+        // below it. The mouse button is still down when the block runs one
+        // iteration later, so the session starts normally. The *thread* must
+        // not change — DoDragDrop takes the mouse capture on the calling
+        // thread and only the HWND owner ever sees the mouse-up.
+        dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+            .dispatch(kotlin.coroutines.EmptyCoroutineContext) {
+                onCompleted(runWindowsOutboundDrag(request))
+            }
+        return true
+    }
+
+    @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
+    private fun runWindowsOutboundDrag(
+        request: dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager.OutboundRequest,
     ): androidx.compose.ui.draganddrop.DragAndDropTransferAction? {
+        // Re-checked at execution time: the window may have closed between
+        // the pointer dispatch that scheduled the session and this tick.
         if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.isLoaded) return null
         if (hwnd == 0L) return null
         return dev.nucleusframework.window.tao.dnd.TaoSceneDnD.launchOutboundDrag(
@@ -697,15 +724,11 @@ internal class TaoComposeSceneHostWindows(
      * Drives the host from inside `DoDragDrop`'s modal loop — see
      * [dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DragPump].
      *
-     * Reentrancy, deliberately accepted: `DoDragDrop` is entered synchronously
-     * from `TaoDragAndDropManager.requestDragAndDropTransfer`, which Compose
-     * calls from inside `sendPointerEvent`. Every frame painted here therefore
-     * renders the scene while a pointer dispatch is still on the stack. There
-     * is no way to render during the drag *without* that nesting — refusing to
-     * render would just restore the freeze this exists to fix — so the scene is
-     * re-entered knowingly. If it proves unsafe, the principled fix is to defer
-     * the `DoDragDrop` call onto the main dispatcher so the session starts one
-     * loop iteration later, with no Compose dispatch below it.
+     * No Compose reentrancy (#435): `DoDragDrop` is deferred onto
+     * [dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher] by
+     * [launchWindowsOutboundDrag], so the modal session starts from a pump
+     * tick with no `sendPointerEvent` dispatch below it, and every frame
+     * painted here is a plain top-level render.
      *
      * Named class (not a lambda) for GraalVM JNI reachability, same as
      * [InboundDnDCallback].


### PR DESCRIPTION
Fixes #435.

## Summary
- `TaoDragAndDropManager.OutboundLauncher` becomes asynchronous — `launch(request, onCompleted): Boolean` — because `startDragAndDropTransfer` must answer Compose before the OS session necessarily exists. `onCompleted` is invoked exactly once when the session ends; a refused launch now returns `false` to Compose (gesture treated as not started) instead of a pseudo-cancel.
- Windows: `launchWindowsOutboundDrag` no longer enters `DoDragDrop` synchronously from inside `sendPointerEvent`. It posts the session onto `TaoMainDispatcher`, so `DoDragDrop` starts one event-loop iteration later from a pump tick with no Compose dispatch below it — every frame painted by `OutboundDragPump` is now a plain top-level render, removing the reentrancy hazard entirely. Guards (`isLoaded`, `hwnd != 0`) are re-checked at execution time in case the window closed in the interim. The VSync drop and `resetRedrawLatch()` are unchanged.
- macOS/Linux: adapted to the new signature but keep their synchronous path (their native calls cooperatively pump the platform run loop) and report the result inline.
- The *thread* never changes — `DoDragDrop` stays on the HWND-owning thread; only the moment it is called moves (running it off-thread wedges the OS drag session system-wide, see #435).
- `isTransferInProgress` reported to Compose now reflects the actual in-progress state instead of the post-hoc accepted action.

## Test plan
- [x] `./gradlew :decorated-window-tao:check` (tests, ktlint, detekt, apiCheck)
- [x] `./gradlew ktlintFormat ktlintCheck detekt`
- [x] Manual on Windows: `examples:tao-demo` outbound text/file drag → drop accepted, window keeps painting during the drag, no exception
- [ ] Manual on macOS/Linux (synchronous path unchanged, signature-only adaptation)