### PR TITLE
fix(tao): overlay-safe detach and set_focusable retain leak on macOS

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayController.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayController.kt
@@ -307,6 +307,14 @@ internal class NativeViewOverlayController(
         // bookkeeping change.
         if (firstBoundsApplied) {
             val capturedScale = scale
+            // Decided NOW, against the pre-update bookkeeping: by the time the
+            // deferred block runs, `widthPx`/`heightPx` have already been set
+            // to the new values below, so comparing inside the block is always
+            // false — the inner scene's viewport would never be updated and
+            // the overlay content would keep its stale layout size (visible
+            // as the content slot not resizing across a fullscreen
+            // round-trip).
+            val sizeChanged = widthPxNew != widthPx || heightPxNew != heightPx
             host.scheduleInterop {
                 // May execute AFTER dispose(): an action queued for the next
                 // interop transaction outlives the embedding (dispose cannot
@@ -335,7 +343,7 @@ internal class NativeViewOverlayController(
                         capturedScale,
                     )
                 }
-                if (widthPxNew != widthPx || heightPxNew != heightPx) {
+                if (sizeChanged) {
                     scene?.size = IntSize(widthPxNew, heightPxNew)
                 }
             }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayController.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayController.kt
@@ -283,7 +283,6 @@ internal class NativeViewOverlayController(
                 widthPxNew == widthPx &&
                 heightPxNew == heightPx
         if (frameUnchanged) return
-        val capturedHandle = overlayNsView
 
         // Steady-state path: defer EVERYTHING (AppKit setFrame, Metal
         // layer resize, ComposeScene size) into a single CATransaction
@@ -307,27 +306,37 @@ internal class NativeViewOverlayController(
         // values into the deferred block independent of any racing
         // bookkeeping change.
         if (firstBoundsApplied) {
-            val capturedAttachment = attachmentHandle
             val capturedScale = scale
-            val capturedScene = scene
             host.scheduleInterop {
+                // May execute AFTER dispose(): an action queued for the next
+                // interop transaction outlives the embedding (dispose cannot
+                // reach into the host's transaction queue to cancel it), and
+                // by then nativeDetach has freed the attachment struct and
+                // nativeReleaseOverlay the NSView — captured raw handles
+                // would be use-after-free (observed SIGSEGV inside
+                // nativeSetOverlayFrame). Re-read the live fields instead:
+                // dispose zeroes them before freeing, all on the main thread.
+                if (disposed) return@scheduleInterop
+                val liveOverlay = overlayNsView
+                if (liveOverlay == 0L) return@scheduleInterop
                 NativeTaoMacOsNativeViewBridge.nativeSetOverlayFrame(
-                    capturedHandle,
+                    liveOverlay,
                     xPx,
                     yPx,
                     widthPxNew,
                     heightPxNew,
                 )
-                if (capturedAttachment != 0L) {
+                val liveAttachment = attachmentHandle
+                if (liveAttachment != 0L) {
                     NativeMetalBridge.nativeResize(
-                        capturedAttachment,
+                        liveAttachment,
                         widthPxNew,
                         heightPxNew,
                         capturedScale,
                     )
                 }
                 if (widthPxNew != widthPx || heightPxNew != heightPx) {
-                    capturedScene?.size = IntSize(widthPxNew, heightPxNew)
+                    scene?.size = IntSize(widthPxNew, heightPxNew)
                 }
             }
             lastFrameX = xPx
@@ -348,7 +357,7 @@ internal class NativeViewOverlayController(
         // (CALayer.frame doesn't auto-follow NSView.frame post layer
         // assignment).
         NativeTaoMacOsNativeViewBridge.nativeSetOverlayFrame(
-            capturedHandle,
+            overlayNsView,
             xPx,
             yPx,
             widthPxNew,
@@ -529,8 +538,12 @@ internal class NativeViewOverlayController(
         val handle = attachmentHandle
         attachmentHandle = 0
         if (handle != 0L) NativeMetalBridge.nativeDetach(handle)
-        NativeTaoMacOsNativeViewBridge.nativeReleaseOverlay(overlayNsView)
+        // Zero out BEFORE freeing, like attachmentHandle above: a queued
+        // interop action re-reads this field at execution time and must see 0
+        // instead of a freed NSView pointer.
+        val overlayView = overlayNsView
         overlayNsView = 0
+        if (overlayView != 0L) NativeTaoMacOsNativeViewBridge.nativeReleaseOverlay(overlayView)
     }
 
     private companion object {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
@@ -456,6 +456,20 @@ internal object NativeMetalBridge {
     @JvmStatic
     external fun nativeUpdateFullScreenButtons(nsViewPtr: Long)
 
+    /**
+     * Executes any pending [nativePresentWithInterop] main-thread callouts
+     * while the caller — which must be the macOS main thread — is blocked
+     * waiting on the render thread. The callouts are registered on the main
+     * run loop in a private mode exactly for this: a main thread parked in
+     * `future.get()` never drains its run loop, and the render thread's
+     * present-with-transaction would otherwise wait on it forever (the
+     * fullscreen-freeze deadlock with a live NativeView). Bounded to one
+     * callout or ~4ms per call; no-op off the main thread or when no callout
+     * is pending.
+     */
+    @JvmStatic
+    external fun nativeInteropPump()
+
     // ── Window-state diagnostics (headful e2e probes) ──────────────────
     //
     // Read-only probes for the stage-2 headful suite, mirroring the sheet

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
@@ -470,6 +470,15 @@ internal object NativeMetalBridge {
     @JvmStatic
     external fun nativeInteropPump()
 
+    /**
+     * True on the AppKit main thread. [dispatch.TaoMainDispatcher.taoMainThread]
+     * cannot answer this on macOS: `nativeRunBlocking` marshals the event loop
+     * onto thread 0, so AppKit callbacks run on a different JVM thread than the
+     * one that entered `taoApplication`.
+     */
+    @JvmStatic
+    external fun nativeIsMainThread(): Boolean
+
     // ── Window-state diagnostics (headful e2e probes) ──────────────────
     //
     // Read-only probes for the stage-2 headful suite, mirroring the sheet

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
@@ -503,6 +503,15 @@ internal object NativeMetalBridge {
     external fun nativeDiagWindowRetainCount(nsViewPtr: Long): Long
 
     /**
+     * Frame size of an arbitrary NSView in physical pixels, packed
+     * `(w shl 32) or h`. Lets the headful suite assert an embedded
+     * `NativeView` subview actually tracked a layout change (fullscreen
+     * round-trip). `0` when the view is gone.
+     */
+    @JvmStatic
+    external fun nativeDiagViewFrameSize(nsViewPtr: Long): Long
+
+    /**
      * Disables native → JVM callbacks and removes any active menu bar
      * monitors. Called from a JVM shutdown hook so AppKit can't fire a
      * callback into a half-destroyed JVM.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
@@ -456,6 +456,29 @@ internal object NativeMetalBridge {
     @JvmStatic
     external fun nativeUpdateFullScreenButtons(nsViewPtr: Long)
 
+    // ── Window-state diagnostics (headful e2e probes) ──────────────────
+    //
+    // Read-only probes for the stage-2 headful suite, mirroring the sheet
+    // parent probe on NativeTaoBridge: they assert native invariants that
+    // have no other JVM-visible signal. Not used by any production path.
+
+    /**
+     * Bitmask of the window-level state [nativeAttach] installs on the
+     * view's NSWindow: bit 0 = primary attachment associated object,
+     * bit 1 = fullscreen-transition observer (#327). `-1` when the view or
+     * its window is gone.
+     */
+    @JvmStatic
+    external fun nativeDiagWindowState(nsViewPtr: Long): Int
+
+    /**
+     * `CFGetRetainCount` of the view's NSWindow. Only deltas are meaningful
+     * (AppKit holds its own references); the `set_focusable` leak regression
+     * compares before/after a burst of calls. `-1` when view/window is gone.
+     */
+    @JvmStatic
+    external fun nativeDiagWindowRetainCount(nsViewPtr: Long): Long
+
     /**
      * Disables native → JVM callbacks and removes any active menu bar
      * monitors. Called from a JVM shutdown hook so AppKit can't fire a

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeMetalBridge.kt
@@ -512,6 +512,17 @@ internal object NativeMetalBridge {
     external fun nativeDiagViewFrameSize(nsViewPtr: Long): Long
 
     /**
+     * Top-left origin of an NSView within its superview, physical pixels,
+     * top-left coordinate convention, packed as two signed 32-bit values
+     * `(x shl 32) or (y and 0xFFFFFFFF)`. [Long.MIN_VALUE] when the view is
+     * gone. Complements [nativeDiagViewFrameSize]: right size at the wrong
+     * offset is the fullscreen-transition failure mode (bottom-left AppKit
+     * anchoring against a stale parent height).
+     */
+    @JvmStatic
+    external fun nativeDiagViewTopLeftPx(nsViewPtr: Long): Long
+
+    /**
      * Disables native → JVM callbacks and removes any active menu bar
      * monitors. Called from a JVM shutdown hook so AppKit can't fire a
      * callback into a half-destroyed JVM.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -1222,9 +1222,10 @@ internal class TaoComposeSceneHost(
      */
     fun <T> runOnRenderThread(block: () -> T): T {
         val future = renderExecutor.submit(Callable { block() })
-        if (NativeMetalBridge.isLoaded &&
-            Thread.currentThread() === TaoMainDispatcher.taoMainThread
-        ) {
+        // nativeIsMainThread, not taoMainThread: on macOS the event loop is
+        // marshalled onto AppKit thread 0, which is a different JVM thread
+        // than the one that entered taoApplication.
+        if (NativeMetalBridge.isLoaded && NativeMetalBridge.nativeIsMainThread()) {
             while (!future.isDone) {
                 NativeMetalBridge.nativeInteropPump()
                 // The pump returns immediately when no callout is queued in the

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.skia.DirectContext
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.locks.LockSupport
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.cos
@@ -1146,6 +1147,10 @@ internal class TaoComposeSceneHost(
     }
 
     private companion object {
+        // Pause between interop pumps in [runOnRenderThread]'s cooperative
+        // wait — the pump returns immediately when nothing is queued.
+        private const val PUMP_PARK_NANOS = 250_000L // 0.25 ms
+
         // Wire scales (must match `TRACKPAD_VALUE_FIXED_SCALE` and
         // `CURSOR_FIXED_SCALE` on the Rust side).
         private const val TRACKPAD_POSITION_SCALE: Float = 1024f
@@ -1203,11 +1208,32 @@ internal class TaoComposeSceneHost(
     /**
      * Runs [block] on the render thread and blocks until it returns. Used for
      * `DirectContext` create/use/close that must respect Skia's Metal context
-     * thread-affinity. Safe to call from the main thread during composition /
-     * disposal / lifecycle — at those points the render thread is idle (see the
-     * lifetime invariant above), so it never deadlocks against a replay.
+     * thread-affinity.
+     *
+     * The wait is cooperative when called on the Tao main thread: an in-flight
+     * or queued replay may be inside `nativePresentWithInterop`, whose
+     * CATransaction callout runs on the main thread — parking in a bare
+     * `get()` would deadlock (the fullscreen freeze with a live `NativeView`:
+     * `windowWillEnterFullScreen` → [prepareFullscreenFrame] →
+     * [renderFrameBlocking] blocks main while the render thread waits on the
+     * main run loop; same shape for the overlay first-attach). Pumping the
+     * private interop run-loop mode executes exactly those callouts — and
+     * nothing else — while we wait.
      */
-    fun <T> runOnRenderThread(block: () -> T): T = renderExecutor.submit(Callable { block() }).get()
+    fun <T> runOnRenderThread(block: () -> T): T {
+        val future = renderExecutor.submit(Callable { block() })
+        if (NativeMetalBridge.isLoaded &&
+            Thread.currentThread() === TaoMainDispatcher.taoMainThread
+        ) {
+            while (!future.isDone) {
+                NativeMetalBridge.nativeInteropPump()
+                // The pump returns immediately when no callout is queued in the
+                // private mode; park briefly so the wait isn't a hot spin.
+                if (!future.isDone) LockSupport.parkNanos(PUMP_PARK_NANOS)
+            }
+        }
+        return future.get()
+    }
 
     // ── VSync-paced render loop (AWT/skiko MetalVSyncer pattern) ──
     private var frameDispatcher: org.jetbrains.skiko.FrameDispatcher? = null

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -1148,8 +1148,11 @@ internal class TaoComposeSceneHost(
 
     private companion object {
         // Pause between interop pumps in [runOnRenderThread]'s cooperative
-        // wait — the pump returns immediately when nothing is queued.
-        private const val PUMP_PARK_NANOS = 250_000L // 0.25 ms
+        // wait — the pump is a non-blocking single pass, so this park is the
+        // whole per-iteration cost. Kept small: the wait sits on TextureView's
+        // per-video-frame snapshot hop, where every fixed microsecond is paid
+        // once per frame.
+        private const val PUMP_PARK_NANOS = 50_000L // 50 µs
 
         // Wire scales (must match `TRACKPAD_VALUE_FIXED_SCALE` and
         // `CURSOR_FIXED_SCALE` on the Rust side).

--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -2544,6 +2544,31 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeDiagWindowState
     return state;
 }
 
+/* Frame SIZE of an arbitrary NSView in physical pixels (points scaled by
+ * its window's backingScaleFactor), packed (w << 32) | h. Lets the headful
+ * suite assert that an embedded NativeView subview actually tracked a layout
+ * change (e.g. across a fullscreen round-trip). Returns 0 when the view is
+ * gone. */
+JNIEXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeDiagViewFrameSize(
+        JNIEnv *env, jclass clazz, jlong nsViewPtr) {
+    if (nsViewPtr == 0) return 0;
+    void *rawPtr = (void *)(uintptr_t)nsViewPtr;
+    __block jlong packed = 0;
+    dispatch_block_t read = ^{
+        NSView *view = (__bridge NSView *)rawPtr;
+        if (view == nil) return;
+        CGFloat scale = view.window.backingScaleFactor;
+        if (scale <= 0) scale = 1.0;
+        jlong w = (jlong) lround(view.frame.size.width * scale);
+        jlong h = (jlong) lround(view.frame.size.height * scale);
+        packed = (w << 32) | (h & 0xFFFFFFFFLL);
+    };
+    if ([NSThread isMainThread]) read();
+    else                          dispatch_sync(dispatch_get_main_queue(), read);
+    return packed;
+}
+
 /* CFGetRetainCount of view.window. Only deltas are meaningful (AppKit holds
  * its own references); the set_focusable leak regression compares the count
  * before/after a burst of calls. Returns -1 when view/window is gone. */

--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -301,6 +301,14 @@ typedef struct {
     // first resize.
     double prev_origin_x;
     double prev_origin_y;
+
+    // YES for attachments created by nativeAttachOverlay (popup NSPanels,
+    // in-window NativeView overlay subviews). Overlays never install the
+    // window-level associated objects (fullscreen observer, attachment key —
+    // see the observer-skip note on nativeAttachOverlay); nativeDetach reads
+    // this so an overlay dispose can't tear down state owned by the host
+    // window's primary attachment.
+    BOOL isOverlay;
 } NucleusTaoMetalAttachment;
 
 #define HANDLE_OF(ptr) ((NucleusTaoMetalAttachment *)(uintptr_t)(ptr))
@@ -1237,6 +1245,7 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeAttachOverlay(
     att->view   = view;
     att->prev_origin_x = NAN;
     att->prev_origin_y = NAN;
+    att->isOverlay = YES;
     return (jlong)(uintptr_t)att;
 }
 
@@ -1959,11 +1968,20 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeDetach(
         att->vsyncSem = NULL;
     }
     NSWindow *win = att->view.window;
+    BOOL isOverlay = att->isOverlay;
     att->layer  = nil;
     att->device = nil;
     att->queue  = nil;
     att->view   = nil;
-    if (win != nil) {
+    // Overlay attachments (nativeAttachOverlay) never installed the
+    // window-level state below — it belongs to the primary attachment of the
+    // window hosting the overlay's parent NSView. Tearing it down here on an
+    // overlay dispose (e.g. a NativeView unmounting from the main window)
+    // would deallocate the window's NucleusTaoFSObserver out from under its
+    // still-alive primary attachment — permanently dropping the #327
+    // fullscreen-transition handling — and leave attachmentForWindow()
+    // returning NULL for the rest of the window's life.
+    if (win != nil && !isOverlay) {
         removeMenuBarMonitor(win);
         objc_setAssociatedObject(win, &kTaoFSObserverKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(win, &kTaoAttachmentKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -2406,6 +2424,55 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeUpdateFullScree
     };
     if ([NSThread isMainThread]) apply();
     else                          dispatch_async(dispatch_get_main_queue(), apply);
+}
+
+// ── Window-state diagnostics (headful e2e probes) ────────────────────────
+//
+// Same role as nativeMacOsProbeSheetParent in the Tao bridge: tiny read-only
+// entry points the stage-2 headful suite uses to assert native invariants
+// that have no other JVM-visible signal. Not part of any production path.
+
+/* Bitmask of the window-level state nativeAttach installs on view.window:
+ * bit 0 = kTaoAttachmentKey (primary attachment reachable via
+ * attachmentForWindow), bit 1 = kTaoFSObserverKey (fullscreen-transition
+ * observer, #327). Returns -1 when the view or its window is gone. */
+JNIEXPORT jint JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeDiagWindowState(
+        JNIEnv *env, jclass clazz, jlong nsViewPtr) {
+    if (nsViewPtr == 0) return -1;
+    void *rawPtr = (void *)(uintptr_t)nsViewPtr;
+    __block jint state = -1;
+    dispatch_block_t read = ^{
+        NSView *view = (__bridge NSView *)rawPtr;
+        NSWindow *w = view.window;
+        if (w == nil) return;
+        state = 0;
+        if (objc_getAssociatedObject(w, &kTaoAttachmentKey) != nil) state |= 1;
+        if (objc_getAssociatedObject(w, &kTaoFSObserverKey) != nil) state |= 2;
+    };
+    if ([NSThread isMainThread]) read();
+    else                          dispatch_sync(dispatch_get_main_queue(), read);
+    return state;
+}
+
+/* CFGetRetainCount of view.window. Only deltas are meaningful (AppKit holds
+ * its own references); the set_focusable leak regression compares the count
+ * before/after a burst of calls. Returns -1 when view/window is gone. */
+JNIEXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeDiagWindowRetainCount(
+        JNIEnv *env, jclass clazz, jlong nsViewPtr) {
+    if (nsViewPtr == 0) return -1;
+    void *rawPtr = (void *)(uintptr_t)nsViewPtr;
+    __block jlong count = -1;
+    dispatch_block_t read = ^{
+        NSView *view = (__bridge NSView *)rawPtr;
+        NSWindow *w = view.window;
+        if (w == nil) return;
+        count = (jlong) CFGetRetainCount((__bridge CFTypeRef) w);
+    };
+    if ([NSThread isMainThread]) read();
+    else                          dispatch_sync(dispatch_get_main_queue(), read);
+    return count;
 }
 
 JNIEXPORT void JNICALL

--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -2411,7 +2411,13 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeInteropPump(
     // The permanent source keeps the mode non-empty — without it RunInMode
     // returns kCFRunLoopRunFinished at once and never executes queued blocks.
     ensureInteropModeSource();
-    CFRunLoopRunInMode((__bridge CFStringRef) kNucleusTaoInteropMode, 0.004, true);
+    // Timeout 0: one non-blocking pass — run whatever callout is already
+    // queued and return. The caller (runOnRenderThread's cooperative wait)
+    // polls; a positive timeout here would PARK the main thread for its
+    // full duration on every pump with nothing queued, a fixed tax paid
+    // once per TextureView producer frame via the per-frame snapshot hop
+    // (measured 4.5ms/hop with 4ms — enough to halve 90Hz video to 45fps).
+    CFRunLoopRunInMode((__bridge CFStringRef) kNucleusTaoInteropMode, 0.0, true);
 }
 
 // ── newFullscreenControls JNI bridge ─────────────────────────────────────

--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -2569,6 +2569,37 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeDiagViewFrameSi
     return packed;
 }
 
+/* TOP-LEFT origin of an NSView within its superview, in physical pixels
+ * with a top-left coordinate system (Compose convention), packed as two
+ * signed 32-bit values (x << 32) | (y & 0xFFFFFFFF). Complements
+ * nativeDiagViewFrameSize: a subview can have the right SIZE but sit at the
+ * wrong offset after a fullscreen transition (bottom-left AppKit anchoring
+ * vs a stale parent height). Returns LLONG_MIN when the view is gone. */
+JNIEXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeDiagViewTopLeftPx(
+        JNIEnv *env, jclass clazz, jlong nsViewPtr) {
+    if (nsViewPtr == 0) return LLONG_MIN;
+    void *rawPtr = (void *)(uintptr_t)nsViewPtr;
+    __block jlong packed = LLONG_MIN;
+    dispatch_block_t read = ^{
+        NSView *view = (__bridge NSView *)rawPtr;
+        NSView *parent = view.superview;
+        if (view == nil || parent == nil) return;
+        CGFloat scale = view.window.backingScaleFactor;
+        if (scale <= 0) scale = 1.0;
+        NSRect f = view.frame;
+        CGFloat topPt = parent.isFlipped
+            ? f.origin.y
+            : parent.bounds.size.height - (f.origin.y + f.size.height);
+        int64_t x = (int64_t) lround(f.origin.x * scale);
+        int64_t y = (int64_t) lround(topPt * scale);
+        packed = (jlong)((((uint64_t)(uint32_t) x) << 32) | ((uint64_t)(uint32_t) y));
+    };
+    if ([NSThread isMainThread]) read();
+    else                          dispatch_sync(dispatch_get_main_queue(), read);
+    return packed;
+}
+
 /* CFGetRetainCount of view.window. Only deltas are meaningful (AppKit holds
  * its own references); the set_focusable leak regression compares the count
  * before/after a burst of calls. Returns -1 when view/window is gone. */

--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -2246,6 +2246,27 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeSetPresentsWith
  * pumping cannot re-enter event dispatch or Compose rendering. */
 static NSString *const kNucleusTaoInteropMode = @"NucleusTaoInteropMode";
 
+/* A mode that contains nothing but queued blocks is considered EMPTY by
+ * CFRunLoopRunInMode, which then returns kCFRunLoopRunFinished immediately
+ * WITHOUT executing them — the pump would spin uselessly and every blocked
+ * present would ride the 2s backstop (visible as a 2-3s freeze on fullscreen
+ * entry). This permanent no-op source keeps the mode non-empty; the
+ * scheduler signals it so a pumping main thread wakes instantly. */
+static CFRunLoopSourceRef sInteropModeSource = NULL;
+
+static void interopModeSourceNoop(void *info) { (void) info; }
+
+static void ensureInteropModeSource(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        CFRunLoopSourceContext ctx = {0};
+        ctx.perform = interopModeSourceNoop;
+        sInteropModeSource = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &ctx);
+        CFRunLoopAddSource(CFRunLoopGetMain(), sInteropModeSource,
+                           (__bridge CFStringRef) kNucleusTaoInteropMode);
+    });
+}
+
 /* Atomic present-with-transaction path. See the Kotlin doc on
  * NativeMetalBridge.nativePresentWithInterop for the full sequence.
  *
@@ -2350,9 +2371,13 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativePresentWithInte
         work();
         dispatch_semaphore_signal(sem);
     };
+    ensureInteropModeSource();
     CFRunLoopRef mainLoop = CFRunLoopGetMain();
     CFRunLoopPerformBlock(mainLoop, kCFRunLoopCommonModes, once);
     CFRunLoopPerformBlock(mainLoop, (__bridge CFStringRef) kNucleusTaoInteropMode, once);
+    // Wake a main thread parked inside nativeInteropPump's RunInMode as well
+    // as the regular event loop.
+    CFRunLoopSourceSignal(sInteropModeSource);
     CFRunLoopWakeUp(mainLoop);
     // Generous backstop: if the main thread is wedged somewhere that neither
     // runs its loop nor pumps, degrade to a late/skipped transaction (the
@@ -2367,11 +2392,25 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativePresentWithInte
  * macOS main thread) is blocked waiting on the render thread — see
  * kNucleusTaoInteropMode above and TaoComposeSceneHost.runOnRenderThread.
  * Bounded: returns after one callout or ~4ms, whichever comes first. */
+/* True on the AppKit main thread. Kotlin cannot decide this itself: on macOS
+ * nativeRunBlocking marshals the event loop onto thread 0, so the JVM thread
+ * that entered taoApplication (TaoMainDispatcher.taoMainThread) is NOT the
+ * thread AppKit callbacks run on. */
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeIsMainThread(
+        JNIEnv *env, jclass clazz) {
+    (void) env; (void) clazz;
+    return [NSThread isMainThread] ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT void JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeInteropPump(
         JNIEnv *env, jclass clazz) {
     (void) env; (void) clazz;
     if (![NSThread isMainThread]) return;
+    // The permanent source keeps the mode non-empty — without it RunInMode
+    // returns kCFRunLoopRunFinished at once and never executes queued blocks.
+    ensureInteropModeSource();
     CFRunLoopRunInMode((__bridge CFStringRef) kNucleusTaoInteropMode, 0.004, true);
 }
 

--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -2238,6 +2238,14 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeSetPresentsWith
     else                          dispatch_sync(dispatch_get_main_queue(), apply);
 }
 
+/* Private run-loop mode for the interop callout below. Blocks scheduled in
+ * this mode (in addition to the common modes) can be executed by a main
+ * thread that is otherwise BLOCKED waiting on the render thread — it spins
+ * CFRunLoopRunInMode on this mode via nativeInteropPump. Tao's own run-loop
+ * observers/sources live in the default/common modes and never fire here, so
+ * pumping cannot re-enter event dispatch or Compose rendering. */
+static NSString *const kNucleusTaoInteropMode = @"NucleusTaoInteropMode";
+
 /* Atomic present-with-transaction path. See the Kotlin doc on
  * NativeMetalBridge.nativePresentWithInterop for the full sequence.
  *
@@ -2254,11 +2262,16 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativePresentWithInte
     // Stage 2: this is invoked from the host's background render thread (after
     // the scene's GPU encode), but CATransaction + the explicit [drawable
     // present] + the AppKit mutations in `interopActions` must run on the macOS
-    // main thread. We therefore dispatch the whole atomic block to the main
-    // queue. The render thread blocks (dispatch_sync) until it completes, which
-    // is safe: the main thread is never itself blocked on the render thread
-    // while a frame's replay is in flight (all main→render hops happen during
-    // the main-thread record pass, when the render thread is idle).
+    // main thread. This used to be a plain dispatch_sync to the main queue on
+    // the assumption that "the main thread is never itself blocked on the
+    // render thread while a frame's replay is in flight" — which the
+    // fullscreen prepare (#327: windowWillEnterFullScreen → blocking frame via
+    // runOnRenderThread) and the NativeView overlay first-attach violate,
+    // deadlocking the app the moment either coincides with an in-flight
+    // interop present. The block is therefore scheduled on the main RUN LOOP
+    // instead, registered in the common modes (normal drain) AND the private
+    // kNucleusTaoInteropMode, which a blocked main thread pumps via
+    // nativeInteropPump while it waits on the render thread.
     ensureMetalJVMCached(env);
 
     // Promote the Runnable to a global ref: the local ref `interopActions` is
@@ -2321,8 +2334,45 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativePresentWithInte
         [CATransaction commit];
     };
 
-    if ([NSThread isMainThread]) work();
-    else                          dispatch_sync(dispatch_get_main_queue(), work);
+    if ([NSThread isMainThread]) {
+        work();
+        return;
+    }
+
+    // Once-guard shared by both mode registrations (copies of the same block
+    // share the __block slot; both callouts run on the main thread, so no
+    // atomics needed).
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    __block BOOL ran = NO;
+    void (^once)(void) = ^{
+        if (ran) return;
+        ran = YES;
+        work();
+        dispatch_semaphore_signal(sem);
+    };
+    CFRunLoopRef mainLoop = CFRunLoopGetMain();
+    CFRunLoopPerformBlock(mainLoop, kCFRunLoopCommonModes, once);
+    CFRunLoopPerformBlock(mainLoop, (__bridge CFStringRef) kNucleusTaoInteropMode, once);
+    CFRunLoopWakeUp(mainLoop);
+    // Generous backstop: if the main thread is wedged somewhere that neither
+    // runs its loop nor pumps, degrade to a late/skipped transaction (the
+    // queued block still presents when the loop resumes) instead of parking
+    // the render thread forever.
+    if (dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC)) != 0) {
+        NTLOG("nativePresentWithInterop: main-thread callout timed out after 2s");
+    }
+}
+
+/* Executes any pending interop callouts while the caller (which must be the
+ * macOS main thread) is blocked waiting on the render thread — see
+ * kNucleusTaoInteropMode above and TaoComposeSceneHost.runOnRenderThread.
+ * Bounded: returns after one callout or ~4ms, whichever comes first. */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeInteropPump(
+        JNIEnv *env, jclass clazz) {
+    (void) env; (void) clazz;
+    if (![NSThread isMainThread]) return;
+    CFRunLoopRunInMode((__bridge CFStringRef) kNucleusTaoInteropMode, 0.004, true);
 }
 
 // ── newFullscreenControls JNI bridge ─────────────────────────────────────

--- a/decorated-window-tao/src/main/native/macos/native_view.m
+++ b/decorated-window-tao/src/main/native/macos/native_view.m
@@ -289,6 +289,22 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeSe
         ? NSMakeRect(xPt, yPt, wPt, hPt)
         : NSMakeRect(xPt, parentH - yPt - hPt, wPt, hPt);
 
+    // Margin-only autoresizing: fixed size, fixed TOP-LEFT anchor. The
+    // bottom-left frame above is computed against parentH AT CALL TIME —
+    // during an AppKit fullscreen transition the interop-deferred call
+    // lands while the parent still has its pre-transition height, and a
+    // mask of 0 (all margins fixed = glued to the parent's BOTTOM-left)
+    // leaves the child offset by the full height delta once the window
+    // reaches its final size, with no Compose re-issue coming (the
+    // Compose-side rect didn't change). Flexible bottom/right margins
+    // make AppKit preserve the top-left anchor across parent resizes
+    // instead; size stays Compose-owned (no Width/HeightSizable bits, so
+    // the live-resize two-writer jitter this file guards against
+    // elsewhere cannot come back).
+    child.autoresizingMask = parent.isFlipped
+        ? (NSViewMaxXMargin | NSViewMaxYMargin)
+        : (NSViewMaxXMargin | NSViewMinYMargin);
+
     // Wrap in a CATransaction with disableActions so the layer-backed
     // subview (typically a WKWebView) doesn't kick off the default 0.25s
     // implicit position/bounds animation on every layout pass — that's
@@ -361,8 +377,9 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeCr
     if (parent == nil) return 0;
     NucleusTaoNativeOverlayView *overlay =
         [[NucleusTaoNativeOverlayView alloc] initWithFrame:parent.bounds];
-    // Intentionally NO autoresizingMask. We previously set
-    // `NSViewWidthSizable | NSViewHeightSizable` so the overlay would
+    // Intentionally NO SIZE bits in the autoresizingMask (margin-only
+    // anchoring is applied later by nativeSetOverlayFrame). We previously
+    // set `NSViewWidthSizable | NSViewHeightSizable` so the overlay would
     // visually track parent resizes "for free", but that creates two
     // independent frame writers competing during a window live-resize:
     //
@@ -406,6 +423,15 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeSe
     NSRect newFrame = parent.isFlipped
         ? NSMakeRect(xPt, yPt, wPt, hPt)
         : NSMakeRect(xPt, parentH - yPt - hPt, wPt, hPt);
+    // Margin-only anchoring, same reasoning as nativeSetSubviewFrame: keeps
+    // the top-left corner in place when the parent's height changes between
+    // Compose frame updates (fullscreen enter/exit). Size bits stay unset —
+    // the "no autoresizingMask" rule from nativeCreateOverlay only ever
+    // concerned Width/HeightSizable (the live-resize two-writer jitter);
+    // margins have a single writer (AppKit) and Compose still owns the size.
+    overlay.autoresizingMask = parent.isFlipped
+        ? (NSViewMaxXMargin | NSViewMaxYMargin)
+        : (NSViewMaxXMargin | NSViewMinYMargin);
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     [overlay setFrame:newFrame];

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/macos/window.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/macos/window.rs
@@ -733,8 +733,13 @@ impl UnownedWindow {
   pub fn set_focusable(&self, focusable: bool) {
     #[allow(deprecated)] // TODO: Use define_class!
     unsafe {
-      let ns_window =
-        Retained::into_raw(Retained::cast_unchecked::<Object>(self.ns_window.clone()));
+      // PATCH(nucleus): borrow the NSWindow pointer instead of leaking a
+      // retain. The previous `clone()` + `Retained::into_raw` retained the
+      // window (+1) with nothing ever releasing it — one leaked reference
+      // per call, keeping the NSWindow alive forever after close.
+      // `Retained::as_ptr` reads the pointer without touching the refcount;
+      // the ivar write does not need ownership.
+      let ns_window = Retained::as_ptr(&self.ns_window) as *const Object as *mut Object;
       *((*ns_window).get_mut_ivar::<Bool>("focusable")) = focusable.into();
     }
   }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoRuntimeResizableSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoRuntimeResizableSmokeTest.kt
@@ -33,10 +33,18 @@ class TaoRuntimeResizableSmokeTest {
 
         // The tao event loop takes over this thread; if exitApplication is
         // never reached the forked test JVM would hang with no timeout.
-        thread(isDaemon = true, name = "tao-smoke-watchdog") {
-            Thread.sleep(WATCHDOG_MS)
-            Runtime.getRuntime().halt(WATCHDOG_EXIT_CODE)
-        }
+        // Disarmed via interrupt once the loop returns: the Gradle executor
+        // JVM is shared, and a still-armed watchdog would halt whatever test
+        // class happens to run WATCHDOG_MS later.
+        val watchdog =
+            thread(isDaemon = true, name = "tao-smoke-watchdog") {
+                try {
+                    Thread.sleep(WATCHDOG_MS)
+                } catch (_: InterruptedException) {
+                    return@thread // test finished in time
+                }
+                Runtime.getRuntime().halt(WATCHDOG_EXIT_CODE)
+            }
 
         taoApplication {
             var resizable by remember { mutableStateOf(true) }
@@ -56,6 +64,7 @@ class TaoRuntimeResizableSmokeTest {
                 }
             }
         }
+        watchdog.interrupt()
 
         assertEquals(
             false,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import dev.nucleusframework.window.tao.NativeView
@@ -45,6 +46,7 @@ internal object MacWindowChromeStateHeadfulCases {
             overlayDetachKeepsWindowChromeState(),
             setFocusableDoesNotLeakWindowRetains(),
             fullscreenWithLiveNativeViewDoesNotFreeze(),
+            nativeViewTracksFullscreenRoundTrip(),
         )
 
     /** Bit 0 = primary attachment associated object, bit 1 = FS observer. */
@@ -266,6 +268,153 @@ internal object MacWindowChromeStateHeadfulCases {
         }
     }
 
+    /**
+     * The embedded NSView must track its Compose slot's size through a
+     * fullscreen round-trip: a `NativeView(Modifier.fillMaxSize())` has to
+     * grow to the fullscreen layout on enter and shrink back on exit —
+     * asserted against the AppKit view's REAL frame, not Compose state.
+     */
+    private fun nativeViewTracksFullscreenRoundTrip(): TaoWindowTestCase {
+        val childViewPtr = AtomicLong(0)
+        val embeddingComposed = AtomicLong(0)
+        // Laid-out width of the overlay `content` slot, in px, packed by the
+        // inner scene's own layout pass — the only signal of the overlay
+        // ComposeScene's real viewport.
+        val overlayContentWidthPx = AtomicLong(0)
+        return TaoWindowTestCase(
+            name = "NativeView frame tracks a fullscreen round-trip (#494 patch)",
+            timeoutMillis = 90_000L,
+            skip = { if (!isMac) "macOS only" else null },
+            content = {
+                FillingNativeViewProbe(window.handle, childViewPtr, embeddingComposed, overlayContentWidthPx)
+            },
+        ) {
+            awaitUntil("window mapped") { bounds() != null }
+            settle()
+            awaitUntil("NativeView embedding composed") { embeddingComposed.get() == 1L }
+            settle()
+
+            fun childSizePx(): Pair<Long, Long> {
+                val packed = NativeMetalBridge.nativeDiagViewFrameSize(childViewPtr.get())
+                return (packed ushr 32) to (packed and 0xFFFFFFFFL)
+            }
+
+            val windowedBounds = requireNotNull(bounds())
+            val (w0, h0) = childSizePx()
+            check(w0 > 0 && h0 > 0) { "embedded NSView never got an initial frame (${w0}x$h0)" }
+
+            window.setFullscreen(true)
+            awaitUntil("entered fullscreen (bounds grew)", timeoutMillis = FS_TIMEOUT_MS) {
+                val b = bounds() ?: return@awaitUntil false
+                b[2] > windowedBounds[2] + FS_GROWTH_MIN_PX
+            }
+            settle(FS_SETTLE_MS)
+            val fsBounds = requireNotNull(bounds())
+            val (wFs, hFs) = childSizePx()
+            // fillMaxSize minus chrome: width must match the window's client
+            // width; height is within the title-bar inset.
+            check(abs(wFs - fsBounds[2]) <= TRACK_TOLERANCE_PX) {
+                "embedded NSView did not grow to the fullscreen layout: " +
+                    "view=${wFs}x$hFs window=${fsBounds[2]}x${fsBounds[3]} (was ${w0}x$h0)"
+            }
+            // The overlay `content` slot must have relaid out to the same
+            // width — a stale inner-scene viewport keeps the Compose content
+            // (and its hit regions) at the pre-fullscreen size.
+            val overlayFsWidth = overlayContentWidthPx.get()
+            check(abs(overlayFsWidth - wFs) <= TRACK_TOLERANCE_PX) {
+                "NativeView overlay content kept a stale viewport in fullscreen: " +
+                    "content=${overlayFsWidth}px embed=${wFs}px"
+            }
+
+            window.setFullscreen(false)
+            awaitUntil("exited fullscreen (bounds restored)", timeoutMillis = FS_TIMEOUT_MS) {
+                val b = bounds() ?: return@awaitUntil false
+                abs(b[2] - windowedBounds[2]) <= FS_RESTORE_TOLERANCE_PX
+            }
+            settle(FS_SETTLE_MS)
+            val restoredBounds = requireNotNull(bounds())
+            val (wBack, hBack) = childSizePx()
+            check(abs(wBack - restoredBounds[2]) <= TRACK_TOLERANCE_PX) {
+                "embedded NSView kept stale dimensions after exiting fullscreen: " +
+                    "view=${wBack}x$hBack window=${restoredBounds[2]}x${restoredBounds[3]} " +
+                    "(fullscreen was ${wFs}x$hFs)"
+            }
+
+            // A window resize AFTER the round-trip must still reach the
+            // embed — catches a wedged interop pipeline that the restore
+            // path alone can miss (the restore size is re-applied by the
+            // fullscreen-prepare machinery, a resize is not).
+            val scale = window.scaleFactor.coerceAtLeast(1f).toDouble()
+            window.setInnerSize(
+                restoredBounds[2] / scale + POST_FS_RESIZE_DELTA_DP,
+                restoredBounds[3] / scale + POST_FS_RESIZE_DELTA_DP,
+            )
+            awaitUntil("window resized after the round-trip", timeoutMillis = FS_TIMEOUT_MS) {
+                val b = bounds() ?: return@awaitUntil false
+                b[2] > restoredBounds[2] + (POST_FS_RESIZE_DELTA_DP * scale / 2).toInt()
+            }
+            settle(FS_SETTLE_MS)
+            val resizedBounds = requireNotNull(bounds())
+            val (wResized, _) = childSizePx()
+            check(abs(wResized - resizedBounds[2]) <= TRACK_TOLERANCE_PX) {
+                "embedded NSView stopped tracking resizes after the fullscreen " +
+                    "round-trip: view width=$wResized window width=${resizedBounds[2]}"
+            }
+            val overlayResizedWidth = overlayContentWidthPx.get()
+            check(abs(overlayResizedWidth - wResized) <= TRACK_TOLERANCE_PX) {
+                "NativeView overlay content kept a stale viewport after the " +
+                    "round-trip + resize: content=${overlayResizedWidth}px embed=${wResized}px"
+            }
+
+            childViewPtr.get().takeIf { it != 0L }?.let {
+                NativeTaoMacOsNativeViewBridge.nativeReleaseOverlay(it)
+            }
+        }
+    }
+
+    /**
+     * A `NativeView(Modifier.fillMaxSize())` around a fabricated NSView, with
+     * a content slot that reports its laid-out width — the probe body of
+     * [nativeViewTracksFullscreenRoundTrip].
+     */
+    @androidx.compose.runtime.Composable
+    private fun FillingNativeViewProbe(
+        windowHandle: Long,
+        childViewPtr: AtomicLong,
+        embeddingComposed: AtomicLong,
+        overlayContentWidthPx: AtomicLong,
+    ) {
+        val parentNsView = NativeTaoBridge.nativeNsViewHandle(windowHandle)
+        val child =
+            remember(parentNsView) {
+                if (parentNsView != 0L) {
+                    NativeTaoMacOsNativeViewBridge
+                        .nativeCreateOverlay(parentNsView)
+                        .also(childViewPtr::set)
+                } else {
+                    0L
+                }
+            }
+        if (child != 0L) {
+            SideEffect { embeddingComposed.set(1) }
+            NativeView(
+                factory = {
+                    object : NucleusPlatformView.NsView {
+                        override val nsViewHandle: Long = child
+                    }
+                },
+                modifier = Modifier.fillMaxSize(),
+                content = {
+                    Box(
+                        Modifier.fillMaxSize().onGloballyPositioned {
+                            overlayContentWidthPx.set(it.size.width.toLong())
+                        },
+                    )
+                },
+            )
+        }
+    }
+
     private const val PHASE_PERIOD_MS = 500
     private const val FULL_TURN_DEGREES = 360f
     private const val EMBED_BASE_OFFSET_PX = 140
@@ -275,4 +424,7 @@ internal object MacWindowChromeStateHeadfulCases {
     private const val FS_ENTRY_MAX_MS = 2_000L
     private const val FS_GROWTH_MIN_PX = 200
     private const val FS_RESTORE_TOLERANCE_PX = 64
+    private const val FS_SETTLE_MS = 1_200L
+    private const val TRACK_TOLERANCE_PX = 8
+    private const val POST_FS_RESIZE_DELTA_DP = 120.0
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
@@ -1,8 +1,33 @@
 package dev.nucleusframework.window.tao.headful
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import dev.nucleusframework.window.tao.NativeView
+import dev.nucleusframework.window.tao.NucleusPlatformView
 import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoMacOsNativeViewBridge
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 /**
  * Headful e2e cases for the macOS window-level native state reported against
@@ -19,6 +44,7 @@ internal object MacWindowChromeStateHeadfulCases {
         listOf(
             overlayDetachKeepsWindowChromeState(),
             setFocusableDoesNotLeakWindowRetains(),
+            fullscreenWithLiveNativeViewDoesNotFreeze(),
         )
 
     /** Bit 0 = primary attachment associated object, bit 1 = FS observer. */
@@ -113,4 +139,129 @@ internal object MacWindowChromeStateHeadfulCases {
         }
 
     private const val FOCUSABLE_CALLS = 40
+
+    /**
+     * Entering fullscreen with a live `NativeView` must not deadlock. The
+     * freeze: `windowWillEnterFullScreen` → `prepareFullscreenFrame` →
+     * `renderFrameBlocking` parks the main thread on the render executor,
+     * while the render thread sits inside `nativePresentWithInterop`'s
+     * main-thread callout (present-with-transaction) — AB-BA. Fixed by
+     * scheduling the callout in a private run-loop mode that the blocked main
+     * thread pumps ([NativeMetalBridge.nativeInteropPump]).
+     *
+     * The content keeps an animation running and animates the embed's
+     * position so every frame carries an interop action — the exact regime
+     * the deadlock needs (an interop present in flight when fullscreen
+     * starts).
+     */
+    private fun fullscreenWithLiveNativeViewDoesNotFreeze(): TaoWindowTestCase {
+        var showNativeView by mutableStateOf(false)
+        val childViewPtr = AtomicLong(0)
+        val embeddingComposed = AtomicLong(0)
+        return TaoWindowTestCase(
+            name = "fullscreen with a live NativeView does not deadlock (#494 patch)",
+            timeoutMillis = 90_000L,
+            skip = { if (!isMac) "macOS only" else null },
+            content = {
+                // Captured before Box: the @LayoutScopeMarker on BoxScope
+                // blocks the outer TaoDecoratedWindowScope implicit receiver.
+                val taoWindow = window
+                val drive = rememberInfiniteTransition(label = "drive")
+                val phase by drive.animateFloat(
+                    initialValue = 0f,
+                    targetValue = 1f,
+                    animationSpec = infiniteRepeatable(tween(PHASE_PERIOD_MS, easing = LinearEasing)),
+                    label = "phase",
+                )
+                Box(Modifier.fillMaxSize().background(Color.DarkGray)) {
+                    Box(
+                        Modifier
+                            .size(80.dp)
+                            .graphicsLayer { rotationZ = phase * FULL_TURN_DEGREES }
+                            .background(Color(0xFF3366CC)),
+                    )
+                    if (showNativeView) {
+                        val parentNsView = NativeTaoBridge.nativeNsViewHandle(taoWindow.handle)
+                        val child =
+                            remember(parentNsView) {
+                                if (parentNsView != 0L) {
+                                    NativeTaoMacOsNativeViewBridge
+                                        .nativeCreateOverlay(parentNsView)
+                                        .also(childViewPtr::set)
+                                } else {
+                                    0L
+                                }
+                            }
+                        if (child != 0L) {
+                            SideEffect { embeddingComposed.set(1) }
+                            NativeView(
+                                factory = {
+                                    object : NucleusPlatformView.NsView {
+                                        override val nsViewHandle: Long = child
+                                    }
+                                },
+                                modifier =
+                                    Modifier
+                                        .offset {
+                                            IntOffset(
+                                                EMBED_BASE_OFFSET_PX + (phase * EMBED_SWAY_PX).roundToInt(),
+                                                EMBED_BASE_OFFSET_PX,
+                                            )
+                                        }.size(120.dp),
+                            )
+                        }
+                    }
+                }
+            },
+        ) {
+            awaitUntil("window mapped") { bounds() != null }
+            settle()
+            val before = requireNotNull(bounds())
+
+            // Mount the NativeView during steady-state rendering (the demo
+            // navigation pattern), then let interop presents get going.
+            showNativeView = true
+            awaitUntil("NativeView embedding composed") { embeddingComposed.get() == 1L }
+            settle(INTEROP_WARMUP_MS)
+
+            window.setFullscreen(true)
+            awaitUntil("entered fullscreen (bounds grew)", timeoutMillis = FS_TIMEOUT_MS) {
+                val b = bounds() ?: return@awaitUntil false
+                b[2] > before[2] + FS_GROWTH_MIN_PX
+            }
+            // Keep animating in fullscreen for a moment — interop presents must
+            // keep flowing there too.
+            settle(INTEROP_WARMUP_MS)
+
+            window.setFullscreen(false)
+            awaitUntil("exited fullscreen (bounds restored)", timeoutMillis = FS_TIMEOUT_MS) {
+                val b = bounds() ?: return@awaitUntil false
+                abs(b[2] - before[2]) <= FS_RESTORE_TOLERANCE_PX
+            }
+            settle()
+
+            // The window survived a full interop-active fullscreen round-trip
+            // and its native chrome state is still intact.
+            val nsView = NativeTaoBridge.nativeNsViewHandle(window.handle)
+            val diag = NativeMetalBridge.nativeDiagWindowState(nsView)
+            check(diag == WINDOW_STATE_INTACT) {
+                "window chrome state lost across the fullscreen round-trip (diag=$diag)"
+            }
+
+            showNativeView = false
+            settle()
+            childViewPtr.get().takeIf { it != 0L }?.let {
+                NativeTaoMacOsNativeViewBridge.nativeReleaseOverlay(it)
+            }
+        }
+    }
+
+    private const val PHASE_PERIOD_MS = 500
+    private const val FULL_TURN_DEGREES = 360f
+    private const val EMBED_BASE_OFFSET_PX = 140
+    private const val EMBED_SWAY_PX = 60f
+    private const val INTEROP_WARMUP_MS = 1_500L
+    private const val FS_TIMEOUT_MS = 20_000L
+    private const val FS_GROWTH_MIN_PX = 200
+    private const val FS_RESTORE_TOLERANCE_PX = 64
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
@@ -224,10 +224,20 @@ internal object MacWindowChromeStateHeadfulCases {
             awaitUntil("NativeView embedding composed") { embeddingComposed.get() == 1L }
             settle(INTEROP_WARMUP_MS)
 
+            val fsRequestedAt = System.currentTimeMillis()
             window.setFullscreen(true)
             awaitUntil("entered fullscreen (bounds grew)", timeoutMillis = FS_TIMEOUT_MS) {
                 val b = bounds() ?: return@awaitUntil false
                 b[2] > before[2] + FS_GROWTH_MIN_PX
+            }
+            // Latency guard: a deadlock resolved only by the 2s present
+            // backstop (instead of the cooperative interop pump) still enters
+            // fullscreen, just ~2-3s late. The nominal entry is well under a
+            // second; anything past the backstop means the pump didn't run.
+            val fsEntryMs = System.currentTimeMillis() - fsRequestedAt
+            check(fsEntryMs < FS_ENTRY_MAX_MS) {
+                "fullscreen entry stalled for ${fsEntryMs}ms — the interop present " +
+                    "rode the 2s backstop instead of being pumped cooperatively"
             }
             // Keep animating in fullscreen for a moment — interop presents must
             // keep flowing there too.
@@ -262,6 +272,7 @@ internal object MacWindowChromeStateHeadfulCases {
     private const val EMBED_SWAY_PX = 60f
     private const val INTEROP_WARMUP_MS = 1_500L
     private const val FS_TIMEOUT_MS = 20_000L
+    private const val FS_ENTRY_MAX_MS = 2_000L
     private const val FS_GROWTH_MIN_PX = 200
     private const val FS_RESTORE_TOLERANCE_PX = 64
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import dev.nucleusframework.window.tao.NativeView
@@ -281,12 +282,23 @@ internal object MacWindowChromeStateHeadfulCases {
         // inner scene's own layout pass — the only signal of the overlay
         // ComposeScene's real viewport.
         val overlayContentWidthPx = AtomicLong(0)
+        val expectedRect = AtomicLong(0)
         return TaoWindowTestCase(
             name = "NativeView frame tracks a fullscreen round-trip (#494 patch)",
             timeoutMillis = 90_000L,
             skip = { if (!isMac) "macOS only" else null },
+            // The suite's default DarkGray Box(fillMaxSize) is a Column
+            // sibling composed BEFORE the case content — it would eat the
+            // whole height and leave the NativeView a degenerate 1px slot.
+            paintDefaultBackground = false,
             content = {
-                FillingNativeViewProbe(window.handle, childViewPtr, embeddingComposed, overlayContentWidthPx)
+                FillingNativeViewProbe(
+                    window.handle,
+                    childViewPtr,
+                    embeddingComposed,
+                    overlayContentWidthPx,
+                    expectedRect,
+                )
             },
         ) {
             awaitUntil("window mapped") { bounds() != null }
@@ -297,6 +309,37 @@ internal object MacWindowChromeStateHeadfulCases {
             fun childSizePx(): Pair<Long, Long> {
                 val packed = NativeMetalBridge.nativeDiagViewFrameSize(childViewPtr.get())
                 return (packed ushr 32) to (packed and 0xFFFFFFFFL)
+            }
+
+            fun childTopLeftPx(): Pair<Int, Int> {
+                val packed = NativeMetalBridge.nativeDiagViewTopLeftPx(childViewPtr.get())
+                check(packed != Long.MIN_VALUE) { "embedded NSView left the hierarchy" }
+                return (packed ushr 32).toInt() to packed.toInt()
+            }
+
+            // The contract: the embed's REAL AppKit frame (top-left origin)
+            // must match the Compose slot rect, whatever the window state.
+            // Correct SIZE at the wrong offset is the stale-anchor failure
+            // mode a size-only check can't see.
+            fun checkChildMatchesSlot(stage: String) {
+                val (x, y) = childTopLeftPx()
+                val (w, h) = childSizePx()
+                val exp = unpackRect(expectedRect.get())
+                System.err.println(
+                    "[nv-diag] $stage child=($x,$y ${w}x$h) slot=(${exp[0]},${exp[1]} ${exp[2]}x${exp[3]})",
+                )
+                check(exp[2] > 1 && exp[3] > 1) {
+                    "probe slot is degenerate (${exp[2]}x${exp[3]}) — test layout broken"
+                }
+                check(
+                    abs(x - exp[0]) <= TRACK_TOLERANCE_PX &&
+                        abs(y - exp[1]) <= TRACK_TOLERANCE_PX &&
+                        abs(w - exp[2]) <= TRACK_TOLERANCE_PX &&
+                        abs(h - exp[3]) <= TRACK_TOLERANCE_PX,
+                ) {
+                    "embedded NSView diverged from its Compose slot $stage: " +
+                        "view=($x,$y ${w}x$h) slot=(${exp[0]},${exp[1]} ${exp[2]}x${exp[3]})"
+                }
             }
 
             val windowedBounds = requireNotNull(bounds())
@@ -325,6 +368,7 @@ internal object MacWindowChromeStateHeadfulCases {
                 "NativeView overlay content kept a stale viewport in fullscreen: " +
                     "content=${overlayFsWidth}px embed=${wFs}px"
             }
+            checkChildMatchesSlot("in fullscreen")
 
             window.setFullscreen(false)
             awaitUntil("exited fullscreen (bounds restored)", timeoutMillis = FS_TIMEOUT_MS) {
@@ -339,6 +383,7 @@ internal object MacWindowChromeStateHeadfulCases {
                     "view=${wBack}x$hBack window=${restoredBounds[2]}x${restoredBounds[3]} " +
                     "(fullscreen was ${wFs}x$hFs)"
             }
+            checkChildMatchesSlot("after exiting fullscreen")
 
             // A window resize AFTER the round-trip must still reach the
             // embed — catches a wedged interop pipeline that the restore
@@ -365,6 +410,7 @@ internal object MacWindowChromeStateHeadfulCases {
                 "NativeView overlay content kept a stale viewport after the " +
                     "round-trip + resize: content=${overlayResizedWidth}px embed=${wResized}px"
             }
+            checkChildMatchesSlot("after the round-trip + resize")
 
             childViewPtr.get().takeIf { it != 0L }?.let {
                 NativeTaoMacOsNativeViewBridge.nativeReleaseOverlay(it)
@@ -383,6 +429,8 @@ internal object MacWindowChromeStateHeadfulCases {
         childViewPtr: AtomicLong,
         embeddingComposed: AtomicLong,
         overlayContentWidthPx: AtomicLong,
+        /** Compose-side slot rect, packed x/y/w/h × 16 bits — the contract the native frame must match. */
+        expectedRect: AtomicLong,
     ) {
         val parentNsView = NativeTaoBridge.nativeNsViewHandle(windowHandle)
         val child =
@@ -397,23 +445,51 @@ internal object MacWindowChromeStateHeadfulCases {
             }
         if (child != 0L) {
             SideEffect { embeddingComposed.set(1) }
-            NativeView(
-                factory = {
-                    object : NucleusPlatformView.NsView {
-                        override val nsViewHandle: Long = child
-                    }
-                },
-                modifier = Modifier.fillMaxSize(),
-                content = {
-                    Box(
-                        Modifier.fillMaxSize().onGloballyPositioned {
-                            overlayContentWidthPx.set(it.size.width.toLong())
-                        },
+            Box(
+                Modifier.fillMaxSize().onGloballyPositioned { c ->
+                    val p = c.positionInRoot()
+                    expectedRect.set(
+                        packRect(p.x.roundToInt(), p.y.roundToInt(), c.size.width, c.size.height),
                     )
                 },
-            )
+            ) {
+                NativeView(
+                    factory = {
+                        object : NucleusPlatformView.NsView {
+                            override val nsViewHandle: Long = child
+                        }
+                    },
+                    modifier = Modifier.fillMaxSize(),
+                    content = {
+                        Box(
+                            Modifier.fillMaxSize().onGloballyPositioned {
+                                overlayContentWidthPx.set(it.size.width.toLong())
+                            },
+                        )
+                    },
+                )
+            }
         }
     }
+
+    private fun packRect(
+        x: Int,
+        y: Int,
+        w: Int,
+        h: Int,
+    ): Long =
+        ((x.toLong() and 0xFFFF) shl 48) or
+            ((y.toLong() and 0xFFFF) shl 32) or
+            ((w.toLong() and 0xFFFF) shl 16) or
+            (h.toLong() and 0xFFFF)
+
+    private fun unpackRect(packed: Long): IntArray =
+        intArrayOf(
+            ((packed ushr 48) and 0xFFFF).toInt(),
+            ((packed ushr 32) and 0xFFFF).toInt(),
+            ((packed ushr 16) and 0xFFFF).toInt(),
+            (packed and 0xFFFF).toInt(),
+        )
 
     private const val PHASE_PERIOD_MS = 500
     private const val FULL_TURN_DEGREES = 360f

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
@@ -280,6 +280,7 @@ internal object MacWindowChromeStateHeadfulCases {
      * asserted against the AppKit view's REAL frame, not Compose state.
      */
     private fun nativeViewTracksFullscreenRoundTrip(): TaoWindowTestCase {
+        var showNativeView by mutableStateOf(true)
         val childViewPtr = AtomicLong(0)
         val embeddingComposed = AtomicLong(0)
         // Laid-out width of the overlay `content` slot, in px, packed by the
@@ -296,13 +297,15 @@ internal object MacWindowChromeStateHeadfulCases {
             // whole height and leave the NativeView a degenerate 1px slot.
             paintDefaultBackground = false,
             content = {
-                FillingNativeViewProbe(
-                    window.handle,
-                    childViewPtr,
-                    embeddingComposed,
-                    overlayContentWidthPx,
-                    expectedRect,
-                )
+                if (showNativeView) {
+                    FillingNativeViewProbe(
+                        window.handle,
+                        childViewPtr,
+                        embeddingComposed,
+                        overlayContentWidthPx,
+                        expectedRect,
+                    )
+                }
             },
         ) {
             awaitUntil("window mapped") { bounds() != null }
@@ -416,6 +419,14 @@ internal object MacWindowChromeStateHeadfulCases {
             }
             checkChildMatchesSlot("after the round-trip + resize")
 
+            // Unmount the NativeView FIRST: its dispose path detaches the
+            // child from the hierarchy (nativeRemoveSubview). Releasing the
+            // fabricated NSView while it is still composed is a double free —
+            // the later detach then messages a deallocated object (crashed CI
+            // as `-[AppleParavirtTexture removeFromSuperview]: unrecognized
+            // selector` once the freed memory got reused).
+            showNativeView = false
+            settle()
             childViewPtr.get().takeIf { it != 0L }?.let {
                 NativeTaoMacOsNativeViewBridge.nativeReleaseOverlay(it)
             }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
@@ -27,7 +27,10 @@ import dev.nucleusframework.window.tao.NucleusPlatformView
 import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoMacOsNativeViewBridge
+import dev.nucleusframework.window.tao.scene.LocalTaoMetalTextureHost
+import dev.nucleusframework.window.tao.scene.TaoMetalTextureHost
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -48,6 +51,7 @@ internal object MacWindowChromeStateHeadfulCases {
             setFocusableDoesNotLeakWindowRetains(),
             fullscreenWithLiveNativeViewDoesNotFreeze(),
             nativeViewTracksFullscreenRoundTrip(),
+            renderThreadHopStaysCheap(),
         )
 
     /** Bit 0 = primary attachment associated object, bit 1 = FS observer. */
@@ -490,6 +494,46 @@ internal object MacWindowChromeStateHeadfulCases {
             ((packed ushr 16) and 0xFFFF).toInt(),
             (packed and 0xFFFF).toInt(),
         )
+
+    /**
+     * A main-thread `runOnRenderThread` hop must stay in the sub-millisecond
+     * range: `TextureView` performs one blocking hop per producer frame from
+     * the draw pass (`MacImportedTexture.snapshot`), so any fixed cost added
+     * to the hop is paid per video frame. The interop pump's first version
+     * parked the main thread for the pump timeout (4ms) when no callout was
+     * pending — +4ms per frame halves 90Hz video to 45fps.
+     */
+    private fun renderThreadHopStaysCheap(): TaoWindowTestCase {
+        val hostRef = AtomicReference<TaoMetalTextureHost?>()
+        return TaoWindowTestCase(
+            name = "main-thread render hop stays sub-millisecond (#494 patch)",
+            skip = { if (!isMac) "macOS only" else null },
+            content = {
+                val host = LocalTaoMetalTextureHost.current
+                SideEffect { hostRef.set(host) }
+            },
+        ) {
+            awaitUntil("window mapped") { bounds() != null }
+            settle()
+            awaitUntil("texture host published") { hostRef.get() != null }
+            val host = requireNotNull(hostRef.get())
+
+            repeat(HOP_WARMUP) { host.runOnRenderThread { } }
+            val start = System.nanoTime()
+            repeat(HOP_SAMPLES) { host.runOnRenderThread { } }
+            val avgMicros = (System.nanoTime() - start) / 1_000 / HOP_SAMPLES
+            System.err.println("[hop-diag] avg main->render hop = ${avgMicros}µs over $HOP_SAMPLES hops")
+            check(avgMicros < HOP_MAX_MICROS) {
+                "main-thread render hop costs ${avgMicros}µs on average — a fixed " +
+                    "stall here is paid once per TextureView producer frame " +
+                    "(4000µs ≈ the interop pump parking for its full timeout)"
+            }
+        }
+    }
+
+    private const val HOP_WARMUP = 20
+    private const val HOP_SAMPLES = 200
+    private const val HOP_MAX_MICROS = 1_000L
 
     private const val PHASE_PERIOD_MS = 500
     private const val FULL_TURN_DEGREES = 360f

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacWindowChromeStateHeadfulCases.kt
@@ -1,0 +1,116 @@
+package dev.nucleusframework.window.tao.headful
+
+import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoMacOsNativeViewBridge
+
+/**
+ * Headful e2e cases for the macOS window-level native state reported against
+ * the #494 follow-up patch: real Tao window, real AppKit objects, live
+ * assertions through the [NativeMetalBridge] diagnostics.
+ */
+internal object MacWindowChromeStateHeadfulCases {
+    private val isMac: Boolean =
+        System.getProperty("os.name", "").lowercase().let {
+            it.contains("mac") || it.contains("darwin")
+        }
+
+    fun all(): List<TaoWindowTestCase> =
+        listOf(
+            overlayDetachKeepsWindowChromeState(),
+            setFocusableDoesNotLeakWindowRetains(),
+        )
+
+    /** Bit 0 = primary attachment associated object, bit 1 = FS observer. */
+    private const val WINDOW_STATE_INTACT = 3
+
+    /**
+     * Detaching an overlay Metal attachment must not tear down the host
+     * window's own native state. The driver replays the exact JNI sequence
+     * `NativeViewOverlayController` runs when a `NativeView` is composed and
+     * disposed (`nativeCreateOverlay` → `nativeAttachOverlay`, then
+     * `nativeDetach` → `nativeReleaseOverlay`, all on the main thread) — an
+     * unguarded detach wipes the window's primary-attachment associated
+     * object and the fullscreen observer (the #327 machinery), killing
+     * fullscreen transitions and `attachmentForWindow`-based features for
+     * the rest of the window's life.
+     *
+     * Driven at the bridge level rather than through the `NativeView`
+     * composable: the composable path can deadlock a mid-flight
+     * `nativePresentWithInterop` (render thread `dispatch_sync` to main vs.
+     * main blocked in `runOnRenderThread(...).get()` creating the overlay's
+     * DirectContext) — a separate pre-existing race, not what this case
+     * guards.
+     */
+    private fun overlayDetachKeepsWindowChromeState(): TaoWindowTestCase =
+        TaoWindowTestCase(
+            name = "overlay detach keeps main-window chrome state (#494 patch)",
+            skip = { if (!isMac) "macOS only" else null },
+        ) {
+            awaitUntil("window mapped") { bounds() != null }
+            settle()
+            val contentNsView = NativeTaoBridge.nativeNsViewHandle(window.handle)
+            check(contentNsView != 0L) { "content NSView must be non-zero on a mapped window" }
+
+            val before = NativeMetalBridge.nativeDiagWindowState(contentNsView)
+            check(before == WINDOW_STATE_INTACT) {
+                "window state must be intact before the overlay round-trip (diag=$before)"
+            }
+
+            // NativeViewOverlayController.attach()'s native half.
+            val overlayNsView = NativeTaoMacOsNativeViewBridge.nativeCreateOverlay(contentNsView)
+            check(overlayNsView != 0L) { "nativeCreateOverlay failed" }
+            val attachment = NativeMetalBridge.nativeAttachOverlay(overlayNsView)
+            check(attachment != 0L) { "nativeAttachOverlay failed" }
+            settle()
+
+            // NativeViewOverlayController.dispose()'s native half, same order.
+            NativeMetalBridge.nativeDetach(attachment)
+            NativeTaoMacOsNativeViewBridge.nativeReleaseOverlay(overlayNsView)
+            settle()
+
+            val after = NativeMetalBridge.nativeDiagWindowState(contentNsView)
+            check(after == WINDOW_STATE_INTACT) {
+                "overlay nativeDetach wiped main-window native state: diag=$after " +
+                    "(bit0=primary attachment, bit1=fullscreen observer)"
+            }
+        }
+
+    /**
+     * `TaoWindow.setFocusable` funnels into the vendored tao's
+     * `set_focusable`, which used to retain the NSWindow (+1 per call via
+     * `clone()` + `Retained::into_raw`) and never release it — the window
+     * could never deallocate after close. Asserted via the retain-count
+     * delta across a burst of calls.
+     */
+    private fun setFocusableDoesNotLeakWindowRetains(): TaoWindowTestCase =
+        TaoWindowTestCase(
+            name = "setFocusable does not leak NSWindow retains (#494 patch)",
+            skip = { if (!isMac) "macOS only" else null },
+        ) {
+            awaitUntil("window mapped") { bounds() != null }
+            settle()
+            val nsView = window.nativeHandle
+            check(nsView != 0L) { "nativeHandle must be non-zero on a mapped window" }
+
+            val before = NativeMetalBridge.nativeDiagWindowRetainCount(nsView)
+            check(before > 0) { "retain-count diagnostic unavailable (got $before)" }
+
+            // `true` keeps behavior unchanged (the window is already
+            // focusable); the leak was in the pointer plumbing, not the value.
+            repeat(FOCUSABLE_CALLS) { window.setFocusable(true) }
+            // setFocusable is queued through the tao user-event loop — let it
+            // drain fully before measuring.
+            settle()
+
+            val after = NativeMetalBridge.nativeDiagWindowRetainCount(nsView)
+            check(after > 0) { "retain-count diagnostic unavailable after calls (got $after)" }
+            val delta = after - before
+            check(delta < FOCUSABLE_CALLS / 2) {
+                "set_focusable leaked ~$delta NSWindow retains over $FOCUSABLE_CALLS calls " +
+                    "(before=$before after=$after) — Retained::into_raw without a matching release"
+            }
+        }
+
+    private const val FOCUSABLE_CALLS = 40
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -348,7 +348,8 @@ public object TaoHeadfulTestSuiteMain {
                         "nsView=0x${nsView.toString(16)} probe=OK",
                 )
             },
-        ) + ChromeReviewHeadfulCases.all() + DisplayScaleHeadfulCases.all() + FramePacingHeadfulCases.all()
+        ) + ChromeReviewHeadfulCases.all() + DisplayScaleHeadfulCases.all() + FramePacingHeadfulCases.all() +
+            MacWindowChromeStateHeadfulCases.all()
 
     private val cases: List<TaoWindowTestCase> =
         allCases.filter { nameFilter == null || it.name.contains(nameFilter, ignoreCase = true) }


### PR DESCRIPTION
Follow-up to #494: the community patch attached there ([comment](https://github.com/NucleusFramework/Nucleus/issues/494#issuecomment-5230936469)) flagged several issues beyond the autorelease-pool leak fixed in #495. Each claim was verified with a real-window e2e before fixing. Two were confirmed — and the new e2e coverage surfaced four more real bugs in the same area (a fullscreen deadlock, a use-after-free, a stale overlay viewport, and a stranded embed anchor), all fixed here.

## Summary

- **Overlay `nativeDetach` wiped the host window's native state** (`NucleusTaoMetal.m`). The detach path unconditionally cleared the window-level associated objects — primary attachment key, `NucleusTaoFSObserver`, menu bar monitor — on `att->view.window`. For overlay attachments (`nativeAttachOverlay`: NativeView overlays, popup panels) that window is the host's, whose primary attachment is still alive. Disposing a `NativeView` permanently dropped the #327 fullscreen-transition handling and left `attachmentForWindow()` returning `NULL`. A new `isOverlay` flag skips the window-level teardown for overlays.
  *Repro: window-state diag bitmask went `3 → 0` across an overlay attach/detach round-trip; stays `3` after.*

- **`set_focusable` leaked one NSWindow retain per call** (vendored tao, `macos/window.rs`). `clone()` + `Retained::into_raw` retained the window with nothing releasing it — a window driven through `TaoWindow.setFocusable` / `DecoratedWindow(focusable = false)` could never deallocate after close. `PATCH(nucleus)`: borrow with `Retained::as_ptr`.
  *Repro: `CFGetRetainCount` rose +38 over 40 calls; delta ~0 after.*

- **Fullscreen with a live `NativeView` deadlocked the whole app.** `windowWillEnterFullScreen` → `prepareFullscreenFrame` → `renderFrameBlocking` parks the main thread on the render executor while the render thread sits inside `nativePresentWithInterop`'s main-thread callout — AB-BA. The callout is now scheduled on the main **run loop** (common modes + a private `NucleusTaoInteropMode` kept non-empty by a permanent no-op source, same arrangement as the JDK's `AWTRunLoopMode`; 2s backstop), and `runOnRenderThread` pumps that mode cooperatively via `nativeInteropPump` when called on the AppKit main thread (`nativeIsMainThread` — `TaoMainDispatcher.taoMainThread` is the wrong thread on macOS since `nativeRunBlocking` marshals the loop onto thread 0).
  *Repro: froze until the 60s watchdog before; enters nominally after — the e2e asserts fullscreen-entry latency < 2s, so riding the backstop fails the test (caught the initial stall at 2027-2068ms).*
  The pump is a 0-timeout single pass: its first version parked the main thread for a 4ms timeout on every hop with nothing queued — a fixed tax paid once per TextureView producer frame via the per-frame snapshot hop, capping 90Hz video at 45fps (field report on beta-03). Guarded by a hop-latency e2e: 4505µs → 63µs average main→render hop.

- **Use-after-free in the deferred overlay interop action** (found by the new e2e as a SIGSEGV in `nativeSetOverlayFrame`). `NativeViewOverlayController.setBoundsInternal` captured raw `overlayNsView`/`attachmentHandle` longs; executing after `dispose()` dereferenced freed memory. The action now re-reads the live fields behind a `disposed` guard, and `dispose()` zeroes `overlayNsView` before releasing it.

- **NativeView overlay content kept a stale viewport after resizes.** The same deferred action guarded the inner ComposeScene viewport update with `widthPxNew != widthPx` — but the synchronous bookkeeping sets `widthPx = widthPxNew` right after scheduling, so the guard was always false by execution time and `scene.size` was never updated after first attach. The size-changed decision is now taken at schedule time.
  *Repro: content viewport stuck at 800px while the embed grew to 2560px in fullscreen; tracks exactly after.*

- **NativeView embeds stranded by fullscreen transitions** (the field report on beta-02: "the native view doesn't take the new dimensions after enter/exit fullscreen"). `nativeSetSubviewFrame`/`nativeSetOverlayFrame` convert Compose's top-left rect to AppKit bottom-left coords against `parent.frame.size.height` at call time; during a fullscreen transition the interop-deferred call lands while the parent still has its pre-transition height (measured: fullscreen rect applied against `parentH=600` → `frame.y=-480`), and with `autoresizingMask=0` the child is glued to the parent's **bottom**-left — once the window reaches its final size the child sits offset by the full height delta, and Compose never re-issues (its rect didn't change). Both setters now apply a margin-only autoresizing mask (fixed top-left anchor, fixed size): AppKit preserves the anchor across parent resizes between Compose updates, while Compose remains the only size writer (no `Width/HeightSizable` bits, so the documented live-resize two-writer jitter cannot come back).
  *Repro: embed at `(0,480)` vs slot `(0,0)` in fullscreen without the mask; exact slot match at every stage with it.*

- **New e2e coverage**: four macOS cases in the stage-2 headful suite (`MacWindowChromeStateHeadfulCases`), driven by four read-only diagnostics on `NativeMetalBridge` (`nativeDiagWindowState`, `nativeDiagWindowRetainCount`, `nativeDiagViewFrameSize`, `nativeDiagViewTopLeftPx`). The tracking case asserts the embed's real AppKit frame — origin AND size — against the Compose slot rect across fullscreen enter, exit, and a post-round-trip resize, plus the overlay content's layout width.

- **Test-infra**: `TaoRuntimeResizableSmokeTest` disarms its 120s `halt(42)` watchdog once the loop returns, so a passing run can't kill the shared Gradle test executor.

Also reviewed from the patch, **not** applied: caching `nativeViewHost()`/`popupHost()` (the provider scope composes once per window and reads no snapshot state — unreachable identity churn), and the `app_state.rs` autoreleasepool wraps + `NUCLEUS_UNPACED_PRESENT` toggle (no confirmed leak).

## Test plan

- [x] Every fix has a headful e2e that failed before it and passes after (repro numbers above)
- [x] Fullscreen + NativeView deadlock case: 5/5 consecutive green runs; slot-tracking case: 3/3
- [x] Full stage-2 headful suite: 19 run, 0 failed (`taoHeadfulTest`)
- [x] `:decorated-window-tao:test`: green, including the #494 missing-pool e2e (`NUCLEUS_TAO_SMOKE=1`) against the rebuilt dylibs
- [x] `apiCheck`, `detekt`, `ktlintCheck` green
- [x] Natives rebuilt for both macOS archs (Rust + ObjC); field-validated via maven-local `2.3.3-beta-01`…`beta-04`
