### PR TITLE
fix(tao/linux): keep VSync through the resize burst for frame-paced GPU content

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureViewLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureViewLinux.kt
@@ -219,6 +219,13 @@ internal fun releaseGlTextureImports(context: DirectContext) {
     glTextureImports.closeAllFor(context)
 }
 
+/**
+ * Whether the scene drawing with [context] composites at least one live
+ * `TextureView` import — the Linux counterpart of [hasWindowsTextureImports],
+ * consulted by the resize-burst pacing decision (#484).
+ */
+internal fun hasGlTextureImports(context: DirectContext): Boolean = glTextureImports.hasImportsFor(context)
+
 /** Whether an acquire fence descriptor can be owned (and closed) on this platform. */
 internal fun canOwnAcquireFence(): Boolean = Platform.Current == Platform.Linux && NativeTaoLinuxTextureBridge.isLoaded
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.TaoEventCode
+import dev.nucleusframework.window.tao.TaoGpuRenderContextConsumers
 import dev.nucleusframework.window.tao.TaoModifierMask
 import dev.nucleusframework.window.tao.TaoPointerScrollEvent
 import dev.nucleusframework.window.tao.TaoTouchEvent
@@ -46,6 +47,7 @@ import dev.nucleusframework.window.tao.event.taoTypedKeyEvent
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoEglBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxTouchBridge
+import dev.nucleusframework.window.tao.hasGlTextureImports
 import dev.nucleusframework.window.tao.popup.TaoPopupHostLinux
 import dev.nucleusframework.window.tao.popup.TaoPopupSceneLayerLinux
 import dev.nucleusframework.window.tao.releaseGlTextureImports
@@ -1116,7 +1118,18 @@ internal class TaoComposeSceneHostLinux(
         // subsurface/geometry lag of this kind. All DEs (GNOME, KDE, …).
         lastResizeEventNs = System.nanoTime()
         if (attachedKind == 2 && !window.isPopup) {
-            if (!resizeBurstActive) {
+            // Keep VSync when the scene composites a TextureView or holds a
+            // TaoGpuRenderContext consumer — the Linux twin of the Windows
+            // modal-loop rule (#484). At interval 0 their withFrameNanos
+            // producers re-enter the render path at event-pump speed for the
+            // whole drag; such a window trades the burst's catch-up latency
+            // for a display-paced frame clock. Windows without frame-paced
+            // GPU content keep the interval-0 burst unchanged.
+            val framePacedContent =
+                directContext?.let {
+                    hasGlTextureImports(it) || TaoGpuRenderContextConsumers.isActive(it)
+                } == true
+            if (!resizeBurstActive && !framePacedContent) {
                 resizeBurstActive = true
                 pendingSwapInterval = 0
             }


### PR DESCRIPTION
## Summary
- The Wayland resize burst drops the swap interval to 0 so resize buffers land without waiting on a frame callback — but with no other pacer, any frame-clock-driven content (a `TextureView` `withFrameNanos` producer, a `TaoGpuRenderContext` consumer) re-enters the render path at event-pump speed for the whole drag.
- Applies the Windows modal-loop rule (#484) at burst entry: when the scene's `DirectContext` has live TextureView imports or GPU-context consumers, the interval-0 burst is skipped and the frame clock stays display-paced. Windows without frame-paced GPU content keep the burst (and its resize latency behavior) unchanged.
- Adds `hasGlTextureImports(context)` — the Linux counterpart of `hasWindowsTextureImports` over the shared `TextureImportRegistry.hasImportsFor`.

## Test plan
- [x] Manual on GNOME Wayland (89 Hz): Texture tab producer holds a flat ~90 fps through a continuous resize drag (previously ran away at event-pump speed)
- [x] `:decorated-window-tao:compileKotlin` / `apiCheck` / `detekt` pass