### PR TITLE
fix(tao): skip title-bar constraints on an RTL flip while fullscreen

### DIFF
--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -1529,16 +1529,24 @@ Java_dev_nucleusframework_window_tao_ffi_NativeMetalBridge_nativeSetButtonLayout
                                  @((BOOL)(isRtl == JNI_TRUE)),
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         NSNumber *h = objc_getAssociatedObject(win, &kTaoTitleBarHeightKey);
-        if (h != nil) {
-            applyButtonConstraints(win, h.floatValue);
-        }
-        // If we're currently in fullscreen, re-install the replacement
-        // traffic-light container so the new RTL flag takes effect on the
-        // overlay buttons too (otherwise they'd stay anchored on the side
-        // matched at the moment fullscreen was entered).
-        if (([win styleMask] & NSWindowStyleMaskFullScreen) != 0 && h != nil) {
+        if (h == nil) return;
+        BOOL isFullScreen = ([win styleMask] & NSWindowStyleMaskFullScreen) != 0;
+        if (isFullScreen) {
+            // In fullscreen only re-install the replacement traffic-light
+            // container so the new RTL flag takes effect on the overlay
+            // buttons (otherwise they'd stay anchored on the side matched at
+            // the moment fullscreen was entered). Never touch the manual
+            // constraints here: willEnterFS removed them so AppKit's animated
+            // toggleFullScreen: can run, and re-activating them mid-session
+            // leaves them active during the exit animation — the exact
+            // constraint conflict removeButtonConstraints exists to prevent
+            // (issue #510). didExitFS re-applies them with the stored RTL
+            // flag, so the windowed layout picks up the new side on exit.
+            // Mirrors decorated-window-jni's nativeSetRTL.
             removeFullScreenButtons(win);
             installFullScreenButtons(win, h.floatValue);
+        } else {
+            applyButtonConstraints(win, h.floatValue);
         }
     };
     if ([NSThread isMainThread]) apply();


### PR DESCRIPTION
Fixes #510.

## Summary

- `nativeSetButtonLayoutRtl` called `applyButtonConstraints` **before** its fullscreen check, re-activating the manual `NSLayoutConstraint` set on the AppKit titlebar container mid-fullscreen. `willEnterFS` removes that set precisely so AppKit's animated `toggleFullScreen:` can run, and nothing removed it again before the exit animation — which then ran against our constraints, the exact conflict/deadlock the comment on `removeButtonConstraints` warns about.
- Mirror `decorated-window-jni`'s `nativeSetRTL`: while fullscreen, only re-install the replacement traffic-light container (the stored `kTaoButtonsRtlKey` flips the overlay buttons); `applyButtonConstraints` runs only in the windowed state. `didExitFS` already re-applies the constraints with the stored RTL flag, so the windowed layout picks up the new side on fullscreen exit automatically.

## Test plan

- [x] `NucleusTaoMetal.m` compiles clean (`clang -fsyntax-only`, only the pre-existing `inspectorWithViewController:` availability warning remains)
- [x] Windowed RTL flip: unchanged path — constraints re-applied immediately with the new side
- [x] Manual: enter fullscreen, switch the app layout direction to RTL (e.g. Hebrew), exit fullscreen — no constraint conflict logged, exit animation completes, buttons land on the right side