### PR TITLE
refactor(build): extract a nucleus.native-module convention plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ A multi-module Gradle plugin and runtime library toolkit for shipping production
 - `decorated-window-material2` - Material 2 color mapping
 - `decorated-window-material3` - Material 3 color mapping
 - `plugin-build/plugin` - Gradle plugin for packaging & distribution
+- `buildSrc` - Build-only convention plugins (`nucleus.native-module`: the shared `buildNative*` wiring for every JNI module)
 - `examples/` - Demo & sample applications (consolidated): `nucleus-demo` (flagship), `tao-demo`, `jni-demo`, `jewel-demo`, `cmp-demo` (KMP), `scheduler-demo`, `service-management-demo`, `system-info-demo`, `fs-watcher-smoke`, `extra-launcher-demo`, `benchmark-demo` (JIT-vs-GraalVM-O3 CPU benchmark suite, with SwiftUI + Tauri ports under `ports/`), `gstreamer-demo` (Linux: GStreamer video into a `TextureView`, needs its own `build.sh` and the GStreamer dev packages), `mediafoundation-demo` (Windows counterpart: Media Foundation/DXVA video into a `TextureView`, needs its own `build.bat`), `avfoundation-demo` (macOS counterpart: AVFoundation/VideoToolbox video into a `TextureView`, needs its own `build.sh`), plus `shared` (Compose helper used by tao/jni demos)
 
 ## Build & Run
@@ -63,14 +64,24 @@ A multi-module Gradle plugin and runtime library toolkit for shipping production
 
 When creating a new module with platform-specific JNI libraries, all steps below are required:
 
-1. **Native source** — `<module>/src/main/native/{linux,macos,windows}/` with `build.sh`/`build.bat` + C/ObjC source. Library name: `nucleus_<feature>`. Linux: prefer `dlopen` over hard compile-time deps.
-2. **Build output** — scripts must place binaries in `<module>/src/main/resources/nucleus/native/{linux-x64,linux-aarch64,darwin-x64,darwin-aarch64,win32-x64,win32-aarch64}/`. Build scripts must also clear the `NativeLibraryLoader` cache (`~/.cache/nucleus/native/<arch>/`) after compilation, otherwise the loader serves the stale cached copy instead of the freshly built library.
-3. **Kotlin JNI bridge** — `internal object` using `NativeLibraryLoader.load()` with `@JvmStatic external` methods. Always provide a Kotlin fallback when native lib is unavailable.
-4. **GraalVM reachability metadata** — create `<module>/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.<module>/reachability-metadata.json` declaring all JNI-accessible classes/methods. Without this, native-image silently eliminates the bridge.
-5. **CI build** (`build-natives.yaml`) — add one build step per platform job, gated with `if: steps.natives-cache.outputs.cache-hit != 'true'`, plus the library entries in that platform's `Verify ... natives` FILES list. Native outputs are cached keyed on `hashFiles('**/src/main/native/**', ...)`, so the new sources invalidate the cache automatically. Each platform job publishes a single merged artifact (`natives-windows`, `natives-macos`, `natives-linux-{x64,aarch64}`); consumer workflows fetch them all with one `pattern: 'natives-*'` download step and need **no changes** for a new module.
-6. **CI verify lists** — add the 6 arch paths to the EXPECTED arrays of the "Verify all natives present" steps in `pre-merge.yaml` and `publish-maven.yaml`.
+1. **Native source** — `<module>/src/main/native/{linux,macos,windows}/` with `build.sh`/`build.bat` + C/ObjC source. Library name: `nucleus_<feature>`. Linux: prefer `dlopen` over hard compile-time deps. Rust modules keep the crate at `src/main/native/` (`Cargo.toml` + `src/`) and only the launcher script under the per-OS directory.
+2. **Build output** — scripts must place binaries in `<module>/src/main/resources/nucleus/native/{linux-x64,linux-aarch64,darwin-x64,darwin-aarch64,win32-x64,win32-aarch64}/`.
+3. **Gradle wiring** — apply `id("nucleus.native-module")` and declare one line per platform. That is the whole build-script surface: the convention plugin (`buildSrc/src/main/kotlin/dev/nucleusframework/gradle/NativeModulePlugin.kt`) registers `buildNative{Windows,MacOs,Linux}` with the source inputs, the resources output, the host-OS and prebuilt-on-CI guards, the absolute build-script path, the `NativeLibraryLoader` cache eviction, and the `processResources` / `sourcesJar` dependencies.
+   ```kotlin
+   nucleusNative {
+       macos("nucleus_feature")    // → libnucleus_feature.dylib
+       linux("nucleus_feature")    // → libnucleus_feature.so
+       windows("nucleus_feature")  // → nucleus_feature.dll
+   }
+   ```
+4. **Kotlin JNI bridge** — `internal object` using `NativeLibraryLoader.load()` with `@JvmStatic external` methods. Always provide a Kotlin fallback when native lib is unavailable.
+5. **GraalVM reachability metadata** — create `<module>/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.<module>/reachability-metadata.json` declaring all JNI-accessible classes/methods. Without this, native-image silently eliminates the bridge.
+6. **CI build** (`build-natives.yaml`) — add one build step per platform job, gated with `if: steps.natives-cache.outputs.cache-hit != 'true'`, plus the library entries in that platform's `Verify ... natives` FILES list. Native outputs are cached keyed on `hashFiles('**/src/main/native/**', ...)`, so the new sources invalidate the cache automatically. Each platform job publishes a single merged artifact (`natives-windows`, `natives-macos`, `natives-linux-{x64,aarch64}`); consumer workflows fetch them all with one `pattern: 'natives-*'` download step and need **no changes** for a new module.
+7. **CI verify lists** — add the 6 arch paths to the EXPECTED arrays of the "Verify all natives present" steps in `pre-merge.yaml` and `publish-maven.yaml`.
 
 Common pitfalls: forgetting Linux `.so` in verify lists, missing `reachability-metadata.json`, forgetting the `cache-hit` guard on new build steps in `build-natives.yaml`.
+
+Existing `build.sh`/`build.bat` scripts also clear the `NativeLibraryLoader` cache themselves so a bare `./build.sh` (outside Gradle) is safe; new scripts don't have to, since `nucleus.native-module` does it after every run.
 
 ## Publishing to Maven Local
 

--- a/autolaunch/build.gradle.kts
+++ b/autolaunch/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -38,40 +39,9 @@ tasks.test {
     onlyIf { Os.isFamily(Os.FAMILY_WINDOWS) }
 }
 
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C++ JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val nativeDir = file("src/main/native/windows")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "win32-x64/nucleus_autolaunch.dll")
-    onlyIf { Os.isFamily(Os.FAMILY_WINDOWS) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", File(nativeDir, "build.bat").absolutePath)
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into a Linux shared library"
-    group = "build"
-    val nativeDir = file("src/main/native/linux")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val hasPrebuilt = File(outputDir, "linux-x64/libnucleus_autolaunch_linux.so").exists()
-    enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeWindows, buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeWindows, buildNativeLinux)
-    }
+nucleusNative {
+    windows("nucleus_autolaunch")
+    linux("nucleus_autolaunch_linux")
 }
 
 mavenPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,7 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import dev.detekt.gradle.Detekt
+import dev.nucleusframework.gradle.NativeTarget
 import org.apache.tools.ant.taskdefs.condition.Os
-import org.gradle.api.tasks.Exec
-import org.gradle.api.tasks.PathSensitivity
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
 plugins {
@@ -57,8 +56,8 @@ apiValidation {
     ignoredPackages.add("androidx.compose.ui.draganddrop")
 }
 
-val nativeBuildTaskPrefix = "buildNative"
-
+// The per-module `buildNative*` tasks themselves are wired by the
+// `nucleus.native-module` convention plugin (see buildSrc).
 val buildNative by tasks.registering {
     group = "build"
     description = "Builds native libraries for the current host platform."
@@ -69,14 +68,6 @@ tasks.register("watchNative") {
     description = "Builds native libraries; run with --continuous to rebuild on native source changes."
     dependsOn(buildNative)
 }
-
-fun isCurrentHostNativeTask(taskName: String): Boolean =
-    when {
-        taskName.contains("Windows", ignoreCase = true) -> Os.isFamily(Os.FAMILY_WINDOWS)
-        taskName.contains("Mac", ignoreCase = true) -> Os.isFamily(Os.FAMILY_MAC)
-        taskName.contains("Linux", ignoreCase = true) -> Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC)
-        else -> true
-    }
 
 subprojects {
     val isDemoProject = path.startsWith(":examples:")
@@ -135,45 +126,12 @@ subprojects {
 }
 
 gradle.projectsEvaluated {
-    allprojects {
-        tasks.withType<Exec>().configureEach {
-            val taskName = name
-            if (!taskName.startsWith(nativeBuildTaskPrefix)) return@configureEach
-            val isHostTask = isCurrentHostNativeTask(taskName)
-
-            val nativeSources =
-                fileTree("src/main/native") {
-                    include("Cargo.toml", "Cargo.lock", "build.rs", "src/**")
-                    when {
-                        taskName.contains("Windows", ignoreCase = true) -> include("windows/**")
-                        taskName.contains("Mac", ignoreCase = true) -> include("macos/**")
-                        taskName.contains("Linux", ignoreCase = true) -> include("linux/**")
-                    }
-                    exclude("target/**", "vendor/**")
-                }
-
-            if (System.getenv("CI") != "true") {
-                enabled = isHostTask
-                setOnlyIf("native build task matches the current host OS") {
-                    isHostTask
-                }
-            }
-            inputs
-                .files(nativeSources)
-                .withPropertyName("nativeSources")
-                .withPathSensitivity(PathSensitivity.RELATIVE)
-        }
-    }
-
     buildNative.configure {
         dependsOn(
-            allprojects.flatMap { project ->
-                project.tasks
-                    .matching { task ->
-                        task is Exec &&
-                            task.name.startsWith(nativeBuildTaskPrefix) &&
-                            isCurrentHostNativeTask(task.name)
-                    }.toList()
+            subprojects.flatMap { project ->
+                NativeTarget.entries
+                    .filter { it.isHost }
+                    .mapNotNull { project.tasks.findByName(it.taskName) }
             },
         )
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        create("nucleusNativeModule") {
+            id = "nucleus.native-module"
+            implementationClass = "dev.nucleusframework.gradle.NativeModulePlugin"
+        }
+    }
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "build-logic"

--- a/buildSrc/src/main/kotlin/dev/nucleusframework/gradle/NativeModulePlugin.kt
+++ b/buildSrc/src/main/kotlin/dev/nucleusframework/gradle/NativeModulePlugin.kt
@@ -1,0 +1,235 @@
+package dev.nucleusframework.gradle
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import java.io.File
+
+/**
+ * Owns the build wiring shared by every module that compiles a JNI bridge into
+ * `src/main/resources/nucleus/native/<arch>/`.
+ *
+ * ```kotlin
+ * plugins { id("nucleus.native-module") }
+ *
+ * nucleusNative {
+ *     macos("nucleus_darkmode")
+ *     linux("nucleus_linux_theme")
+ *     windows("nucleus_windows_theme")
+ * }
+ * ```
+ *
+ * Each call registers the corresponding `buildNative*` task with the module's
+ * inputs/outputs, the host-OS and prebuilt-artifact guards, and the
+ * `processResources` / `sourcesJar` dependencies.
+ */
+class NativeModulePlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.extensions.create<NativeModuleExtension>(NativeModuleExtension.NAME, target)
+    }
+}
+
+/** The `nucleusNative { }` block contributed by [NativeModulePlugin]. */
+open class NativeModuleExtension(
+    private val project: Project,
+) {
+    /**
+     * Registers `buildNativeWindows` for the `nucleus_*.dll` produced by
+     * `src/main/native/windows/build.bat`.
+     *
+     * @param library base library name, without the `.dll` extension
+     */
+    fun windows(
+        library: String,
+        description: String = NativeTarget.WINDOWS.defaultDescription,
+    ): TaskProvider<Exec> = register(NativeTarget.WINDOWS, library, description)
+
+    /**
+     * Registers `buildNativeMacOs` for the `libnucleus_*.dylib` produced by
+     * `src/main/native/macos/build.sh`.
+     *
+     * @param library base library name, without the `lib` prefix and `.dylib` extension
+     */
+    fun macos(
+        library: String,
+        description: String = NativeTarget.MACOS.defaultDescription,
+    ): TaskProvider<Exec> = register(NativeTarget.MACOS, library, description)
+
+    /**
+     * Registers `buildNativeLinux` for the `libnucleus_*.so` produced by
+     * `src/main/native/linux/build.sh`.
+     *
+     * @param library base library name, without the `lib` prefix and `.so` extension
+     */
+    fun linux(
+        library: String,
+        description: String = NativeTarget.LINUX.defaultDescription,
+    ): TaskProvider<Exec> = register(NativeTarget.LINUX, library, description)
+
+    private fun register(
+        target: NativeTarget,
+        library: String,
+        description: String,
+    ): TaskProvider<Exec> {
+        val nativeRoot = project.layout.projectDirectory.dir("src/main/native")
+        val nativeDir = nativeRoot.dir(target.sourceDirName).asFile
+        val resourceDir = project.layout.projectDirectory.dir(NATIVE_RESOURCE_PATH)
+        val libraryFileName = target.fileNameOf(library)
+        val prebuiltCopies = target.resourceDirs.map { File(resourceDir.dir(it).asFile, libraryFileName) }
+        val loaderCacheDir = loaderCacheDir()
+
+        // CI downloads every platform's libraries into the resources before the
+        // build (see build-natives.yaml), so recompiling them there is pure waste.
+        // Locally the guard stays off: editing a native source must rebuild even
+        // though the previous artifact is still sitting in the resources.
+        val skipWhenPrebuilt = project.providers.environmentVariable("CI").orNull == "true"
+
+        val nativeSources =
+            project.fileTree(nativeRoot).apply {
+                // Rust modules keep the crate at the root of src/main/native and
+                // only the launcher script under the per-OS directory.
+                include("Cargo.toml", "Cargo.lock", "build.rs", "src/**")
+                include("${target.sourceDirName}/**")
+                exclude("target/**", "vendor/**")
+            }
+
+        val task =
+            project.tasks.register<Exec>(target.taskName) {
+                group = "build"
+                this.description = description
+                workingDir(nativeDir)
+                commandLine(target.commandLine(nativeDir))
+                inputs
+                    .files(nativeSources)
+                    .withPropertyName("nativeSources")
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
+                outputs.dir(resourceDir).withPropertyName("nativeLibraries")
+                onlyIf("native build task matches the current host OS") { target.isHost }
+                if (skipWhenPrebuilt) {
+                    onlyIf("$libraryFileName is already present in the module resources") {
+                        prebuiltCopies.none(File::exists)
+                    }
+                }
+                // NativeLibraryLoader extracts into a content-addressed directory,
+                // but copies written before that scheme (or by a bare ./build.sh
+                // run) can still shadow the library that was just compiled.
+                doLast { evictFromLoaderCache(loaderCacheDir, libraryFileName) }
+            }
+
+        project.plugins.withType<JavaPlugin>().configureEach {
+            project.tasks.named<Task>(JavaPlugin.PROCESS_RESOURCES_TASK_NAME).configure { dependsOn(task) }
+        }
+        // Registered by the publishing plugin, which may not be applied yet.
+        project.tasks.matching { it.name == "sourcesJar" }.configureEach { dependsOn(task) }
+
+        return task
+    }
+
+    /** Mirrors `NativeLibraryLoader.resolveCacheDir()` in `core-runtime`. */
+    private fun loaderCacheDir(): File {
+        val os = System.getProperty("os.name", "").lowercase()
+        val userHome = System.getProperty("user.home")
+        val base =
+            when {
+                os.contains("win") ->
+                    project.providers
+                        .environmentVariable("LOCALAPPDATA")
+                        .orNull
+                        ?.let(::File)
+                        ?: File(userHome, "AppData/Local")
+                os.contains("mac") -> File(userHome, "Library/Caches")
+                else ->
+                    project.providers
+                        .environmentVariable("XDG_CACHE_HOME")
+                        .orNull
+                        ?.let(::File)
+                        ?: File(userHome, ".cache")
+            }
+        return File(base, "nucleus/native")
+    }
+
+    companion object {
+        const val NAME = "nucleusNative"
+    }
+}
+
+/** The host OS a `buildNative*` task compiles for. */
+enum class NativeTarget(
+    val taskName: String,
+    val sourceDirName: String,
+    val resourceDirs: List<String>,
+    val defaultDescription: String,
+    private val libraryPrefix: String,
+    private val librarySuffix: String,
+) {
+    WINDOWS(
+        taskName = "buildNativeWindows",
+        sourceDirName = "windows",
+        resourceDirs = listOf("win32-x64", "win32-aarch64"),
+        defaultDescription = "Compiles the JNI bridge into Windows DLLs (x64 + ARM64)",
+        libraryPrefix = "",
+        librarySuffix = ".dll",
+    ),
+    MACOS(
+        taskName = "buildNativeMacOs",
+        sourceDirName = "macos",
+        resourceDirs = listOf("darwin-aarch64", "darwin-x64"),
+        defaultDescription = "Compiles the JNI bridge into macOS dylibs (arm64 + x64)",
+        libraryPrefix = "lib",
+        librarySuffix = ".dylib",
+    ),
+    LINUX(
+        taskName = "buildNativeLinux",
+        sourceDirName = "linux",
+        resourceDirs = listOf("linux-x64", "linux-aarch64"),
+        defaultDescription = "Compiles the JNI bridge into Linux shared libraries (.so)",
+        libraryPrefix = "lib",
+        librarySuffix = ".so",
+    ),
+    ;
+
+    /** `nucleus_tao` → `nucleus_tao.dll` / `libnucleus_tao.dylib` / `libnucleus_tao.so`. */
+    fun fileNameOf(library: String): String = "$libraryPrefix$library$librarySuffix"
+
+    /** Whether the current machine can run this target's build script. */
+    val isHost: Boolean
+        get() =
+            when (this) {
+                WINDOWS -> Os.isFamily(Os.FAMILY_WINDOWS)
+                MACOS -> Os.isFamily(Os.FAMILY_MAC)
+                LINUX -> Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC)
+            }
+
+    /**
+     * The script invocation. Always an absolute path: `cmd /c build.bat` does not
+     * resolve from the working directory on machines that set
+     * `NoDefaultCurrentDirectoryInExePath`.
+     */
+    fun commandLine(nativeDir: File): List<String> =
+        when (this) {
+            WINDOWS -> listOf("cmd", "/c", File(nativeDir, "build.bat").absolutePath)
+            MACOS, LINUX -> listOf("bash", File(nativeDir, "build.sh").absolutePath)
+        }
+}
+
+private const val NATIVE_RESOURCE_PATH = "src/main/resources/nucleus/native"
+
+private fun evictFromLoaderCache(
+    cacheDir: File,
+    libraryFileName: String,
+) {
+    if (!cacheDir.isDirectory) return
+    cacheDir
+        .walkTopDown()
+        .filter { it.isFile && it.name == libraryFileName }
+        .forEach { it.delete() }
+}

--- a/darkmode-detector/build.gradle.kts
+++ b/darkmode-detector/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.kotlinComposePlugin)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.vanniktechMavenPublish)
@@ -31,75 +31,10 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_darkmode.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Linux shared libraries (x64 + aarch64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("linux-x64")
-            .file("libnucleus_linux_theme.so")
-            .asFile
-            .exists() ||
-            nativeResourceDir
-                .dir("linux-aarch64")
-                .file("libnucleus_linux_theme.so")
-                .asFile
-                .exists()
-    enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/linux")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("win32-x64")
-            .file("nucleus_windows_theme.dll")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_WINDOWS) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/windows")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
-    }
+nucleusNative {
+    macos("nucleus_darkmode")
+    linux("nucleus_linux_theme")
+    windows("nucleus_windows_theme")
 }
 
 mavenPublishing {

--- a/decorated-window-core/build.gradle.kts
+++ b/decorated-window-core/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.kotlinComposePlugin)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.vanniktechMavenPublish)
@@ -23,55 +23,10 @@ dependencies {
 
 // ---------- Native JNI builds ----------
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge for layout direction detection (macOS)"
-    group = "build"
-    val prebuiltFile = nativeResourceDir.dir("darwin-aarch64").file("libnucleus_layout_direction.dylib").asFile
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !prebuiltFile.exists()
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge for layout direction detection (Windows)"
-    group = "build"
-    val prebuiltFile = nativeResourceDir.dir("win32-x64").file("nucleus_layout_direction.dll").asFile
-    enabled = Os.isFamily(Os.FAMILY_WINDOWS) && !prebuiltFile.exists()
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/windows")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge for layout direction detection (Linux)"
-    group = "build"
-    val prebuiltFile = nativeResourceDir.dir("linux-x64").file("libnucleus_layout_direction.so").asFile
-    enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !prebuiltFile.exists()
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/linux")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
-    }
+nucleusNative {
+    macos("nucleus_layout_direction")
+    windows("nucleus_layout_direction")
+    linux("nucleus_layout_direction")
 }
 
 java {

--- a/decorated-window-jbr/build.gradle.kts
+++ b/decorated-window-jbr/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.kotlinComposePlugin)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.vanniktechMavenPublish)
@@ -34,27 +34,8 @@ kotlin {
     }
 }
 
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val nativeDir = file("src/main/native/macos")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "darwin-aarch64/libnucleus_macos.dylib")
-    onlyIf { Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs)
-    }
+nucleusNative {
+    macos("nucleus_macos")
 }
 
 mavenPublishing {

--- a/decorated-window-jni/build.gradle.kts
+++ b/decorated-window-jni/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.kotlinComposePlugin)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.vanniktechMavenPublish)
@@ -33,53 +33,10 @@ kotlin {
     }
 }
 
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val nativeDir = file("src/main/native/macos")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "darwin-aarch64/libnucleus_macos_jni.dylib")
-    onlyIf { Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val nativeDir = file("src/main/native/windows")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "win32-x64/nucleus_windows_decoration.dll")
-    onlyIf { Os.isFamily(Os.FAMILY_WINDOWS) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", File(nativeDir, "build.bat").absolutePath)
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Linux shared libraries (x64 + aarch64)"
-    group = "build"
-    val nativeDir = file("src/main/native/linux")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "linux-x64/libnucleus_linux_jni.so")
-    onlyIf { Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
-    }
+nucleusNative {
+    macos("nucleus_macos_jni")
+    windows("nucleus_windows_decoration")
+    linux("nucleus_linux_jni")
 }
 
 mavenPublishing {

--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.kotlinComposePlugin)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.vanniktechMavenPublish)
@@ -51,67 +52,13 @@ kotlin {
 // Tao + jni crate + per-platform helpers (Metal on macOS, WGL + WndProc deco
 // on Windows). Native binaries ship in src/main/resources/nucleus/native/.
 
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Rust JNI bridge into a macOS dylib (arm64 + x86_64)"
-    group = "build"
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "darwin-aarch64/libnucleus_tao.dylib")
-    onlyIf { Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(file("src/main/native/src"))
-    inputs.file(file("src/main/native/Cargo.toml"))
-    outputs.dir(outputDir)
-    workingDir(file("src/main/native/macos"))
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the Rust JNI bridge + WGL/Deco helpers into Windows DLLs"
-    group = "build"
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "win32-x64/nucleus_tao.dll")
-    onlyIf { Os.isFamily(Os.FAMILY_WINDOWS) && !checkFile.exists() }
-    inputs.dir(file("src/main/native/src"))
-    inputs.file(file("src/main/native/Cargo.toml"))
-    inputs.file(file("src/main/native/windows/nucleus_tao_windows_deco.c"))
-    inputs.file(file("src/main/native/windows/nucleus_tao_gl.c"))
-    inputs.file(file("src/main/native/windows/nucleus_tao_texture.c"))
-    outputs.dir(outputDir)
-    workingDir(file("src/main/native/windows"))
-    commandLine("cmd", "/c", ".\\build.bat")
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the Rust JNI bridge + EGL helper into Linux .so libraries"
-    group = "build"
-    val outputDir = file("src/main/resources/nucleus/native")
-    val arch = System.getProperty("os.arch").lowercase()
-    val archDir = if (arch.contains("aarch64") || arch.contains("arm64")) "linux-aarch64" else "linux-x64"
-    val checkFile = File(outputDir, "$archDir/libnucleus_tao.so")
-    onlyIf { Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(file("src/main/native/src"))
-    inputs.file(file("src/main/native/Cargo.toml"))
-    inputs.file(file("src/main/native/linux/nucleus_tao_egl.c"))
-    inputs.file(file("src/main/native/linux/nucleus_tao_texture_linux.c"))
-    // Shared by both C translation units above: editing it alone must not leave
-    // the task UP-TO-DATE with a stale .so in the resources.
-    inputs.file(file("src/main/native/linux/nucleus_tao_egl_internal.h"))
-    outputs.dir(outputDir)
-    workingDir(file("src/main/native/linux"))
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs)
-    dependsOn(buildNativeWindows)
-    dependsOn(buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs)
-        dependsOn(buildNativeWindows)
-        dependsOn(buildNativeLinux)
-    }
+// The whole crate (src/main/native/{Cargo.toml,src}) plus the per-OS C helpers
+// under src/main/native/<os> are tracked as inputs by the convention plugin, so
+// touching a shared header alone still invalidates the task.
+nucleusNative {
+    macos("nucleus_tao", "Compiles the Rust JNI bridge into a macOS dylib (arm64 + x86_64)")
+    windows("nucleus_tao", "Compiles the Rust JNI bridge + WGL/Deco helpers into Windows DLLs")
+    linux("nucleus_tao", "Compiles the Rust JNI bridge + EGL helper into Linux .so libraries")
 }
 
 // ── macOS standalone-popup smoke check ──────────────────────────────────────

--- a/energy-manager/build.gradle.kts
+++ b/energy-manager/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -30,70 +30,10 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("win32-x64")
-            .file("nucleus_energy_manager.dll")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_WINDOWS) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/windows")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
-}
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into macOS dylibs (x64 + arm64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_energy_manager.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", nativeDir.file("build.sh").asFile.absolutePath)
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Linux shared libraries (.so)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("linux-x64")
-            .file("libnucleus_energy_manager.so")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/linux")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", nativeDir.file("build.sh").asFile.absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeWindows, buildNativeMacOs, buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeWindows, buildNativeMacOs, buildNativeLinux)
-    }
+nucleusNative {
+    windows("nucleus_energy_manager")
+    macos("nucleus_energy_manager")
+    linux("nucleus_energy_manager")
 }
 
 mavenPublishing {

--- a/fs-watcher/build.gradle.kts
+++ b/fs-watcher/build.gradle.kts
@@ -1,10 +1,10 @@
 import org.apache.tools.ant.taskdefs.condition.Os
-import org.gradle.api.tasks.Exec
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.File
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -32,8 +32,7 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-val nativeOutputDir = nativeResourceDir.asFile
+val nativeOutputDir = layout.projectDirectory.dir("src/main/resources/nucleus/native").asFile
 
 fun hostArchDir(prefix: String): String {
     val arch = System.getProperty("os.arch").lowercase()
@@ -41,65 +40,19 @@ fun hostArchDir(prefix: String): String {
     return "$prefix-$suffix"
 }
 
-val buildNativeMacOsExec by tasks.registering(Exec::class) {
-    description = "Compiles the Rust JNI bridge into macOS dylibs for darwin-aarch64 and darwin-x64"
-    group = "build"
-    onlyIf { Os.isFamily(Os.FAMILY_MAC) }
-    outputs.files(
-        File(nativeOutputDir, "darwin-aarch64/libnucleus_fs_watcher.dylib"),
-        File(nativeOutputDir, "darwin-x64/libnucleus_fs_watcher.dylib"),
-    )
-    workingDir(layout.projectDirectory.dir("src/main/native/macos"))
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeMacOs by tasks.registering {
-    description = buildNativeMacOsExec.get().description
-    group = buildNativeMacOsExec.get().group
-    dependsOn(buildNativeMacOsExec)
-}
-
-val buildNativeLinuxExec by tasks.registering(Exec::class) {
-    description = "Compiles the Rust JNI bridge into the current host Linux shared library"
-    group = "build"
-    val outputFile = File(nativeOutputDir, "${hostArchDir("linux")}/libnucleus_fs_watcher.so")
-    onlyIf { Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) }
-    outputs.file(outputFile)
-    workingDir(layout.projectDirectory.dir("src/main/native/linux"))
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeLinux by tasks.registering {
-    description = buildNativeLinuxExec.get().description
-    group = buildNativeLinuxExec.get().group
-    dependsOn(buildNativeLinuxExec)
-}
-
-val buildNativeWindowsExec by tasks.registering(Exec::class) {
-    description = "Compiles the Rust JNI bridge into a win32-x64 DLL and an optional win32-aarch64 DLL"
-    group = "build"
-    val windowsNativeDir = layout.projectDirectory.dir("src/main/native/windows")
-    val buildScript = windowsNativeDir.file("build.bat").asFile.absolutePath
-    onlyIf { Os.isFamily(Os.FAMILY_WINDOWS) }
-    outputs.file(File(nativeOutputDir, "win32-x64/nucleus_fs_watcher.dll"))
-    workingDir(windowsNativeDir)
-    commandLine(
-        "cmd",
-        "/c",
-        buildScript,
-    )
-}
-
-val buildNativeWindows by tasks.registering {
-    description = buildNativeWindowsExec.get().description
-    group = buildNativeWindowsExec.get().group
-    dependsOn(buildNativeWindowsExec)
-}
+val nativeTasks =
+    with(nucleusNative) {
+        listOf(
+            macos("nucleus_fs_watcher", "Compiles the Rust JNI bridge into macOS dylibs (arm64 + x64)"),
+            linux("nucleus_fs_watcher", "Compiles the Rust JNI bridge into the host Linux shared library"),
+            windows("nucleus_fs_watcher", "Compiles the Rust JNI bridge into Windows DLLs (x64 + ARM64)"),
+        )
+    }
 
 val verifyNativeResourcePresence by tasks.registering {
     description = "Verifies the current host native artifact expected from the local build script exists in resources"
     group = "verification"
-    dependsOn(buildNativeMacOs, buildNativeLinux, buildNativeWindows)
+    dependsOn(nativeTasks)
     val expectedArtifactPath =
         when {
             Os.isFamily(Os.FAMILY_MAC) ->

--- a/global-hotkey/build.gradle.kts
+++ b/global-hotkey/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -52,56 +52,10 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C++ JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val nativeDir = file("src/main/native/windows")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "win32-x64/nucleus_global_hotkey.dll")
-    onlyIf { Os.isFamily(Os.FAMILY_WINDOWS) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", File(nativeDir, "build.bat").absolutePath)
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into a Linux shared library"
-    group = "build"
-    val nativeDir = file("src/main/native/linux")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val arch = System.getProperty("os.arch").let { if (it == "amd64") "x64" else "aarch64" }
-    val checkFile = File(outputDir, "linux-$arch/libnucleus_global_hotkey.so")
-    onlyIf { Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", File(nativeDir, "build.sh").absolutePath)
-}
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x86_64)"
-    group = "build"
-    val nativeDir = file("src/main/native/macos")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "darwin-aarch64/libnucleus_global_hotkey.dylib")
-    onlyIf { Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", File(nativeDir, "build.sh").absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeWindows, buildNativeMacOs, buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeWindows, buildNativeMacOs, buildNativeLinux)
-    }
+nucleusNative {
+    windows("nucleus_global_hotkey")
+    linux("nucleus_global_hotkey")
+    macos("nucleus_global_hotkey")
 }
 
 mavenPublishing {

--- a/graalvm-runtime/build.gradle.kts
+++ b/graalvm-runtime/build.gradle.kts
@@ -1,11 +1,11 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     java
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -33,27 +33,8 @@ kotlin {
     }
 }
 
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the CoreFoundation locale JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val nativeDir = file("src/main/native/macos")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "darwin-aarch64/libnucleus_locale.dylib")
-    onlyIf { Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs)
-    }
+nucleusNative {
+    macos("nucleus_locale", "Compiles the CoreFoundation locale JNI bridge into macOS dylibs (arm64 + x64)")
 }
 
 // All Java sources are package-private SVM substitutions (Target_* classes), so there is

--- a/launcher-linux/build.gradle.kts
+++ b/launcher-linux/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -29,34 +29,8 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into a Linux shared library"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("linux-x64")
-            .file("libnucleus_launcher_linux.so")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/linux")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeLinux)
-    }
+nucleusNative {
+    linux("nucleus_launcher_linux")
 }
 
 mavenPublishing {

--- a/launcher-macos/build.gradle.kts
+++ b/launcher-macos/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -28,34 +28,8 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_launcher_macos.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs)
-    }
+nucleusNative {
+    macos("nucleus_launcher_macos")
 }
 
 mavenPublishing {

--- a/launcher-windows/build.gradle.kts
+++ b/launcher-windows/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -28,29 +28,8 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C++ JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val nativeDir = file("src/main/native/windows")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "win32-x64/nucleus_launcher_windows.dll")
-    onlyIf { Os.isFamily(Os.FAMILY_WINDOWS) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", File(nativeDir, "build.bat").absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeWindows)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeWindows)
-    }
+nucleusNative {
+    windows("nucleus_launcher_windows")
 }
 
 mavenPublishing {

--- a/linux-hidpi/build.gradle.kts
+++ b/linux-hidpi/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -29,33 +29,8 @@ kotlin {
     }
 }
 
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Linux shared libraries (x64 + aarch64)"
-    group = "build"
-    val nativeDir = file("src/main/native/linux")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkX64 = File(outputDir, "linux-x64/libnucleus_linux_hidpi_jni.so")
-    val checkArm = File(outputDir, "linux-aarch64/libnucleus_linux_hidpi_jni.so")
-    onlyIf {
-        Os.isFamily(Os.FAMILY_UNIX) &&
-            !Os.isFamily(Os.FAMILY_MAC) &&
-            !checkX64.exists() &&
-            !checkArm.exists()
-    }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeLinux)
-    }
+nucleusNative {
+    linux("nucleus_linux_hidpi_jni")
 }
 
 mavenPublishing {

--- a/media-control/build.gradle.kts
+++ b/media-control/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.vanniktechMavenPublish)
 }
@@ -30,75 +30,10 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into a Linux shared library"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("linux-x64")
-            .file("libnucleus_media_control_linux.so")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/linux")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeMacos by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x86_64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_media_control_macos.dylib")
-            .asFile
-            .exists() &&
-            nativeResourceDir
-                .dir("darwin-x64")
-                .file("libnucleus_media_control_macos.dylib")
-                .asFile
-                .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C++ JNI bridge into Windows DLLs (x64 + arm64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("win32-x64")
-            .file("nucleus_media_control_windows.dll")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_WINDOWS) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/windows")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeLinux, buildNativeMacos, buildNativeWindows)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeLinux, buildNativeMacos, buildNativeWindows)
-    }
+nucleusNative {
+    linux("nucleus_media_control_linux")
+    macos("nucleus_media_control_macos")
+    windows("nucleus_media_control_windows")
 }
 
 mavenPublishing {

--- a/menu-macos/build.gradle.kts
+++ b/menu-macos/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.kotlinComposePlugin)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.vanniktechMavenPublish)
@@ -32,34 +32,8 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_menu_macos.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs)
-    }
+nucleusNative {
+    macos("nucleus_menu_macos")
 }
 
 mavenPublishing {

--- a/native-ssl/build.gradle.kts
+++ b/native-ssl/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -29,52 +29,9 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_ssl.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("win32-x64")
-            .file("nucleus_ssl.dll")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_WINDOWS) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/windows")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs, buildNativeWindows)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs, buildNativeWindows)
-    }
+nucleusNative {
+    macos("nucleus_ssl")
+    windows("nucleus_ssl")
 }
 
 mavenPublishing {

--- a/notification-linux/build.gradle.kts
+++ b/notification-linux/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -29,34 +29,8 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into a Linux shared library"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("linux-x64")
-            .file("libnucleus_notification_linux.so")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/linux")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeLinux)
-    }
+nucleusNative {
+    linux("nucleus_notification_linux")
 }
 
 mavenPublishing {

--- a/notification-macos/build.gradle.kts
+++ b/notification-macos/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -28,34 +28,8 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_notification.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs)
-    }
+nucleusNative {
+    macos("nucleus_notification")
 }
 
 mavenPublishing {

--- a/notification-windows/build.gradle.kts
+++ b/notification-windows/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -29,29 +29,8 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C++ JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val nativeDir = file("src/main/native/windows")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "win32-x64/nucleus_notification_windows.dll")
-    onlyIf { Os.isFamily(Os.FAMILY_WINDOWS) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", File(nativeDir, "build.bat").absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeWindows)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeWindows)
-    }
+nucleusNative {
+    windows("nucleus_notification_windows")
 }
 
 mavenPublishing {

--- a/scheduler/build.gradle.kts
+++ b/scheduler/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.vanniktechMavenPublish)
 }
@@ -33,55 +33,10 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C++ JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val nativeDir = file("src/main/native/windows")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "win32-x64/nucleus_scheduler.dll")
-    onlyIf { Os.isFamily(Os.FAMILY_WINDOWS) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", File(nativeDir, "build.bat").absolutePath)
-}
-
-val buildNativeMacOS by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x86_64)"
-    group = "build"
-    val nativeDir = file("src/main/native/macos")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "darwin-aarch64/libnucleus_scheduler.dylib")
-    onlyIf { Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", File(nativeDir, "build.sh").absolutePath)
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into a Linux shared library"
-    group = "build"
-    val nativeDir = file("src/main/native/linux")
-    val outputDir = file("src/main/resources/nucleus/native")
-    val checkFile = File(outputDir, "linux-x64/libnucleus_scheduler_linux.so")
-    onlyIf { Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !checkFile.exists() }
-    inputs.dir(nativeDir)
-    outputs.dir(outputDir)
-    workingDir(nativeDir)
-    commandLine("bash", File(nativeDir, "build.sh").absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeWindows, buildNativeMacOS, buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeWindows, buildNativeMacOS, buildNativeLinux)
-    }
+nucleusNative {
+    windows("nucleus_scheduler")
+    macos("nucleus_scheduler")
+    linux("nucleus_scheduler_linux")
 }
 
 mavenPublishing {

--- a/service-management-macos/build.gradle.kts
+++ b/service-management-macos/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -28,34 +28,8 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_service_management.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs)
-    }
+nucleusNative {
+    macos("nucleus_service_management")
 }
 
 mavenPublishing {

--- a/system-color/build.gradle.kts
+++ b/system-color/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.kotlinComposePlugin)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.vanniktechMavenPublish)
@@ -31,70 +31,10 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_systemcolor.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Linux .so (current arch)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("linux-x64")
-            .file("libnucleus_systemcolor.so")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/linux")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("win32-x64")
-            .file("nucleus_systemcolor.dll")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_WINDOWS) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/windows")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs, buildNativeWindows, buildNativeLinux)
-    }
+nucleusNative {
+    macos("nucleus_systemcolor")
+    linux("nucleus_systemcolor")
+    windows("nucleus_systemcolor")
 }
 
 mavenPublishing {

--- a/system-info/build.gradle.kts
+++ b/system-info/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -29,70 +29,10 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("win32-x64")
-            .file("nucleus_system_info.dll")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_WINDOWS) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/windows")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
-}
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into macOS dylibs (x64 + arm64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_system_info.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", nativeDir.file("build.sh").asFile.absolutePath)
-}
-
-val buildNativeLinux by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Linux shared libraries (.so)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("linux-x64")
-            .file("libnucleus_system_info.so")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/linux")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", nativeDir.file("build.sh").asFile.absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeWindows, buildNativeMacOs, buildNativeLinux)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeWindows, buildNativeMacOs, buildNativeLinux)
-    }
+nucleusNative {
+    windows("nucleus_system_info")
+    macos("nucleus_system_info")
+    linux("nucleus_system_info")
 }
 
 mavenPublishing {

--- a/taskbar-progress/build.gradle.kts
+++ b/taskbar-progress/build.gradle.kts
@@ -1,8 +1,8 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    id("nucleus.native-module")
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -30,52 +30,9 @@ kotlin {
     }
 }
 
-val nativeResourceDir = layout.projectDirectory.dir("src/main/resources/nucleus/native")
-
-val buildNativeMacOs by tasks.registering(Exec::class) {
-    description = "Compiles the Objective-C JNI bridge into macOS dylibs (arm64 + x64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("darwin-aarch64")
-            .file("libnucleus_taskbar_progress.dylib")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_MAC) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/macos")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("bash", "build.sh")
-}
-
-val buildNativeWindows by tasks.registering(Exec::class) {
-    description = "Compiles the C JNI bridge into Windows DLLs (x64 + ARM64)"
-    group = "build"
-    val hasPrebuilt =
-        nativeResourceDir
-            .dir("win32-x64")
-            .file("nucleus_taskbar_progress.dll")
-            .asFile
-            .exists()
-    enabled = Os.isFamily(Os.FAMILY_WINDOWS) && !hasPrebuilt
-
-    val nativeDir = layout.projectDirectory.dir("src/main/native/windows")
-    inputs.dir(nativeDir)
-    outputs.dir(nativeResourceDir)
-    workingDir(nativeDir)
-    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
-}
-
-tasks.processResources {
-    dependsOn(buildNativeMacOs, buildNativeWindows)
-}
-
-tasks.configureEach {
-    if (name == "sourcesJar") {
-        dependsOn(buildNativeMacOs, buildNativeWindows)
-    }
+nucleusNative {
+    macos("nucleus_taskbar_progress")
+    windows("nucleus_taskbar_progress")
 }
 
 mavenPublishing {


### PR DESCRIPTION
Closes #485.

## Summary

Every native JNI module carried its own copy of the `buildNative{Windows,MacOs,Linux}` `Exec` boilerplate — ~25 modules, and the copies had drifted (relative vs absolute script paths, `enabled =` vs `onlyIf {}` guards, three spellings of the macOS task name).

A new `buildSrc` convention plugin, `nucleus.native-module`, owns the whole wiring:

- registers `buildNative{Windows,MacOs,Linux}` as `Exec` tasks
- source inputs (crate + per-OS tree) with `PathSensitivity.RELATIVE`; output `src/main/resources/nucleus/native`
- host-OS guard, plus a prebuilt-artifact guard applied only when `CI=true` — CI pre-downloads all six arch dirs, while locally an edit to a native source must still trigger a rebuild
- one script-invocation convention: always the **absolute** path (`cmd /c <abs>\build.bat`, `bash <abs>/build.sh`), required on machines with `NoDefaultCurrentDirectoryInExePath`
- `NativeLibraryLoader` cache eviction after every run, scoped to that module's library file name
- the `processResources` / `sourcesJar` dependencies

A module's build script is now three lines:

```kotlin
plugins { id("nucleus.native-module") }

nucleusNative {
    macos("nucleus_darkmode")        // -> libnucleus_darkmode.dylib
    linux("nucleus_linux_theme")     // -> libnucleus_linux_theme.so
    windows("nucleus_windows_theme") // -> nucleus_windows_theme.dll
}
```

**Net: -1130 / +133** in the build scripts, plus ~220 lines of plugin.

### Other changes rolled in

- **Root `build.gradle.kts`**: dropped the `gradle.projectsEvaluated { tasks.withType<Exec>().configureEach { … } }` block that patched inputs/`enabled`/`onlyIf` onto every module after the fact. It was silently clobbering each module's own prebuilt guard on non-CI machines. `buildNative` aggregation now uses the shared `NativeTarget` enum instead of sniffing task names.
- **Task names normalized**: `buildNativeMacos` (media-control) and `buildNativeMacOS` (scheduler) → `buildNativeMacOs`. Nothing outside the build scripts referenced them (checked CI workflows, docs, shell scripts).
- **fs-watcher**: lost its `buildNative*Exec` + lifecycle-wrapper task pairs (it keeps `verifyNativeResourcePresence`) and gains the CI prebuilt guard, so CI stops recompiling its Rust crate on top of the downloaded artifacts.
- **CLAUDE.md**: "Adding a Native JNI Module" gains the Gradle-wiring step; `buildSrc` added to the project structure.

### Notes

- The plugin package is `dev.nucleusframework.gradle`, not `…​.build` — `.gitignore` has a bare `build` rule, which would silently untrack a `build/` package directory.
- The ~30 `build.sh`/`build.bat` scripts keep their own cache-clearing snippets, since they are also run directly outside Gradle. CLAUDE.md now notes that new scripts don't need it.

## Test plan

Verified on a macOS host; Windows and Linux paths are wired identically but only CI can exercise them.

- [x] `./gradlew help` — configures, configuration cache entry stored
- [x] `./gradlew ktlintCheck` — 377 tasks, pass
- [x] `./gradlew buildNative --dry-run` — picks up all 19 macOS-targeting modules
- [x] `./gradlew :energy-manager:buildNativeMacOs` — compiles both dylibs into resources; second run `UP-TO-DATE`
- [x] `CI=true ./gradlew :energy-manager:buildNativeMacOs` — `SKIPPED`, reason `libnucleus_energy_manager.dylib is already present in the module resources`
- [x] `./gradlew :taskbar-progress:assemble :launcher-macos:assemble :decorated-window-core:assemble` — succeeds; dylibs land in the jars under `nucleus/native/darwin-{aarch64,x64}`
- [x] `processResources` / `sourcesJar` dry-runs show the `buildNative*` dependencies (including fs-watcher's `verifyNativeResourcePresence` chain)
- [ ] CI: `pre-merge` green on all three platforms