### PR TITLE
fix(tao): keep VSync through the Windows modal loop for frame-paced GPU content

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoGpuRenderContext.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoGpuRenderContext.kt
@@ -151,14 +151,70 @@ public fun rememberTaoGpuRenderContext(): TaoGpuRenderContext? {
     val metalHost = LocalTaoMetalTextureHost.current
     val glHost = LocalTaoGlTextureHost.current
     val windowsHost = LocalTaoWindowsTextureHost.current
-    return remember(metalHost, glHost, windowsHost) {
-        when {
-            metalHost != null -> MetalRenderContext(metalHost)
-            glHost != null -> LinuxOpenGlRenderContext(glHost)
-            windowsHost != null -> WindowsOpenGlRenderContext(windowsHost)
-            else -> null
+    val context =
+        remember(metalHost, glHost, windowsHost) {
+            when {
+                metalHost != null -> MetalRenderContext(metalHost)
+                glHost != null -> LinuxOpenGlRenderContext(glHost)
+                windowsHost != null -> WindowsOpenGlRenderContext(windowsHost)
+                else -> null
+            }
         }
+    if (context != null) {
+        // Composition-lifetime consumer mark: the Windows host keeps VSync
+        // on through the OS modal resize/move loop while its DirectContext
+        // has GPU-context consumers (#484). A RememberObserver so an
+        // abandoned composition can never leak the mark.
+        remember(context) { TaoGpuRenderContextLease(context.skiaContext) }
     }
+    return context
+}
+
+/**
+ * Ledger of the [DirectContext]s whose composition currently holds a
+ * [TaoGpuRenderContext]. Such a consumer typically drives per-frame GPU work
+ * off `withFrameNanos`; the Windows host consults this (together with the
+ * `TextureView` import ledger) to keep VSync on through the OS modal
+ * resize/move loop, where an unpaced frame clock would otherwise free-run at
+ * event-pump speed (#484).
+ */
+internal object TaoGpuRenderContextConsumers {
+    private val counts = java.util.concurrent.ConcurrentHashMap<DirectContext, Int>()
+
+    fun retain(context: DirectContext) {
+        counts.merge(context, 1, Int::plus)
+    }
+
+    fun release(context: DirectContext) {
+        counts.computeIfPresent(context) { _, n -> if (n <= 1) null else n - 1 }
+    }
+
+    /** Whether [context]'s composition holds at least one live consumer. */
+    fun isActive(context: DirectContext): Boolean = counts.containsKey(context)
+}
+
+/**
+ * Marks a [DirectContext] as having a live [TaoGpuRenderContext] consumer for
+ * exactly as long as the `remember` that produced the context stays in the
+ * composition. `onAbandoned` covers compositions computed but never applied.
+ */
+private class TaoGpuRenderContextLease(
+    private val context: DirectContext,
+) : androidx.compose.runtime.RememberObserver {
+    private var retained = false
+
+    override fun onRemembered() {
+        retained = true
+        TaoGpuRenderContextConsumers.retain(context)
+    }
+
+    override fun onForgotten() {
+        if (!retained) return
+        retained = false
+        TaoGpuRenderContextConsumers.release(context)
+    }
+
+    override fun onAbandoned(): Unit = onForgotten()
 }
 
 /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureImportRegistry.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureImportRegistry.kt
@@ -85,6 +85,12 @@ internal class TextureImportRegistry<H : Any, I : Any>(
             closeImport(entry.imported)
         }
     }
+
+    /**
+     * Whether any live import targets [context] — i.e. the scene composites
+     * at least one `TextureView` right now.
+     */
+    fun hasImportsFor(context: DirectContext): Boolean = entries.keys.any { it.context == context }
 }
 
 /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureViewWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureViewWindows.kt
@@ -148,6 +148,13 @@ internal fun releaseWindowsTextureImports(context: DirectContext) {
     windowsTextureImports.closeAllFor(context)
 }
 
+/**
+ * Whether [context] currently composites at least one `TextureView`. The
+ * Windows host keeps VSync on through the OS modal resize/move loop in that
+ * case — see `TaoComposeSceneHostWindows.onResizeLoopChanged` (#484).
+ */
+internal fun hasWindowsTextureImports(context: DirectContext): Boolean = windowsTextureImports.hasImportsFor(context)
+
 private fun importTexture(
     host: TaoWindowsTextureHost,
     source: D3D11SharedTextureSource,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -40,6 +40,7 @@ import dev.nucleusframework.window.tao.event.taoTypedKeyEvent
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoGlBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
+import dev.nucleusframework.window.tao.hasWindowsTextureImports
 import dev.nucleusframework.window.tao.popup.TaoPopupHostWindows
 import dev.nucleusframework.window.tao.popup.TaoPopupSceneLayerWindows
 import dev.nucleusframework.window.tao.releaseWindowsTextureImports
@@ -1015,7 +1016,24 @@ internal class TaoComposeSceneHostWindows(
         if (attachmentHandle == 0L) return
         resizeLoopActive = active
         if (active) {
-            NativeTaoGlBridge.nativeSetVSyncEnabled(attachmentHandle, false)
+            // Keep VSync when the scene composites a TextureView or holds a
+            // TaoGpuRenderContext consumer (#484). With interval 0 and no
+            // other pacer, their `withFrameNanos`-driven producers re-enter
+            // the render path at event-pump speed for the whole drag
+            // (~1300 fps observed) — VSync is the only pacer available
+            // inside the modal loop, so such a window trades the #477
+            // border-drag responsiveness for a display-paced frame clock.
+            // Windows without frame-paced GPU content keep the interval-0
+            // regime and its resize behavior unchanged.
+            val framePacedContent =
+                directContext?.let {
+                    hasWindowsTextureImports(it) ||
+                        dev.nucleusframework.window.tao.TaoGpuRenderContextConsumers
+                            .isActive(it)
+                } == true
+            if (!framePacedContent) {
+                NativeTaoGlBridge.nativeSetVSyncEnabled(attachmentHandle, false)
+            }
         } else {
             NativeTaoGlBridge.nativeSetVSyncEnabled(attachmentHandle, true)
             // Paint the settled size once more so the first steady-state frame


### PR DESCRIPTION
Fixes the move-loop half of #484; the resize half is tracked in a follow-up issue.

## Problem

Since #477 the OS modal resize/move loop presents at swap interval 0, so any frame-clock-driven content — a `TextureView`'s `withFrameNanos` producer, a `TaoGpuRenderContext` (#481) consumer, a Compose animation — re-entered the render path at event-pump speed (~1300 fps observed) for the whole drag, during pure moves as much as resizes.

## Fix

Keep VSync on through the modal loop when the window actually hosts frame-paced GPU content: the scene's `DirectContext` has live `TextureView` imports (`TextureImportRegistry.hasImportsFor`) or `TaoGpuRenderContext` consumers (a new composition-lifetime ledger, `TaoGpuRenderContextConsumers`, backed by a `RememberObserver` so abandoned compositions can't leak the mark).

Windows without such content keep the interval-0 regime of #477 completely unchanged.

## Measured (89 Hz display, scripted + manual drags on `NUCLEUS_DEMO_TAB=Texture tao-demo`)

| phase | before | after |
|---|---|---|
| window move | ~1300 fps free-run | flat **90 fps** for the whole drag |
| border resize | free-run | still free-runs (~500–750 fps) — see below |

## Known limit (follow-up issue)

During an active border **resize**, the per-WM_SIZE `nativeResize` recreates the ANGLE swapchain, so the present queue never fills and interval-1 never blocks — VSync cannot pace that phase (this is also why attempt 3 of #481 failed). Every pacing approach tried so far (8 ms floor, lazy VSync drop, display-refresh floor + quiet window, native WM_TIMER pacer, frame-clock pacing, WM_SIZING geometry quantization) is recorded in the follow-up issue, together with the most promising lead: the WM_SIZING quantizer, which measured at display rate but needs the trembling interaction resolved in isolation.
