### PR TITLE
fix(tao): guard nativeLinuxHandles calls behind a Linux platform check

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -586,6 +586,7 @@ private fun absolutePositionForPopup(
 
 /** Parent outer origin in logical dp when [parent] is a native Wayland surface. */
 private fun parentOuterOriginLogical(parent: TaoWindow): Pair<Double, Double>? {
+    if (Platform.Current != Platform.Linux || !NativeTaoBridge.isLoaded) return null
     val handles = NativeTaoBridge.nativeLinuxHandles(parent.handle) ?: return null
     if (handles.isEmpty() || handles[0] != 2L) return null
     val rect = parent.outerBoundsPx() ?: return null
@@ -617,6 +618,7 @@ private val decoratedWindowLogger: java.util.logging.Logger =
 
 private fun warnIfWaylandIgnoresPosition(window: TaoWindow) {
     if (waylandPositionWarned.get()) return
+    if (Platform.Current != Platform.Linux || !NativeTaoBridge.isLoaded) return
     val handles = NativeTaoBridge.nativeLinuxHandles(window.handle) ?: return
     if (handles.isEmpty() || handles[0] != 2L) return
     if (!waylandPositionWarned.compareAndSet(false, true)) return

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -696,6 +696,7 @@ public class TaoWindow internal constructor(
 
     /** `true` when the popup parent is a native Wayland surface (kind == 2). */
     private fun parentIsNativeWayland(): Boolean {
+        if (Platform.Current != Platform.Linux || !NativeTaoBridge.isLoaded) return false
         val handles = NativeTaoBridge.nativeLinuxHandles(popupParentHandle) ?: return false
         return handles.isNotEmpty() && handles[0] == WAYLAND_HANDLE_KIND
     }


### PR DESCRIPTION
## Summary

`NativeTaoBridge.nativeLinuxHandles` is only implemented in the Linux native build (`src/main/native/src/platform/linux/handles.rs`), so calling it elsewhere throws `UnsatisfiedLinkError`. Three call sites had no platform guard:

- `DecoratedWindowComposable.parentOuterOriginLogical()` — reached from `absolutePositionForPopup()`; dragging a tab out of a window (popup + `WindowPosition.Absolute`) killed the event loop on Windows
- `DecoratedWindowComposable.warnIfWaylandIgnoresPosition()` — same crash for any `WindowPosition.Aligned`
- `TaoWindow.parentIsNativeWayland()` — would crash on the next `setOuterPosition()` for a popup

All three now use the guard already established by `TaoWindow.x11WindowId`: `Platform.Current != Platform.Linux || !NativeTaoBridge.isLoaded`, degrading to the existing non-Wayland fallback.

## Test plan

- [x] `:decorated-window-tao:compileKotlin`
- [ ] Windows: drag a tab out of a `DecoratedWindow` to detach it — ghost follows the cursor, no `UnsatisfiedLinkError`
- [ ] Windows/macOS: open a window with `WindowPosition.Aligned` — no crash, no Wayland warning
- [ ] Linux X11 + native Wayland: popup positioning and the Wayland-ignores-position warning unchanged