### PR TITLE
fix(tao/linux): align popup surfaces to the Wayland buffer_scale

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
@@ -35,6 +35,7 @@ import dev.nucleusframework.window.tao.ffi.NativeTaoEglBridge
 import dev.nucleusframework.window.tao.releaseGlTextureImports
 import dev.nucleusframework.window.tao.scene.LocalTaoGlTextureHost
 import dev.nucleusframework.window.tao.scene.TaoGlTextureHost
+import dev.nucleusframework.window.tao.scene.alignToBufferScale
 import dev.nucleusframework.window.tao.scene.preservingEglBinding
 import dev.nucleusframework.window.tao.scene.renderGlFrame
 import dev.nucleusframework.window.tao.scene.withEglContextCurrent
@@ -55,7 +56,8 @@ import kotlin.math.roundToInt
  * is the content rect in parent-window physical pixels, the inner scene is
  * laid out at screen work-area size (see the "measurement chicken-and-egg"
  * note on [TaoPopupSceneLayer]), and rendering translates by
- * `-bounds.topLeft` into a window sized exactly to the content.
+ * `-bounds.topLeft` into a window sized to the content, rounded up to a
+ * multiple of the surface scale ([alignToBufferScale]).
  *
  * Differences from Windows/macOS driven by platform reality:
  *  - Window creation is asynchronous (Tao posts a CreateWindow user event);
@@ -123,19 +125,34 @@ internal class TaoPopupSceneLayerLinux(
 
     private val scale: Float = if (host.scale > 0f) host.scale else 1f
 
+    /**
+     * Integer surface scale announced to the compositor
+     * (`wl_surface.set_buffer_scale`) — GTK3 only ever reports integer scales.
+     * Every physical size we hand to the native surface goes through
+     * [alignToBufferScale] with it: an unaligned buffer is a fatal Wayland
+     * protocol error (#502).
+     */
+    private val bufferScale: Int = scale.roundToInt().coerceAtLeast(1)
+
     // Work-area sized (not parent-window sized) so a popup larger than its
     // owner window lays out at full size — same contract as macOS/Windows.
     private val sceneLayoutSize: IntSize =
         host.workAreaSize.let {
             IntSize(it.width.coerceAtLeast(1), it.height.coerceAtLeast(1))
         }
-    private var widthPx: Int = 1
-    private var heightPx: Int = 1
 
     /**
-     * The popup's Tao window. Created hidden at 1×1; the real frame is
-     * pushed by the first `boundsInWindow` write and the window is shown
-     * then. `popupOf` makes it override-redirect on X11 and a
+     * Physical size of the popup's native surface and render target. Always
+     * a multiple of [bufferScale]; the content occupies its top-left and the
+     * ≤ `bufferScale - 1` px edge stays transparent.
+     */
+    private var widthPx: Int = bufferScale
+    private var heightPx: Int = bufferScale
+
+    /**
+     * The popup's Tao window. Created hidden at one logical pixel; the real
+     * frame is pushed by the first `boundsInWindow` write and the window is
+     * shown then. `popupOf` makes it override-redirect on X11 and a
      * `wl_subsurface` on Wayland.
      */
     private val popupWindow: TaoWindow =
@@ -227,7 +244,7 @@ internal class TaoPopupSceneLayerLinux(
                         nativeWin,
                         w,
                         h,
-                        scale.roundToInt().coerceAtLeast(1),
+                        bufferScale,
                         0,
                     )
                 else -> 0L
@@ -396,8 +413,14 @@ internal class TaoPopupSceneLayerLinux(
         val offset = host.coordinateOffset
         val xPx = _bounds.left + offset.x + origin.x
         val yPx = _bounds.top + offset.y + origin.y
-        val w = _bounds.width.coerceAtLeast(1)
-        val h = _bounds.height.coerceAtLeast(1)
+        // Aligned to the surface scale: Compose bounds are arbitrary physical
+        // pixels (odd widths come out of text measurement and half-dp padding
+        // all the time), and a buffer that isn't a multiple of the announced
+        // `buffer_scale` is a fatal Wayland protocol error — the compositor
+        // drops the connection and the process dies (#502). It also keeps the
+        // logical size below an exact integer for GTK.
+        val w = alignToBufferScale(_bounds.width, bufferScale)
+        val h = alignToBufferScale(_bounds.height, bufferScale)
         popupWindow.setOuterPosition((xPx / scale).toDouble(), (yPx / scale).toDouble())
         popupWindow.setInnerSize((w / scale).toDouble(), (h / scale).toDouble())
         if (w != widthPx || h != heightPx) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/WaylandBufferScale.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/WaylandBufferScale.kt
@@ -1,0 +1,34 @@
+package dev.nucleusframework.window.tao.scene
+
+/**
+ * Rounds a physical pixel size **up** to the next multiple of [bufferScale].
+ *
+ * Every Wayland surface we render into announces
+ * `wl_surface.set_buffer_scale(bufferScale)` so the compositor reads our
+ * `logical × scale` pixel buffer as `logical` surface units. The protocol then
+ * requires the attached buffer to be an integer multiple of that scale:
+ * committing anything else is a fatal `wl_surface.invalid_size` error
+ * (Mutter: *"Buffer size (101x61) must be an integer multiple of the
+ * buffer_scale (2)"*), which kills the client. Compose popup bounds are
+ * arbitrary physical pixels — a text-measured width or a `.5.dp` padding
+ * lands on an odd number about half the time on a 200% output — so every
+ * surface size has to be aligned before it reaches `wl_egl_window`.
+ *
+ * Rounding **up** (never down: a 1 px popup would collapse to 0) grows the
+ * surface by at most `bufferScale - 1` px. The content is drawn from the
+ * top-left and the surface is cleared transparent, so the extra edge is
+ * invisible — the same trade GDK makes for its own popup buffers (a 51 × 31
+ * logical popup gets a 102 × 62 shm buffer at scale 2).
+ *
+ * Also applied on X11, where the alignment is harmless but keeps
+ * `size / scale` an exact integer for the GTK-side logical geometry.
+ */
+internal fun alignToBufferScale(
+    px: Int,
+    bufferScale: Int,
+): Int {
+    val scale = bufferScale.coerceAtLeast(1)
+    if (px <= scale) return scale
+    val remainder = px % scale
+    return if (remainder == 0) px else px + (scale - remainder)
+}

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
@@ -1021,6 +1021,28 @@ static void wl_set_buffer_scale(EglAttachment *att, int scale) {
         p_wl_proxy_get_version(att->wl_child_surface), 0, scale);
 }
 
+/**
+ * Rounds a buffer dimension UP to the next multiple of `scale`.
+ *
+ * The buffer we attach must be an integer multiple of the `buffer_scale`
+ * announced above — the protocol says so and Mutter enforces it as a fatal
+ * `wl_surface.invalid_size` ("Buffer size (101x61) must be an integer multiple
+ * of the buffer_scale (2)"), which drops the connection and kills the client
+ * (issue #502; weston silently tolerates it, so this only ever bit real GNOME
+ * sessions). Callers are expected to pass aligned sizes already — Compose popup
+ * bounds are aligned in `TaoPopupSceneLayerLinux`, window sizes come from the
+ * compositor's own configure — so this is the backstop that keeps *any* future
+ * caller from turning a rounding slip into a crash. Rounding up (never down:
+ * a 1 px surface would collapse to 0) costs at most `scale - 1` px of
+ * transparent edge.
+ */
+static int wl_align_to_buffer_scale(int px, int scale) {
+    if (scale < 1) scale = 1;
+    if (px <= scale) return scale;
+    int remainder = px % scale;
+    return remainder == 0 ? px : px + (scale - remainder);
+}
+
 
 /**
  * Wayland-native attach.
@@ -1061,8 +1083,11 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeAttachWayland(
 
     wl_display *wdpy  = (wl_display *) (uintptr_t) wlDisplayPtr;
     wl_proxy   *wparent = (wl_proxy *)   (uintptr_t) wlSurfacePtr;
-    int phys_w = widthPx > 0 ? widthPx : 1;
-    int phys_h = heightPx > 0 ? heightPx : 1;
+    int bscale = bufferScale > 0 ? bufferScale : 1;
+    /* Aligned to the scale we are about to announce — see
+     * wl_align_to_buffer_scale (an unaligned first commit is fatal). */
+    int phys_w = wl_align_to_buffer_scale(widthPx  > 0 ? widthPx  : 1, bscale);
+    int phys_h = wl_align_to_buffer_scale(heightPx > 0 ? heightPx : 1, bscale);
     DBG("attachWayland: wl_display=%p parent_wl_surface=%p wxh=%dx%d\n",
         (void*)wdpy, (void*)wparent, phys_w, phys_h);
 
@@ -1351,10 +1376,10 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeAttachWayland(
     att->wl_window        = wlwin;
     att->widthPx          = phys_w;
     att->heightPx         = phys_h;
-    att->scale            = (float) (bufferScale > 0 ? bufferScale : 1);
+    att->scale            = (float) bscale;
     /* Match GTK's integer surface scale so the `logical × scale` px buffer is
      * read as `logical` surface units (no oversize, input stays calibrated). */
-    wl_set_buffer_scale(att, bufferScale);
+    wl_set_buffer_scale(att, bscale);
     DBG("attached (Wayland subsurface): edpy=%p ctx=%p surf=%p child_surf=%p subsurf=%p scale=%d\n",
         edpy, (void*)ctx, (void*)surf, (void*)child_surface, (void*)subsurface,
         bufferScale);
@@ -1469,12 +1494,18 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeResize(
      * eglSwapBuffers. Without this the buffer stays at its original
      * dimensions and the compositor scales it up, blurring the result. */
     if (att->wl_window && p_wl_egl_window_resize) {
+        int bscale = (int) (scale + 0.5f);
+        if (bscale < 1) bscale = 1;
+        /* Keep the new buffer an integer multiple of the announced scale — see
+         * wl_align_to_buffer_scale. */
+        att->widthPx  = wl_align_to_buffer_scale(att->widthPx,  bscale);
+        att->heightPx = wl_align_to_buffer_scale(att->heightPx, bscale);
         p_wl_egl_window_resize(att->wl_window,
                                att->widthPx, att->heightPx, 0, 0);
         /* Track DPI changes: re-assert the integer buffer scale so the new
          * buffer is still read as `logical` surface units. Queued state, lands
          * with the next eglSwapBuffers commit. */
-        wl_set_buffer_scale(att, (int) (scale + 0.5f));
+        wl_set_buffer_scale(att, bscale);
     }
     /* If we render straight into the GTK X window, the EGL surface follows
      * automatically (GTK already issues XResizeWindow on the parent). */

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -213,6 +213,9 @@ public object TaoSceneTestBattery {
         run("TaoScenePopupTest: click inside a focusable popup does not dismiss it") {
             TaoScenePopupTest().`click inside a focusable popup does not dismiss it`()
         }
+        run("TaoScenePopupTest: buffer scale alignment rounds up and never collapses to zero") {
+            TaoScenePopupTest().`buffer scale alignment rounds up and never collapses to zero`()
+        }
         run(
             "TaoSceneOuterLocalsBridgeTest: wrapping window content in outer locals with " +
                 "CompositionLocalProvider breaks Popup",

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/PopupScaleHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/PopupScaleHeadfulCases.kt
@@ -1,0 +1,112 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import dev.nucleusframework.core.runtime.Platform
+import kotlinx.coroutines.delay
+
+/**
+ * Headful regression cases for issue #502 — "Tao/Wayland: 1x1 popup surface
+ * trips a protocol error and crash".
+ *
+ * With `nativePopupLayers = true` a Compose `Popup` becomes a real Tao popup
+ * window whose EGL child is a `wl_subsurface` announcing
+ * `wl_surface.set_buffer_scale(scale)`. Wayland requires every attached buffer
+ * to be an integer multiple of that scale, and Mutter enforces it by dropping
+ * the connection:
+ *
+ * ```
+ * wl_display#1.error(wl_surface#66, 2,
+ *   "Buffer size (1x1) must be an integer multiple of the buffer_scale (2).")
+ * Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
+ * ```
+ *
+ * Both cases assert the same thing — the process is still alive after the popup
+ * was shown — because the defect kills it outright. They are only meaningful on
+ * a Wayland session with `scale >= 2`: at 100% every size is trivially aligned,
+ * on X11 there is no `buffer_scale`, and weston does not police the rule at all
+ * (it silently upscales), so a green run there proves nothing. Verified against
+ * GNOME 50 Wayland at 200%, where both cases fail before the fix.
+ */
+internal object PopupScaleHeadfulCases {
+    private val isLinux: Boolean get() = Platform.Current == Platform.Linux
+
+    fun all(): List<TaoWindowTestCase> =
+        listOf(
+            oddSizedPopup(),
+            zeroSizedPopup(),
+        )
+
+    /**
+     * A popup whose content measures an ODD number of physical pixels
+     * (50.5 dp × 30.5 dp at density 2 = 101 × 61 px) — the everyday shape of
+     * the bug, since text measurement and half-dp padding produce odd sizes
+     * routinely.
+     */
+    private fun oddSizedPopup(): TaoWindowTestCase =
+        TaoWindowTestCase(
+            name = "#502 popup sized to an odd pixel count survives a scaled output",
+            skip = { if (!isLinux) "Linux only" else null },
+            nativePopupLayers = true,
+            content = {
+                var show by remember { mutableStateOf(false) }
+                LaunchedEffect(Unit) {
+                    delay(POPUP_DELAY_MILLIS)
+                    show = true
+                }
+                if (show) {
+                    Popup(alignment = Alignment.Center) {
+                        Box(Modifier.size(ODD_W_DP.dp, ODD_H_DP.dp).background(Color.Red))
+                    }
+                }
+            },
+        ) {
+            awaitUntil("window mapped") { bounds() != null }
+            settle(SETTLE_MILLIS)
+            check(bounds() != null) { "window must survive an odd-sized popup" }
+        }
+
+    /**
+     * The literal shape reported in #502: a popup that measures 0 × 0, whose
+     * native frame the layer coerces to the smallest legal surface. Before the
+     * fix that was 1 × 1 — committed with `buffer_scale = 2`.
+     */
+    private fun zeroSizedPopup(): TaoWindowTestCase =
+        TaoWindowTestCase(
+            name = "#502 popup that measures zero survives a scaled output",
+            skip = { if (!isLinux) "Linux only" else null },
+            nativePopupLayers = true,
+            content = {
+                var show by remember { mutableStateOf(false) }
+                LaunchedEffect(Unit) {
+                    delay(POPUP_DELAY_MILLIS)
+                    show = true
+                }
+                if (show) {
+                    Popup(alignment = Alignment.Center) {
+                        Box(Modifier.size(0.dp))
+                    }
+                }
+            },
+        ) {
+            awaitUntil("window mapped") { bounds() != null }
+            settle(SETTLE_MILLIS)
+            check(bounds() != null) { "window must survive a zero-sized popup" }
+        }
+
+    private const val ODD_W_DP = 50.5f
+    private const val ODD_H_DP = 30.5f
+    private const val POPUP_DELAY_MILLIS = 500L
+    private const val SETTLE_MILLIS = 2_500L
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -349,7 +349,7 @@ public object TaoHeadfulTestSuiteMain {
                 )
             },
         ) + ChromeReviewHeadfulCases.all() + DisplayScaleHeadfulCases.all() + FramePacingHeadfulCases.all() +
-            MacWindowChromeStateHeadfulCases.all()
+            MacWindowChromeStateHeadfulCases.all() + PopupScaleHeadfulCases.all()
 
     private val cases: List<TaoWindowTestCase> =
         allCases.filter { nameFilter == null || it.name.contains(nameFilter, ignoreCase = true) }
@@ -403,6 +403,7 @@ public object TaoHeadfulTestSuiteMain {
                         onCloseRequest = { /* cases drive their own lifecycle */ },
                         title = "tao-headful: ${case.name}",
                         transparent = case.transparent,
+                        nativePopupLayers = case.nativePopupLayers,
                     ) {
                         // Default chrome surface; cases may paint over it via
                         // [TaoWindowTestCase.content] (scaffold, backdrop, …).

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
@@ -36,6 +36,12 @@ internal class TaoWindowTestCase(
      * `transparent` parameter (#416). Creation-time only.
      */
     val transparent: Boolean = false,
+    /**
+     * Forwarded to [dev.nucleusframework.window.tao.DecoratedWindow]'s
+     * `nativePopupLayers`: Compose `Popup` content becomes a real Tao popup
+     * window instead of being drawn inline. Creation-time only.
+     */
+    val nativePopupLayers: Boolean = false,
     /** Optional extra window content composed inside the DecoratedWindow. */
     val content: @Composable TaoDecoratedWindowScope.() -> Unit = {},
     val driver: suspend TaoWindowTestScope.() -> Unit,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoScenePopupTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoScenePopupTest.kt
@@ -119,6 +119,35 @@ class TaoScenePopupTest {
             assertEquals(BLUE, pixelAt(40, 40))
         }
 
+    /**
+     * #502: a popup surface whose physical size is not a multiple of the
+     * announced Wayland `buffer_scale` is a fatal protocol error, so
+     * [alignToBufferScale] must round every dimension UP — and never to zero,
+     * which is what the popup bootstrap (an unmeasured, 0-sized layer) feeds it.
+     */
+    @Test
+    fun `buffer scale alignment rounds up and never collapses to zero`() {
+        // Scale 1: identity, except that a surface always has at least one pixel.
+        assertEquals(1, alignToBufferScale(0, 1))
+        assertEquals(1, alignToBufferScale(1, 1))
+        assertEquals(101, alignToBufferScale(101, 1))
+        // Scale 2: the bootstrap 0/1 px popup and the odd sizes that crashed.
+        assertEquals(2, alignToBufferScale(0, 2))
+        assertEquals(2, alignToBufferScale(1, 2))
+        assertEquals(2, alignToBufferScale(2, 2))
+        assertEquals(102, alignToBufferScale(101, 2))
+        assertEquals(62, alignToBufferScale(61, 2))
+        assertEquals(800, alignToBufferScale(800, 2))
+        // Scale 3: alignment costs at most scale - 1 px.
+        assertEquals(3, alignToBufferScale(1, 3))
+        assertEquals(102, alignToBufferScale(100, 3))
+        assertEquals(102, alignToBufferScale(101, 3))
+        assertEquals(102, alignToBufferScale(102, 3))
+        // Degenerate scales are clamped, not divided by.
+        assertEquals(1, alignToBufferScale(0, 0))
+        assertEquals(7, alignToBufferScale(7, -1))
+    }
+
     private companion object {
         const val BLUE = 0xFF0000FF.toInt()
         const val WHITE = 0xFFFFFFFF.toInt()


### PR DESCRIPTION
Closes #502.

## The bug

A Compose `Popup` opened with `nativePopupLayers = true` becomes a Tao popup window whose EGL child is a `wl_subsurface` announcing `wl_surface.set_buffer_scale(scale)`. Wayland requires the attached buffer to be an integer multiple of that scale. `TaoPopupSceneLayerLinux` passed the raw Compose bounds through (only `coerceAtLeast(1)`), so on a 200% output any popup with an odd physical width or height committed an illegal buffer. Mutter enforces the rule by dropping the connection:

```
wl_display#1.error(wl_surface#66, 2, "Buffer size (1x1) must be an integer multiple of the buffer_scale (2).")
Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
```

The process dies at first composition. Two things made this hard to see:

- **weston does not police the rule at all** (it silently upscales), so it only reproduces on real GNOME sessions — the error string is Mutter's.
- The reported `1x1` is the popup *bootstrap* (a layer whose content has not been measured yet), but **odd sizes are the common case**: text measurement and half-dp padding produce them routinely. The bug is wider than the 1x1 in the report.

The main window is unaffected: its initial 1x1 is never committed (`present` is gated on `frame != IntRect.Zero`) and its sizes follow the compositor's own `configure`.

## The fix

- `alignToBufferScale(px, scale)` — rounds a physical size **up** to the next multiple of the surface scale, with a floor at `scale` (never down: a 1 px popup would collapse to 0).
- `TaoPopupSceneLayerLinux` applies it in `updateNativeFrame` before `setInnerSize` / `nativeResize` / `nativeAttachWayland`, and hoists the integer `bufferScale` into a field instead of recomputing it at the single attach site. Rendering keeps the true content dimensions, so the ≤ `scale - 1` px of extra edge stays transparent — the same trade GDK makes for its own popup buffers (a 51×31 logical popup gets a 102×62 shm buffer at scale 2).
- The same clamp lands in `nativeAttachWayland` and `nativeResize` (`wl_align_to_buffer_scale`) as a backstop, so a future caller passing an unaligned size gets a transparent edge rather than a killed client. That also covers the main-window and standalone-popup attach paths.

## Test plan

Two headful regression cases (`PopupScaleHeadfulCases`) plus a unit test for the rounding, registered in `TaoSceneTestBattery` so the native-image drift guard stays satisfied. The headful harness did not forward `nativePopupLayers` to `DecoratedWindow`, so no case could reach the native popup path at all — wired up here.

Verified on a real GNOME 50 Wayland session at 200%:

- [x] Negative control — with the two production files reverted and the `.so` rebuilt, both cases die with `Error 71`, exit 1.
- [x] With the fix, both cases pass; on the wire the popup buffer goes `create(101, 61, …)` → `create(102, 62, …)` and the bootstrap `1x1` → `2x2`, with no `wl_display#1.error`.
- [x] Visual check (weston headless `--scale=2` + `weston-screenshooter`): the popup content is still painted at **exactly 101×61 px** at the expected position — the alignment padding is invisible, nothing stretched or shifted.
- [x] Both cases also pass under `NUCLEUS_TAO_LINUX_RENDERER=x11` (the workaround from the issue), confirming X11 was never affected.
- [x] `:decorated-window-tao:test`, `detekt`, `apiCheck`, `ktlintCheck`.
- [x] Headful groups `#416`, `#418`, `WindowScaffold hideBar`, `render loop sustains` — unchanged.

Note: these cases are only meaningful on a Wayland session with `scale >= 2`. At 100% every size is trivially aligned, on X11 there is no `buffer_scale`, and weston does not enforce the rule — a green run in those environments proves nothing.

Two headful cases are red on this machine **independently of this change** (verified against an unmodified `main`) and are left untouched: `maximize grows the window and restore shrinks it back`, and `noWindowDrag blocks ancestor windowDragArea` (the session's RemoteDesktop portal refuses `NotifyPointer`, killing the JVM).