### PR TITLE
fix(tao/macos): seed the scene density from the window's own display

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -950,10 +950,24 @@ private fun initialMacOsSize(
     return if (width > 0 && height > 0) width to height else fallbackPhysicalSize()
 }
 
-internal fun initialMacOsScaleFactor(window: TaoWindow): Float {
-    val windowScale = NativeTaoBridge.nativeScaleFactor(window.handle).coerceAtLeast(1000) / 1000f
-    return maxOf(windowScale, primaryMacOsScaleFactor())
-}
+/**
+ * Scale factor the Compose scene's density is seeded with in
+ * [dev.nucleusframework.window.tao.scene.TaoComposeSceneHost.attach].
+ *
+ * A scale factor is a property of the display a window is on, so the window's
+ * own reading is the only valid answer. This used to take the *max* with the
+ * primary monitor's scale, as a guard against a not-yet-ready reading — but no
+ * other display's scale is ever a substitute: with a Retina Main display and
+ * the window on a 1x screen, the max laid the whole window out at 2x (#506).
+ *
+ * The guard was unnecessary anyway. `nativeScaleFactor` reports 1000 both for
+ * a genuine 1x window and for a handle the loop does not know, so a stale
+ * reading is not detectable here to begin with — and by `attach()` the window
+ * is registered (EVENT_WINDOW_READY precedes it) and carries its display's
+ * real scale.
+ */
+internal fun initialMacOsScaleFactor(window: TaoWindow): Float =
+    NativeTaoBridge.nativeScaleFactor(window.handle).coerceAtLeast(1000) / 1000f
 
 internal fun primaryMacOsScaleFactor(): Float {
     if (!NativeTaoMacOsDecoBridge.isLoaded) return 1f

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/DisplayScaleHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/DisplayScaleHeadfulCases.kt
@@ -1,13 +1,24 @@
 package dev.nucleusframework.window.tao.headful
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.dp
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.tao.TaoEventCode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.awt.GraphicsEnvironment
 import java.awt.Rectangle
+import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -39,6 +50,9 @@ import kotlin.math.roundToInt
  *  - [scaleChangeWithSuggestedSize] drives the event pair at the Kotlin seam.
  *    It runs anywhere, but it cannot reach `event_loop.rs`: reverting the
  *    native hunk leaves it green.
+ *  - [backingScaleSwitch] does reach the loop, on one display, by changing the
+ *    screen's backing scale under the window — added when #418 was re-reported
+ *    as #507 against a version that predates the loop fix.
  */
 internal object DisplayScaleHeadfulCases {
     private val isMac: Boolean get() = Platform.Current == Platform.MacOS
@@ -49,6 +63,7 @@ internal object DisplayScaleHeadfulCases {
         listOf(
             scaleChangeWithSuggestedSize(),
             realDisplayHop(),
+            backingScaleSwitch(),
         )
 
     /** Live scene metrics published from inside the window composition. */
@@ -115,10 +130,10 @@ internal object DisplayScaleHeadfulCases {
                 awaitUntil("scene metrics published") { metrics.ready }
                 settle()
 
-                // Baseline off the scene's own numbers, never off
-                // `window.scaleFactor`: the host seeds its scale from
-                // `initialMacOsScaleFactor`, i.e. max(window, primary monitor),
-                // so on a mixed-DPI Mac the two legitimately disagree.
+                // Baseline off the scene's own numbers rather than off
+                // `window.scaleFactor`: this case injects its scale changes at
+                // the Kotlin seam, so the scene and the real window deliberately
+                // disagree for the length of the probe.
                 val basePxW = metrics.widthPx.get()
                 val basePxH = metrics.heightPx.get()
                 val baseScale = metrics.density
@@ -247,6 +262,123 @@ internal object DisplayScaleHeadfulCases {
         )
     }
 
+    /**
+     * The #418 loop fix again (re-reported as #507), reachable **without a
+     * second display**: flipping the screen between the 1x and the HiDPI
+     * variant of its own pixel resolution fires the same
+     * `windowDidChangeBackingProperties:` a display hop fires, with the
+     * window's frame in points untouched. That is the exact condition — a
+     * backing-size change with no `Resized` of its own — under which the
+     * scene and the `CAMetalLayer` would keep the previous scale's pixel size.
+     *
+     * So unlike [realDisplayHop] this one is a regression gate that actually
+     * runs on a normal dev Mac (see [MacDisplayModeTool]); what it cannot
+     * cover is the move between two physical screens.
+     *
+     * Screenshots of the fixed-dp ruler land in [SHOT_DIR] so the on-screen
+     * size can be compared across the switch by eye as well.
+     */
+    private fun backingScaleSwitch(): TaoWindowTestCase {
+        val metrics = SceneMetrics()
+        return TaoWindowTestCase(
+            name = "#507 backing-scale switch re-establishes the drawable at the new size",
+            timeoutMillis = SWITCH_TIMEOUT,
+            skip = { if (!isMac) "macOS only" else MacDisplayModeTool.unavailableReason() },
+            // The suite's default chrome is a fillMaxSize sibling; the window
+            // content slot stacks children vertically, so it would push the
+            // ruler out of the viewport.
+            paintDefaultBackground = false,
+            content = {
+                ScaleRuler()
+                SceneMetricsProbe(metrics)
+            },
+            driver = {
+                awaitUntil("window mapped") { bounds() != null }
+                awaitUntil("scene metrics published") { metrics.ready }
+                window.setOuterPosition(HOP_MARGIN_DP, HOP_MARGIN_DP)
+                window.setInnerSize(HOP_W_DP, HOP_H_DP)
+                awaitUntil("scene resized to ${HOP_W_DP.toInt()}x${HOP_H_DP.toInt()}dp") {
+                    abs(metrics.logicalWidth - HOP_W_DP.toFloat()) <= HOP_SIZE_TOLERANCE_DP &&
+                        abs(metrics.logicalHeight - HOP_H_DP.toFloat()) <= HOP_SIZE_TOLERANCE_DP
+                }
+                settle(SETTLE_LONG)
+
+                val baseScale = metrics.density
+                val baseLogicalW = metrics.logicalWidth
+                val baseLogicalH = metrics.logicalHeight
+                val fromMode = if (baseScale >= HIDPI) "2x" else "1x"
+                val toMode = if (baseScale >= HIDPI) "1x" else "2x"
+                val expectedScale = if (baseScale >= HIDPI) baseScale / 2f else baseScale * 2f
+                System.err.println("[probe] baseline ${metrics.describe()} nativeScale=${window.scaleFactor}")
+                capture("before-$fromMode")
+
+                try {
+                    System.err.println("[probe] setmode $toMode -> ${MacDisplayModeTool.run(toMode)}")
+                    awaitUntil("window reports the new backing scale ($expectedScale)") {
+                        abs(window.scaleFactor - expectedScale) < TOLERANCE_SCALE
+                    }
+                    settle(SETTLE_LONG)
+                    System.err.println("[probe] after switch ${metrics.describe()} nativeScale=${window.scaleFactor}")
+                    capture("after-$toMode")
+
+                    check(abs(metrics.density - expectedScale) < TOLERANCE_SCALE) {
+                        "scene density ${metrics.density} never followed the backing scale $expectedScale"
+                    }
+                    val coherent =
+                        abs(metrics.logicalWidth - baseLogicalW) <= TOLERANCE_DP &&
+                            abs(metrics.logicalHeight - baseLogicalH) <= TOLERANCE_DP
+                    check(coherent) {
+                        "REPRO #507: $fromMode->$toMode left the scene at " +
+                            "${metrics.logicalWidth.roundToInt()}x${metrics.logicalHeight.roundToInt()}dp " +
+                            "instead of ${baseLogicalW.roundToInt()}x${baseLogicalH.roundToInt()}dp " +
+                            "(${metrics.describe()})"
+                    }
+                    val expectedPxW = (baseLogicalW * expectedScale).roundToInt()
+                    check(abs(metrics.widthPx.get() - expectedPxW) <= HOP_SIZE_TOLERANCE_DP) {
+                        "REPRO #507: drawable stayed at ${metrics.widthPx.get()}px, expected ${expectedPxW}px"
+                    }
+                } finally {
+                    System.err.println("[probe] restoring $fromMode -> ${MacDisplayModeTool.run(fromMode)}")
+                    awaitUntil("window back at the original scale ($baseScale)") {
+                        abs(window.scaleFactor - baseScale) < TOLERANCE_SCALE
+                    }
+                    settle(SETTLE_LONG)
+                    capture("restored-$fromMode")
+                }
+                System.err.println("[VERDICT] OK — scene and drawable followed a real backing-scale change")
+            },
+        )
+    }
+
+    /**
+     * Fixed-dp blocks: their size **on screen** must not change across a
+     * backing-scale switch. Doubling or halving is the #507 / #506 symptom.
+     */
+    @Composable
+    private fun ScaleRuler() {
+        Box(Modifier.fillMaxSize().background(Color(0xFF202020))) {
+            Box(Modifier.padding(20.dp).size(200.dp, 100.dp).background(Color(0xFFE53935)))
+            Box(Modifier.padding(start = 20.dp, top = 140.dp).size(400.dp, 20.dp).background(Color(0xFF43A047)))
+        }
+    }
+
+    private suspend fun TaoWindowTestScope.capture(tag: String) {
+        val b = bounds() ?: return
+        val scale = window.scaleFactor
+        val x = (b[0] / scale).roundToInt()
+        val y = (b[1] / scale).roundToInt()
+        val w = (b[2] / scale).roundToInt()
+        val h = (b[3] / scale).roundToInt()
+        withContext(Dispatchers.IO) {
+            File(SHOT_DIR).mkdirs()
+            ProcessBuilder("screencapture", "-x", "-R$x,$y,$w,$h", "$SHOT_DIR/$tag.png")
+                .redirectErrorStream(true)
+                .start()
+                .waitFor()
+        }
+        System.err.println("[probe] captured $SHOT_DIR/$tag.png (${w}x$h pts at $x,$y, scale=$scale)")
+    }
+
     private class ScreenInfo(
         val bounds: Rectangle,
         val scale: Float,
@@ -272,4 +404,6 @@ internal object DisplayScaleHeadfulCases {
     private const val HOP_H_DP = 400.0
     private const val HOP_SIZE_TOLERANCE_DP = 2f
     private const val HOP_MARGIN_DP = 80.0
+    private const val SWITCH_TIMEOUT = 120_000L
+    private const val SHOT_DIR = "build/reports/tao-display-scale"
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacDisplayModeTool.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MacDisplayModeTool.kt
@@ -1,0 +1,131 @@
+package dev.nucleusframework.window.tao.headful
+
+import java.io.File
+
+/**
+ * Flips the main display between the 1x and the HiDPI variant of its *current*
+ * pixel resolution — same pixels, same refresh rate, only the backing scale
+ * changes.
+ *
+ * That is the one way to get AppKit to fire `windowDidChangeBackingProperties:`
+ * (what tao turns into `ScaleFactorChanged`) with the window's frame in points
+ * untouched without owning two displays, which is what makes a single-display
+ * Mac able to run the #507 regression probe at all.
+ *
+ * `CGDisplaySetDisplayMode` has no JNI bridge in this module and pulling one in
+ * for a test would ship native code nobody needs at runtime, so the helper is a
+ * few lines of Swift compiled on demand into the system temp dir. Everything
+ * that can be missing (no Swift toolchain, no HiDPI twin for the current mode)
+ * reports a skip reason rather than failing a case.
+ */
+internal object MacDisplayModeTool {
+    private val binary = File(System.getProperty("java.io.tmpdir"), "nucleus-tao-display-mode")
+
+    /** Skip reason, or `null` when the helper is ready to use. */
+    fun unavailableReason(): String? {
+        if (!File(SWIFTC).canExecute()) return "no Swift toolchain at $SWIFTC"
+        if (!binary.canExecute() && !compile()) return "could not compile the display-mode helper"
+        // A display with no HiDPI twin (most 1080p panels) cannot change its
+        // backing scale at all — nothing to probe.
+        val probe = run("query")
+        return if (probe.startsWith("current")) null else "display-mode helper unusable: $probe"
+    }
+
+    /** `mode` is `1x`, `2x` or `query`; returns the helper's one-line report. */
+    fun run(mode: String): String {
+        val process =
+            ProcessBuilder(binary.absolutePath, mode)
+                .redirectErrorStream(true)
+                .start()
+        val out =
+            process.inputStream
+                .bufferedReader()
+                .readText()
+                .trim()
+        val code = process.waitFor()
+        return if (code == 0) out else "exit $code: $out"
+    }
+
+    private fun compile(): Boolean {
+        val source = File(binary.parentFile, "${binary.name}.swift")
+        source.writeText(SOURCE)
+        val compiler =
+            ProcessBuilder(SWIFTC, "-O", source.absolutePath, "-o", binary.absolutePath)
+                .redirectErrorStream(true)
+                .start()
+        val log = compiler.inputStream.bufferedReader().readText()
+        if (compiler.waitFor() != 0) {
+            System.err.println("[display-mode] swiftc failed: $log")
+            return false
+        }
+        return binary.canExecute()
+    }
+
+    private const val SWIFTC = "/usr/bin/swiftc"
+
+    private val SOURCE =
+        """
+        import AppKit
+        import CoreGraphics
+        import Foundation
+
+        // usage: <tool> 1x|2x|query
+        let want = CommandLine.arguments.count >= 2 ? CommandLine.arguments[1] : "query"
+        let display = CGMainDisplayID()
+        let opts = [kCGDisplayShowDuplicateLowResolutionModes as String: kCFBooleanTrue!] as CFDictionary
+        guard let modes = CGDisplayCopyAllDisplayModes(display, opts) as? [CGDisplayMode],
+              let cur = CGDisplayCopyDisplayMode(display) else {
+            FileHandle.standardError.write("cannot enumerate display modes\n".data(using: .utf8)!)
+            exit(3)
+        }
+
+        func report(_ prefix: String) {
+            let m = CGDisplayCopyDisplayMode(display)!
+            let scale = NSScreen.main?.backingScaleFactor ?? -1
+            print("\(prefix) pts=\(m.width)x\(m.height) px=\(m.pixelWidth)x\(m.pixelHeight) backingScale=\(scale)")
+        }
+
+        if want == "query" {
+            // Report only when the current mode has a twin at the opposite
+            // backing scale; without one the caller has nothing to switch to.
+            guard modes.contains(where: {
+                ${'$'}0.pixelWidth == cur.pixelWidth && ${'$'}0.pixelHeight == cur.pixelHeight &&
+                    Int(${'$'}0.refreshRate) == Int(cur.refreshRate) &&
+                    (${'$'}0.pixelWidth > ${'$'}0.width) != (cur.pixelWidth > cur.width)
+            }) else {
+                FileHandle.standardError.write("no HiDPI twin for the current mode\n".data(using: .utf8)!)
+                exit(7)
+            }
+            report("current")
+            exit(0)
+        }
+
+        let wantHiDpi = (want == "2x")
+        let target = modes.first {
+            ${'$'}0.pixelWidth == cur.pixelWidth && ${'$'}0.pixelHeight == cur.pixelHeight &&
+                Int(${'$'}0.refreshRate) == Int(cur.refreshRate) &&
+                ((${'$'}0.pixelWidth > ${'$'}0.width) == wantHiDpi)
+        }
+        guard let mode = target else {
+            FileHandle.standardError.write("no \(want) mode at \(cur.pixelWidth)x\(cur.pixelHeight)\n".data(using: .utf8)!)
+            exit(4)
+        }
+        if mode.ioDisplayModeID == cur.ioDisplayModeID {
+            report("unchanged")
+            exit(0)
+        }
+
+        var config: CGDisplayConfigRef?
+        guard CGBeginDisplayConfiguration(&config) == .success else { exit(5) }
+        CGConfigureDisplayWithDisplayMode(config, display, mode, nil)
+        let err = CGCompleteDisplayConfiguration(config, .permanently)
+        guard err == .success else {
+            FileHandle.standardError.write("CGCompleteDisplayConfiguration: \(err.rawValue)\n".data(using: .utf8)!)
+            exit(6)
+        }
+        // AppKit publishes the new backing scale a little after the mode is set;
+        // the caller polls the window, this just avoids reporting a stale one.
+        Thread.sleep(forTimeInterval: 1.5)
+        report("set")
+        """.trimIndent()
+}


### PR DESCRIPTION
Closes #506.

## The bug

`initialMacOsScaleFactor` seeded the Compose scene's density with `maxOf(window scale, primary monitor scale)`. A scale factor is a property of the display a window is on — no other display's is ever a substitute. With a Retina Main display and the window opening on a 1x external screen, every dp in the window is multiplied by 2: text, padding, control sizes and the title bar all come out double size, and roughly a quarter of the content fits.

The `maxOf` was a guard against a not-yet-ready reading from the bridge (added in 2ca1d58c). It cannot work as one: `nativeScaleFactor` returns `1000` both for a genuine 1x window and for a handle the loop does not know, so a stale reading is not distinguishable at that call site. It is also unnecessary — by `attach()` the window is registered (`EVENT_WINDOW_READY` precedes it) and reports its display's real scale.

## Verification

No mixed-DPI Mac here, so the reporter's arrangement was reproduced by stubbing the one OS query that differs on it — `primaryMacOsScaleFactor` → `2.0`, what a Retina Main display returns — with the real display at 1x:

```
before: scenePx=600x400 density=2.0 logical=300x200dp   ← 600x400pt window holding 300x200dp
after:  scenePx=600x400 density=1.0 logical=600x400dp
```

The "before" screenshot matches the one in the issue: a 200x100 dp block drawn 400x200 pt, a 400 dp bar overflowing the window.

That the dropped guard is not needed was checked on real hardware, with the display switched to a HiDPI mode: the first frame comes up at density 2.0 / 1600x1020 px, i.e. the window's own reading is already correct at `attach()`.

## The added probe

Issue #418 — a display hop leaving the scene and the `CAMetalLayer` at the previous scale's pixel size — was re-reported as #507 against 2.1.9, a version that predates its fix in `event_loop.rs`. Its only regression gate, `realDisplayHop`, needs two displays with different scale factors, so it skips on CI and on single-display dev machines, and nothing would have caught a regression there.

Flipping one display between the 1x and the HiDPI variant of its own pixel resolution fires the same `windowDidChangeBackingProperties:` a hop fires, with the window's frame in points untouched — the exact condition the bug needs. `MacDisplayModeTool` compiles a few lines of Swift on demand for `CGDisplaySetDisplayMode` (skips cleanly with no Swift toolchain or no HiDPI twin), so the gate now runs on a normal dev Mac. It still cannot cover the move between two physical screens.

Both directions verified locally, plus screenshots of a fixed-dp ruler under `build/reports/tao-display-scale/`:

| | scene | density | logical |
|---|---|---|---|
| 1x → 2x | 600x400 → 1200x800 px | 1.0 → 2.0 | 600x400 dp |
| 2x → 1x | 1200x800 → 600x400 px | 2.0 → 1.0 | 600x400 dp |

## Out of scope

`initialMacOsSize` and `applyMacOsInitialMaximizedSize` still resolve a maximized first frame against the *primary* monitor's work area, which is the same class of assumption for a window opening on another display.
