### PR TITLE
fix(updater): validate provider at construction, snapshot config, stage downloads privately

### DIFF
--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/NucleusUpdater.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/NucleusUpdater.kt
@@ -28,14 +28,21 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.nio.file.Files
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.coroutines.cancellation.CancellationException
 
 public class NucleusUpdater(
-    private val config: UpdaterConfig,
+    config: UpdaterConfig,
 ) {
-    public val currentVersion: String get() = config.currentVersion
+    /**
+     * The config is validated and frozen here, once: a missing provider fails at construction,
+     * and mutating the [UpdaterConfig] afterwards has no effect on this updater.
+     */
+    private val config: ResolvedUpdaterConfig = config.resolve()
+
+    public val currentVersion: String get() = this.config.currentVersion
 
     private var pendingUpdateVersion: String? = null
 
@@ -78,18 +85,19 @@ public class NucleusUpdater(
         flow {
             pendingUpdateVersion = info.version
             val targetFile = info.currentFile
-            val tempDir = System.getProperty("java.io.tmpdir")
-            val tempFile = File(tempDir, "${targetFile.fileName}.download")
-            val finalFile = File(tempDir, targetFile.fileName)
+            // A fresh, owner-only (0700 on POSIX) staging directory: a predictable path in the
+            // shared temp dir would be a pre-created-file/symlink hazard on multi-user systems.
+            val stagingDir = Files.createTempDirectory("nucleus-update-").toFile()
+            val tempFile = File(stagingDir, "${targetFile.fileName}.download")
+            val finalFile = File(stagingDir, targetFile.fileName)
 
             try {
                 val outcome =
                     downloadDifferentially(targetFile, tempFile)
                         ?: downloadFully(targetFile, tempFile)
 
-                // Rename to final file
-                if (finalFile.exists()) finalFile.delete()
-                tempFile.renameTo(finalFile)
+                // Rename to final file (the staging directory is fresh, so the name is free)
+                check(tempFile.renameTo(finalFile)) { "Could not stage $finalFile" }
 
                 // Best-effort: fetch the detached signature next to the package so a signature-verified
                 // silent install (Linux passwordless update) can use it. Absent signature is not fatal —
@@ -109,15 +117,15 @@ public class NucleusUpdater(
                     ),
                 )
             } catch (e: UpdateException) {
-                tempFile.delete()
+                stagingDir.deleteRecursively()
                 throw e
             } catch (e: CancellationException) {
-                tempFile.delete()
+                stagingDir.deleteRecursively()
                 throw e
             } catch (
                 @Suppress("TooGenericExceptionCaught") e: Exception,
             ) {
-                tempFile.delete()
+                stagingDir.deleteRecursively()
                 throw NetworkException("Download failed", e)
             }
         }.flowOn(Dispatchers.IO)

--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/UpdaterConfig.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/UpdaterConfig.kt
@@ -47,13 +47,48 @@ public class UpdaterConfig {
      */
     public var cacheDir: File? = null
 
-    internal fun resolvedAllowPrerelease(): Boolean = allowPrerelease || currentVersion.contains("-")
-
-    internal fun isDevMode(): Boolean = currentVersion == DEV_VERSION
+    /**
+     * Validates the config and freezes it into an immutable snapshot, so a [NucleusUpdater]
+     * never observes post-construction mutation and a missing [provider] fails at
+     * construction instead of at the first network call.
+     */
+    internal fun resolve(): ResolvedUpdaterConfig {
+        require(::provider.isInitialized) {
+            "UpdaterConfig.provider must be set, e.g. NucleusUpdater { provider = GitHubProvider(\"owner/repo\") }"
+        }
+        return ResolvedUpdaterConfig(
+            currentVersion = currentVersion,
+            provider = provider,
+            channel = channel,
+            allowDowngrade = allowDowngrade,
+            allowPrerelease = allowPrerelease,
+            executableType = executableType,
+            httpClient = httpClient,
+            differentialDownload = differentialDownload,
+            cacheDir = cacheDir,
+        )
+    }
 
     public companion object {
         public const val DEV_VERSION: String = "0.0.0-dev"
     }
+}
+
+/** The immutable snapshot of an [UpdaterConfig], taken once when a [NucleusUpdater] is constructed. */
+internal data class ResolvedUpdaterConfig(
+    val currentVersion: String,
+    val provider: UpdateProvider,
+    val channel: String,
+    val allowDowngrade: Boolean,
+    val allowPrerelease: Boolean,
+    val executableType: String?,
+    val httpClient: HttpClient?,
+    val differentialDownload: Boolean,
+    val cacheDir: File?,
+) {
+    fun resolvedAllowPrerelease(): Boolean = allowPrerelease || currentVersion.contains("-")
+
+    fun isDevMode(): Boolean = currentVersion == UpdaterConfig.DEV_VERSION
 }
 
 public fun NucleusUpdater(block: UpdaterConfig.() -> Unit): NucleusUpdater {

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/UpdaterConfigSnapshotTest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/UpdaterConfigSnapshotTest.kt
@@ -1,0 +1,165 @@
+package dev.nucleusframework.updater
+
+import dev.nucleusframework.core.runtime.Platform
+import dev.nucleusframework.updater.delta.RangeHttpServer
+import dev.nucleusframework.updater.provider.UpdateProvider
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Guards the construction-time contract of [NucleusUpdater] (issue #487):
+ * a missing provider fails at construction rather than at the first network call,
+ * the whole config is snapshotted once so later mutation is inert, and downloads
+ * are staged in a private per-download directory instead of a predictable path
+ * in the shared temp dir.
+ */
+class UpdaterConfigSnapshotTest {
+    private lateinit var server: RangeHttpServer
+    private val staged = mutableListOf<File>()
+
+    @Before
+    fun setUp() {
+        server = RangeHttpServer()
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+        staged.forEach { it.parentFile?.deleteRecursively() }
+    }
+
+    @Test
+    fun `a config without a provider is rejected at construction`() {
+        val failure =
+            assertThrows(IllegalArgumentException::class.java) {
+                NucleusUpdater { currentVersion = "1.0.0" }
+            }
+        assertTrue(
+            "the error must point at the missing provider, got: ${failure.message}",
+            failure.message.orEmpty().contains("provider"),
+        )
+    }
+
+    @Test
+    fun `mutating the config after construction has no effect`() {
+        publish(version = "2.0.0", fileName = "MyApp-2.0.0.zip", artifact = ARTIFACT)
+        val config =
+            UpdaterConfig().apply {
+                currentVersion = "1.0.0"
+                provider = LoopbackProvider(server.baseUrl)
+                executableType = "zip"
+            }
+        val updater = NucleusUpdater(config)
+
+        // Post-construction mutation must be inert: the version must not change and the
+        // dead provider must never be consulted for the update check.
+        config.currentVersion = "9.9.9"
+        config.provider = DeadProvider
+
+        assertEquals("1.0.0", updater.currentVersion)
+        val result = runBlocking { updater.checkForUpdates() }
+        assertTrue(
+            "the update check must still use the snapshotted provider, got $result",
+            result is UpdateResult.Available,
+        )
+    }
+
+    @Test
+    fun `downloads are staged in a private directory, not at a predictable temp path`() {
+        publish(version = "2.0.0", fileName = "MyApp-2.0.0.zip", artifact = ARTIFACT)
+        val updater =
+            NucleusUpdater {
+                currentVersion = "1.0.0"
+                provider = LoopbackProvider(server.baseUrl)
+                executableType = "zip"
+                differentialDownload = false
+            }
+
+        val file =
+            runBlocking {
+                val result = updater.checkForUpdates()
+                assertTrue("an update must be offered, got $result", result is UpdateResult.Available)
+                updater.downloadUpdate((result as UpdateResult.Available).info).toList()
+            }.last().file.also { it?.let(staged::add) }
+
+        requireNotNull(file) { "the final progress event must carry the artifact" }
+        assertTrue("the artifact must be intact", ARTIFACT.contentEquals(file.readBytes()))
+
+        val tempDir = File(System.getProperty("java.io.tmpdir"))
+        assertNotEquals(
+            "the artifact must not land directly in the shared temp dir",
+            tempDir.canonicalFile,
+            file.parentFile.canonicalFile,
+        )
+        val perms = runCatching { Files.getPosixFilePermissions(file.parentFile.toPath()) }.getOrNull()
+        if (perms != null) {
+            assertTrue(
+                "the staging directory must be owner-only, got $perms",
+                perms.none { it.name.startsWith("GROUP_") || it.name.startsWith("OTHERS_") },
+            )
+        }
+    }
+
+    private fun publish(
+        version: String,
+        fileName: String,
+        artifact: ByteArray,
+    ) {
+        server.put("/$fileName", artifact)
+        val sha512 = Base64.getEncoder().encodeToString(MessageDigest.getInstance("SHA-512").digest(artifact))
+        val yaml =
+            buildString {
+                appendLine("version: $version")
+                appendLine("files:")
+                appendLine("  - url: $fileName")
+                appendLine("    sha512: $sha512")
+                appendLine("    size: ${artifact.size}")
+                appendLine("path: $fileName")
+                appendLine("sha512: $sha512")
+                appendLine("releaseDate: '2026-01-01T00:00:00.000Z'")
+            }
+        server.put("/latest.yml", yaml.toByteArray())
+    }
+
+    private class LoopbackProvider(
+        private val baseUrl: String,
+    ) : UpdateProvider {
+        override fun getUpdateMetadataUrl(
+            channel: String,
+            platform: Platform,
+        ): String = "$baseUrl/$channel.yml"
+
+        override fun getDownloadUrl(
+            fileName: String,
+            version: String,
+        ): String = "$baseUrl/$fileName"
+    }
+
+    /** A provider that fails every call, proving it is never consulted. */
+    private object DeadProvider : UpdateProvider {
+        override fun getUpdateMetadataUrl(
+            channel: String,
+            platform: Platform,
+        ): String = error("the snapshotted provider must be used, not this one")
+
+        override fun getDownloadUrl(
+            fileName: String,
+            version: String,
+        ): String = error("the snapshotted provider must be used, not this one")
+    }
+
+    private companion object {
+        val ARTIFACT: ByteArray = ByteArray(64 * 1024) { (it % 251).toByte() }
+    }
+}

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/delta/DifferentialUpdateE2ETest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/delta/DifferentialUpdateE2ETest.kt
@@ -46,11 +46,8 @@ class DifferentialUpdateE2ETest {
     @After
     fun tearDown() {
         server.close()
-        // downloadUpdate() stages artifacts in the JVM temp dir; do not leave them behind.
-        downloaded.forEach { file ->
-            file.delete()
-            File(file.parentFile, "${file.name}.asc").delete()
-        }
+        // downloadUpdate() stages artifacts in a private per-download temp directory; drop it whole.
+        downloaded.forEach { file -> file.parentFile?.deleteRecursively() }
     }
 
     @Test


### PR DESCRIPTION
Fixes #487

## Reproduction

New `UpdaterConfigSnapshotTest` e2e tests (against a loopback release host) confirmed all three problems on `main`:

1. `NucleusUpdater { }` without a `provider` constructed fine and only threw `UninitializedPropertyAccessException` at the first network call.
2. Mutating the `UpdaterConfig` after construction took effect (`currentVersion`, `provider`) — except for `httpClient`, which was already snapshotted.
3. The downloaded artifact landed at the predictable `java.io.tmpdir/<fileName>` path in the shared temp dir.

## Fix

- `UpdaterConfig.resolve()` (internal) validates and freezes the config into an immutable `ResolvedUpdaterConfig` snapshot taken once in the `NucleusUpdater` constructor. A missing provider now fails there with `IllegalArgumentException: UpdaterConfig.provider must be set…`, and later mutation of the config is inert for every field.
- `downloadUpdate` stages the artifact in a fresh `Files.createTempDirectory("nucleus-update-")` (0700 on POSIX) instead of the shared temp dir, removing the pre-created-file/symlink hazard; the whole staging dir is discarded on failure.

No public API change (`apiCheck` green): `UpdaterConfig` stays the mutable DSL receiver and the `NucleusUpdater(UpdaterConfig)` constructor signature is unchanged, so existing callers are source- and binary-compatible.

## Verification

- The 3 new tests fail on `main` and pass with the fix.
- `:updater-runtime:test` (incl. the differential-update e2e suite), `apiCheck`, `detekt`, `ktlintCheck` all green; `nucleus-demo` compiles.

