### PR TITLE
fix(tao): macOS Metal render thread leaks native memory on every frame

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
@@ -287,6 +287,29 @@ internal object NativeMetalBridge {
     )
 
     /**
+     * Pushes an ObjC autorelease pool on the calling thread and returns its
+     * opaque token, to be balanced with [nativeAutoreleasePoolPop] on the
+     * same thread (#494).
+     *
+     * The dedicated Metal render threads are plain JVM threads with no pool;
+     * without one drained per frame, the autoreleased `CAMetalDrawable` from
+     * [nativeBeginFrame] and the command buffer autoreleased inside skiko's
+     * `flushAndSubmit` leak on every rendered frame. The pool wraps the whole
+     * per-frame render-thread task so skiko's flush — which runs between our
+     * JNI calls — is covered too.
+     */
+    @JvmStatic
+    external fun nativeAutoreleasePoolPush(): Long
+
+    /**
+     * Pops the pool pushed by [nativeAutoreleasePoolPush], releasing every
+     * object autoreleased on this thread since. Must run on the pushing
+     * thread. No-op for a 0 token.
+     */
+    @JvmStatic
+    external fun nativeAutoreleasePoolPop(pool: Long)
+
+    /**
      * Acquires the next CAMetalLayer drawable. Returns null if the system
      * is not ready to render this frame (e.g. no drawable available).
      *

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
@@ -28,6 +28,7 @@ import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.scene.LocalTaoMetalTextureHost
 import dev.nucleusframework.window.tao.scene.MetalTextureHostCache
 import dev.nucleusframework.window.tao.scene.TaoMetalTextureHost
+import dev.nucleusframework.window.tao.scene.newMetalRenderExecutor
 import dev.nucleusframework.window.tao.scene.recordSceneToPicture
 import dev.nucleusframework.window.tao.scene.replayPictureToFrame
 import org.jetbrains.skia.DirectContext
@@ -99,10 +100,10 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
     // init blocks in declaration order — a later-declared executor would be
     // null at that point. (Skia's Metal context is thread-affine, so it is owned
     // by this single-thread executor for the lifetime of the host.)
+    // Every task drains its own ObjC autorelease pool — see
+    // newMetalRenderExecutor (#494).
     private val renderExecutor: ExecutorService =
-        Executors.newSingleThreadExecutor { r ->
-            Thread(r, "TaoStandalonePopupMetalRender").apply { isDaemon = true }
-        }
+        newMetalRenderExecutor("TaoStandalonePopupMetalRender")
 
     init {
         var valid = false

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/MetalRenderExecutor.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/MetalRenderExecutor.kt
@@ -1,0 +1,59 @@
+package dev.nucleusframework.window.tao.scene
+
+import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Single-thread daemon executor for the macOS Metal render threads, where
+ * every submitted task runs inside its own ObjC autorelease pool (#494).
+ *
+ * The render thread is a plain JVM thread, so without a pool the ObjC runtime
+ * "just leaks" every object autoreleased on it: per rendered frame, the
+ * `CAMetalDrawable` returned by `nextDrawable` and the `MTLCommandBuffer` (plus
+ * encoders and driver objects) autoreleased inside skiko's `flushAndSubmit` —
+ * ~20 MB/min of native memory while anything on screen animates. skiko's own
+ * AWT `MetalRedrawer.mm` wraps its render entry points in `@autoreleasepool`
+ * for the same reason.
+ *
+ * Draining per *task* rather than per JNI call covers the whole frame — begin
+ * frame, skiko's flush (which autoreleases between our JNI calls), present and
+ * vsync wait all run within one dispatch — and every other render-thread hop
+ * (`DirectContext` create/close, TextureView imports) for free.
+ */
+internal fun newMetalRenderExecutor(threadName: String): ExecutorService =
+    object : ThreadPoolExecutor(
+        1,
+        1,
+        0L,
+        TimeUnit.MILLISECONDS,
+        LinkedBlockingQueue(),
+        ThreadFactory { r -> Thread(r, threadName).apply { isDaemon = true } },
+    ) {
+        // Confined to the single worker thread: beforeExecute/afterExecute
+        // both run on the thread executing the task.
+        private var pool = 0L
+
+        override fun beforeExecute(
+            t: Thread,
+            r: Runnable,
+        ) {
+            if (NativeMetalBridge.isLoaded) {
+                pool = NativeMetalBridge.nativeAutoreleasePoolPush()
+            }
+        }
+
+        override fun afterExecute(
+            r: Runnable,
+            t: Throwable?,
+        ) {
+            val p = pool
+            if (p != 0L) {
+                pool = 0L
+                NativeMetalBridge.nativeAutoreleasePoolPop(p)
+            }
+        }
+    }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/MetalSceneRenderer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/MetalSceneRenderer.kt
@@ -45,14 +45,17 @@ internal fun recordSceneToPicture(
     widthPx: Int,
     heightPx: Int,
     nanoTime: Long = System.nanoTime(),
-): Picture {
-    val recorder = PictureRecorder()
-    // The cull bounds match the drawable size (physical pixels). The scene is
-    // rendered at this size; the clear happens at replay time, not here.
-    val canvas = recorder.beginRecording(Rect.makeWH(widthPx.toFloat(), heightPx.toFloat()))
-    scene.render(canvas.asComposeCanvas(), nanoTime)
-    return recorder.finishRecordingAsPicture()
-}
+): Picture =
+    PictureRecorder().use { recorder ->
+        // The cull bounds match the drawable size (physical pixels). The scene is
+        // rendered at this size; the clear happens at replay time, not here.
+        val canvas = recorder.beginRecording(Rect.makeWH(widthPx.toFloat(), heightPx.toFloat()))
+        scene.render(canvas.asComposeCanvas(), nanoTime)
+        // Closing the recorder here frees its native memory deterministically
+        // (one recorder per frame — a GC-driven Cleaner would lag far behind);
+        // the returned Picture owns its own native ref and survives the close.
+        recorder.finishRecordingAsPicture()
+    }
 
 /**
  * Replays a [picture] recorded by [recordSceneToPicture] into the attachment's

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -58,7 +58,6 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.skia.DirectContext
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.cos
@@ -1196,10 +1195,9 @@ internal class TaoComposeSceneHost(
     // this render thread is idle. Overlay surfaces can therefore close their
     // `DirectContext` here (blocking) and detach natively on the main thread
     // without racing an in-flight replay.
-    private val renderExecutor: ExecutorService =
-        Executors.newSingleThreadExecutor { r ->
-            Thread(r, "TaoMetalRender").apply { isDaemon = true }
-        }
+    // Every task drains its own ObjC autorelease pool — see
+    // newMetalRenderExecutor (#494).
+    private val renderExecutor: ExecutorService = newMetalRenderExecutor("TaoMetalRender")
     private val renderDispatcher = renderExecutor.asCoroutineDispatcher()
 
     /**

--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -2051,6 +2051,36 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeResize(
     else                          dispatch_sync(dispatch_get_main_queue(), resize);
 }
 
+// ── Per-frame autorelease pool (#494) ────────────────────────────────────
+//
+// The JVM render thread ("TaoMetalRender") has no ObjC autorelease pool, so
+// the CAMetalDrawable returned by nextDrawable and the MTLCommandBuffer
+// autoreleased inside skiko's flushAndSubmit would "just leak" — one pair per
+// rendered frame (~20 MB/min while anything animates). The Kotlin side pushes
+// a pool before each render-thread task and pops it after, covering
+// beginFrame, skiko's flush (which runs between our JNI calls, so pools
+// inside the JNI functions alone would not reach it) and present in one
+// drain. These are the exact calls ARC emits for @autoreleasepool; exported
+// by libobjc with a stable ABI but only declared in objc-internal.h, hence
+// the local declarations.
+extern void *objc_autoreleasePoolPush(void);
+extern void objc_autoreleasePoolPop(void *pool);
+
+JNIEXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeAutoreleasePoolPush(
+        JNIEnv *env, jclass clazz) {
+    (void) env; (void) clazz;
+    return (jlong)(uintptr_t) objc_autoreleasePoolPush();
+}
+
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeAutoreleasePoolPop(
+        JNIEnv *env, jclass clazz, jlong pool) {
+    (void) env; (void) clazz;
+    if (pool == 0) return;
+    objc_autoreleasePoolPop((void *)(uintptr_t) pool);
+}
+
 JNIEXPORT jobject JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeBeginFrame(
         JNIEnv *env, jclass clazz, jlong handle) {

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoMetalMissingPoolE2ETest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoMetalMissingPoolE2ETest.kt
@@ -1,0 +1,104 @@
+package dev.nucleusframework.window.tao
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Opt-in e2e for #494 (set `NUCLEUS_TAO_SMOKE=1`): the Tao Metal render thread
+ * is a plain JVM thread — without an autorelease pool drained per frame, every
+ * rendered frame leaks the autoreleased `CAMetalDrawable` returned by
+ * `nextDrawable` plus the `MTLCommandBuffer` autoreleased inside skiko's
+ * `flushAndSubmit` (~20 MB/min of native memory while anything animates).
+ *
+ * Reproduction is deterministic via the ObjC runtime itself: a child JVM
+ * ([headful.MetalPoolProbeMain]) animates a real Tao window for a few seconds
+ * with `OBJC_DEBUG_MISSING_POOLS=YES`, which makes the runtime print one
+ * "autoreleased with no pool in place — just leaking" line per doomed object.
+ * The test fails if any such line names a `CAMetalDrawable` or a command
+ * buffer — the per-frame leak signature from the issue.
+ *
+ * Not run by default: opens a real window, so it needs a display.
+ */
+class TaoMetalMissingPoolE2ETest {
+    @Test
+    fun animatedRenderLoopDrainsAutoreleasePools() {
+        if (!System.getProperty("os.name", "").lowercase().contains("mac")) return
+        if (System.getenv("NUCLEUS_TAO_SMOKE") == null) {
+            println("SKIPPED: set NUCLEUS_TAO_SMOKE=1 to run the #494 missing-pool e2e")
+            return
+        }
+
+        val java = File(File(System.getProperty("java.home"), "bin"), "java")
+        assertTrue(java.isFile, "java launcher not found at $java")
+
+        val pb = ProcessBuilder(java.absolutePath, PROBE_MAIN_CLASS)
+        // Must be set at process launch — the ObjC runtime reads it once during
+        // libobjc initialization, which is why the probe is a child process.
+        pb.environment()["OBJC_DEBUG_MISSING_POOLS"] = "YES"
+        // CLASSPATH env instead of -cp: the test classpath can exceed argv limits.
+        pb.environment()["CLASSPATH"] = System.getProperty("java.class.path")
+
+        val proc = pb.start()
+        val stdout = StringBuilder()
+        val stderr = StringBuilder()
+        val outPump =
+            thread(name = "pool-probe-stdout") {
+                proc.inputStream.bufferedReader().forEachLine { synchronized(stdout) { stdout.appendLine(it) } }
+            }
+        val errPump =
+            thread(name = "pool-probe-stderr") {
+                proc.errorStream.bufferedReader().forEachLine { synchronized(stderr) { stderr.appendLine(it) } }
+            }
+        val finished = proc.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        if (!finished) proc.destroyForcibly()
+        outPump.join(PUMP_JOIN_MS)
+        errPump.join(PUMP_JOIN_MS)
+        val out = synchronized(stdout) { stdout.toString() }
+        val err = synchronized(stderr) { stderr.toString() }
+
+        assertTrue(finished, "probe timed out after ${PROBE_TIMEOUT_SECONDS}s\n${tail(err)}")
+        assertEquals(0, proc.exitValue(), "probe exited abnormally\n${tail(out)}\n${tail(err)}")
+
+        val frames =
+            Regex("""\[pool-probe] frames=(\d+)""")
+                .find(out)
+                ?.groupValues
+                ?.get(1)
+                ?.toInt()
+        assertNotNull(frames, "probe never reported its frame count\n${tail(out)}\n${tail(err)}")
+        assertTrue(frames >= MIN_FRAMES, "probe rendered only $frames frames — animation never ran")
+
+        // The per-frame leak signature: one CAMetalDrawable (nextDrawable) and
+        // one command buffer (skiko flushAndSubmit) autoreleased on the pool-less
+        // render thread per frame. Class names are GPU-family-specific for the
+        // command buffer (AGXG16XFamilyCommandBuffer, …), so match the suffix.
+        val leakLines =
+            err
+                .lineSequence()
+                .filter { line ->
+                    line.contains("autoreleased with no pool in place") &&
+                        (line.contains("CAMetalDrawable") || line.contains("CommandBuffer"))
+                }.toList()
+        assertEquals(
+            0,
+            leakLines.size,
+            "#494: ${leakLines.size} per-frame Metal objects leaked with no autorelease pool " +
+                "over $frames rendered frames; first: ${leakLines.firstOrNull()}",
+        )
+    }
+
+    private fun tail(s: CharSequence): String = s.takeLast(MAX_REPORT_CHARS).toString()
+
+    private companion object {
+        const val PROBE_MAIN_CLASS = "dev.nucleusframework.window.tao.headful.MetalPoolProbeMain"
+        const val PROBE_TIMEOUT_SECONDS = 120L
+        const val PUMP_JOIN_MS = 5_000L
+        const val MIN_FRAMES = 30
+        const val MAX_REPORT_CHARS = 4_000
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -64,6 +64,8 @@ class TaoSceneTestBatteryDriftTest {
             MacExternalTextureNativeSmokeTest::class.java to "drives a real Metal device + IOSurface import",
             LinuxExternalTextureNativeSmokeTest::class.java to "drives a real GBM/EGL device + DMA-BUF import",
             TaoRuntimeResizableSmokeTest::class.java to "opt-in headful smoke (NUCLEUS_TAO_SMOKE=1)",
+            TaoMetalMissingPoolE2ETest::class.java to
+                "opt-in headful e2e (NUCLEUS_TAO_SMOKE=1); spawns a child JVM",
             TaoSyntheticDndTest::class.java to "pins an AWT DropTarget; the no-AWT image never initialises AWT",
             TaoTransferableAccessGuardTest::class.java to "Compose interop ABI guard, not a scene behaviour",
             TaoSceneTestBatteryDriftTest::class.java to "meta-test for the battery itself",

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MetalPoolProbeMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MetalPoolProbeMain.kt
@@ -1,0 +1,98 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.rememberWindowState
+import dev.nucleusframework.window.tao.DecoratedWindow
+import dev.nucleusframework.window.tao.taoApplication
+import kotlinx.coroutines.delay
+import kotlin.concurrent.thread
+import kotlin.system.exitProcess
+
+/**
+ * Child process of `TaoMetalMissingPoolE2ETest` (#494): opens a real Tao window
+ * with a continuously animating box (`rememberInfiniteTransition`, the exact
+ * repro from the issue) so the Metal render thread acquires a drawable and
+ * submits a command buffer on every frame, then exits after a few seconds.
+ *
+ * The parent test launches this main with `OBJC_DEBUG_MISSING_POOLS=YES` and
+ * counts the ObjC runtime's "autoreleased with no pool in place" diagnostics
+ * on stderr — the env var must be set at process launch, which is why this
+ * runs as a separate process rather than inside the test JVM.
+ *
+ * Prints `[pool-probe] frames=N` (frame-clock ticks during the animation
+ * window) so the parent can verify frames were actually rendered — without it
+ * a broken launch would pass vacuously with zero warnings.
+ */
+object MetalPoolProbeMain {
+    private const val SETTLE_MS = 2_000L
+    private const val ANIMATE_MS = 4_000L
+    private const val SPIN_PERIOD_MS = 500
+    private const val WATCHDOG_MS = 60_000L
+    private const val WATCHDOG_EXIT_CODE = 42
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        // The tao event loop takes over this thread; if exitApplication is
+        // never reached the probe would hang the parent test's waitFor.
+        thread(isDaemon = true, name = "pool-probe-watchdog") {
+            Thread.sleep(WATCHDOG_MS)
+            Runtime.getRuntime().halt(WATCHDOG_EXIT_CODE)
+        }
+
+        taoApplication {
+            DecoratedWindow(
+                onCloseRequest = ::exitApplication,
+                state = rememberWindowState(size = DpSize(420.dp, 320.dp)),
+                title = "pool-probe #494",
+            ) {
+                val spin = rememberInfiniteTransition(label = "spin")
+                val angle by spin.animateFloat(
+                    initialValue = 0f,
+                    targetValue = 360f,
+                    animationSpec = infiniteRepeatable(tween(SPIN_PERIOD_MS, easing = LinearEasing)),
+                    label = "angle",
+                )
+                Box(
+                    Modifier.fillMaxSize().background(Color.DarkGray),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box(
+                        Modifier
+                            .size(160.dp)
+                            .graphicsLayer { rotationZ = angle }
+                            .background(Color(0xFF3366CC)),
+                    )
+                }
+                LaunchedEffect(Unit) {
+                    delay(SETTLE_MS)
+                    var frames = 0
+                    val end = System.currentTimeMillis() + ANIMATE_MS
+                    while (System.currentTimeMillis() < end) {
+                        withFrameNanos { }
+                        frames++
+                    }
+                    println("[pool-probe] frames=$frames")
+                    exitApplication()
+                }
+            }
+        }
+        exitProcess(0)
+    }
+}


### PR DESCRIPTION
Fixes #494.

## Summary

- The Tao Metal render threads (`TaoMetalRender`, `TaoStandalonePopupMetalRender`) are plain JVM threads with no ObjC autorelease pool, so every rendered frame leaked the autoreleased `CAMetalDrawable` returned by `nextDrawable` plus the `MTLCommandBuffer` (and driver objects) autoreleased inside skiko's `flushAndSubmit` — ~20 MB/min of MALLOC_SMALL growth while anything on screen animates.
- `NucleusTaoMetal.m` gains `nativeAutoreleasePoolPush`/`nativeAutoreleasePoolPop` JNI helpers — the exact calls ARC emits for `@autoreleasepool` (stable libobjc ABI, declared extern since they only live in `objc-internal.h`).
- New `newMetalRenderExecutor(threadName)` wraps **every render-thread task** in its own pool via `beforeExecute`/`afterExecute`. Draining per task rather than per JNI call is the complete option from the issue: it covers the command buffer skiko autoreleases *between* our `nativeBeginFrame` and `nativePresent` calls, plus every other render-thread hop (`DirectContext` create/close, TextureView imports) for free. Both the window host and the standalone popup host now use it.
- Secondary issue from the report: `recordSceneToPicture` now closes its per-frame `PictureRecorder` deterministically (`use {}`) instead of leaving the native memory to a GC-driven Cleaner.
- The drawable ownership contract is untouched: `__bridge_retained` takes ownership before any pool drain, so only the doomed autoreleased references are released.

## Reproduction / e2e

New opt-in e2e (`NUCLEUS_TAO_SMOKE=1`, same convention as the existing real-window smokes): `TaoMetalMissingPoolE2ETest` launches `MetalPoolProbeMain` in a child JVM under `OBJC_DEBUG_MISSING_POOLS=YES` (env var must be set at process launch), animates a real Tao window for 4 s with the issue's exact repro (`rememberInfiniteTransition` + `graphicsLayer { rotationZ }`), and fails on any `CAMetalDrawable`/command-buffer "autoreleased with no pool in place" diagnostic. The probe reports its frame-clock tick count so a broken launch cannot pass vacuously.

- Before the fix: **1,066 leaked Metal objects over 361 frames** (one `CAMetalDrawable` + one `AGXG16GFamilyCommandBuffer` per frame).
- After the fix: **0** over the same animated run.

## Test plan

- [x] `NUCLEUS_TAO_SMOKE=1 ./gradlew :decorated-window-tao:test --tests "*.TaoMetalMissingPoolE2ETest"` fails before the fix (1,066 leaks / 361 frames), passes after
- [x] `./gradlew :decorated-window-tao:buildNativeMacOs` (arm64 + x86_64 dylibs rebuilt, new JNI symbols exported)
- [x] `./gradlew :decorated-window-tao:check` (unit tests, ktlint, detekt, apiCheck — no public API change, everything is internal)
- [x] New test class registered as JVM-only in `TaoSceneTestBatteryDriftTest` (spawns a child JVM; not runnable in the native-image battery)