### PR TITLE
fix(tao-demo): render the GPU-context demo inside the frame callback

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoGpuRenderContext.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoGpuRenderContext.kt
@@ -121,6 +121,14 @@ public sealed interface TaoOpenGlRenderContext : TaoGpuRenderContext {
      * from composition, layout/draw and disposal; must be called from the
      * composition thread.
      *
+     * Frame-paced renderers must do their GPU work **inside** the
+     * `withFrameNanos` callback (or in composition/layout/draw), not in the
+     * code that follows the suspension: on Linux the context is handed to a
+     * swap thread for the blocking `eglSwapBuffers` right after every frame,
+     * so a post-frame continuation loses the race almost every vsync and gets
+     * `null` — the callback itself runs inside the render pass, while the
+     * context is bindable.
+     *
      * Whatever was current before is put back afterwards, so a disposal
      * running inside *another* surface's render pass cannot corrupt that
      * surface's frame. After [action] returns, Skia's GL state cache is

--- a/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/GpuContextSection.kt
+++ b/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/GpuContextSection.kt
@@ -85,8 +85,12 @@ fun GpuContextSection(
     LaunchedEffect(renderer) {
         var tick = 0
         while (isActive) {
-            withFrameNanos { }
-            val next = renderer.renderFrame(tick) ?: continue
+            // Render inside the frame callback: it runs during the scene's
+            // render pass, when the swap thread is idle and the GL context is
+            // bindable. A post-frame continuation would race the blocking
+            // eglSwapBuffers on Linux and lose almost every frame
+            // (withContextCurrent → null → the animation crawls).
+            val next = withFrameNanos { renderer.renderFrame(tick) } ?: continue
             frame?.let(renderer::retire)
             frame = next
             tick++


### PR DESCRIPTION
## Summary
- The `TaoGpuRenderContext` demo section crawled on Linux: its `LaunchedEffect` loop did `withFrameNanos { }` **then** `renderer.renderFrame(tick)`, and that post-frame continuation races the swap thread — the Linux host releases the EGL context after every render pass so the swap thread can park in the blocking `eglSwapBuffers` until vsync. `withContextCurrent` therefore returned `null` ~once per vsync (measured: ~89 failed binds/s on an 89 Hz panel, only 4–60 successful ticks/s) and the `?: continue` never advanced the animation.
- Fix: issue the GPU work **inside** the `withFrameNanos` callback, which runs within the render pass (`frameClock.sendFrame` in `onRedrawRequested`) while the swap thread is idle and the context is bindable. Measured after: 89 renders/s, zero failed binds, tick rate locked to the display.
- Document the timing requirement in the `TaoOpenGlRenderContext.withContextCurrent` KDoc so frame-paced consumers (map engines, chart engines) don't hit the same trap.
- Explains why this went unnoticed at merge time of #481: the tray-panel variant runs on a popup surface (`swapInterval = 0`, no blocking swap) and was always smooth; only the main-window section lost the race.

## Test plan
- [x] Instrumented run on Linux/X11 (89 Hz): before — ~89 null binds/s, 4–60 ticks/s; after — 0 null binds, steady 89 ticks/s
- [x] Visually verified smooth animation on Linux (X11 and Wayland backends)
- [x] `:decorated-window-tao:compileKotlin` / `:examples:tao-demo:compileKotlin` pass (KDoc-only change in the runtime module, no ABI change)