### PR TITLE
fix(tao): purge the GPU cache with the host's own ES context current

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -989,13 +989,37 @@ internal class TaoComposeSceneHostWindows(
             val now = System.nanoTime()
             if (now - lastResizePurgeNs >= RESIZE_PURGE_INTERVAL_NS) {
                 lastResizePurgeNs = now
-                directContext?.let {
-                    it.resourceCacheLimit = 0
-                    it.resourceCacheLimit = RESOURCE_CACHE_LIMIT_BYTES
-                }
+                purgeGpuResourceCache()
             }
         }
         onRedrawRequested()
+    }
+
+    /**
+     * Frees the GPU resource cache synchronously: toggling the limit to 0 runs
+     * Skia's `purgeAsNeeded` inline, releasing every unlocked resource, and
+     * restoring the budget lets the next frame re-mint only what it needs.
+     *
+     * The purge issues `glDelete*`, so it MUST run with **this** host's ES
+     * context current. Both callers sit on the resize path, where a sibling
+     * host (a second `DecoratedWindow`, a `DecoratedDialog`) can have left its
+     * own context bound after painting a frame of its own between two of our
+     * WM_SIZEs — the modal size/move loop pumps the whole thread's messages,
+     * so the sibling's WM_PAINT is dispatched in the middle of our drag.
+     * Purging against that foreign context deletes ids in the *sibling's*
+     * namespace (the two contexts are unshared, so both number their objects
+     * from 1 and the ids collide wholesale): its live textures die while our
+     * own are merely leaked. Skia keeps believing the sibling's glyph atlas is
+     * resident, so that window goes on drawing geometry but loses every glyph
+     * and icon — the parent window blanking behind a fast child resize (#514).
+     *
+     * Same foreign-context hazard the make-current in [detach] guards against.
+     */
+    private fun purgeGpuResourceCache() {
+        val ctx = directContext ?: return
+        if (attachmentHandle != 0L) NativeTaoGlBridge.nativeMakeCurrent(attachmentHandle)
+        ctx.resourceCacheLimit = 0
+        ctx.resourceCacheLimit = RESOURCE_CACHE_LIMIT_BYTES
     }
 
     /**
@@ -1049,14 +1073,10 @@ internal class TaoComposeSceneHostWindows(
             pendingResizeApply = true
             onRedrawRequested()
             // Reclaim the per-size scratch (stencil/render-target attachments)
-            // accumulated across the drag. Toggling the limit to 0 runs
-            // purgeAsNeeded synchronously, freeing every unlocked resource; the
-            // next frame re-mints only what the final size needs. Without this
-            // the drag's peak footprint is released only by a later GC.
-            directContext?.let {
-                it.resourceCacheLimit = 0
-                it.resourceCacheLimit = RESOURCE_CACHE_LIMIT_BYTES
-            }
+            // accumulated across the drag; the next frame re-mints only what
+            // the final size needs. Without this the drag's peak footprint is
+            // released only by a later GC.
+            purgeGpuResourceCache()
             // The purge above only frees Skia's GPU cache. Every remeasure of
             // the drag also minted Compose layers/pictures whose native Skia
             // memory is released by the skiko Cleaner only after a GC — and a


### PR DESCRIPTION
Fixes #514 — on Windows/Tao, rapidly resizing a secondary `DecoratedWindow` left the parent window drawing its layout but losing every glyph and icon (blank panels, chrome remnants) until it was forced to repaint.

## Summary

- `TaoComposeSceneHostWindows` toggled `resourceCacheLimit` in two resize paths (the periodic in-drag purge in `onResized`, and the drag-end purge in `onResizeLoopChanged`) **without** making this host's ANGLE context current first. Skia runs `purgeAsNeeded` inline, so those are real `glDelete*` calls.
- The OS modal size/move loop pumps the whole thread's messages, so a sibling host's `WM_PAINT` is dispatched between two of the dragged window's `WM_SIZE`s and leaves *its* EGL context bound. The two contexts are unshared, so both number their objects from 1 and the ids collide wholesale: the purge destroyed the sibling's live textures and only leaked our own.
- Skia still believed the sibling's glyph atlas was resident, so the parent kept drawing geometry but lost every glyph and cached image until an atlas reallocation (focus, minimize/restore) — exactly the reported symptom.
- Both call sites now go through `purgeGpuResourceCache()`, which binds `attachmentHandle` before touching the cache. Same foreign-context guard `detach()` already carries.

## Test plan

- [x] Reproduced on Windows 11 with two Tao `DecoratedWindow`s (tao-demo main window + child): fast border drag on the child blanked the parent's text
- [x] With the fix, the same drag leaves the parent's content intact
- [x] `./gradlew preMerge`