### PR TITLE
fix(tao): repaint on move so off-screen-created windows aren't white

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -402,7 +402,15 @@ internal class TaoComposeSceneHostWindows(
 
         // Notify overlay/popup layers when the host window moves on screen
         // — top-level WS_POPUP children of the owner don't auto-track.
-        window.onMoved { _, _ -> onOwnerMoved() }
+        // Also re-present a frame: the ANGLE child-HWND swapchain presents
+        // through the GDI redirection surface, clipped to the visible region,
+        // so a window created partly off-screen has uninitialized (white)
+        // pixels there — each move re-presents and fills the newly exposed
+        // area. Free while the window is stationary (no WM_MOVE, no frame).
+        window.onMoved { _, _ ->
+            onOwnerMoved()
+            window.requestRedraw()
+        }
 
         // Notify overlay/popup layers when the host window loses keyboard
         // focus — for instance, the user clicked the embedded WebView,


### PR DESCRIPTION
## Summary
- On Windows, a Tao window created partly outside the visible screen area showed a white region when dragged into view: the ANGLE child-HWND swapchain presents through the GDI redirection surface, clipped to the visible region, so the off-screen part never received pixels and nothing re-presented when it was exposed (the render-surface child's `WM_PAINT` just validates, and `onMoved` only notified popup/overlay layers).
- The `onMoved` hook in `TaoComposeSceneHostWindows` now also calls `window.requestRedraw()`: each `WM_MOVE` re-presents a full frame, filling the newly exposed area as the window enters the screen. No cost while the window is stationary, and rapid moves coalesce into a single `WM_PAINT` via `InvalidateRect`.

## Test plan
- [ ] Create a window with a partially off-screen position (e.g. negative `x`) and drag it into view — the previously hidden region paints during the drag instead of staying white
- [ ] Drag a window with a static scene around the screen — no visual regression, no frame accumulation
- [ ] Popups/overlays still track the owner window during moves