### PR TITLE
fix(tao): draw Win11 CSD contour via DWM so corners are not clipped

### DIFF
--- a/decorated-window-core/detekt-baseline.xml
+++ b/decorated-window-core/detekt-baseline.xml
@@ -45,7 +45,6 @@
     <ID>UndocumentedPublicFunction:DecoratedWindowCore.kt:DecoratedWindowState$public fun copy: DecoratedWindowState</ID>
     <ID>UndocumentedPublicFunction:DecoratedWindowCore.kt:DecoratedWindowState.Companion$public fun of: DecoratedWindowState</ID>
     <ID>UndocumentedPublicFunction:DecoratedWindowStyling.kt:DecoratedWindowColors$@Composable public fun borderFor: State&lt;Color&gt;</ID>
-    <ID>UndocumentedPublicFunction:InsideBorderModifier.kt:public fun Modifier.insideBorder: Modifier</ID>
     <ID>UndocumentedPublicFunction:LinuxTitleBarIconSet.kt:@Composable public fun linuxTitleBarIcons: LinuxTitleBarIconSet</ID>
     <ID>UndocumentedPublicFunction:NucleusDecoratedWindowTheme.kt:@Suppress("FunctionNaming") @Composable public fun NucleusDecoratedWindowTheme</ID>
     <ID>UndocumentedPublicFunction:NucleusDecoratedWindowTheme.kt:DecoratedWindowDefaults$public fun darkTitleBarStyle: TitleBarStyle</ID>

--- a/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/internal/InsideBorderModifier.kt
+++ b/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/internal/InsideBorderModifier.kt
@@ -2,16 +2,30 @@ package dev.nucleusframework.window.internal
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.addOutline
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
+/**
+ * Draws a [width]-thick stroke fully inside this node's bounds, following
+ * [shape].
+ *
+ * Unlike a centred stroke, the outer edge sits on the shape outline so
+ * nothing is clipped by a parent clip or by a platform window clip
+ * (Win11 DWM rounded HWND, Linux XShape / Skia carve). Corner radii shrink
+ * by half the stroke so the outline stays concentric with [shape].
+ */
 public fun Modifier.insideBorder(
     width: Dp = 1.dp,
     color: Color,
@@ -20,17 +34,67 @@ public fun Modifier.insideBorder(
     drawWithContent {
         drawContent()
         val strokeWidth = width.toPx()
-        if (strokeWidth <= 0f || color == Color.Transparent) return@drawWithContent
+        if (strokeWidth <= 0f ||
+            color == Color.Transparent ||
+            size.width <= strokeWidth ||
+            size.height <= strokeWidth
+        ) {
+            return@drawWithContent
+        }
 
         val halfStroke = strokeWidth / 2f
-        val insetSize = Size(size.width - strokeWidth, size.height - strokeWidth)
-        val outline = shape.createOutline(insetSize, layoutDirection, this)
-
-        translate(halfStroke, halfStroke) {
-            drawOutline(
-                outline = outline,
-                color = color,
-                style = Stroke(width = strokeWidth),
-            )
+        val outline = shape.createOutline(size, layoutDirection, this)
+        val clip = Path().apply { addOutline(outline) }
+        clipPath(clip) {
+            when (outline) {
+                is Outline.Rectangle ->
+                    drawRect(
+                        color = color,
+                        topLeft = Offset(halfStroke, halfStroke),
+                        size = Size(size.width - strokeWidth, size.height - strokeWidth),
+                        style = Stroke(width = strokeWidth),
+                    )
+                is Outline.Rounded -> {
+                    val rr = outline.roundRect
+                    val inset =
+                        RoundRect(
+                            left = rr.left + halfStroke,
+                            top = rr.top + halfStroke,
+                            right = rr.right - halfStroke,
+                            bottom = rr.bottom - halfStroke,
+                            topLeftCornerRadius = shrinkCorner(rr.topLeftCornerRadius, halfStroke),
+                            topRightCornerRadius = shrinkCorner(rr.topRightCornerRadius, halfStroke),
+                            bottomRightCornerRadius =
+                                shrinkCorner(rr.bottomRightCornerRadius, halfStroke),
+                            bottomLeftCornerRadius =
+                                shrinkCorner(rr.bottomLeftCornerRadius, halfStroke),
+                        )
+                    drawPath(
+                        path = Path().apply { addRoundRect(inset) },
+                        color = color,
+                        style = Stroke(width = strokeWidth),
+                    )
+                }
+                is Outline.Generic -> {
+                    val insetSize = Size(size.width - strokeWidth, size.height - strokeWidth)
+                    val insetOutline = shape.createOutline(insetSize, layoutDirection, this)
+                    val insetPath = Path().apply { addOutline(insetOutline) }
+                    insetPath.translate(Offset(halfStroke, halfStroke))
+                    drawPath(
+                        path = insetPath,
+                        color = color,
+                        style = Stroke(width = strokeWidth),
+                    )
+                }
+            }
         }
     }
+
+private fun shrinkCorner(
+    corner: CornerRadius,
+    inset: Float,
+): CornerRadius =
+    CornerRadius(
+        (corner.x - inset).coerceAtLeast(0f),
+        (corner.y - inset).coerceAtLeast(0f),
+    )

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/UndecoratedWindowBorder.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/UndecoratedWindowBorder.kt
@@ -4,15 +4,22 @@ package dev.nucleusframework.window.tao.deco
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.DecoratedWindowState
 import dev.nucleusframework.window.internal.insideBorder
 import dev.nucleusframework.window.styling.LocalDecoratedWindowStyle
+import dev.nucleusframework.window.tao.LocalTaoWindow
+import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
 
 // Soft elevation stroke layered under a dialog's regular border to lift it off
 // the (dimmed) parent. The window-border layer runs above where the app theme
@@ -38,6 +45,10 @@ private val DialogElevationStroke = Color(0x1F000000)
  *
  * Returns [Modifier] (no-op) when the window is maximized/fullscreen — the
  * border would otherwise overflow into the system reserved area.
+ *
+ * On Windows the contour is DWM's 1px frame (`DWMWA_BORDER_COLOR`), not a
+ * Compose stroke. A client-edge stroke is clipped by the rounded HWND or,
+ * if inset, reads as a second frame around the window (#526).
  */
 @Composable
 internal fun rememberUndecoratedWindowBorder(
@@ -47,8 +58,21 @@ internal fun rememberUndecoratedWindowBorder(
     kdeCornerArc: Float,
     isDialog: Boolean = false,
 ): Modifier {
-    if (state.isMaximized || state.isFullscreen) return Modifier
     val style = LocalDecoratedWindowStyle.current
+    val color by style.colors.borderFor(state)
+    if (Platform.Current == Platform.Windows) {
+        val window = LocalTaoWindow.current
+        val showFrame = !state.isMaximized && !state.isFullscreen
+        val frameArgb = color.compositeOver(style.colors.background).toArgb()
+        SideEffect {
+            val hwnd = window?.let { NativeTaoBridge.nativeHwndHandle(it.handle) } ?: 0L
+            if (hwnd != 0L && NativeTaoWindowsDecoBridge.isLoaded) {
+                NativeTaoWindowsDecoBridge.nativeSetBorderColor(hwnd, frameArgb, showFrame)
+            }
+        }
+        return Modifier
+    }
+    if (state.isMaximized || state.isFullscreen) return Modifier
     val borderShape =
         when {
             // Tiled/snapped windows sit flush against the screen edge with
@@ -65,18 +89,16 @@ internal fun rememberUndecoratedWindowBorder(
                     bottomStart = 0.dp,
                     bottomEnd = 0.dp,
                 )
-            // Win11 DWMWCP_ROUND is 8 logical px. A square stroke on a
-            // rounded HWND is clipped at the corners and reads as a box.
-            Platform.Current == Platform.Windows -> RoundedCornerShape(8.dp)
             else -> RoundedCornerShape(0.dp)
         }
-    val color by style.colors.borderFor(state)
     var modifier =
-        Modifier.insideBorder(
-            width = style.metrics.borderWidth,
-            color = color,
-            shape = borderShape,
-        )
+        Modifier
+            .clip(borderShape)
+            .insideBorder(
+                width = style.metrics.borderWidth,
+                color = color,
+                shape = borderShape,
+            )
     // Linux dialogs are undecorated, so the compositor draws no drop shadow —
     // lift them with an extra elevation stroke. Gated on a known Linux DE
     // (Windows passes Unknown) to keep native-shadowed platforms untouched.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
@@ -61,6 +61,17 @@ internal object NativeTaoWindowsDecoBridge {
     )
 
     /**
+     * Sets the DWM 1px frame colour so the contour follows Win11's rounded
+     * HWND clip. [visible] false hides it (maximized / fullscreen).
+     */
+    @JvmStatic
+    external fun nativeSetBorderColor(
+        hwnd: Long,
+        argb: Int,
+        visible: Boolean,
+    )
+
+    /**
      * Applies a system backdrop, where [style] is the
      * `DWM_SYSTEMBACKDROP_TYPE` wire value — see
      * [dev.nucleusframework.window.WindowsBackdropStyle]. Degrades across

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -73,6 +73,12 @@ typedef struct {
     WNDPROC originalWndProc;
     int     titleBarHeightPx;
     COLORREF bgColor;
+    /* Theme CSD contour (#526). When set, windowed chrome uses this as
+     * DWMWA_BORDER_COLOR so the 1px frame follows the rounded HWND —
+     * a Compose stroke on the client is either clipped at the corners
+     * or inset into a second contour. */
+    COLORREF borderColor;
+    BOOL    hasBorderColor;
     BOOL    startupBackgroundErase;
     BOOL    isFullscreen;
     LONG    savedStyle;
@@ -383,11 +389,13 @@ static void revertBackdropForClose(HWND hwnd, DecoState *state) {
  * border keeps DWM's default: COLOR_NONE on the border renders the top edge
  * as a bare black line instead of the subtle system frame.
  *
- * Windowed CSD (no backdrop) clears only the DWM *fill* (COLOR_NONE) so
- * Compose `insideBorder` is not painted over (#522). The 1px visible-frame
- * thickness stays: zeroing it (as overlays/fullscreen do) drops Win11's
- * 8px rounded clip and the window looks squared-off. The 1px bottom
- * DwmExtendFrame margin is unchanged — it only keeps the drop shadow. */
+ * Windowed CSD (no backdrop) keeps the 1px visible-frame thickness
+ * (zeroing it drops Win11's 8px rounded clip) and, when the app has
+ * pushed a theme colour, paints that as DWMWA_BORDER_COLOR so the
+ * contour follows the rounded HWND (#526). Compose no longer strokes
+ * the client edge — that stroke was either clipped at the corners or
+ * inset into a second frame. The 1px bottom DwmExtendFrame margin is
+ * unchanged — it only keeps the drop shadow. */
 static void applyCaptionColors(HWND hwnd, DecoState *state) {
     BOOL backdrop = state && state->backdropActive;
     BOOL borderless = state && state->borderlessChrome;
@@ -409,7 +417,9 @@ static void applyCaptionColors(HWND hwnd, DecoState *state) {
         thickness = 0;
         corner = NUCLEUS_DWMWCP_DONOTROUND;
     } else if (!backdrop) {
-        border = (COLORREF)DWMWA_COLOR_NONE;
+        border = (state && state->hasBorderColor)
+            ? state->borderColor
+            : (COLORREF)DWMWA_COLOR_NONE;
     }
     DwmSetWindowAttribute(hwnd, 35 /* DWMWA_CAPTION_COLOR */, &caption, sizeof(caption));
     DwmSetWindowAttribute(hwnd, 34 /* DWMWA_BORDER_COLOR */, &border, sizeof(border));
@@ -1118,6 +1128,33 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeSetBac
     }
     DwmSetWindowAttribute(hwnd, 20 /* DWMWA_USE_IMMERSIVE_DARK_MODE */,
                           &dark, sizeof(dark));
+}
+
+/**
+ * Theme colour for the DWM 1px frame (Win11 rounded clip). [visible] false
+ * hides it (maximized / fullscreen — same as skipping Compose insideBorder).
+ */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeSetBorderColor(
+    JNIEnv *env, jclass clazz, jlong hwndLong, jint argb, jboolean visible)
+{
+    (void)env; (void)clazz;
+    HWND hwnd = (HWND)(uintptr_t)hwndLong;
+    if (!hwnd) return;
+
+    DecoState *state = getState(hwnd);
+    if (state) {
+        if (visible) {
+            int r = (argb >> 16) & 0xFF;
+            int g = (argb >>  8) & 0xFF;
+            int b =  argb        & 0xFF;
+            state->borderColor = RGB(r, g, b);
+            state->hasBorderColor = TRUE;
+        } else {
+            state->hasBorderColor = FALSE;
+        }
+    }
+    applyCaptionColors(hwnd, state);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes #526: the Compose 1px CSD stroke was clipped by Win11 DWM rounded corners (and an inset stroke read as a second frame).
- Windowed Tao chrome now paints the contour with `DWMWA_BORDER_COLOR` so it follows the rounded HWND. Hidden when maximized/fullscreen.
- `insideBorder` now draws a concentric inside stroke (corner radii shrink by half the stroke, clipped to the shape) for Linux and other callers.

## Test plan
- [x] `./gradlew :examples:nucleus-demo:run` on Windows 11 — 1px frame follows all four rounded corners, no inner halo
- [x] Maximize / restore / fullscreen — no leftover DWM frame on the work area
- [x] Light and dark Material themes — frame color matches `outlineVariant`
- [x] Tiled/snapped window — square frame, no rounded leftover
- [x] Linux GNOME/KDE CSD still draws the Compose `insideBorder`