### PR TITLE
fix(tao): hide the DWM 1px contour so the CSD frame shows

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/UndecoratedWindowBorder.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/UndecoratedWindowBorder.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
+import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.DecoratedWindowState
 import dev.nucleusframework.window.internal.insideBorder
 import dev.nucleusframework.window.styling.LocalDecoratedWindowStyle
@@ -64,6 +65,9 @@ internal fun rememberUndecoratedWindowBorder(
                     bottomStart = 0.dp,
                     bottomEnd = 0.dp,
                 )
+            // Win11 DWMWCP_ROUND is 8 logical px. A square stroke on a
+            // rounded HWND is clipped at the corners and reads as a box.
+            Platform.Current == Platform.Windows -> RoundedCornerShape(8.dp)
             else -> RoundedCornerShape(0.dp)
         }
     val color by style.colors.borderFor(state)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -224,13 +224,15 @@ internal class TaoPopupSceneLayerWindows(
             type: Int,
             button: Int,
         ) {
+            if (released) return
+            val handler = onOutsidePointerEvent ?: return
             val pointerButton =
                 when (button) {
                     TaoNativeWireFormat.BUTTON_PRIMARY -> PointerButton.Primary
                     TaoNativeWireFormat.BUTTON_SECONDARY -> PointerButton.Secondary
                     else -> PointerButton.Tertiary
                 }
-            onOutsidePointerEvent?.invoke(PointerEventType.Press, pointerButton)
+            handler(PointerEventType.Press, pointerButton)
         }
     }
 

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -380,24 +380,38 @@ static void revertBackdropForClose(HWND hwnd, DecoState *state) {
  * caption fill is suppressed entirely (an opaque caption is what otherwise
  * leaves the title bar as a flat band above a Mica client area), but the
  * border keeps DWM's default: COLOR_NONE on the border renders the top edge
- * as a bare black line instead of the subtle system frame. */
+ * as a bare black line instead of the subtle system frame.
+ *
+ * Windowed CSD (no backdrop) also hides that 1px DWM contour — Compose
+ * already draws `insideBorder` on the same edge pixels, and the themed DWM
+ * stroke clips it (#522). The 1px bottom DwmExtendFrame margin is unchanged:
+ * it only keeps the drop shadow. */
 static void applyCaptionColors(HWND hwnd, DecoState *state) {
     BOOL backdrop = state && state->backdropActive;
     BOOL borderless = state && state->borderlessChrome;
+    BOOL fullscreen = state && state->isFullscreen;
     COLORREF themed = state ? state->bgColor : RGB(255, 255, 255);
     COLORREF caption = backdrop ? (COLORREF)DWMWA_COLOR_NONE : themed;
     COLORREF border = backdrop ? (COLORREF)DWMWA_COLOR_DEFAULT : themed;
+    UINT thickness = 1;
     /* Fullscreen: the borderless window covers the monitor exactly, so any
      * fill DWM still draws for these attributes shows as a 1px contour of
      * the wrong colour around the content — the issue-413 white edge (worst
      * with a backdrop, where the border is otherwise the light system
-     * default). Same for borderlessChrome overlays (no system frame at all). */
-    if (state && (state->isFullscreen || borderless)) {
+     * default). Same for borderlessChrome overlays (no system frame at all).
+     * Regular CSD: hide the DWM stroke so the Compose 1dp frame is visible. */
+    if (fullscreen || borderless) {
         caption = (COLORREF)DWMWA_COLOR_NONE;
         border = (COLORREF)DWMWA_COLOR_NONE;
+        thickness = 0;
+    } else if (!backdrop) {
+        border = (COLORREF)DWMWA_COLOR_NONE;
+        thickness = 0;
     }
     DwmSetWindowAttribute(hwnd, 35 /* DWMWA_CAPTION_COLOR */, &caption, sizeof(caption));
     DwmSetWindowAttribute(hwnd, 34 /* DWMWA_BORDER_COLOR */, &border, sizeof(border));
+    DwmSetWindowAttribute(hwnd, DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
+                          &thickness, sizeof(thickness));
 }
 
 /* The DwmExtendFrameIntoClientArea margins for the current mode. Windowed
@@ -963,6 +977,7 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeInstal
      * transparent pixels render as black (invisible on dark themes). */
     MARGINS margins = {0, 0, 0, 1};
     DwmExtendFrameIntoClientArea(hwnd, &margins);
+    applyCaptionColors(hwnd, state);
 
     SetWindowPos(hwnd, NULL, 0, 0, 0, 0,
         SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE |
@@ -1041,10 +1056,6 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeSetBor
                           &corner, sizeof(corner));
 
     if (wanted) {
-        /* Win11: zero the visible 1px non-client border thickness. */
-        UINT thickness = 0;
-        DwmSetWindowAttribute(hwnd, DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
-                              &thickness, sizeof(thickness));
         /* DWMSBT_NONE — no system material halo around the HWND. */
         int none = 1;
         DwmSetWindowAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE,

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -186,6 +186,7 @@ static BOOL isCaptionButtonHit(WPARAM code) {
 /* DWM_WINDOW_CORNER_PREFERENCE wire values (avoid depending on a 22H2 SDK). */
 #define NUCLEUS_DWMWCP_DEFAULT    0
 #define NUCLEUS_DWMWCP_DONOTROUND 1
+#define NUCLEUS_DWMWCP_ROUND      2
 #ifndef DWMWA_VISIBLE_FRAME_BORDER_THICKNESS
 /* Win11 22000+: thickness of the visible non-client border (logical px). */
 #define DWMWA_VISIBLE_FRAME_BORDER_THICKNESS 37
@@ -382,10 +383,11 @@ static void revertBackdropForClose(HWND hwnd, DecoState *state) {
  * border keeps DWM's default: COLOR_NONE on the border renders the top edge
  * as a bare black line instead of the subtle system frame.
  *
- * Windowed CSD (no backdrop) also hides that 1px DWM contour — Compose
- * already draws `insideBorder` on the same edge pixels, and the themed DWM
- * stroke clips it (#522). The 1px bottom DwmExtendFrame margin is unchanged:
- * it only keeps the drop shadow. */
+ * Windowed CSD (no backdrop) clears only the DWM *fill* (COLOR_NONE) so
+ * Compose `insideBorder` is not painted over (#522). The 1px visible-frame
+ * thickness stays: zeroing it (as overlays/fullscreen do) drops Win11's
+ * 8px rounded clip and the window looks squared-off. The 1px bottom
+ * DwmExtendFrame margin is unchanged — it only keeps the drop shadow. */
 static void applyCaptionColors(HWND hwnd, DecoState *state) {
     BOOL backdrop = state && state->backdropActive;
     BOOL borderless = state && state->borderlessChrome;
@@ -394,24 +396,27 @@ static void applyCaptionColors(HWND hwnd, DecoState *state) {
     COLORREF caption = backdrop ? (COLORREF)DWMWA_COLOR_NONE : themed;
     COLORREF border = backdrop ? (COLORREF)DWMWA_COLOR_DEFAULT : themed;
     UINT thickness = 1;
+    int corner = NUCLEUS_DWMWCP_ROUND;
     /* Fullscreen: the borderless window covers the monitor exactly, so any
      * fill DWM still draws for these attributes shows as a 1px contour of
      * the wrong colour around the content — the issue-413 white edge (worst
      * with a backdrop, where the border is otherwise the light system
      * default). Same for borderlessChrome overlays (no system frame at all).
-     * Regular CSD: hide the DWM stroke so the Compose 1dp frame is visible. */
+     * Regular CSD: hide the DWM colour fill only; keep thickness + rounding. */
     if (fullscreen || borderless) {
         caption = (COLORREF)DWMWA_COLOR_NONE;
         border = (COLORREF)DWMWA_COLOR_NONE;
         thickness = 0;
+        corner = NUCLEUS_DWMWCP_DONOTROUND;
     } else if (!backdrop) {
         border = (COLORREF)DWMWA_COLOR_NONE;
-        thickness = 0;
     }
     DwmSetWindowAttribute(hwnd, 35 /* DWMWA_CAPTION_COLOR */, &caption, sizeof(caption));
     DwmSetWindowAttribute(hwnd, 34 /* DWMWA_BORDER_COLOR */, &border, sizeof(border));
     DwmSetWindowAttribute(hwnd, DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
                           &thickness, sizeof(thickness));
+    DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE,
+                          &corner, sizeof(corner));
 }
 
 /* The DwmExtendFrameIntoClientArea margins for the current mode. Windowed

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_popup.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_popup.c
@@ -146,14 +146,29 @@ static JNIEnv *attachThread(void) {
     return NULL;
 }
 
+/* Look up methods on the *interface*, not the concrete sample class.
+ * Scene-layer and standalone-panel listeners are different classes
+ * implementing the same interface. A jmethodID from one used with
+ * CallVoidMethod on the other runs the wrong bytecode with the wrong
+ * `this` and crashes the JVM (observed: PopupOutsideListener.onOutsideClick
+ * invoked on a PanelOutsideClickListener). */
+static jclass globalRefNamedClass(JNIEnv *env, const char *name) {
+    jclass local = (*env)->FindClass(env, name);
+    if (!local) {
+        if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+        return NULL;
+    }
+    jclass global = (*env)->NewGlobalRef(env, local);
+    (*env)->DeleteLocalRef(env, local);
+    return global;
+}
+
 static void ensureEventCallbackCache(JNIEnv *env, jobject sample) {
     if (sCacheInitedBits & 1) return;
     if (sJVM == NULL) (*env)->GetJavaVM(env, &sJVM);
     if (!sample) return;
-    jclass local = (*env)->GetObjectClass(env, sample);
-    if (!local) return;
-    jclass global = (*env)->NewGlobalRef(env, local);
-    (*env)->DeleteLocalRef(env, local);
+    jclass global = globalRefNamedClass(env,
+        "dev/nucleusframework/window/tao/ffi/PopupNativeBridgeWindows$EventCallback");
     if (!global) return;
     jmethodID m1 = (*env)->GetMethodID(env, global, "onPointerEvent", "(IFFII)V");
     jmethodID m2 = (*env)->GetMethodID(env, global, "onScroll", "(FFFF)V");
@@ -163,6 +178,7 @@ static void ensureEventCallbackCache(JNIEnv *env, jobject sample) {
         sOnPointerMethod = m1; sOnScrollMethod = m2; sOnKeyMethod = m3;
         InterlockedOr(&sCacheInitedBits, 1);
     } else {
+        if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
         (*env)->DeleteGlobalRef(env, global);
     }
 }
@@ -171,16 +187,15 @@ static void ensureOutsideCallbackCache(JNIEnv *env, jobject sample) {
     if (sCacheInitedBits & 2) return;
     if (sJVM == NULL) (*env)->GetJavaVM(env, &sJVM);
     if (!sample) return;
-    jclass local = (*env)->GetObjectClass(env, sample);
-    if (!local) return;
-    jclass global = (*env)->NewGlobalRef(env, local);
-    (*env)->DeleteLocalRef(env, local);
+    jclass global = globalRefNamedClass(env,
+        "dev/nucleusframework/window/tao/ffi/PopupNativeBridgeWindows$OutsideClickListener");
     if (!global) return;
     jmethodID m = (*env)->GetMethodID(env, global, "onOutsideClick", "(II)V");
     if (m) {
         sOutsideClass = global; sOnOutsideClickMethod = m;
         InterlockedOr(&sCacheInitedBits, 2);
     } else {
+        if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
         (*env)->DeleteGlobalRef(env, global);
     }
 }


### PR DESCRIPTION
## Summary

- On windowed CSD (no Mica/Acrylic backdrop), clear only the DWM border *fill* (`DWMWA_BORDER_COLOR = COLOR_NONE`) so Compose `insideBorder` is not painted over. That 1px system contour was the clipped Material frame (#522), the gray ring around a flush WebView2 page (#520), and the dark-mode border that failed to follow Win11 corners / vanished at the top (#517).
- Keep `DWMWA_VISIBLE_FRAME_BORDER_THICKNESS = 1` and `DWMWCP_ROUND`. Zeroing the thickness dropped Win11's 8px rounded clip and made the window look squared-off.
- Draw the Compose stroke with `RoundedCornerShape(8.dp)` on Windows so it follows the DWM corner instead of a square line clipped at the curves.
- Keep the 1px bottom `DwmExtendFrameIntoClientArea` margin so the drop shadow stays.
- Apply caption/border attributes at decoration install, not only on the first theme push.
- Leave backdrop windows on the system frame (`COLOR_NONE` still draws a black top edge over Mica).
- Also: resolve popup JNI `onOutsideClick` / event callbacks on the *interface* `jmethodID`, not the first concrete listener class. Scene-layer and standalone-panel implementors were crashing the JVM with `CallVoidMethod` on the wrong `this`.

Related to #517 (border / corner clip only). Control-button hover colour and fade animations stay open there.

Closes #520
Closes #522

## Test plan

- [x] `nucleus-demo` on Windows 11, light Material theme: 1dp `outlineVariant` frame visible on left, right, and bottom
- [x] Window stays Win11-rounded (8px), not a sharp rectangle
- [x] Dark theme: same frame still visible, follows the rounded corners, present on all four sides
- [x] Maximize / restore: no leftover DWM contour, no missing shadow when restored
- [x] Fullscreen enter/exit: no 1px light edge (#413)
- [ ] `undecorated = true` overlay: still no system contour or shadow
- [x] Window with `WindowsBackdrop` (Mica/Acrylic): system frame unchanged, no black top line
- [x] WebView2 tab: no extra 1px gray ring around the page area
- [ ] Compose dropdown / standalone popup: click outside dismisses without an ACCESS_VIOLATION
