### PR TITLE
feat(energy): AwakeMode — keep the system awake without blocking the screen saver

### DIFF
--- a/energy-manager/api/energy-manager.api
+++ b/energy-manager/api/energy-manager.api
@@ -1,3 +1,11 @@
+public final class dev/nucleusframework/energymanager/AwakeMode : java/lang/Enum {
+	public static final field SYSTEM_AND_DISPLAY Ldev/nucleusframework/energymanager/AwakeMode;
+	public static final field SYSTEM_ONLY Ldev/nucleusframework/energymanager/AwakeMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/nucleusframework/energymanager/AwakeMode;
+	public static fun values ()[Ldev/nucleusframework/energymanager/AwakeMode;
+}
+
 public final class dev/nucleusframework/energymanager/EnergyManager {
 	public static final field INSTANCE Ldev/nucleusframework/energymanager/EnergyManager;
 	public final fun disableEfficiencyMode ()Ldev/nucleusframework/energymanager/EnergyManager$Result;
@@ -7,8 +15,12 @@ public final class dev/nucleusframework/energymanager/EnergyManager {
 	public final fun enableLightEfficiencyMode ()Ldev/nucleusframework/energymanager/EnergyManager$Result;
 	public final fun enableThreadEfficiencyMode ()Ldev/nucleusframework/energymanager/EnergyManager$Result;
 	public final fun isAvailable ()Z
+	public final fun isAwakeActive ()Z
 	public final fun isScreenAwakeActive ()Z
+	public final fun keepAwake (Ldev/nucleusframework/energymanager/AwakeMode;)Ldev/nucleusframework/energymanager/EnergyManager$Result;
+	public static synthetic fun keepAwake$default (Ldev/nucleusframework/energymanager/EnergyManager;Ldev/nucleusframework/energymanager/AwakeMode;ILjava/lang/Object;)Ldev/nucleusframework/energymanager/EnergyManager$Result;
 	public final fun keepScreenAwake ()Ldev/nucleusframework/energymanager/EnergyManager$Result;
+	public final fun releaseAwake ()Ldev/nucleusframework/energymanager/EnergyManager$Result;
 	public final fun releaseScreenAwake ()Ldev/nucleusframework/energymanager/EnergyManager$Result;
 	public final fun withEfficiencyMode (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun withLightEfficiencyMode (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/AwakeMode.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/AwakeMode.kt
@@ -1,0 +1,22 @@
+package dev.nucleusframework.energymanager
+
+/**
+ * Scope of an awake request issued through [EnergyManager.keepAwake].
+ */
+public enum class AwakeMode {
+    /**
+     * Prevents both system sleep and display sleep: the screen stays on and no
+     * screen saver kicks in for as long as the request is held.
+     */
+    SYSTEM_AND_DISPLAY,
+
+    /**
+     * Prevents system sleep only. The display is free to turn off and the screen
+     * saver / lock screen behave as usual — suited to long background work that
+     * must survive the user walking away from the machine.
+     *
+     * Currently implemented on Windows only; macOS and Linux report the request
+     * as unsupported.
+     */
+    SYSTEM_ONLY,
+}

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/AwakeMode.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/AwakeMode.kt
@@ -15,8 +15,9 @@ public enum class AwakeMode {
      * saver / lock screen behave as usual — suited to long background work that
      * must survive the user walking away from the machine.
      *
-     * Currently implemented on Windows only; macOS and Linux report the request
-     * as unsupported.
+     * Implemented on Windows and macOS; Linux reports the request as unsupported.
+     * On macOS this is what `caffeinate -i` holds, and — like every idle-sleep
+     * assertion — it does not keep the machine running once the lid is closed.
      */
     SYSTEM_ONLY,
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/AwakeMode.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/AwakeMode.kt
@@ -15,9 +15,11 @@ public enum class AwakeMode {
      * saver / lock screen behave as usual — suited to long background work that
      * must survive the user walking away from the machine.
      *
-     * Implemented on Windows and macOS; Linux reports the request as unsupported.
      * On macOS this is what `caffeinate -i` holds, and — like every idle-sleep
      * assertion — it does not keep the machine running once the lid is closed.
+     * On Linux it maps to a suspend-only session inhibitor, so it needs a session
+     * bus (GNOME, PowerManagement) or systemd-logind to be reachable; the X11
+     * screen-saver fallback cannot serve this mode.
      */
     SYSTEM_ONLY,
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
@@ -21,8 +21,8 @@ import java.util.concurrent.Executors
  * Awake (caffeine):
  *   Windows: SetThreadExecutionState — ES_SYSTEM_REQUIRED, plus ES_DISPLAY_REQUIRED
  *            unless [AwakeMode.SYSTEM_ONLY] is requested.
- *   macOS:   IOPMAssertionCreateWithName(kIOPMAssertPreventUserIdleDisplaySleep);
- *            [AwakeMode.SYSTEM_ONLY] is not implemented yet.
+ *   macOS:   IOPMAssertionCreateWithName — kIOPMAssertPreventUserIdleDisplaySleep,
+ *            or kIOPMAssertPreventUserIdleSystemSleep for [AwakeMode.SYSTEM_ONLY].
  *   Linux:   GNOME SessionManager / systemd-logind / X11 inhibitors;
  *            [AwakeMode.SYSTEM_ONLY] is not implemented yet.
  */
@@ -99,9 +99,9 @@ public object EnergyManager {
      * from entering sleep until [releaseAwake] is called.
      *
      * [AwakeMode.SYSTEM_ONLY] lets the screen saver and display sleep behave normally
-     * while long background work keeps running. It is implemented on Windows only;
-     * macOS and Linux return an unsuccessful [Result] instead of silently downgrading
-     * to [AwakeMode.SYSTEM_AND_DISPLAY].
+     * while long background work keeps running. It is implemented on Windows and macOS;
+     * Linux returns an unsuccessful [Result] instead of silently downgrading to
+     * [AwakeMode.SYSTEM_AND_DISPLAY].
      *
      * Calling this while a request is already active replaces it with [mode].
      */

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
@@ -23,8 +23,9 @@ import java.util.concurrent.Executors
  *            unless [AwakeMode.SYSTEM_ONLY] is requested.
  *   macOS:   IOPMAssertionCreateWithName — kIOPMAssertPreventUserIdleDisplaySleep,
  *            or kIOPMAssertPreventUserIdleSystemSleep for [AwakeMode.SYSTEM_ONLY].
- *   Linux:   GNOME SessionManager / systemd-logind / X11 inhibitors;
- *            [AwakeMode.SYSTEM_ONLY] is not implemented yet.
+ *   Linux:   GNOME SessionManager / freedesktop PowerManagement / systemd-logind /
+ *            X11 inhibitors — [AwakeMode.SYSTEM_ONLY] drops the idle bits and skips
+ *            the X11 screen-saver backend.
  */
 @Suppress("TooManyFunctions")
 public object EnergyManager {
@@ -99,9 +100,7 @@ public object EnergyManager {
      * from entering sleep until [releaseAwake] is called.
      *
      * [AwakeMode.SYSTEM_ONLY] lets the screen saver and display sleep behave normally
-     * while long background work keeps running. It is implemented on Windows and macOS;
-     * Linux returns an unsuccessful [Result] instead of silently downgrading to
-     * [AwakeMode.SYSTEM_AND_DISPLAY].
+     * while long background work keeps running.
      *
      * Calling this while a request is already active replaces it with [mode].
      *

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
@@ -121,15 +121,24 @@ public object EnergyManager {
      */
     public fun isAwakeActive(): Boolean = delegate?.isAwakeActive() ?: false
 
+    /**
+     * Prevents the system and display from sleeping until [releaseAwake] is called.
+     */
     @Deprecated(
         "Renamed to keepAwake(), which also accepts an AwakeMode",
         ReplaceWith("keepAwake()"),
     )
     public fun keepScreenAwake(): Result = keepAwake()
 
+    /**
+     * Releases the awake state, allowing the OS to sleep normally.
+     */
     @Deprecated("Renamed to releaseAwake()", ReplaceWith("releaseAwake()"))
     public fun releaseScreenAwake(): Result = releaseAwake()
 
+    /**
+     * Returns true if an awake request is currently held.
+     */
     @Deprecated("Renamed to isAwakeActive()", ReplaceWith("isAwakeActive()"))
     public fun isScreenAwakeActive(): Boolean = isAwakeActive()
 

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
@@ -104,6 +104,10 @@ public object EnergyManager {
      * [AwakeMode.SYSTEM_AND_DISPLAY].
      *
      * Calling this while a request is already active replaces it with [mode].
+     *
+     * The request is held by a dedicated internal thread, so it stays active
+     * regardless of which thread calls this function — including short-lived
+     * coroutine dispatcher workers.
      */
     public fun keepAwake(mode: AwakeMode = AwakeMode.SYSTEM_AND_DISPLAY): Result =
         delegate?.keepAwake(mode) ?: unsupported

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
@@ -18,9 +18,13 @@ import java.util.concurrent.Executors
  *   macOS:   setpriority(PRIO_DARWIN_BG) + task_policy_set(TIER_5).
  *   Linux:   nice +19, ioprio IDLE, timerslack 100ms — reversible without root.
  *
- * Screen awake:
- *   Windows: SetThreadExecutionState (ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED).
- *   macOS/Linux: not yet implemented.
+ * Awake (caffeine):
+ *   Windows: SetThreadExecutionState — ES_SYSTEM_REQUIRED, plus ES_DISPLAY_REQUIRED
+ *            unless [AwakeMode.SYSTEM_ONLY] is requested.
+ *   macOS:   IOPMAssertionCreateWithName(kIOPMAssertPreventUserIdleDisplaySleep);
+ *            [AwakeMode.SYSTEM_ONLY] is not implemented yet.
+ *   Linux:   GNOME SessionManager / systemd-logind / X11 inhibitors;
+ *            [AwakeMode.SYSTEM_ONLY] is not implemented yet.
  */
 @Suppress("TooManyFunctions")
 public object EnergyManager {
@@ -91,22 +95,40 @@ public object EnergyManager {
     public fun disableThreadEfficiencyMode(): Result = delegate?.disableThreadEfficiencyMode() ?: unsupported
 
     /**
-     * Prevents the display and system from entering sleep.
+     * Prevents the system — and, unless [mode] is [AwakeMode.SYSTEM_ONLY], the display —
+     * from entering sleep until [releaseAwake] is called.
      *
-     * Windows: uses SetThreadExecutionState with ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED.
-     * macOS/Linux: not yet implemented.
+     * [AwakeMode.SYSTEM_ONLY] lets the screen saver and display sleep behave normally
+     * while long background work keeps running. It is implemented on Windows only;
+     * macOS and Linux return an unsuccessful [Result] instead of silently downgrading
+     * to [AwakeMode.SYSTEM_AND_DISPLAY].
+     *
+     * Calling this while a request is already active replaces it with [mode].
      */
-    public fun keepScreenAwake(): Result = delegate?.keepScreenAwake() ?: unsupported
+    public fun keepAwake(mode: AwakeMode = AwakeMode.SYSTEM_AND_DISPLAY): Result =
+        delegate?.keepAwake(mode) ?: unsupported
 
     /**
-     * Releases the screen-awake state, allowing the OS to sleep normally.
+     * Releases the awake state, allowing the OS to sleep normally.
      */
-    public fun releaseScreenAwake(): Result = delegate?.releaseScreenAwake() ?: unsupported
+    public fun releaseAwake(): Result = delegate?.releaseAwake() ?: unsupported
 
     /**
-     * Returns true if screen-awake mode is currently active.
+     * Returns true if an awake request is currently held.
      */
-    public fun isScreenAwakeActive(): Boolean = delegate?.isScreenAwakeActive() ?: false
+    public fun isAwakeActive(): Boolean = delegate?.isAwakeActive() ?: false
+
+    @Deprecated(
+        "Renamed to keepAwake(), which also accepts an AwakeMode",
+        ReplaceWith("keepAwake()"),
+    )
+    public fun keepScreenAwake(): Result = keepAwake()
+
+    @Deprecated("Renamed to releaseAwake()", ReplaceWith("releaseAwake()"))
+    public fun releaseScreenAwake(): Result = releaseAwake()
+
+    @Deprecated("Renamed to isAwakeActive()", ReplaceWith("isAwakeActive()"))
+    public fun isScreenAwakeActive(): Boolean = isAwakeActive()
 
     /**
      * Executes [block] on a dedicated thread with efficiency mode enabled.

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/PlatformEnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/PlatformEnergyManager.kt
@@ -17,9 +17,9 @@ internal interface PlatformEnergyManager {
 
     fun disableThreadEfficiencyMode(): EnergyManager.Result
 
-    fun keepScreenAwake(): EnergyManager.Result
+    fun keepAwake(mode: AwakeMode): EnergyManager.Result
 
-    fun releaseScreenAwake(): EnergyManager.Result
+    fun releaseAwake(): EnergyManager.Result
 
-    fun isScreenAwakeActive(): Boolean
+    fun isAwakeActive(): Boolean
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/linux/LinuxEnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/linux/LinuxEnergyManager.kt
@@ -42,26 +42,31 @@ internal object LinuxEnergyManager : PlatformEnergyManager {
         callNative { NativeLinuxEnergyBridge.nativeDisableThreadEfficiencyMode() }
 
     /**
-     * [AwakeMode.SYSTEM_ONLY] would need the GNOME/logind inhibitors to be split
-     * (INHIBIT_SUSPEND without INHIBIT_IDLE) and the X11 screen-saver backend to be
-     * skipped — not implemented yet, so the request is rejected rather than silently
-     * keeping the display on as well.
+     * The inhibitor the composite backend takes depends on [mode]: GNOME gets
+     * INHIBIT_SUSPEND alone instead of INHIBIT_SUSPEND | INHIBIT_IDLE, the X11
+     * screen-saver backend is skipped entirely (it never keeps the system awake),
+     * and org.freedesktop.PowerManagement — which inhibits automatic sleep only —
+     * joins the chain for the desktops without org.gnome.SessionManager.
      */
     @Synchronized
     override fun keepAwake(mode: AwakeMode): EnergyManager.Result =
-        if (mode == AwakeMode.SYSTEM_ONLY) {
-            EnergyManager.Result(false, -1, "AwakeMode.SYSTEM_ONLY is not implemented on Linux yet")
-        } else {
-            callNative { NativeLinuxEnergyBridge.nativeKeepScreenAwake() }
-        }
+        callNative { NativeLinuxEnergyBridge.nativeKeepAwake(mode.nativeCode) }
 
     @Synchronized
     override fun releaseAwake(): EnergyManager.Result =
         callNative {
-            NativeLinuxEnergyBridge.nativeReleaseScreenAwake()
+            NativeLinuxEnergyBridge.nativeReleaseAwake()
         }
 
     override fun isAwakeActive(): Boolean =
         NativeLinuxEnergyBridge.isLoaded &&
-            runCatching { NativeLinuxEnergyBridge.nativeIsScreenAwakeActive() }.getOrDefault(false)
+            runCatching { NativeLinuxEnergyBridge.nativeIsAwakeActive() }.getOrDefault(false)
+
+    /** Mirrors the AWAKE_* constants in the native bridge. */
+    private val AwakeMode.nativeCode: Int
+        get() =
+            when (this) {
+                AwakeMode.SYSTEM_AND_DISPLAY -> 0
+                AwakeMode.SYSTEM_ONLY -> 1
+            }
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/linux/LinuxEnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/linux/LinuxEnergyManager.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.energymanager.linux
 
+import dev.nucleusframework.energymanager.AwakeMode
 import dev.nucleusframework.energymanager.EnergyManager
 import dev.nucleusframework.energymanager.PlatformEnergyManager
 
@@ -40,19 +41,27 @@ internal object LinuxEnergyManager : PlatformEnergyManager {
     override fun disableThreadEfficiencyMode(): EnergyManager.Result =
         callNative { NativeLinuxEnergyBridge.nativeDisableThreadEfficiencyMode() }
 
-    @Suppress("MaxLineLength")
+    /**
+     * [AwakeMode.SYSTEM_ONLY] would need the GNOME/logind inhibitors to be split
+     * (INHIBIT_SUSPEND without INHIBIT_IDLE) and the X11 screen-saver backend to be
+     * skipped — not implemented yet, so the request is rejected rather than silently
+     * keeping the display on as well.
+     */
     @Synchronized
-    override fun keepScreenAwake(): EnergyManager.Result =
-        callNative { NativeLinuxEnergyBridge.nativeKeepScreenAwake() }
+    override fun keepAwake(mode: AwakeMode): EnergyManager.Result =
+        if (mode == AwakeMode.SYSTEM_ONLY) {
+            EnergyManager.Result(false, -1, "AwakeMode.SYSTEM_ONLY is not implemented on Linux yet")
+        } else {
+            callNative { NativeLinuxEnergyBridge.nativeKeepScreenAwake() }
+        }
 
-    @Suppress("MaxLineLength")
     @Synchronized
-    override fun releaseScreenAwake(): EnergyManager.Result =
+    override fun releaseAwake(): EnergyManager.Result =
         callNative {
             NativeLinuxEnergyBridge.nativeReleaseScreenAwake()
         }
 
-    override fun isScreenAwakeActive(): Boolean =
+    override fun isAwakeActive(): Boolean =
         NativeLinuxEnergyBridge.isLoaded &&
             runCatching { NativeLinuxEnergyBridge.nativeIsScreenAwakeActive() }.getOrDefault(false)
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/linux/NativeLinuxEnergyBridge.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/linux/NativeLinuxEnergyBridge.kt
@@ -30,12 +30,21 @@ internal object NativeLinuxEnergyBridge {
     @JvmStatic
     external fun nativeDisableThreadEfficiencyMode(): Int
 
+    /** @param mode 0 = system + display, 1 = system only. */
     @JvmStatic
-    external fun nativeKeepScreenAwake(): Int
+    external fun nativeKeepAwake(mode: Int): Int
 
     @JvmStatic
-    external fun nativeReleaseScreenAwake(): Int
+    external fun nativeReleaseAwake(): Int
 
     @JvmStatic
-    external fun nativeIsScreenAwakeActive(): Boolean
+    external fun nativeIsAwakeActive(): Boolean
+
+    /**
+     * Returns the inhibitor backend currently holding the awake request
+     * (0 = none, 1 = GNOME SessionManager, 2 = systemd-logind, 3 = X11,
+     * 4 = freedesktop PowerManagement). Exposed for verification.
+     */
+    @JvmStatic
+    external fun nativeQueryAwakeBackend(): Int
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/macos/MacOsEnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/macos/MacOsEnergyManager.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.energymanager.macos
 
+import dev.nucleusframework.energymanager.AwakeMode
 import dev.nucleusframework.energymanager.EnergyManager
 import dev.nucleusframework.energymanager.PlatformEnergyManager
 
@@ -40,11 +41,21 @@ internal object MacOsEnergyManager : PlatformEnergyManager {
     override fun disableThreadEfficiencyMode(): EnergyManager.Result =
         callNative { NativeMacOsEnergyBridge.nativeDisableThreadEfficiencyMode() }
 
-    override fun keepScreenAwake() = callNative { NativeMacOsEnergyBridge.nativeKeepScreenAwake() }
+    /**
+     * [AwakeMode.SYSTEM_ONLY] would map to kIOPMAssertPreventUserIdleSystemSleep,
+     * but that path is not implemented yet — the request is rejected rather than
+     * silently keeping the display on as well.
+     */
+    override fun keepAwake(mode: AwakeMode) =
+        if (mode == AwakeMode.SYSTEM_ONLY) {
+            EnergyManager.Result(false, -1, "AwakeMode.SYSTEM_ONLY is not implemented on macOS yet")
+        } else {
+            callNative { NativeMacOsEnergyBridge.nativeKeepScreenAwake() }
+        }
 
-    override fun releaseScreenAwake() = callNative { NativeMacOsEnergyBridge.nativeReleaseScreenAwake() }
+    override fun releaseAwake() = callNative { NativeMacOsEnergyBridge.nativeReleaseScreenAwake() }
 
-    override fun isScreenAwakeActive(): Boolean =
+    override fun isAwakeActive(): Boolean =
         NativeMacOsEnergyBridge.isLoaded &&
             runCatching { NativeMacOsEnergyBridge.nativeIsScreenAwakeActive() }.getOrDefault(false)
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/macos/MacOsEnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/macos/MacOsEnergyManager.kt
@@ -42,20 +42,26 @@ internal object MacOsEnergyManager : PlatformEnergyManager {
         callNative { NativeMacOsEnergyBridge.nativeDisableThreadEfficiencyMode() }
 
     /**
-     * [AwakeMode.SYSTEM_ONLY] would map to kIOPMAssertPreventUserIdleSystemSleep,
-     * but that path is not implemented yet — the request is rejected rather than
-     * silently keeping the display on as well.
+     * [AwakeMode.SYSTEM_AND_DISPLAY] takes a kIOPMAssertPreventUserIdleDisplaySleep
+     * assertion, [AwakeMode.SYSTEM_ONLY] a kIOPMAssertPreventUserIdleSystemSleep one
+     * (what `caffeinate -i` holds). Both only inhibit *idle* sleep: closing the lid
+     * or choosing Sleep from the Apple menu still puts the machine to sleep.
      */
-    override fun keepAwake(mode: AwakeMode) =
-        if (mode == AwakeMode.SYSTEM_ONLY) {
-            EnergyManager.Result(false, -1, "AwakeMode.SYSTEM_ONLY is not implemented on macOS yet")
-        } else {
-            callNative { NativeMacOsEnergyBridge.nativeKeepScreenAwake() }
-        }
+    @Synchronized
+    override fun keepAwake(mode: AwakeMode) = callNative { NativeMacOsEnergyBridge.nativeKeepAwake(mode.nativeCode) }
 
-    override fun releaseAwake() = callNative { NativeMacOsEnergyBridge.nativeReleaseScreenAwake() }
+    @Synchronized
+    override fun releaseAwake() = callNative { NativeMacOsEnergyBridge.nativeReleaseAwake() }
 
     override fun isAwakeActive(): Boolean =
         NativeMacOsEnergyBridge.isLoaded &&
-            runCatching { NativeMacOsEnergyBridge.nativeIsScreenAwakeActive() }.getOrDefault(false)
+            runCatching { NativeMacOsEnergyBridge.nativeIsAwakeActive() }.getOrDefault(false)
+
+    /** Mirrors the AWAKE_* constants in the native bridge. */
+    private val AwakeMode.nativeCode: Int
+        get() =
+            when (this) {
+                AwakeMode.SYSTEM_AND_DISPLAY -> 0
+                AwakeMode.SYSTEM_ONLY -> 1
+            }
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/macos/NativeMacOsEnergyBridge.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/macos/NativeMacOsEnergyBridge.kt
@@ -30,12 +30,21 @@ internal object NativeMacOsEnergyBridge {
     @JvmStatic
     external fun nativeDisableThreadEfficiencyMode(): Int
 
+    /** @param mode 0 = system + display, 1 = system only. */
     @JvmStatic
-    external fun nativeKeepScreenAwake(): Int
+    external fun nativeKeepAwake(mode: Int): Int
 
     @JvmStatic
-    external fun nativeReleaseScreenAwake(): Int
+    external fun nativeReleaseAwake(): Int
 
     @JvmStatic
-    external fun nativeIsScreenAwakeActive(): Boolean
+    external fun nativeIsAwakeActive(): Boolean
+
+    /**
+     * Returns the mode of the IOKit assertion this process currently holds
+     * (0 = system + display, 1 = system only, -1 = none), read back from the
+     * assertion's own properties. Exposed for verification.
+     */
+    @JvmStatic
+    external fun nativeQueryAwakeMode(): Int
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/windows/NativeWindowsEnergyBridge.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/windows/NativeWindowsEnergyBridge.kt
@@ -30,12 +30,21 @@ internal object NativeWindowsEnergyBridge {
     @JvmStatic
     external fun nativeDisableLightEfficiencyMode(): Int
 
+    /** @param mode 0 = system + display, 1 = system only. */
     @JvmStatic
-    external fun nativeKeepScreenAwake(): Int
+    external fun nativeKeepAwake(mode: Int): Int
 
     @JvmStatic
-    external fun nativeReleaseScreenAwake(): Int
+    external fun nativeReleaseAwake(): Int
 
     @JvmStatic
-    external fun nativeIsScreenAwakeActive(): Boolean
+    external fun nativeIsAwakeActive(): Boolean
+
+    /**
+     * Returns the EXECUTION_STATE flags Windows currently holds for the calling
+     * thread (ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED), or 0 if
+     * the query failed. Exposed for verification — the state is per-thread.
+     */
+    @JvmStatic
+    external fun nativeQueryAwakeFlags(): Int
 }

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/windows/WindowsEnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/windows/WindowsEnergyManager.kt
@@ -3,8 +3,41 @@ package dev.nucleusframework.energymanager.windows
 import dev.nucleusframework.energymanager.AwakeMode
 import dev.nucleusframework.energymanager.EnergyManager
 import dev.nucleusframework.energymanager.PlatformEnergyManager
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
+@Suppress("TooManyFunctions")
 internal object WindowsEnergyManager : PlatformEnergyManager {
+    /**
+     * SetThreadExecutionState is per-thread state: Windows drops the request as
+     * soon as the thread that issued it exits. Routing every awake call through
+     * this single long-lived daemon thread keeps the request alive regardless
+     * of which caller thread (e.g. a recycled Dispatchers.IO worker) invoked it.
+     */
+    private val awakeExecutor: ExecutorService by lazy {
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "nucleus-awake").apply { isDaemon = true }
+        }
+    }
+
+    /** Runs [block] on the dedicated awake thread and waits for its result. */
+    fun <T> onAwakeThread(block: () -> T): T = awakeExecutor.submit(block).get()
+
+    private fun callNativeOnAwakeThread(block: () -> Int): EnergyManager.Result {
+        if (!NativeWindowsEnergyBridge.isLoaded) {
+            return EnergyManager.Result(false, -1, "Native library not loaded")
+        }
+        return try {
+            onAwakeThread { callNative(block) }
+        } catch (e: ExecutionException) {
+            EnergyManager.Result(false, -1, "Exception: ${(e.cause ?: e).message}")
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            EnergyManager.Result(false, -1, "Interrupted: ${e.message}")
+        }
+    }
+
     private fun callNative(block: () -> Int): EnergyManager.Result {
         if (!NativeWindowsEnergyBridge.isLoaded) {
             return EnergyManager.Result(false, -1, "Native library not loaded")
@@ -41,9 +74,10 @@ internal object WindowsEnergyManager : PlatformEnergyManager {
     override fun disableThreadEfficiencyMode(): EnergyManager.Result =
         callNative { NativeWindowsEnergyBridge.nativeDisableThreadEfficiencyMode() }
 
-    override fun keepAwake(mode: AwakeMode) = callNative { NativeWindowsEnergyBridge.nativeKeepAwake(mode.nativeCode) }
+    override fun keepAwake(mode: AwakeMode) =
+        callNativeOnAwakeThread { NativeWindowsEnergyBridge.nativeKeepAwake(mode.nativeCode) }
 
-    override fun releaseAwake() = callNative { NativeWindowsEnergyBridge.nativeReleaseAwake() }
+    override fun releaseAwake() = callNativeOnAwakeThread { NativeWindowsEnergyBridge.nativeReleaseAwake() }
 
     override fun isAwakeActive(): Boolean =
         NativeWindowsEnergyBridge.isLoaded &&

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/windows/WindowsEnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/windows/WindowsEnergyManager.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.energymanager.windows
 
+import dev.nucleusframework.energymanager.AwakeMode
 import dev.nucleusframework.energymanager.EnergyManager
 import dev.nucleusframework.energymanager.PlatformEnergyManager
 
@@ -40,11 +41,19 @@ internal object WindowsEnergyManager : PlatformEnergyManager {
     override fun disableThreadEfficiencyMode(): EnergyManager.Result =
         callNative { NativeWindowsEnergyBridge.nativeDisableThreadEfficiencyMode() }
 
-    override fun keepScreenAwake() = callNative { NativeWindowsEnergyBridge.nativeKeepScreenAwake() }
+    override fun keepAwake(mode: AwakeMode) = callNative { NativeWindowsEnergyBridge.nativeKeepAwake(mode.nativeCode) }
 
-    override fun releaseScreenAwake() = callNative { NativeWindowsEnergyBridge.nativeReleaseScreenAwake() }
+    override fun releaseAwake() = callNative { NativeWindowsEnergyBridge.nativeReleaseAwake() }
 
-    override fun isScreenAwakeActive(): Boolean =
+    override fun isAwakeActive(): Boolean =
         NativeWindowsEnergyBridge.isLoaded &&
-            runCatching { NativeWindowsEnergyBridge.nativeIsScreenAwakeActive() }.getOrDefault(false)
+            runCatching { NativeWindowsEnergyBridge.nativeIsAwakeActive() }.getOrDefault(false)
+
+    /** Mirrors the AWAKE_* constants in the native bridge. */
+    private val AwakeMode.nativeCode: Int
+        get() =
+            when (this) {
+                AwakeMode.SYSTEM_AND_DISPLAY -> 0
+                AwakeMode.SYSTEM_ONLY -> 1
+            }
 }

--- a/energy-manager/src/main/native/linux/build.sh
+++ b/energy-manager/src/main/native/linux/build.sh
@@ -59,3 +59,10 @@ else
     gcc "${COMMON_FLAGS[@]}" \
         -o "$RESOURCE_DIR/linux-$ARCH/libnucleus_energy_manager.so" "$SRC"
 fi
+
+# Clear NativeLibraryLoader cache to avoid serving stale cached copy
+CACHE_DIR="${HOME}/.cache/nucleus/native"
+if [ -d "$CACHE_DIR" ]; then
+    find "$CACHE_DIR" -name "libnucleus_energy_manager.so" -delete 2>/dev/null || true
+    echo "Cleared NativeLibraryLoader cache"
+fi

--- a/energy-manager/src/main/native/linux/nucleus_energy_manager.c
+++ b/energy-manager/src/main/native/linux/nucleus_energy_manager.c
@@ -5,10 +5,11 @@
  *   - Checking if Linux energy APIs are available (compile-time check)
  *   - Enabling efficiency mode (nice +19, timer slack 100ms, ioprio IDLE)
  *   - Disabling efficiency mode (restore defaults)
- *   - Screen-awake via composite backend:
+ *   - Awake (caffeine) via composite backend:
  *       1. GNOME SessionManager DBus Inhibit (session bus)
- *       2. systemd-logind DBus Inhibit (system bus)
- *       3. X11 XScreenSaverSuspend (via libXss)
+ *       2. freedesktop PowerManagement DBus Inhibit (session bus, SYSTEM_ONLY)
+ *       3. systemd-logind DBus Inhibit (system bus)
+ *       4. X11 XScreenSaverSuspend (via libXss, SYSTEM_AND_DISPLAY only)
  *
  * All native libraries (libdbus-1, libX11, libXss) are loaded at runtime
  * via dlopen() to avoid hard dependencies.
@@ -208,27 +209,40 @@ Java_dev_nucleusframework_energymanager_linux_NativeLinuxEnergyBridge_nativeDisa
 }
 
 /* ==================================================================
- * Screen-awake (caffeine) via composite backend
+ * Awake (caffeine) via composite backend
  *
- * Three backends are tried in order:
- *   1. GNOME SessionManager DBus Inhibit  (session bus)
- *   2. systemd-logind DBus Inhibit        (system bus)
- *   3. X11 XScreenSaverSuspend            (libXss)
+ * Backends are tried in order, and which ones are eligible depends on
+ * the requested mode:
+ *
+ *   SYSTEM_AND_DISPLAY           SYSTEM_ONLY
+ *   ------------------           -----------
+ *   1. GNOME (IDLE|SUSPEND)      1. GNOME (SUSPEND)
+ *   2. logind (idle)             2. freedesktop PowerManagement
+ *   3. X11 (XScreenSaverSuspend) 3. logind (idle)
+ *
+ * X11 XScreenSaverSuspend only holds off the screen saver, so it can
+ * never satisfy a SYSTEM_ONLY request and is skipped there. Conversely
+ * org.freedesktop.PowerManagement only inhibits automatic sleep and
+ * leaves the screen saver alone, so it is only used for SYSTEM_ONLY.
  *
  * All libraries are loaded lazily via dlopen() so that the module
  * works even when some libraries are not installed.
  * ================================================================== */
 
+/* Must match AwakeMode.nativeCode in LinuxEnergyManager.kt */
+#define AWAKE_SYSTEM_AND_DISPLAY 0
+#define AWAKE_SYSTEM_ONLY        1
+#define AWAKE_NONE               (-1)
+
 /* ---- Backend type tracking ---------------------------------------- */
 
-enum screen_awake_backend {
-    BACKEND_NONE   = 0,
-    BACKEND_GNOME  = 1,
-    BACKEND_LOGIND = 2,
-    BACKEND_X11    = 3
+enum awake_backend {
+    BACKEND_NONE              = 0,
+    BACKEND_GNOME             = 1,
+    BACKEND_LOGIND            = 2,
+    BACKEND_X11               = 3,
+    BACKEND_POWER_MANAGEMENT  = 4
 };
-
-static volatile enum screen_awake_backend g_activeBackend = BACKEND_NONE;
 
 /* ---- DBus types and constants ------------------------------------- */
 
@@ -251,6 +265,38 @@ typedef struct {
 #define DBUS_TYPE_UINT32    ((int)'u')
 #define DBUS_TYPE_UNIX_FD   ((int)'h')
 #define DBUS_TIMEOUT_MS     2000
+
+/* ---- X11 types ---------------------------------------------------- */
+
+typedef void* Display;
+
+/*
+ * One held awake request. Every backend fills in only the handles it
+ * needs; the rest stay at their empty values. Keeping the whole request
+ * in one value lets nativeKeepAwake() acquire the new request before
+ * dropping the old one, so a mode switch never leaves a gap during which
+ * the machine is free to sleep.
+ *
+ * Access is single-threaded from Kotlin (@Synchronized on the manager).
+ */
+typedef struct {
+    enum awake_backend backend;
+    int                mode;      /* AWAKE_* */
+    DBusConnection    *conn;      /* GNOME, PowerManagement, logind */
+    dbus_uint32_t      cookie;    /* GNOME, PowerManagement */
+    int                fd;        /* logind */
+    Display            display;   /* X11 */
+} awake_request;
+
+#define AWAKE_REQUEST_EMPTY { BACKEND_NONE, AWAKE_NONE, NULL, 0, -1, NULL }
+
+static awake_request g_awake = AWAKE_REQUEST_EMPTY;
+
+/** Human-readable reason, visible in `systemd-inhibit --list` and friends. */
+static const char* awake_reason(int mode) {
+    return (mode == AWAKE_SYSTEM_ONLY) ? "keepAwake(SYSTEM_ONLY)"
+                                       : "keepAwake(SYSTEM_AND_DISPLAY)";
+}
 
 /* ---- DBus function pointers --------------------------------------- */
 
@@ -350,9 +396,18 @@ static void close_private_bus(DBusConnection *conn) {
     p_dbus_connection_unref(conn);
 }
 
-/* ---- X11 function pointers ---------------------------------------- */
+/* Helper: fire a method call that returns nothing we care about. */
+static void send_and_discard(DBusConnection *conn, DBusMessage *msg) {
+    DBusError err;
+    p_dbus_error_init(&err);
+    DBusMessage *reply = p_dbus_send_with_reply(conn, msg, DBUS_TIMEOUT_MS, &err);
+    p_dbus_message_unref(msg);
+    if (reply) p_dbus_message_unref(reply);
+    if (p_dbus_error_is_set && p_dbus_error_is_set(&err))
+        p_dbus_error_free(&err);
+}
 
-typedef void* Display;
+/* ---- X11 function pointers ---------------------------------------- */
 
 static void *g_libx11 = NULL;
 static void *g_libxss = NULL;
@@ -411,14 +466,17 @@ static int load_x11(void) {
 #define GNOME_INHIBIT_IDLE    8
 #define GNOME_INHIBIT_SUSPEND 4
 
-static DBusConnection *g_gnomeConn = NULL;
-static dbus_uint32_t   g_gnomeCookie = 0;
-
-static int gnome_inhibit(void) {
+/*
+ * INHIBIT_SUSPEND stops gnome-session from suspending the machine on idle,
+ * INHIBIT_IDLE additionally stops the session from going idle at all, which
+ * is what keeps the screen saver and display sleep away. SYSTEM_ONLY takes
+ * the former only.
+ */
+static int gnome_inhibit(int mode, awake_request *out) {
     if (!load_dbus()) return -1;
 
-    g_gnomeConn = open_private_bus(DBUS_BUS_SESSION);
-    if (!g_gnomeConn) return -1;
+    DBusConnection *conn = open_private_bus(DBUS_BUS_SESSION);
+    if (!conn) return -1;
 
     DBusMessage *msg = p_dbus_message_new_method_call(
         "org.gnome.SessionManager",
@@ -426,15 +484,16 @@ static int gnome_inhibit(void) {
         "org.gnome.SessionManager",
         "Inhibit");
     if (!msg) {
-        close_private_bus(g_gnomeConn);
-        g_gnomeConn = NULL;
+        close_private_bus(conn);
         return -1;
     }
 
     const char *app_name = "Nucleus EnergyManager";
     dbus_uint32_t xid = 0;
-    const char *reason = "keepScreenAwake";
-    dbus_uint32_t flags = GNOME_INHIBIT_IDLE | GNOME_INHIBIT_SUSPEND;
+    const char *reason = awake_reason(mode);
+    dbus_uint32_t flags = (mode == AWAKE_SYSTEM_ONLY)
+        ? GNOME_INHIBIT_SUSPEND
+        : (GNOME_INHIBIT_IDLE | GNOME_INHIBIT_SUSPEND);
 
     p_dbus_message_append_args(msg,
         DBUS_TYPE_STRING, &app_name,
@@ -446,14 +505,13 @@ static int gnome_inhibit(void) {
     DBusError err;
     p_dbus_error_init(&err);
 
-    DBusMessage *reply = p_dbus_send_with_reply(g_gnomeConn, msg, DBUS_TIMEOUT_MS, &err);
+    DBusMessage *reply = p_dbus_send_with_reply(conn, msg, DBUS_TIMEOUT_MS, &err);
     p_dbus_message_unref(msg);
 
     if (!reply) {
         if (p_dbus_error_is_set && p_dbus_error_is_set(&err))
             p_dbus_error_free(&err);
-        close_private_bus(g_gnomeConn);
-        g_gnomeConn = NULL;
+        close_private_bus(conn);
         return -1;
     }
 
@@ -463,60 +521,141 @@ static int gnome_inhibit(void) {
         DBUS_TYPE_INVALID);
     p_dbus_message_unref(reply);
 
-    if (!parsed) {
-        if (p_dbus_error_is_set && p_dbus_error_is_set(&err))
-            p_dbus_error_free(&err);
-        close_private_bus(g_gnomeConn);
-        g_gnomeConn = NULL;
-        return -1;
-    }
-
     if (p_dbus_error_is_set && p_dbus_error_is_set(&err))
         p_dbus_error_free(&err);
 
-    g_gnomeCookie = cookie;
+    if (!parsed) {
+        close_private_bus(conn);
+        return -1;
+    }
+
+    out->backend = BACKEND_GNOME;
+    out->mode    = mode;
+    out->conn    = conn;
+    out->cookie  = cookie;
     return 0;
 }
 
-static int gnome_uninhibit(void) {
-    if (!g_gnomeConn) return -1;
-
+static int gnome_uninhibit(awake_request *req) {
     DBusMessage *msg = p_dbus_message_new_method_call(
         "org.gnome.SessionManager",
         "/org/gnome/SessionManager",
         "org.gnome.SessionManager",
         "Uninhibit");
-    if (!msg) return -1;
+    if (!msg) {
+        close_private_bus(req->conn);
+        return -1;
+    }
 
     p_dbus_message_append_args(msg,
-        DBUS_TYPE_UINT32, &g_gnomeCookie,
+        DBUS_TYPE_UINT32, &req->cookie,
+        DBUS_TYPE_INVALID);
+
+    send_and_discard(req->conn, msg);
+    close_private_bus(req->conn);
+    return 0;
+}
+
+/* ---- freedesktop PowerManagement backend -------------------------- */
+
+/*
+ * org.freedesktop.PowerManagement.Inhibit inhibits *automatic sleep* and
+ * nothing else — the screen saver is a separate interface
+ * (org.freedesktop.ScreenSaver). That maps exactly onto SYSTEM_ONLY, and
+ * covers the desktops that do not implement org.gnome.SessionManager
+ * (KDE/powerdevil, Xfce, MATE, Cinnamon).
+ */
+static int powermanagement_inhibit(int mode, awake_request *out) {
+    if (!load_dbus()) return -1;
+
+    DBusConnection *conn = open_private_bus(DBUS_BUS_SESSION);
+    if (!conn) return -1;
+
+    DBusMessage *msg = p_dbus_message_new_method_call(
+        "org.freedesktop.PowerManagement",
+        "/org/freedesktop/PowerManagement/Inhibit",
+        "org.freedesktop.PowerManagement.Inhibit",
+        "Inhibit");
+    if (!msg) {
+        close_private_bus(conn);
+        return -1;
+    }
+
+    const char *app_name = "Nucleus EnergyManager";
+    const char *reason = awake_reason(mode);
+
+    p_dbus_message_append_args(msg,
+        DBUS_TYPE_STRING, &app_name,
+        DBUS_TYPE_STRING, &reason,
         DBUS_TYPE_INVALID);
 
     DBusError err;
     p_dbus_error_init(&err);
-    DBusMessage *reply = p_dbus_send_with_reply(g_gnomeConn, msg, DBUS_TIMEOUT_MS, &err);
+
+    DBusMessage *reply = p_dbus_send_with_reply(conn, msg, DBUS_TIMEOUT_MS, &err);
     p_dbus_message_unref(msg);
 
-    if (reply) p_dbus_message_unref(reply);
+    if (!reply) {
+        if (p_dbus_error_is_set && p_dbus_error_is_set(&err))
+            p_dbus_error_free(&err);
+        close_private_bus(conn);
+        return -1;
+    }
+
+    dbus_uint32_t cookie = 0;
+    dbus_bool_t parsed = p_dbus_message_get_args(reply, &err,
+        DBUS_TYPE_UINT32, &cookie,
+        DBUS_TYPE_INVALID);
+    p_dbus_message_unref(reply);
+
     if (p_dbus_error_is_set && p_dbus_error_is_set(&err))
         p_dbus_error_free(&err);
 
-    close_private_bus(g_gnomeConn);
-    g_gnomeConn = NULL;
-    g_gnomeCookie = 0;
+    if (!parsed) {
+        close_private_bus(conn);
+        return -1;
+    }
+
+    out->backend = BACKEND_POWER_MANAGEMENT;
+    out->mode    = mode;
+    out->conn    = conn;
+    out->cookie  = cookie;
+    return 0;
+}
+
+static int powermanagement_uninhibit(awake_request *req) {
+    DBusMessage *msg = p_dbus_message_new_method_call(
+        "org.freedesktop.PowerManagement",
+        "/org/freedesktop/PowerManagement/Inhibit",
+        "org.freedesktop.PowerManagement.Inhibit",
+        "UnInhibit");
+    if (!msg) {
+        close_private_bus(req->conn);
+        return -1;
+    }
+
+    p_dbus_message_append_args(msg,
+        DBUS_TYPE_UINT32, &req->cookie,
+        DBUS_TYPE_INVALID);
+
+    send_and_discard(req->conn, msg);
+    close_private_bus(req->conn);
     return 0;
 }
 
 /* ---- systemd-logind backend --------------------------------------- */
 
-static DBusConnection *g_logindConn = NULL;
-static int             g_logindFd = -1;
-
-static int logind_inhibit(void) {
+/*
+ * An "idle" inhibitor stops logind from running its IdleAction (typically
+ * suspend) and does not touch the screen saver, so it serves both modes:
+ * for SYSTEM_ONLY it is exactly right, for SYSTEM_AND_DISPLAY it is the
+ * best a session-less fallback can do before X11 is tried.
+ */
+static int logind_inhibit(int mode, awake_request *out) {
     if (!load_dbus()) return -1;
 
-    g_logindConn = open_private_bus(DBUS_BUS_SYSTEM);
-    if (!g_logindConn) return -1;
+    DBusConnection *conn = open_private_bus(DBUS_BUS_SYSTEM);
+    if (!conn) return -1;
 
     DBusMessage *msg = p_dbus_message_new_method_call(
         "org.freedesktop.login1",
@@ -524,34 +663,32 @@ static int logind_inhibit(void) {
         "org.freedesktop.login1.Manager",
         "Inhibit");
     if (!msg) {
-        close_private_bus(g_logindConn);
-        g_logindConn = NULL;
+        close_private_bus(conn);
         return -1;
     }
 
     const char *what = "idle";
     const char *who  = "Nucleus EnergyManager";
-    const char *why  = "keepScreenAwake";
-    const char *mode = "block";
+    const char *why  = awake_reason(mode);
+    const char *inhibit_mode = "block";
 
     p_dbus_message_append_args(msg,
         DBUS_TYPE_STRING, &what,
         DBUS_TYPE_STRING, &who,
         DBUS_TYPE_STRING, &why,
-        DBUS_TYPE_STRING, &mode,
+        DBUS_TYPE_STRING, &inhibit_mode,
         DBUS_TYPE_INVALID);
 
     DBusError err;
     p_dbus_error_init(&err);
 
-    DBusMessage *reply = p_dbus_send_with_reply(g_logindConn, msg, DBUS_TIMEOUT_MS, &err);
+    DBusMessage *reply = p_dbus_send_with_reply(conn, msg, DBUS_TIMEOUT_MS, &err);
     p_dbus_message_unref(msg);
 
     if (!reply) {
         if (p_dbus_error_is_set && p_dbus_error_is_set(&err))
             p_dbus_error_free(&err);
-        close_private_bus(g_logindConn);
-        g_logindConn = NULL;
+        close_private_bus(conn);
         return -1;
     }
 
@@ -561,114 +698,148 @@ static int logind_inhibit(void) {
         DBUS_TYPE_INVALID);
     p_dbus_message_unref(reply);
 
-    if (!parsed || fd < 0) {
-        if (p_dbus_error_is_set && p_dbus_error_is_set(&err))
-            p_dbus_error_free(&err);
-        close_private_bus(g_logindConn);
-        g_logindConn = NULL;
-        return -1;
-    }
-
     if (p_dbus_error_is_set && p_dbus_error_is_set(&err))
         p_dbus_error_free(&err);
 
-    g_logindFd = fd;
+    if (!parsed || fd < 0) {
+        close_private_bus(conn);
+        return -1;
+    }
+
+    out->backend = BACKEND_LOGIND;
+    out->mode    = mode;
+    out->conn    = conn;
+    out->fd      = fd;
     return 0;
 }
 
-static int logind_uninhibit(void) {
-    if (g_logindFd >= 0) {
-        close(g_logindFd);
-        g_logindFd = -1;
+static int logind_uninhibit(awake_request *req) {
+    if (req->fd >= 0) {
+        close(req->fd);
+        req->fd = -1;
     }
-    if (g_logindConn) {
-        close_private_bus(g_logindConn);
-        g_logindConn = NULL;
-    }
+    close_private_bus(req->conn);
     return 0;
 }
 
 /* ---- X11 XScreenSaverSuspend backend ------------------------------ */
 
-static Display g_x11Display = NULL;
-
-static int x11_inhibit(void) {
+static int x11_inhibit(int mode, awake_request *out) {
     if (!load_x11()) return -1;
 
-    g_x11Display = p_XOpenDisplay(NULL);
-    if (!g_x11Display) return -1;
+    Display display = p_XOpenDisplay(NULL);
+    if (!display) return -1;
 
-    p_XScreenSaverSuspend(g_x11Display, 1);
-    p_XFlush(g_x11Display);
+    p_XScreenSaverSuspend(display, 1);
+    p_XFlush(display);
+
+    out->backend = BACKEND_X11;
+    out->mode    = mode;
+    out->display = display;
     return 0;
 }
 
-static int x11_uninhibit(void) {
-    if (!g_x11Display) return -1;
-    p_XScreenSaverSuspend(g_x11Display, 0);
-    p_XFlush(g_x11Display);
-    p_XCloseDisplay(g_x11Display);
-    g_x11Display = NULL;
+static int x11_uninhibit(awake_request *req) {
+    p_XScreenSaverSuspend(req->display, 0);
+    p_XFlush(req->display);
+    p_XCloseDisplay(req->display);
+    req->display = NULL;
     return 0;
 }
 
-/* ---- nativeKeepScreenAwake ---------------------------------------- */
+/* ---- Acquire / release dispatch ------------------------------------ */
+
+static int awake_acquire(int mode, awake_request *out) {
+    if (gnome_inhibit(mode, out) == 0) return 0;
+    if (mode == AWAKE_SYSTEM_ONLY && powermanagement_inhibit(mode, out) == 0) return 0;
+    if (logind_inhibit(mode, out) == 0) return 0;
+    /* The screen saver alone never keeps the system awake */
+    if (mode != AWAKE_SYSTEM_ONLY && x11_inhibit(mode, out) == 0) return 0;
+    return -1;
+}
+
+static int awake_release(awake_request *req) {
+    switch (req->backend) {
+        case BACKEND_GNOME:            return gnome_uninhibit(req);
+        case BACKEND_POWER_MANAGEMENT: return powermanagement_uninhibit(req);
+        case BACKEND_LOGIND:           return logind_uninhibit(req);
+        case BACKEND_X11:              return x11_uninhibit(req);
+        case BACKEND_NONE:             return 0;
+    }
+    return 0;
+}
+
+/* ---- nativeKeepAwake ---------------------------------------------- */
 
 JNIEXPORT jint JNICALL
-Java_dev_nucleusframework_energymanager_linux_NativeLinuxEnergyBridge_nativeKeepScreenAwake(
+Java_dev_nucleusframework_energymanager_linux_NativeLinuxEnergyBridge_nativeKeepAwake(
+    JNIEnv *env, jclass clazz, jint mode)
+{
+    (void)env; (void)clazz;
+
+    if (mode != AWAKE_SYSTEM_AND_DISPLAY && mode != AWAKE_SYSTEM_ONLY) {
+        return EINVAL;
+    }
+
+    /* Same mode already held — idempotent */
+    if (g_awake.backend != BACKEND_NONE && g_awake.mode == mode) {
+        return 0;
+    }
+
+    /*
+     * Acquire the new inhibitor before dropping the previous one, otherwise
+     * the machine is briefly free to sleep in between.
+     */
+    awake_request next = AWAKE_REQUEST_EMPTY;
+    if (awake_acquire(mode, &next) != 0) {
+        return -1; /* No backend available */
+    }
+
+    if (g_awake.backend != BACKEND_NONE) {
+        awake_release(&g_awake);
+    }
+    g_awake = next;
+    return 0;
+}
+
+/* ---- nativeReleaseAwake ------------------------------------------- */
+
+JNIEXPORT jint JNICALL
+Java_dev_nucleusframework_energymanager_linux_NativeLinuxEnergyBridge_nativeReleaseAwake(
     JNIEnv *env, jclass clazz)
 {
     (void)env; (void)clazz;
 
-    /* Already active — idempotent */
-    if (g_activeBackend != BACKEND_NONE) return 0;
-
-    /* Try GNOME SessionManager first */
-    if (gnome_inhibit() == 0) {
-        g_activeBackend = BACKEND_GNOME;
-        return 0;
+    if (g_awake.backend == BACKEND_NONE) {
+        return 0; /* Nothing to release */
     }
 
-    /* Try systemd-logind */
-    if (logind_inhibit() == 0) {
-        g_activeBackend = BACKEND_LOGIND;
-        return 0;
-    }
-
-    /* Try X11 XScreenSaverSuspend */
-    if (x11_inhibit() == 0) {
-        g_activeBackend = BACKEND_X11;
-        return 0;
-    }
-
-    return -1; /* No backend available */
-}
-
-/* ---- nativeReleaseScreenAwake ------------------------------------- */
-
-JNIEXPORT jint JNICALL
-Java_dev_nucleusframework_energymanager_linux_NativeLinuxEnergyBridge_nativeReleaseScreenAwake(
-    JNIEnv *env, jclass clazz)
-{
-    (void)env; (void)clazz;
-
-    int rc = 0;
-    switch (g_activeBackend) {
-        case BACKEND_GNOME:  rc = gnome_uninhibit();  break;
-        case BACKEND_LOGIND: rc = logind_uninhibit();  break;
-        case BACKEND_X11:    rc = x11_uninhibit();     break;
-        case BACKEND_NONE:   return 0; /* Nothing to release */
-    }
-    g_activeBackend = BACKEND_NONE;
+    int rc = awake_release(&g_awake);
+    awake_request empty = AWAKE_REQUEST_EMPTY;
+    g_awake = empty;
     return (jint)rc;
 }
 
-/* ---- nativeIsScreenAwakeActive ------------------------------------ */
+/* ---- nativeIsAwakeActive ------------------------------------------ */
 
 JNIEXPORT jboolean JNICALL
-Java_dev_nucleusframework_energymanager_linux_NativeLinuxEnergyBridge_nativeIsScreenAwakeActive(
+Java_dev_nucleusframework_energymanager_linux_NativeLinuxEnergyBridge_nativeIsAwakeActive(
     JNIEnv *env, jclass clazz)
 {
     (void)env; (void)clazz;
-    return g_activeBackend != BACKEND_NONE ? JNI_TRUE : JNI_FALSE;
+    return g_awake.backend != BACKEND_NONE ? JNI_TRUE : JNI_FALSE;
+}
+
+/* ---- nativeQueryAwakeBackend -------------------------------------- */
+
+/*
+ * Which inhibitor is holding the current request (see enum awake_backend).
+ * Exposed so that verification can query the right system service.
+ */
+JNIEXPORT jint JNICALL
+Java_dev_nucleusframework_energymanager_linux_NativeLinuxEnergyBridge_nativeQueryAwakeBackend(
+    JNIEnv *env, jclass clazz)
+{
+    (void)env; (void)clazz;
+    return (jint)g_awake.backend;
 }

--- a/energy-manager/src/main/native/macos/build.sh
+++ b/energy-manager/src/main/native/macos/build.sh
@@ -56,6 +56,13 @@ clang -shared -O2 -Wall -Wextra -std=c11 \
     -o "$OUT_DIR_ARM64/libnucleus_energy_manager.dylib"
 echo "  -> $OUT_DIR_ARM64/libnucleus_energy_manager.dylib"
 
+# Clear NativeLibraryLoader cache to avoid serving stale cached copy
+CACHE_DIR="${HOME}/.cache/nucleus/native"
+if [ -d "$CACHE_DIR" ]; then
+    find "$CACHE_DIR" -name "libnucleus_energy_manager.dylib" -delete 2>/dev/null || true
+    echo "Cleared NativeLibraryLoader cache"
+fi
+
 echo
 echo "Built dylibs:"
 [ -f "$OUT_DIR_X64/libnucleus_energy_manager.dylib" ] && echo "  $OUT_DIR_X64/libnucleus_energy_manager.dylib"

--- a/energy-manager/src/main/native/macos/nucleus_energy_manager.c
+++ b/energy-manager/src/main/native/macos/nucleus_energy_manager.c
@@ -16,8 +16,9 @@
  * No special privileges are required — any process can put itself
  * in background mode.
  *
- * Screen-awake (caffeine) support uses IOPMAssertionCreateWithName from
- * the IOKit framework to prevent display and system sleep.
+ * Awake (caffeine) support uses IOPMAssertionCreateWithName from the IOKit
+ * framework: kIOPMAssertPreventUserIdleDisplaySleep keeps the display on,
+ * kIOPMAssertPreventUserIdleSystemSleep keeps only the machine running.
  *
  * Linked libraries: libSystem (automatic), IOKit, CoreFoundation
  */
@@ -194,8 +195,13 @@ Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeDisa
 }
 
 /* ==================================================================
- * Screen-awake (caffeine) via IOPMAssertion
+ * Awake (caffeine) via IOPMAssertion
  * ================================================================== */
+
+/* Must match AwakeMode.nativeCode in MacOsEnergyManager.kt */
+#define AWAKE_SYSTEM_AND_DISPLAY 0
+#define AWAKE_SYSTEM_ONLY        1
+#define AWAKE_NONE               (-1)
 
 /*
  * Global assertion ID. kIOPMNullAssertionID (0) means no active assertion.
@@ -203,43 +209,56 @@ Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeDisa
  */
 static IOPMAssertionID g_assertionId = kIOPMNullAssertionID;
 
-/* ---- nativeKeepScreenAwake --------------------------------------- */
+/* ---- nativeKeepAwake --------------------------------------------- */
 
+/*
+ * kIOPMAssertPreventUserIdleDisplaySleep keeps the display lit, which also
+ * keeps the machine running — equivalent to ES_DISPLAY_REQUIRED |
+ * ES_SYSTEM_REQUIRED on Windows.
+ * kIOPMAssertPreventUserIdleSystemSleep only blocks idle system sleep; the
+ * display dims, sleeps and locks on the usual schedule. It is the assertion
+ * `caffeinate -i` takes, and — like every idle assertion — it does not
+ * survive the user closing the lid or picking Sleep from the Apple menu.
+ */
 JNIEXPORT jint JNICALL
-Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeKeepScreenAwake(
-    JNIEnv *env, jclass clazz)
+Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeKeepAwake(
+    JNIEnv *env, jclass clazz, jint mode)
 {
     (void)env; (void)clazz;
 
-    /* If already holding an assertion, release it first */
-    if (g_assertionId != kIOPMNullAssertionID) {
-        IOPMAssertionRelease(g_assertionId);
-        g_assertionId = kIOPMNullAssertionID;
-    }
+    int systemOnly = (mode == AWAKE_SYSTEM_ONLY);
+    CFStringRef type = systemOnly ? kIOPMAssertPreventUserIdleSystemSleep
+                                  : kIOPMAssertPreventUserIdleDisplaySleep;
+    CFStringRef reason = systemOnly ? CFSTR("Nucleus EnergyManager keepAwake(SYSTEM_ONLY)")
+                                    : CFSTR("Nucleus EnergyManager keepAwake(SYSTEM_AND_DISPLAY)");
 
     /*
-     * kIOPMAssertPreventUserIdleDisplaySleep prevents both display and
-     * system sleep — equivalent to ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED
-     * on Windows.
+     * An assertion's type is immutable, so switching modes means a new
+     * assertion. Create it before releasing the previous one, otherwise the
+     * machine is briefly free to idle-sleep in between.
      */
-    CFStringRef reason = CFSTR("Nucleus EnergyManager keepScreenAwake");
+    IOPMAssertionID newId = kIOPMNullAssertionID;
     IOReturn ret = IOPMAssertionCreateWithName(
-        kIOPMAssertPreventUserIdleDisplaySleep,
+        type,
         kIOPMAssertionLevelOn,
         reason,
-        &g_assertionId);
+        &newId);
 
     if (ret != kIOReturnSuccess) {
-        g_assertionId = kIOPMNullAssertionID;
         return (jint)ret;
     }
+
+    if (g_assertionId != kIOPMNullAssertionID) {
+        IOPMAssertionRelease(g_assertionId);
+    }
+    g_assertionId = newId;
     return 0;
 }
 
-/* ---- nativeReleaseScreenAwake ------------------------------------ */
+/* ---- nativeReleaseAwake ------------------------------------------ */
 
 JNIEXPORT jint JNICALL
-Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeReleaseScreenAwake(
+Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeReleaseAwake(
     JNIEnv *env, jclass clazz)
 {
     (void)env; (void)clazz;
@@ -254,10 +273,56 @@ Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeRele
     return (ret == kIOReturnSuccess) ? 0 : (jint)ret;
 }
 
-/* ---- nativeIsScreenAwakeActive ----------------------------------- */
+/* ---- nativeQueryAwakeMode ---------------------------------------- */
+
+/*
+ * Reads the assertion back from powerd and maps its type to an AWAKE_*
+ * code, so callers can verify what the kernel actually recorded rather
+ * than what this file believes it requested.
+ */
+JNIEXPORT jint JNICALL
+Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeQueryAwakeMode(
+    JNIEnv *env, jclass clazz)
+{
+    (void)env; (void)clazz;
+
+    if (g_assertionId == kIOPMNullAssertionID) {
+        return AWAKE_NONE;
+    }
+
+    CFDictionaryRef props = IOPMAssertionCopyProperties(g_assertionId);
+    if (props == NULL) {
+        return AWAKE_NONE;
+    }
+
+    int result = AWAKE_NONE;
+    CFStringRef type = (CFStringRef)CFDictionaryGetValue(props, kIOPMAssertionTypeKey);
+    if (type != NULL && CFGetTypeID(type) == CFStringGetTypeID()) {
+        if (CFEqual(type, kIOPMAssertPreventUserIdleSystemSleep)) {
+            result = AWAKE_SYSTEM_ONLY;
+        } else if (CFEqual(type, kIOPMAssertPreventUserIdleDisplaySleep)) {
+            result = AWAKE_SYSTEM_AND_DISPLAY;
+        }
+    }
+
+    /* An assertion left at level Off holds nothing awake */
+    CFNumberRef level = (CFNumberRef)CFDictionaryGetValue(props, kIOPMAssertionLevelKey);
+    if (level != NULL && CFGetTypeID(level) == CFNumberGetTypeID()) {
+        int levelValue = kIOPMAssertionLevelOn;
+        if (CFNumberGetValue(level, kCFNumberIntType, &levelValue) &&
+            levelValue != (int)kIOPMAssertionLevelOn) {
+            result = AWAKE_NONE;
+        }
+    }
+
+    CFRelease(props);
+    return (jint)result;
+}
+
+/* ---- nativeIsAwakeActive ----------------------------------------- */
 
 JNIEXPORT jboolean JNICALL
-Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeIsScreenAwakeActive(
+Java_dev_nucleusframework_energymanager_macos_NativeMacOsEnergyBridge_nativeIsAwakeActive(
     JNIEnv *env, jclass clazz)
 {
     (void)env; (void)clazz;

--- a/energy-manager/src/main/native/windows/nucleus_energy_manager.c
+++ b/energy-manager/src/main/native/windows/nucleus_energy_manager.c
@@ -102,9 +102,9 @@ static PFN_SetThreadInformation ResolveThreadFn(void) {
     return pfnSetThreadInfo;
 }
 
-/* ---- Screen-awake state ----------------------------------------- */
+/* ---- Awake state ------------------------------------------------- */
 
-static volatile BOOL g_screenAwakeActive = FALSE;
+static volatile BOOL g_awakeActive = FALSE;
 
 /* ---- nativeIsSupported ------------------------------------------- */
 
@@ -296,7 +296,7 @@ Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_native
     return 0;
 }
 
-/* ---- nativeKeepScreenAwake -------------------------------------- */
+/* ---- nativeKeepAwake -------------------------------------------- */
 
 #ifndef ES_CONTINUOUS
 #define ES_CONTINUOUS        0x80000000
@@ -308,25 +308,39 @@ Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_native
 #define ES_DISPLAY_REQUIRED  0x00000002
 #endif
 
+/* Must match AwakeMode.nativeCode in WindowsEnergyManager.kt */
+#define AWAKE_SYSTEM_AND_DISPLAY 0
+#define AWAKE_SYSTEM_ONLY        1
+
+/*
+ * SetThreadExecutionState is not additive: each call replaces the calling
+ * thread's request, so switching modes needs no explicit release first.
+ * ES_SYSTEM_REQUIRED alone keeps the machine running while leaving the
+ * display sleep / screen saver timers untouched.
+ */
 JNIEXPORT jint JNICALL
-Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_nativeKeepScreenAwake(
-    JNIEnv *env, jclass clazz)
+Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_nativeKeepAwake(
+    JNIEnv *env, jclass clazz, jint mode)
 {
     (void)env; (void)clazz;
 
-    DWORD prev = SetThreadExecutionState(
-        ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
+    EXECUTION_STATE flags = ES_CONTINUOUS | ES_SYSTEM_REQUIRED;
+    if (mode != AWAKE_SYSTEM_ONLY) {
+        flags |= ES_DISPLAY_REQUIRED;
+    }
+
+    DWORD prev = SetThreadExecutionState(flags);
     if (prev == 0) {
         return (jint)GetLastError();
     }
-    g_screenAwakeActive = TRUE;
+    g_awakeActive = TRUE;
     return 0;
 }
 
-/* ---- nativeReleaseScreenAwake ----------------------------------- */
+/* ---- nativeReleaseAwake ----------------------------------------- */
 
 JNIEXPORT jint JNICALL
-Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_nativeReleaseScreenAwake(
+Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_nativeReleaseAwake(
     JNIEnv *env, jclass clazz)
 {
     (void)env; (void)clazz;
@@ -335,16 +349,38 @@ Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_native
     if (prev == 0) {
         return (jint)GetLastError();
     }
-    g_screenAwakeActive = FALSE;
+    g_awakeActive = FALSE;
     return 0;
 }
 
-/* ---- nativeIsScreenAwakeActive ---------------------------------- */
+/* ---- nativeQueryAwakeFlags -------------------------------------- */
 
-JNIEXPORT jboolean JNICALL
-Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_nativeIsScreenAwakeActive(
+/*
+ * Reads back the execution state Windows currently holds for the calling
+ * thread. There is no getter in the Win32 API, so the state is replaced by a
+ * bare ES_CONTINUOUS — which returns the previous flags — and immediately
+ * restored. Used to verify the flags the kernel actually recorded.
+ */
+JNIEXPORT jint JNICALL
+Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_nativeQueryAwakeFlags(
     JNIEnv *env, jclass clazz)
 {
     (void)env; (void)clazz;
-    return g_screenAwakeActive ? JNI_TRUE : JNI_FALSE;
+
+    DWORD prev = SetThreadExecutionState(ES_CONTINUOUS);
+    if (prev == 0) {
+        return 0;
+    }
+    SetThreadExecutionState(prev);
+    return (jint)prev;
+}
+
+/* ---- nativeIsAwakeActive ---------------------------------------- */
+
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_energymanager_windows_NativeWindowsEnergyBridge_nativeIsAwakeActive(
+    JNIEnv *env, jclass clazz)
+{
+    (void)env; (void)clazz;
+    return g_awakeActive ? JNI_TRUE : JNI_FALSE;
 }

--- a/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
+++ b/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.energymanager
 
+import dev.nucleusframework.energymanager.linux.NativeLinuxEnergyBridge
 import dev.nucleusframework.energymanager.macos.NativeMacOsEnergyBridge
 import dev.nucleusframework.energymanager.windows.NativeWindowsEnergyBridge
 import dev.nucleusframework.energymanager.windows.WindowsEnergyManager
@@ -160,14 +161,149 @@ class EnergyManagerTest {
     }
 
     @Test
-    fun `linux keepAwake system only reports unsupported`() {
+    fun `linux keepAwake system only round trips`() {
         assumeLinux()
-        assertTrue(EnergyManager.isAvailable())
+        assumeSystemOnlyBackend()
 
-        val result = EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
-        assertTrue(!result.success, "SYSTEM_ONLY should not be reported as supported on Linux")
-        assertTrue(!EnergyManager.isAwakeActive(), "No awake request should be held")
+        val enableResult = EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
+        println("Linux keepAwake(SYSTEM_ONLY) result: $enableResult, backend=${linuxAwakeBackendName()}")
+        assertTrue(enableResult.success, "keepAwake failed: ${enableResult.message}")
+        assertTrue(EnergyManager.isAwakeActive(), "Awake request should be active")
+
+        val releaseResult = EnergyManager.releaseAwake()
+        assertTrue(releaseResult.success, "releaseAwake failed: ${releaseResult.message}")
+        assertTrue(!EnergyManager.isAwakeActive(), "Awake request should be released")
     }
+
+    @Test
+    fun `linux keepAwake takes a suspend only GNOME inhibitor in system only mode`() {
+        assumeLinux()
+        assumeGnomeSessionManager()
+
+        // The flags are read back from gnome-session over D-Bus, not from the
+        // value the bridge remembers requesting.
+        try {
+            EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY)
+            val bothFlags = gnomeInhibitorFlags()
+
+            EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
+            val systemOnlyFlags = gnomeInhibitorFlags()
+
+            EnergyManager.releaseAwake()
+            val releasedFlags = gnomeInhibitorFlags()
+
+            println("GNOME inhibitor flags: both=$bothFlags systemOnly=$systemOnlyFlags released=$releasedFlags")
+
+            assertEquals(
+                GNOME_INHIBIT_IDLE or GNOME_INHIBIT_SUSPEND,
+                bothFlags,
+                "SYSTEM_AND_DISPLAY must inhibit both idle and suspend",
+            )
+            assertEquals(
+                GNOME_INHIBIT_SUSPEND,
+                systemOnlyFlags,
+                "SYSTEM_ONLY must inhibit suspend only, leaving the screen saver alone",
+            )
+            assertEquals(null, releasedFlags, "releaseAwake must drop the inhibitor")
+        } finally {
+            EnergyManager.releaseAwake()
+        }
+    }
+
+    @Test
+    fun `linux keepAwake switches between modes without releasing`() {
+        assumeLinux()
+        assumeSystemOnlyBackend()
+
+        // Switching modes swaps in a fresh inhibitor, which is acquired before
+        // the previous one is dropped.
+        try {
+            assertTrue(EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY).success)
+            assertTrue(EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY).success)
+            assertTrue(EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY).success)
+            assertTrue(EnergyManager.isAwakeActive())
+        } finally {
+            assertTrue(EnergyManager.releaseAwake().success)
+        }
+        assertTrue(!EnergyManager.isAwakeActive())
+    }
+
+    // ── Linux awake helpers ──────────────────────────────────────────
+
+    /** Backend that serves an awake request here, without leaving one held. */
+    private fun linuxAwakeBackend(): Int {
+        val acquired = EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY).success
+        val backend =
+            if (acquired) NativeLinuxEnergyBridge.nativeQueryAwakeBackend() else AWAKE_BACKEND_NONE
+        EnergyManager.releaseAwake()
+        return backend
+    }
+
+    private fun linuxAwakeBackendName(): String =
+        when (NativeLinuxEnergyBridge.nativeQueryAwakeBackend()) {
+            AWAKE_BACKEND_GNOME -> "gnome"
+            AWAKE_BACKEND_LOGIND -> "logind"
+            AWAKE_BACKEND_X11 -> "x11"
+            AWAKE_BACKEND_POWER_MANAGEMENT -> "powermanagement"
+            else -> "none"
+        }
+
+    /** Skips the test unless an inhibitor that can serve SYSTEM_ONLY is reachable. */
+    private fun assumeSystemOnlyBackend() {
+        val backend = linuxAwakeBackend()
+        assumeTrue("No awake backend reachable in this environment", backend != AWAKE_BACKEND_NONE)
+        assumeTrue(
+            "Only the X11 screen-saver backend is reachable, which cannot serve SYSTEM_ONLY",
+            backend != AWAKE_BACKEND_X11,
+        )
+    }
+
+    private fun assumeGnomeSessionManager() {
+        assumeTrue("Test requires org.gnome.SessionManager", linuxAwakeBackend() == AWAKE_BACKEND_GNOME)
+        assumeTrue(
+            "Test requires the gdbus CLI",
+            gdbus(GNOME_SESSION_PATH, "$GNOME_SESSION_IFACE.GetInhibitors") != null,
+        )
+    }
+
+    /** Flags of the inhibitor this process holds in gnome-session, or null when it holds none. */
+    private fun gnomeInhibitorFlags(): Int? {
+        val inhibitors = gdbus(GNOME_SESSION_PATH, "$GNOME_SESSION_IFACE.GetInhibitors") ?: return null
+        return INHIBITOR_PATH
+            .findAll(inhibitors)
+            .map { it.value }
+            .firstOrNull { path -> gdbus(path, "$GNOME_INHIBITOR_IFACE.GetAppId")?.contains(AWAKE_APP_ID) == true }
+            ?.let { path -> gdbus(path, "$GNOME_INHIBITOR_IFACE.GetFlags") }
+            ?.let { flags ->
+                UINT32_VALUE
+                    .find(flags)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.toInt()
+            }
+    }
+
+    /** Calls a gnome-session D-Bus method from outside the JVM; null when the call fails. */
+    private fun gdbus(
+        objectPath: String,
+        method: String,
+    ): String? =
+        runCatching {
+            val process =
+                ProcessBuilder(
+                    "gdbus",
+                    "call",
+                    "--session",
+                    "--dest",
+                    GNOME_SESSION_DEST,
+                    "--object-path",
+                    objectPath,
+                    "--method",
+                    method,
+                ).start()
+            val output = process.inputStream.bufferedReader().readText()
+            if (process.waitFor() == 0) output else null
+        }.getOrNull()
 
     // ── macOS tests ──────────────────────────────────────────────────
 
@@ -589,6 +725,26 @@ class EnergyManagerTest {
         private const val AWAKE_NONE = -1
         private const val AWAKE_SYSTEM_AND_DISPLAY = 0
         private const val AWAKE_SYSTEM_ONLY = 1
+
+        /** Mirrors enum awake_backend in the Linux native bridge. */
+        private const val AWAKE_BACKEND_NONE = 0
+        private const val AWAKE_BACKEND_GNOME = 1
+        private const val AWAKE_BACKEND_LOGIND = 2
+        private const val AWAKE_BACKEND_X11 = 3
+        private const val AWAKE_BACKEND_POWER_MANAGEMENT = 4
+
+        /** Mirrors GNOME_INHIBIT_* in the Linux native bridge. */
+        private const val GNOME_INHIBIT_SUSPEND = 4
+        private const val GNOME_INHIBIT_IDLE = 8
+
+        private const val AWAKE_APP_ID = "Nucleus EnergyManager"
+        private const val GNOME_SESSION_DEST = "org.gnome.SessionManager"
+        private const val GNOME_SESSION_PATH = "/org/gnome/SessionManager"
+        private const val GNOME_SESSION_IFACE = "org.gnome.SessionManager"
+        private const val GNOME_INHIBITOR_IFACE = "org.gnome.SessionManager.Inhibitor"
+
+        private val INHIBITOR_PATH = Regex("/org/gnome/SessionManager/Inhibitor\\d+")
+        private val UINT32_VALUE = Regex("uint32 (\\d+)")
 
         /**
          * Reads the nice value of the calling thread via /proc/thread-self/stat.

--- a/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
+++ b/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.energymanager
 
+import dev.nucleusframework.energymanager.macos.NativeMacOsEnergyBridge
 import dev.nucleusframework.energymanager.windows.NativeWindowsEnergyBridge
 import kotlinx.coroutines.runBlocking
 import org.junit.Assume.assumeTrue
@@ -269,15 +270,63 @@ class EnergyManagerTest {
         }
 
     @Test
-    fun `macOS keepAwake system only reports unsupported`() {
+    fun `macOS keepAwake system only round trips`() {
         assumeMacOs()
         assertTrue(EnergyManager.isAvailable())
 
-        // SYSTEM_ONLY is Windows-only for now — it must fail loudly instead of
-        // silently keeping the display awake too.
-        val result = EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
-        assertTrue(!result.success, "SYSTEM_ONLY should not be reported as supported on macOS")
-        assertTrue(!EnergyManager.isAwakeActive(), "No awake request should be held")
+        val enableResult = EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
+        println("macOS keepAwake(SYSTEM_ONLY) result: $enableResult")
+        assertTrue(enableResult.success, "keepAwake failed: ${enableResult.message}")
+        assertTrue(EnergyManager.isAwakeActive(), "Awake request should be active")
+
+        val releaseResult = EnergyManager.releaseAwake()
+        assertTrue(releaseResult.success, "releaseAwake failed: ${releaseResult.message}")
+        assertTrue(!EnergyManager.isAwakeActive(), "Awake request should be released")
+    }
+
+    @Test
+    fun `macOS keepAwake takes the expected IOKit assertion type`() {
+        assumeMacOs()
+        assertTrue(EnergyManager.isAvailable())
+
+        // The mode is read back from the assertion powerd holds, not from the
+        // value the bridge remembers requesting.
+        EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY)
+        val bothMode = NativeMacOsEnergyBridge.nativeQueryAwakeMode()
+
+        EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
+        val systemOnlyMode = NativeMacOsEnergyBridge.nativeQueryAwakeMode()
+
+        EnergyManager.releaseAwake()
+        val releasedMode = NativeMacOsEnergyBridge.nativeQueryAwakeMode()
+
+        println("Assertion modes: both=$bothMode systemOnly=$systemOnlyMode released=$releasedMode")
+
+        assertEquals(
+            AWAKE_SYSTEM_AND_DISPLAY,
+            bothMode,
+            "SYSTEM_AND_DISPLAY must map to kIOPMAssertPreventUserIdleDisplaySleep",
+        )
+        assertEquals(
+            AWAKE_SYSTEM_ONLY,
+            systemOnlyMode,
+            "SYSTEM_ONLY must map to kIOPMAssertPreventUserIdleSystemSleep, leaving display sleep alone",
+        )
+        assertEquals(AWAKE_NONE, releasedMode, "releaseAwake must drop the assertion")
+    }
+
+    @Test
+    fun `macOS keepAwake switches between modes without releasing`() {
+        assumeMacOs()
+        assertTrue(EnergyManager.isAvailable())
+
+        // An assertion's type is immutable, so each switch swaps in a fresh one.
+        assertTrue(EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY).success)
+        assertTrue(EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY).success)
+        assertTrue(EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY).success)
+        assertTrue(EnergyManager.isAwakeActive())
+        assertTrue(EnergyManager.releaseAwake().success)
+        assertTrue(!EnergyManager.isAwakeActive())
     }
 
     @Test
@@ -506,6 +555,11 @@ class EnergyManagerTest {
     companion object {
         private const val ES_SYSTEM_REQUIRED = 0x00000001
         private const val ES_DISPLAY_REQUIRED = 0x00000002
+
+        /** Mirrors the AWAKE_* codes of the macOS native bridge. */
+        private const val AWAKE_NONE = -1
+        private const val AWAKE_SYSTEM_AND_DISPLAY = 0
+        private const val AWAKE_SYSTEM_ONLY = 1
 
         /**
          * Reads the nice value of the calling thread via /proc/thread-self/stat.

--- a/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
+++ b/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.energymanager
 
+import dev.nucleusframework.energymanager.windows.NativeWindowsEnergyBridge
 import kotlinx.coroutines.runBlocking
 import org.junit.Assume.assumeTrue
 import java.io.File
@@ -156,6 +157,16 @@ class EnergyManagerTest {
         assertTrue(EnergyManager.disableLightEfficiencyMode().success)
     }
 
+    @Test
+    fun `linux keepAwake system only reports unsupported`() {
+        assumeLinux()
+        assertTrue(EnergyManager.isAvailable())
+
+        val result = EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
+        assertTrue(!result.success, "SYSTEM_ONLY should not be reported as supported on Linux")
+        assertTrue(!EnergyManager.isAwakeActive(), "No awake request should be held")
+    }
+
     // ── macOS tests ──────────────────────────────────────────────────
 
     @Test
@@ -256,6 +267,18 @@ class EnergyManagerTest {
 
             assertEquals(42, result)
         }
+
+    @Test
+    fun `macOS keepAwake system only reports unsupported`() {
+        assumeMacOs()
+        assertTrue(EnergyManager.isAvailable())
+
+        // SYSTEM_ONLY is Windows-only for now — it must fail loudly instead of
+        // silently keeping the display awake too.
+        val result = EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
+        assertTrue(!result.success, "SYSTEM_ONLY should not be reported as supported on macOS")
+        assertTrue(!EnergyManager.isAwakeActive(), "No awake request should be held")
+    }
 
     @Test
     fun `macOS enable disable cycle is idempotent`() {
@@ -417,9 +440,73 @@ class EnergyManagerTest {
         assertTrue(result, "Thread idempotent enable/disable cycle failed")
     }
 
+    @Test
+    fun `windows keepAwake system only round trips`() {
+        assumeWindows()
+        assertTrue(EnergyManager.isAvailable())
+
+        val enableResult = EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
+        println("Windows keepAwake(SYSTEM_ONLY) result: $enableResult")
+        assertTrue(enableResult.success, "keepAwake failed: ${enableResult.message}")
+        assertTrue(EnergyManager.isAwakeActive(), "Awake request should be active")
+
+        val releaseResult = EnergyManager.releaseAwake()
+        assertTrue(releaseResult.success, "releaseAwake failed: ${releaseResult.message}")
+        assertTrue(!EnergyManager.isAwakeActive(), "Awake request should be released")
+    }
+
+    @Test
+    fun `windows keepAwake sets the expected execution state flags`() {
+        assumeWindows()
+        assertTrue(EnergyManager.isAvailable())
+
+        // The execution state is per-thread, so query it from the very thread
+        // that issued the request.
+        EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY)
+        val bothFlags = NativeWindowsEnergyBridge.nativeQueryAwakeFlags()
+
+        EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
+        val systemOnlyFlags = NativeWindowsEnergyBridge.nativeQueryAwakeFlags()
+
+        EnergyManager.releaseAwake()
+        val releasedFlags = NativeWindowsEnergyBridge.nativeQueryAwakeFlags()
+
+        println("Flags: both=0x${bothFlags.toHexString()} systemOnly=0x${systemOnlyFlags.toHexString()}")
+
+        assertTrue(bothFlags and ES_SYSTEM_REQUIRED != 0, "SYSTEM_AND_DISPLAY must keep the system awake")
+        assertTrue(bothFlags and ES_DISPLAY_REQUIRED != 0, "SYSTEM_AND_DISPLAY must keep the display awake")
+
+        assertTrue(systemOnlyFlags and ES_SYSTEM_REQUIRED != 0, "SYSTEM_ONLY must keep the system awake")
+        assertEquals(
+            0,
+            systemOnlyFlags and ES_DISPLAY_REQUIRED,
+            "SYSTEM_ONLY must leave display sleep and the screen saver alone",
+        )
+
+        assertEquals(0, releasedFlags and ES_SYSTEM_REQUIRED, "releaseAwake must drop the system request")
+        assertEquals(0, releasedFlags and ES_DISPLAY_REQUIRED, "releaseAwake must drop the display request")
+    }
+
+    @Test
+    fun `windows keepAwake switches between modes without releasing`() {
+        assumeWindows()
+        assertTrue(EnergyManager.isAvailable())
+
+        // SetThreadExecutionState replaces the thread's request, so switching
+        // modes back and forth must stay successful and keep the state active.
+        assertTrue(EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY).success)
+        assertTrue(EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY).success)
+        assertTrue(EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY).success)
+        assertTrue(EnergyManager.isAwakeActive())
+        assertTrue(EnergyManager.releaseAwake().success)
+    }
+
     // ── Linux helpers ────────────────────────────────────────────────
 
     companion object {
+        private const val ES_SYSTEM_REQUIRED = 0x00000001
+        private const val ES_DISPLAY_REQUIRED = 0x00000002
+
         /**
          * Reads the nice value of the calling thread via /proc/thread-self/stat.
          * Field layout after (comm): state ppid pgrp session tty_nr tpgid flags

--- a/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
+++ b/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
@@ -2,6 +2,7 @@ package dev.nucleusframework.energymanager
 
 import dev.nucleusframework.energymanager.macos.NativeMacOsEnergyBridge
 import dev.nucleusframework.energymanager.windows.NativeWindowsEnergyBridge
+import dev.nucleusframework.energymanager.windows.WindowsEnergyManager
 import kotlinx.coroutines.runBlocking
 import org.junit.Assume.assumeTrue
 import java.io.File
@@ -509,16 +510,16 @@ class EnergyManagerTest {
         assumeWindows()
         assertTrue(EnergyManager.isAvailable())
 
-        // The execution state is per-thread, so query it from the very thread
-        // that issued the request.
+        // The execution state is per-thread and all awake requests are routed
+        // through the dedicated awake thread, so query it from that thread.
         EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY)
-        val bothFlags = NativeWindowsEnergyBridge.nativeQueryAwakeFlags()
+        val bothFlags = queryAwakeFlags()
 
         EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
-        val systemOnlyFlags = NativeWindowsEnergyBridge.nativeQueryAwakeFlags()
+        val systemOnlyFlags = queryAwakeFlags()
 
         EnergyManager.releaseAwake()
-        val releasedFlags = NativeWindowsEnergyBridge.nativeQueryAwakeFlags()
+        val releasedFlags = queryAwakeFlags()
 
         println("Flags: both=0x${bothFlags.toHexString()} systemOnly=0x${systemOnlyFlags.toHexString()}")
 
@@ -537,6 +538,30 @@ class EnergyManagerTest {
     }
 
     @Test
+    fun `windows keepAwake survives the requesting thread dying`() {
+        assumeWindows()
+        assertTrue(EnergyManager.isAvailable())
+
+        // Regression test: SetThreadExecutionState is per-thread, so a request
+        // issued from a short-lived thread (e.g. a Dispatchers.IO worker) used
+        // to be silently dropped when that thread exited.
+        val thread = Thread { EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY) }
+        thread.start()
+        thread.join()
+
+        try {
+            val flags = queryAwakeFlags()
+            assertTrue(
+                flags and ES_SYSTEM_REQUIRED != 0,
+                "Awake request must survive the requesting thread exiting",
+            )
+            assertTrue(EnergyManager.isAwakeActive(), "Awake request should still be reported active")
+        } finally {
+            EnergyManager.releaseAwake()
+        }
+    }
+
+    @Test
     fun `windows keepAwake switches between modes without releasing`() {
         assumeWindows()
         assertTrue(EnergyManager.isAvailable())
@@ -549,6 +574,10 @@ class EnergyManagerTest {
         assertTrue(EnergyManager.isAwakeActive())
         assertTrue(EnergyManager.releaseAwake().success)
     }
+
+    /** Reads the execution state flags from the dedicated awake thread. */
+    private fun queryAwakeFlags(): Int =
+        WindowsEnergyManager.onAwakeThread { NativeWindowsEnergyBridge.nativeQueryAwakeFlags() }
 
     // ── Linux helpers ────────────────────────────────────────────────
 

--- a/examples/nucleus-demo/src/main/kotlin/com/example/demo/Main.kt
+++ b/examples/nucleus-demo/src/main/kotlin/com/example/demo/Main.kt
@@ -190,7 +190,7 @@ fun main(args: Array<String>) =
                         )
 
                         var caffeineActive by remember {
-                            mutableStateOf(EnergyManager.isScreenAwakeActive())
+                            mutableStateOf(EnergyManager.isAwakeActive())
                         }
                         TitleBarIconButton(
                             imageVector = if (caffeineActive) TablerCoffee else TablerCoffeeOff,
@@ -198,11 +198,11 @@ fun main(args: Array<String>) =
                             modifier = Modifier.align(titleBarAlignment),
                             onClick = {
                                 if (caffeineActive) {
-                                    EnergyManager.releaseScreenAwake()
+                                    EnergyManager.releaseAwake()
                                 } else {
-                                    EnergyManager.keepScreenAwake()
+                                    EnergyManager.keepAwake()
                                 }
-                                caffeineActive = EnergyManager.isScreenAwakeActive()
+                                caffeineActive = EnergyManager.isAwakeActive()
                             },
                         )
                         val isFullscreen = state.placement == WindowPlacement.Fullscreen


### PR DESCRIPTION
Closes #188 on Windows, macOS and Linux.

## Problem

`EnergyManager.keepScreenAwake()` always requested system **and** display wakefulness, so an app running a long background job (large document export, sync, …) had to keep the screen on and the screen saver off just to stop the machine from sleeping.

## API

```kotlin
enum class AwakeMode { SYSTEM_AND_DISPLAY, SYSTEM_ONLY }

EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)   // screen saver / display sleep behave normally
EnergyManager.releaseAwake()
EnergyManager.isAwakeActive()
```

`keepScreenAwake()` / `releaseScreenAwake()` / `isScreenAwakeActive()` remain as `@Deprecated` forwarders with `ReplaceWith`, so the ABI is unchanged and existing code keeps compiling.

## Platform status

| OS | `SYSTEM_AND_DISPLAY` | `SYSTEM_ONLY` |
|---|---|---|
| Windows | `ES_CONTINUOUS \| ES_SYSTEM_REQUIRED \| ES_DISPLAY_REQUIRED` | ✅ `ES_CONTINUOUS \| ES_SYSTEM_REQUIRED` |
| macOS | `kIOPMAssertPreventUserIdleDisplaySleep` (unchanged) | ✅ `kIOPMAssertPreventUserIdleSystemSleep` |
| Linux | GNOME `INHIBIT_IDLE \| INHIBIT_SUSPEND` / logind `idle` / X11 `XScreenSaverSuspend` | ✅ GNOME `INHIBIT_SUSPEND` / freedesktop `PowerManagement.Inhibit` / logind `idle` — X11 skipped |

No platform silently downgrades `SYSTEM_ONLY` to `SYSTEM_AND_DISPLAY`: where nothing can serve it, the request fails and the caller can see it.

### macOS notes

`kIOPMAssertPreventUserIdleSystemSleep` is the assertion `caffeinate -i` takes: the machine keeps running while the display dims, sleeps and locks on its usual schedule. Like every idle assertion — including the pre-existing `SYSTEM_AND_DISPLAY` one — it does **not** survive the user closing the lid or picking Sleep from the Apple menu. That caveat is documented on `AwakeMode.SYSTEM_ONLY`.

An assertion's type is immutable, so switching modes swaps in a new assertion; it is created *before* the previous one is released, otherwise the machine is briefly free to idle-sleep in between. The bridge was also renamed to match the Windows one (`nativeKeepAwake(mode)` / `nativeReleaseAwake` / `nativeIsAwakeActive`), and `MacOsEnergyManager` is now `@Synchronized` — the native side already documented that assumption but nothing enforced it.


### Linux notes

The composite backend now picks its inhibitor from the mode. GNOME takes `INHIBIT_SUSPEND` alone instead of `INHIBIT_SUSPEND | INHIBIT_IDLE`, so the screen saver and display sleep keep their normal schedule. `org.freedesktop.PowerManagement.Inhibit` joins the chain for `SYSTEM_ONLY` — it inhibits automatic sleep only (the screen saver lives behind `org.freedesktop.ScreenSaver`) and covers the desktops that do not implement `org.gnome.SessionManager` (KDE/powerdevil, Xfce, MATE, Cinnamon). logind keeps its `idle` inhibitor, which serves both modes. The X11 `XScreenSaverSuspend` fallback is skipped for `SYSTEM_ONLY`: it only holds off the screen saver and never keeps the system awake, so the request fails there rather than pretending.

A held request is now one struct instead of a set of parallel globals, which lets `keepAwake()` acquire the new inhibitor *before* dropping the old one — same reasoning as the macOS assertion swap. The bridge was renamed to match the other two (`nativeKeepAwake(mode)` / `nativeReleaseAwake` / `nativeIsAwakeActive`), plus an internal `nativeQueryAwakeBackend()`, and the Linux `build.sh` now clears the `NativeLibraryLoader` cache like the other modules.

## Follow-up work (not in this PR)

- **Linux**: `SYSTEM_AND_DISPLAY` still has no `org.freedesktop.ScreenSaver` backend, so on KDE/Xfce it falls through to logind and the display can still blank. Unchanged by this PR.

## Testing

**Windows 11** — verified end-to-end by reading back the execution state the kernel actually holds for the thread (`powercfg -requests` needs elevation, so the test uses a new internal `nativeQueryAwakeFlags()` probe):

```
Flags: both=0x80000003  systemOnly=0x80000001
```

`0x80000003` = `ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED`, `0x80000001` = the same without `ES_DISPLAY_REQUIRED` — and the flags are back to 0 after `releaseAwake()`.

**macOS 15 (arm64)** — same approach with a new internal `nativeQueryAwakeMode()` probe, which reads the assertion type back from powerd via `IOPMAssertionCopyProperties` rather than trusting what the bridge thinks it requested:

```
Assertion modes: both=0 systemOnly=1 released=-1
```

Cross-checked from outside the process with `pmset -g assertions`, which is what the OS itself reports:

```
=== SYSTEM_AND_DISPLAY ===
  pid 61723(java): [0x0003019b0005a135] PreventUserIdleDisplaySleep named: "Nucleus EnergyManager keepAwake(SYSTEM_AND_DISPLAY)"
=== SYSTEM_ONLY ===
  pid 61723(java): [0x0003019b0001a136] PreventUserIdleSystemSleep  named: "Nucleus EnergyManager keepAwake(SYSTEM_ONLY)"
=== RELEASED ===
  (no assertion left for our pid)
```

`./gradlew :energy-manager:test` on macOS → 29 tests, 0 failures (19 skipped, Windows/Linux-only), including a mode round-trip, the assertion-type assertion above, and back-and-forth mode switching without an intervening release. detekt + ktlint + `apiCheck` clean (public API unchanged); `examples:nucleus-demo` updated to the new API.
**Linux (Ubuntu 26.04, GNOME Shell 50.1, Wayland)** — every backend verified against the service that actually holds the inhibitor, from outside the JVM:

*GNOME* — `gdbus` on `org.gnome.SessionManager` from another process, while the JVM holds the request:

```
/org/gnome/SessionManager/Inhibitor11 -> appid=('Nucleus EnergyManager',) flags=(uint32 4,) reason=('keepAwake(SYSTEM_ONLY)',)
```

`4` = `INHIBIT_SUSPEND`, against `12` = `INHIBIT_IDLE | INHIBIT_SUSPEND` for `SYSTEM_AND_DISPLAY`, and no inhibitor left after `releaseAwake()`.

*logind* (session bus made unreachable) — `systemd-inhibit --list`:

```
WHO                    UID  USER          PID   COMM  WHAT  WHY                     MODE
Nucleus EnergyManager  1000 elie-gambache 28753 java  idle  keepAwake(SYSTEM_ONLY)  block
```

*PowerManagement* (private session bus via `dbus-run-session` + a stub service, no logind) — `INHIBIT app='Nucleus EnergyManager' reason='keepAwake(SYSTEM_ONLY)' cookie=101` then `UNINHIBIT cookie=101`; `SYSTEM_AND_DISPLAY` never reaches it.

*X11 only* (no bus at all) — `SYSTEM_AND_DISPLAY` → `backend=x11 active=true`; `SYSTEM_ONLY` → `success=false`, no backend taken.

*No leak on mode switches* — 100 alternating `keepAwake()` calls: open fds 15 → 15, exactly one GNOME inhibitor held throughout, 14 fds after release.

`./gradlew :energy-manager:check` on Linux → 32 tests, 0 failures (25 skipped, Windows/macOS-only), including a `SYSTEM_ONLY` round-trip, the GNOME flag read-back above, and mode switching without an intervening release. detekt + ktlint + `apiCheck` clean.

