### PR TITLE
fix(tao-demo): ephemeral WebKit context for the Linux WebView sample

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NucleusPlatformView.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NucleusPlatformView.kt
@@ -93,6 +93,13 @@ public sealed interface NucleusPlatformView {
      * rendered through GTK's normal cairo / GL paint pipeline. The
      * Compose surface composites on top with alpha; transparency in
      * the embedded rect lets the GTK widget show through.
+     *
+     * **Wayland only.** On the X11 backend (`NUCLEUS_TAO_LINUX_RENDERER=x11`,
+     * or an actual X session) the show-through cannot work: the surface's
+     * opaque-region carve-out is a Wayland protocol concept, and X11 never
+     * blends a child window's alpha against its parent — the embedded
+     * widget renders (and keeps running) behind the GL surface, but the
+     * punched rect shows the desktop instead of the widget.
      */
     public interface GtkWidget : NucleusPlatformView {
         /** Pointer to the user-supplied `GtkWidget*` (cast to Long). */

--- a/examples/tao-demo/src/main/native/linux/sample_webview.c
+++ b/examples/tao-demo/src/main/native/linux/sample_webview.c
@@ -27,7 +27,21 @@ Java_dev_nucleusframework_sampletao_SampleWebViewLinuxBridge_nativeCreate(
     JNIEnv *env, jclass clazz)
 {
     (void) env; (void) clazz;
-    GtkWidget *web_view = webkit_web_view_new();
+    /* Ephemeral context, one per view — deliberately NOT the default
+     * WebKitWebContext. The default context is a process-global with a
+     * persistent network session; once instantiated it is finalized by
+     * a libc exit handler, and if the JVM exits while WebKit teardown
+     * state is dirty (a WebView destroyed shortly before close), that
+     * atexit dispose trips an internal RELEASE_ASSERT and aborts the
+     * whole JVM (silent SIGABRT / exit 134, seen on Wayland). An
+     * ephemeral per-view context dies with the view, on a live main
+     * loop, so nothing WebKit-related is left for exit handlers. */
+    WebKitWebContext *context = webkit_web_context_new_ephemeral();
+    if (context == NULL) return 0;
+    GtkWidget *web_view = webkit_web_view_new_with_context(context);
+    /* The view keeps its own ref on the context; drop the creation ref
+     * so both die together when the view is released. */
+    g_object_unref(context);
     if (web_view == NULL) return 0;
     /* Take a strong floating-ref so the widget survives even when not
      * yet parented (Compose calls `nativeCreate` from `factory{}` and


### PR DESCRIPTION
## Summary
- Fixes the intermittent **silent SIGABRT (exit 134) at window close on Wayland**. Root cause (backtrace captured via an `LD_PRELOAD` SIGABRT handler): once the process-global default `WebKitWebContext` is instantiated, it is finalized by a **libc exit handler**; if the JVM exits while WebKit's async teardown state is dirty (a WebView created/destroyed shortly before close — the Texture ↔ WebView tab-switch combo), the atexit dispose cascade (`WebKitWebContext` → `WebsiteDataManager` → internal `RELEASE_ASSERT`) aborts the whole JVM.
- Fix: create the sample's `WebKitWebView` on a **per-view ephemeral context** (`webkit_web_context_new_ephemeral`). The context dies with the view, on a live main loop — nothing WebKit-related is left for exit handlers to finalize. Terminating web processes / draining pending GLib sources at release was tried first and does **not** prevent the assert.
- Documents on `NucleusPlatformView.GtkWidget` that the show-through is **Wayland-only**: the opaque-region carve-out is a Wayland protocol concept and X11 never blends a child window's alpha against its parent (the widget renders behind the GL surface but the punched rect shows the desktop).

## Test plan
- [x] 8/8 automated open → Texture ↔ WebView switches → close rounds exit clean on Wayland (a crash reproduced on round 1 with the previous default-context code)
- [x] Manual validation: repeated tab-switch + close combos, no crash, WebView loads and navigates normally
- [x] `:decorated-window-tao:compileKotlin` / `apiCheck` pass (KDoc-only Kotlin change)