### PR TITLE
fix(graalvm): copy appResources into native packages and agent runs

### DIFF
--- a/graalvm-runtime/src/main/kotlin/dev/nucleusframework/graalvm/GraalVmInitializer.kt
+++ b/graalvm-runtime/src/main/kotlin/dev/nucleusframework/graalvm/GraalVmInitializer.kt
@@ -32,6 +32,10 @@ public object GraalVmInitializer {
             // Resolve the executable directory
             val execDir = resolveExecDir()
             System.setProperty("java.home", execDir)
+            // Match JVM `run` / jpackage: sidecars from appResourcesRootDir live next to the exe.
+            if (System.getProperty("compose.application.resources.dir").isNullOrBlank()) {
+                System.setProperty("compose.application.resources.dir", execDir)
+            }
 
             // java.library.path → execDir + execDir/bin
             // Must be set BEFORE any System.loadLibrary() call (including HiDPI JNI below).

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JavaLanguageVersion
@@ -69,6 +70,38 @@ private fun escapeNativeImageArgFileArgument(arg: String): String =
 // hiding it in the build tmp dir.
 private val JvmApplicationContext.graalvmOutputDir: Provider<Directory>
     get() = app.nativeDistributions.outputBaseDir.map { it.dir("$appDirName/graalvm-app") }
+
+/**
+ * JVM `run` / jpackage already copy [appResourcesRootDir] via `prepareAppResources` and set
+ * `compose.application.resources.dir`. GraalVM packaging did not, so sidecars such as
+ * Dawn's `dxil.dll` / `dxcompiler.dll` were missing next to the native exe.
+ */
+private fun JvmApplicationContext.prepareAppResourcesTask(): TaskProvider<Sync> =
+    project.tasks.named(
+        "prepare${buildType.classifier.uppercaseFirstChar()}AppResources",
+        Sync::class.java,
+    )
+
+private fun JvmApplicationContext.copyGraalvmAppResources(
+    into: Provider<Directory>,
+    extraDepends: List<TaskProvider<*>> = emptyList(),
+    doNotTrack: Boolean = false,
+): TaskProvider<Copy> {
+    val prepareAppResources = prepareAppResourcesTask()
+    return tasks.register<Copy>(
+        taskNameAction = "copy",
+        taskNameObject = "graalvmAppResources",
+    ) {
+        description = "Copy appResourcesRootDir contents next to the native executable"
+        dependsOn(prepareAppResources)
+        extraDepends.forEach { dependsOn(it) }
+        if (doNotTrack) {
+            doNotTrackState("Output directory is modified by downstream strip/codesign tasks")
+        }
+        from(prepareAppResources.map { it.destinationDir })
+        into(into)
+    }
+}
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 internal fun JvmApplicationContext.configureGraalvmApplication() {
@@ -232,6 +265,9 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                 classpath = runtimeJars
             }
 
+            val prepareAppResources = prepareAppResourcesTask()
+            dependsOn(prepareAppResources)
+
             jvmArgs =
                 buildList {
                     addAll(graalvmDefaultJvmArgs)
@@ -243,6 +279,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                                 !arg.startsWith("-D$APP_RESOURCES_DIR=")
                         },
                     )
+                    add("-D$APP_RESOURCES_DIR=${prepareAppResources.get().destinationDir.absolutePath}")
 
                     if (currentOS == OS.MacOS) {
                         val dockName =
@@ -1804,13 +1841,20 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
             null
         }
 
+    val copyAppResources =
+        copyGraalvmAppResources(
+            into = appBundleDir.map { it.dir("MacOS") },
+            extraDepends = listOf(cleanAppBundle),
+            doNotTrack = true,
+        )
+
     val codesignBundle =
         tasks.register<Exec>(
             taskNameAction = "codesign",
             taskNameObject = "graalvmBundle",
         ) {
             description = "Ad-hoc sign the entire .app bundle"
-            dependsOn(codesignDylibs, copyBinary, fixRpath, stripBinary, copyInfoPlist, copyJawtToLib, copySkikoLib, copyIcon)
+            dependsOn(codesignDylibs, copyBinary, copyAppResources, fixRpath, stripBinary, copyInfoPlist, copyJawtToLib, copySkikoLib, copyIcon)
             copyFileAssociationIcons?.let { dependsOn(it) }
             val bundleDir = graalvmOutputDir.map { it.dir(appBundleName.get()) }
             commandLine("codesign", "--force", "--deep", "--sign", "-", bundleDir.get().asFile.absolutePath)
@@ -1823,6 +1867,7 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
         description = "Build native image and package as macOS .app bundle"
         dependsOn(
             copyBinary,
+            copyAppResources,
             copyAwtDylibs,
             copyJawtToLib,
             copySkikoLib,
@@ -1986,12 +2031,14 @@ private fun JvmApplicationContext.configureWindowsGraalvmPackaging(
             null
         }
 
+    val copyAppResources = copyGraalvmAppResources(into = outputDir)
+
     return tasks.register<DefaultTask>(
         taskNameAction = "package",
         taskNameObject = "graalvmNative",
     ) {
         description = "Build native image and package with DLLs"
-        dependsOn(copyBinary, copyAwtDlls, copyJvmDll, copyJawtToBin, copySkikoLib, copyFontConfig)
+        dependsOn(copyBinary, copyAppResources, copyAwtDlls, copyJvmDll, copyJawtToBin, copySkikoLib, copyFontConfig)
         copyCRuntime?.let { dependsOn(it) }
     }
 }
@@ -2144,12 +2191,25 @@ private fun JvmApplicationContext.configureLinuxGraalvmPackaging(
             commandLine("strip", binary.get().asFile.absolutePath)
         }
 
+    val copyAppResources = copyGraalvmAppResources(into = outputDir)
+
     return tasks.register<DefaultTask>(
         taskNameAction = "package",
         taskNameObject = "graalvmNative",
     ) {
         description = "Build native image and package with .so libs"
-        dependsOn(copyBinary, copyAwtSoLibs, copyJvmSo, copyJawtToLib, copySkikoLib, fixRpath, fixSoRpath, stripSoLibs, stripBinary)
+        dependsOn(
+            copyBinary,
+            copyAppResources,
+            copyAwtSoLibs,
+            copyJvmSo,
+            copyJawtToLib,
+            copySkikoLib,
+            fixRpath,
+            fixSoRpath,
+            stripSoLibs,
+            stripBinary,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Copy `appResourcesRootDir` (`prepareAppResources`) next to the GraalVM native binary on Windows, Linux, and macOS.
- Set `compose.application.resources.dir` to the executable directory in `GraalVmInitializer` when unset.
- Wire the same property into `runWithNativeAgent` (it previously stripped the jpackage placeholder and never put a real path back).

Sidecars such as Dawn's `dxil.dll` / `dxcompiler.dll` were available for `run` / jpackage but missing for native packages and the tracing-agent JVM.

## Test plan
- [x] `run` still loads files from `appResourcesRootDir`
- [x] `runWithNativeAgent` sets `compose.application.resources.dir` to `prepareAppResources` output
- [x] `packageGraalvmNative` copies those files next to the exe (Windows/Linux) or into `Contents/MacOS` (macOS)
- [x] Native-image process sees `compose.application.resources.dir` pointing at the exe directory