### PR TITLE
fix(tao): synchronize Windows multi-monitor popup DPI and work area c…

### DIFF
--- a/decorated-window-tao/POPUP_CONSTRAINTS_PLAN.md
+++ b/decorated-window-tao/POPUP_CONSTRAINTS_PLAN.md
@@ -127,14 +127,22 @@ The existing decoupling between `innerScene.size` (layout constraint, fixed) and
 1. ✅ **macOS JNI** — `nativeOwnerWorkAreaSize` in `NativeMetalBridge` + impl in `NucleusTaoMetal.m` (packs `(width<<32)|height`, returns 0 on unresolved screen).
 2. ✅ **macOS host** — `workAreaSize` added to `TaoPopupHost` (default = `parentWindowSize` fallback), implemented in `TaoComposeSceneHost.popupHost()`, forwarded in `NativeViewOverlayController.overlayPopupHost`.
 3. ✅ **macOS layer** — `TaoPopupSceneLayer` feeds `sceneLayoutSize = host.workAreaSize` to `CanvasLayersComposeScene(size = …)`. `widthPx/heightPx` (CAMetalLayer drawable + NSPanel) kept at `parentWindowSize` to avoid allocating a full-screen Metal drawable up front.
-4. ⏳ **Windows JNI** — add `nativeOwnerMonitorWorkArea` to `NativeTaoWindowsDecoBridge` + native side in `nucleus_tao_windows_deco.c`.
-5. ⏳ **Windows host** — same surface change in `TaoPopupHostWindows` + `TaoComposeSceneHostWindows` + `NativeViewOverlayControllerWindows`.
-6. ⏳ **Windows layer** — swap constant in `TaoPopupSceneLayerWindows`.
-7. ⏳ **GraalVM metadata** — outbound JNI methods don't need explicit registration (resolved by symbol lookup); revisit if a new callback class is introduced.
+4. ✅ **Windows JNI** — add `nativeOwnerMonitorWorkArea` to `NativeTaoWindowsDecoBridge` + native side in `nucleus_tao_windows_deco.c`.
+5. ✅ **Windows host** — same surface change in `TaoPopupHostWindows` + `TaoComposeSceneHostWindows` + `NativeViewOverlayControllerWindows`.
+6. ✅ **Windows layer** — swap constant in `TaoPopupSceneLayerWindows`.
+7. ✅ **GraalVM metadata** — outbound JNI methods don't need explicit registration (resolved by symbol lookup); revisit if a new callback class is introduced.
 8. **Manual verify** on each OS:
    - `nucleus-demo` app: open the title-bar tooltips at various window sizes — they should never be clipped by owner height.
    - Resize main window to 400×300 in the gallery; open the `DropdownMenu` on the gallery's color screen. Content should lay out unconstrained relative to the screen, not the owner.
    - Drag the window to the right edge; open a context menu that would extend past the owner's right edge. Expect normal layout (Compose's PositionProvider flips it, since now it knows the full space).
+
+## Multi-Monitor DPI Synchronization (Windows)
+
+Under Windows Per-Monitor DPI Aware v2 across mixed-DPI displays (e.g. 150% 4K primary + 100% 1080p secondary):
+1. **Creation Coordinates**: `TaoPopupSceneLayerWindows.ensurePanel` creates the native panel at the parent window's current coordinates (`initX, initY`) rather than off-screen (`-10000, -10000`). Off-screen coordinates were assigned to the primary display by OS default, causing a synthetic cross-monitor DPI leap when moved to the secondary display.
+2. **WM_DPICHANGED Handling**: `popupWndProc` in `nucleus_tao_windows_popup.c` ignores `WM_DPICHANGED` without calling `SetWindowPos`. Because Compose Multiplatform's layout engine already measures and positions the popup directly in physical pixels for the target monitor, letting the Win32 message loop auto-scale the HWND caused double-scaling / physical clipping (e.g. 102px window shrunk to 68px).
+3. **Reactive LocalDensity**: `TaoPopupSceneLayerWindows` provides `CompositionLocalProvider(LocalDensity provides densityState.value)` inside `innerScene.setContent`, ensuring font rasterization, `Paragraph` layout, and container measurements stay perfectly in sync with the current monitor's DPI.
+4. **Adapter Density Decoupling**: Removed static `sceneDensity` snapshot in `TaoDecoratedWindowAdapter.kt` that previously locked `LocalDensity` to startup display scale.
 
 ## Out of scope but worth noting later
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
@@ -257,16 +257,24 @@ private fun centerOnParentWindows(
     if (hwnd == 0L) return null
     val parentRectPhys = NativeTaoWindowsDecoBridge.nativeGetWindowRect(hwnd) ?: return null
 
-    val scaleMilli = NativeTaoBridge.nativeScaleFactor(parent.handle).coerceAtLeast(1)
-    val scale = scaleMilli / 1000.0
+    val parentScaleMilli = NativeTaoBridge.nativeScaleFactor(parent.handle).coerceAtLeast(1)
+    val parentScale = parentScaleMilli / 1000.0
 
-    val parentXDp = parentRectPhys[0] / scale
-    val parentYDp = parentRectPhys[1] / scale
-    val parentWDp = parentRectPhys[2] / scale
-    val parentHDp = parentRectPhys[3] / scale
+    // Target physical center in virtual screen coordinates:
+    val dialogWidthPhys = dialogWidthDp * parentScale
+    val dialogHeightPhys = dialogHeightDp * parentScale
+    val targetCenterXPhys = parentRectPhys[0] + (parentRectPhys[2] - dialogWidthPhys) / 2.0
+    val targetCenterYPhys = parentRectPhys[1] + (parentRectPhys[3] - dialogHeightPhys) / 2.0
 
-    val cx = (parentXDp + (parentWDp - dialogWidthDp) / 2.0).toFloat()
-    val cy = (parentYDp + (parentHDp - dialogHeightDp) / 2.0).toFloat()
+    // Tao creates newly constructed windows at the primary monitor's initial scale.
+    // When Tao applies LogicalPosition(x, y), it multiplies by that initial scale.
+    // Converting target physical coordinates by the initial scale guarantees that
+    // Tao's multiplication reproduces the exact physical pixel location on the target monitor.
+    val initScaleMilli = NativeTaoWindowsDecoBridge.nativeGetPrimaryMonitorScaleMilli().coerceAtLeast(1)
+    val initScale = initScaleMilli / 1000.0
+
+    val cx = (targetCenterXPhys / initScale).toFloat()
+    val cy = (targetCenterYPhys / initScale).toFloat()
     return WindowPosition.Absolute(cx.dp, cy.dp)
 }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
@@ -226,6 +226,14 @@ internal object NativeTaoWindowsDecoBridge {
     external fun nativeGetWindowRect(hwnd: Long): LongArray?
 
     /**
+     * Returns the work area (screen minus taskbar) of the monitor hosting [hwnd]
+     * as `[x, y, width, height]` in physical pixels. If [hwnd] is 0 or invalid,
+     * falls back to the primary monitor.
+     */
+    @JvmStatic
+    external fun nativeOwnerMonitorWorkArea(hwnd: Long): LongArray?
+
+    /**
      * Returns the primary monitor's work area (full screen minus taskbar) as
      * `[x, y, width, height]` in physical pixels. Used to resolve
      * [androidx.compose.ui.window.WindowPosition.Aligned] for the initial

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -12,6 +14,8 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
@@ -56,11 +60,9 @@ internal class TaoPopupSceneLayerWindows(
     @Suppress("UNUSED_PARAMETER") parentCompositionContext: CompositionContext,
 ) : ComposeSceneLayer {
     private var _density = initialDensity
-    private val densityState: androidx.compose.runtime.MutableState<Density> =
-        androidx.compose.runtime.mutableStateOf(initialDensity)
+    private val densityState: MutableState<Density> = mutableStateOf(initialDensity)
     private var _layoutDirection = initialLayoutDirection
-    private val layoutDirectionState: androidx.compose.runtime.MutableState<LayoutDirection> =
-        androidx.compose.runtime.mutableStateOf(initialLayoutDirection)
+    private val layoutDirectionState: MutableState<LayoutDirection> = mutableStateOf(initialLayoutDirection)
     private var _focusable = initialFocusable
     private var _bounds: IntRect = IntRect.Zero
     private var _scrimColor: Color? = null
@@ -286,7 +288,6 @@ internal class TaoPopupSceneLayerWindows(
     override var boundsInWindow: IntRect
         get() = _bounds
         set(value) {
-            val oldBounds = _bounds
             _bounds = value
             updateDrawBoundsFromBounds()
             host.requestRedraw()
@@ -327,8 +328,8 @@ internal class TaoPopupSceneLayerWindows(
             val locals = _compositionLocalContext
             val body: @Composable () -> Unit = {
                 CompositionLocalProvider(
-                    androidx.compose.ui.platform.LocalDensity provides densityState.value,
-                    androidx.compose.ui.platform.LocalLayoutDirection provides layoutDirectionState.value,
+                    LocalDensity provides densityState.value,
+                    LocalLayoutDirection provides layoutDirectionState.value,
                 ) {
                     content()
                 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -35,6 +35,17 @@ import org.jetbrains.skia.DirectContext
  * parent-window coordinates. The native popup surface is kept exactly
  * at content bounds because transparent pixels around the content are not
  * reliably alpha-composited by DWM on all Windows drivers.
+ *
+ * ### Multi-Monitor DPI Synchronization:
+ * Under Windows Per-Monitor DPI Aware v2:
+ * 1. The native panel is created at the parent window's current coordinates so
+ *    Windows associates the HWND with the target monitor's DPI immediately.
+ * 2. `WM_DPICHANGED` on the popup HWND is ignored by the native WndProc because
+ *    Compose Multiplatform layout explicitly manages physical pixel sizing via
+ *    [updateNativeFrame].
+ * 3. [densityState] reactively propagates dynamic monitor DPI changes into
+ *    [innerScene]'s [androidx.compose.ui.platform.LocalDensity], ensuring font rasterization
+ *    and container measurement stay synchronized across displays.
  */
 @OptIn(InternalComposeUiApi::class)
 internal class TaoPopupSceneLayerWindows(
@@ -45,7 +56,11 @@ internal class TaoPopupSceneLayerWindows(
     @Suppress("UNUSED_PARAMETER") parentCompositionContext: CompositionContext,
 ) : ComposeSceneLayer {
     private var _density = initialDensity
+    private val densityState: androidx.compose.runtime.MutableState<Density> =
+        androidx.compose.runtime.mutableStateOf(initialDensity)
     private var _layoutDirection = initialLayoutDirection
+    private val layoutDirectionState: androidx.compose.runtime.MutableState<LayoutDirection> =
+        androidx.compose.runtime.mutableStateOf(initialLayoutDirection)
     private var _focusable = initialFocusable
     private var _bounds: IntRect = IntRect.Zero
     private var _scrimColor: Color? = null
@@ -106,12 +121,15 @@ internal class TaoPopupSceneLayerWindows(
     private fun ensurePanel(): Boolean {
         if (panelHandle != 0L) return true
         if (panelCreateFailed) return false
+        val offset = host.coordinateOffset
+        val initX = if (_bounds != IntRect.Zero) _bounds.left + offset.x else 0
+        val initY = if (_bounds != IntRect.Zero) _bounds.top + offset.y else 0
         val handle =
             PopupNativeBridgeWindows
                 .nativeCreatePanel(
                     parentHwnd = host.parentHwnd,
-                    xPx = -OFFSCREEN_OFFSET_PX,
-                    yPx = -OFFSCREEN_OFFSET_PX,
+                    xPx = initX,
+                    yPx = initY,
                     widthPx = widthPx,
                     heightPx = heightPx,
                 )
@@ -253,6 +271,7 @@ internal class TaoPopupSceneLayerWindows(
         get() = _density
         set(value) {
             _density = value
+            densityState.value = value
             innerScene.density = value
         }
 
@@ -260,12 +279,14 @@ internal class TaoPopupSceneLayerWindows(
         get() = _layoutDirection
         set(value) {
             _layoutDirection = value
+            layoutDirectionState.value = value
             innerScene.layoutDirection = value
         }
 
     override var boundsInWindow: IntRect
         get() = _bounds
         set(value) {
+            val oldBounds = _bounds
             _bounds = value
             updateDrawBoundsFromBounds()
             host.requestRedraw()
@@ -304,10 +325,18 @@ internal class TaoPopupSceneLayerWindows(
     override fun setContent(content: @Composable () -> Unit) {
         innerScene.setContent {
             val locals = _compositionLocalContext
+            val body: @Composable () -> Unit = {
+                CompositionLocalProvider(
+                    androidx.compose.ui.platform.LocalDensity provides densityState.value,
+                    androidx.compose.ui.platform.LocalLayoutDirection provides layoutDirectionState.value,
+                ) {
+                    content()
+                }
+            }
             if (locals != null) {
-                CompositionLocalProvider(locals) { content() }
+                CompositionLocalProvider(locals) { body() }
             } else {
-                content()
+                body()
             }
         }
         host.requestRedraw()
@@ -387,10 +416,12 @@ internal class TaoPopupSceneLayerWindows(
         if (panelHandle == 0L) return
         if (drawBounds == IntRect.Zero || _bounds == IntRect.Zero) return
         val offset = host.coordinateOffset
+        val finalX = drawBounds.left + offset.x
+        val finalY = drawBounds.top + offset.y
         PopupNativeBridgeWindows.nativeSetFrameInWindow(
             panel = panelHandle,
-            xPx = drawBounds.left + offset.x,
-            yPx = drawBounds.top + offset.y,
+            xPx = finalX,
+            yPx = finalY,
             widthPx = drawBounds.width.coerceAtLeast(1),
             heightPx = drawBounds.height.coerceAtLeast(1),
             contentXPx = _bounds.left - drawBounds.left,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -4,6 +4,7 @@ package dev.nucleusframework.window.tao.scene
 
 import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,6 +18,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeScenePointer
@@ -194,8 +196,7 @@ internal class TaoComposeSceneHostWindows(
     private var widthPx: Int = 0
     private var heightPx: Int = 0
     private var scale: Float = 1f
-    private val scaleState: androidx.compose.runtime.MutableState<Float> =
-        androidx.compose.runtime.mutableStateOf(1f)
+    private val scaleState: MutableState<Float> = mutableStateOf(1f)
 
     /** True while the OS modal resize/move loop is active. */
     private var resizeLoopActive: Boolean = false
@@ -871,8 +872,8 @@ internal class TaoComposeSceneHostWindows(
             // lines-per-notch factor is reapplied (see TaoWindowsScrollConfig).
             ProvideTaoWindowsScrollConfig {
                 TaoTextToolbarHost(textToolbar) {
-                    androidx.compose.runtime.CompositionLocalProvider(
-                        androidx.compose.ui.platform.LocalDensity provides androidx.compose.ui.unit.Density(scaleState.value),
+                    CompositionLocalProvider(
+                        LocalDensity provides Density(scaleState.value),
                     ) {
                         content()
                     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -194,6 +194,8 @@ internal class TaoComposeSceneHostWindows(
     private var widthPx: Int = 0
     private var heightPx: Int = 0
     private var scale: Float = 1f
+    private val scaleState: androidx.compose.runtime.MutableState<Float> =
+        androidx.compose.runtime.mutableStateOf(1f)
 
     /** True while the OS modal resize/move loop is active. */
     private var resizeLoopActive: Boolean = false
@@ -281,6 +283,7 @@ internal class TaoComposeSceneHostWindows(
         // Title-bar height is set later — the value the TitleBar composable publishes
         // via SideEffect arrives after first composition.
         scale = NativeTaoBridge.nativeScaleFactor(window.handle) / 1000f
+        scaleState.value = scale
         // Borderless overlays have no caption chrome: keep the deco zone at 0
         // so we don't reserve a phantom 28px title-bar hit band.
         val initialTitleBarPx =
@@ -867,7 +870,13 @@ internal class TaoComposeSceneHostWindows(
             // Stock Compose Desktop Windows wheel behavior; only the
             // lines-per-notch factor is reapplied (see TaoWindowsScrollConfig).
             ProvideTaoWindowsScrollConfig {
-                TaoTextToolbarHost(textToolbar, content)
+                TaoTextToolbarHost(textToolbar) {
+                    androidx.compose.runtime.CompositionLocalProvider(
+                        androidx.compose.ui.platform.LocalDensity provides androidx.compose.ui.unit.Density(scaleState.value),
+                    ) {
+                        content()
+                    }
+                }
             }
         }
     }
@@ -1091,6 +1100,7 @@ internal class TaoComposeSceneHostWindows(
     fun onScaleFactorChanged(newScale: Float) {
         if (newScale == scale) return
         scale = newScale
+        scaleState.value = newScale
         scene?.density = Density(scale)
         NativeTaoGlBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
         // Re-publish title-bar height in physical pixels so the deco WndProc
@@ -1463,16 +1473,10 @@ internal class TaoComposeSceneHostWindows(
             override val scale: Float get() = outer.scale
             override val parentWindowSize: IntSize get() = IntSize(outer.widthPx, outer.heightPx)
             override val workAreaSize: IntSize get() {
-                // Use the primary monitor's work area resolved via the
-                // existing JNI bridge — avoids touching AWT
-                // (GraphicsEnvironment.getLocalGraphicsEnvironment) on the
-                // Tao UI thread, which on Windows can lazily initialise
-                // Java2D's D3D pipeline and conflict with the ES context
-                // bound to this thread (manifested as a hang + crash when
-                // a second host attached, e.g. on DecoratedDialog open).
                 if (!NativeTaoWindowsDecoBridge.isLoaded) return parentWindowSize
                 val area =
-                    NativeTaoWindowsDecoBridge.nativeGetPrimaryMonitorWorkArea()
+                    NativeTaoWindowsDecoBridge.nativeOwnerMonitorWorkArea(outer.hwnd)
+                        ?: NativeTaoWindowsDecoBridge.nativeGetPrimaryMonitorWorkArea()
                         ?: return parentWindowSize
                 if (area.size < 4) return parentWindowSize
                 val w = area[2].toInt().coerceAtLeast(1)

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -1663,6 +1663,53 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeGetPri
     return (jint)((dpi * 1000) / 96);
 }
 
+/* Returns [x, y, width, height] of the work area (screen minus taskbar) of the
+ * monitor hosting hwnd in physical pixels. If hwnd is NULL or invalid, falls
+ * back to the primary monitor work area. */
+JNIEXPORT jlongArray JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeOwnerMonitorWorkArea(
+    JNIEnv *env, jclass clazz, jlong hwndLong)
+{
+    (void)clazz;
+    HWND hwnd = (HWND)(uintptr_t)hwndLong;
+    MONITORINFO mi;
+    memset(&mi, 0, sizeof(mi));
+    mi.cbSize = sizeof(mi);
+
+    HMONITOR mon = NULL;
+    if (hwnd && IsWindow(hwnd)) {
+        mon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    }
+    if (!mon) {
+        POINT ptZero = {0, 0};
+        mon = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
+    }
+
+    if (mon && GetMonitorInfoW(mon, &mi)) {
+        jlongArray arr = (*env)->NewLongArray(env, 4);
+        if (!arr) return NULL;
+        jlong values[4];
+        values[0] = (jlong)mi.rcWork.left;
+        values[1] = (jlong)mi.rcWork.top;
+        values[2] = (jlong)(mi.rcWork.right - mi.rcWork.left);
+        values[3] = (jlong)(mi.rcWork.bottom - mi.rcWork.top);
+        (*env)->SetLongArrayRegion(env, arr, 0, 4, values);
+        return arr;
+    }
+
+    RECT r;
+    if (!SystemParametersInfoW(SPI_GETWORKAREA, 0, &r, 0)) return NULL;
+    jlongArray arr = (*env)->NewLongArray(env, 4);
+    if (!arr) return NULL;
+    jlong values[4];
+    values[0] = (jlong)r.left;
+    values[1] = (jlong)r.top;
+    values[2] = (jlong)(r.right - r.left);
+    values[3] = (jlong)(r.bottom - r.top);
+    (*env)->SetLongArrayRegion(env, arr, 0, 4, values);
+    return arr;
+}
+
 /* Returns [x, y, width, height] of the primary monitor's work area (full
  * screen minus the taskbar) in physical pixels. Used by DecoratedWindow to
  * resolve [WindowPosition.Aligned] for the initial outer position. */
@@ -1683,6 +1730,8 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeGetPri
     (*env)->SetLongArrayRegion(env, arr, 0, 4, values);
     return arr;
 }
+
+
 
 /* Converts a window-client physical pixel position to screen physical
  * pixels. Returns [screenX, screenY] or NULL on failure. Used by the

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_popup.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_popup.c
@@ -611,15 +611,10 @@ static LRESULT CALLBACK popupWndProc(HWND hwnd, UINT msg, WPARAM w, LPARAM l) {
         return 0;
     }
 
-    case WM_DPICHANGED: {
-        const RECT *prc = (const RECT *)l;
-        if (prc) {
-            SetWindowPos(hwnd, NULL, prc->left, prc->top,
-                         prc->right - prc->left, prc->bottom - prc->top,
-                         SWP_NOZORDER | SWP_NOACTIVATE);
-        }
+    case WM_DPICHANGED:
+        /* Compose layer explicitly controls popup position and physical pixel size.
+         * Do not let OS auto-scale the HWND behind Compose's back. */
         return 0;
-    }
 
     case WM_ERASEBKGND:
         return 1;

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -145,7 +145,6 @@ internal object TaoDecoratedWindowAdapter {
                 // parentLayoutDirection, captured outside.
                 val bridge = LocalTaoCompositionLocalContextBridge.current
                 SideEffect { bridge?.invoke(outerLocals) }
-                val sceneDensity = LocalDensity.current
                 // The app theme's own LocalTextContextMenu (e.g. Jewel's) is not a
                 // scene-owned local, so it does come through outerLocals and shadows
                 // the scene's selection observer — silently breaking cross-process
@@ -157,7 +156,6 @@ internal object TaoDecoratedWindowAdapter {
                 val sceneTaoWindow = LocalTaoWindow.current
                 val sceneTitleBarInfo = LocalTitleBarInfo.current
                 CompositionLocalProvider(
-                    LocalDensity provides sceneDensity,
                     LocalLayoutDirection provides parentLayoutDirection,
                     LocalTaoTextSelectionA11yPublisher provides scenePublisher,
                     LocalNucleusBackend provides NucleusBackend.Tao,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.window.WindowState


### PR DESCRIPTION
## 🚀 Description
This PR fixes multi-monitor mixed-DPI clipping and positioning issues for Tao Windows popups and dialogs:
1. **Popup WM_DPICHANGED**: Prevents OS-driven auto-resizing of `WS_POPUP` HWNDs in `nucleus_tao_windows_popup.c` under Per-Monitor DPI Aware v2. Compose directly manages popup placement and physical pixel sizing, avoiding double-scaling that previously clipped text and borders when moved to a secondary display.
2. **Popup creation coordinates**: Initializes the native popup panel at the parent window's current relative coordinates rather than off-screen (`-10000, -10000`), preventing Windows from falsely assigning the initial HWND to the primary monitor's DPI.
3. **Reactive LocalDensity**: Propagates `densityState` into `innerScene` via `CompositionLocalProvider(LocalDensity provides densityState.value)` in `TaoPopupSceneLayerWindows`, and removes the stale static snapshot in `TaoDecoratedWindowAdapter`.
4. **Popup layout constraints**: Exposes `nativeOwnerMonitorWorkArea` in `nucleus_tao_windows_deco.c` / `TaoComposeSceneHostWindows` to unconstrain popup inner-scenes to the monitor's work area instead of the owner window size.
5. **DecoratedDialog multi-monitor centering**: Fixes `centerOnParentWindows` in `DecoratedDialog.kt` to compute target physical coordinates on virtual desktop space and convert them using the initial primary scale factor, ensuring newly created dialogs are correctly centered on secondary/lower-DPI monitors rather than placed off-screen.

## 📄 Motivation and Context
- When dragging the main window between monitors with different DPI scales (e.g. 4K @ 150% and 1080p @ 100%), tooltips and popups were clipped horizontally and vertically on the secondary monitor.
- Opening a `DecoratedDialog` (e.g. System Info dialog) while the owner window was on a secondary monitor resulted in the dialog being placed off-screen due to mismatched DP-to-pixel scale assumptions in `set_outer_position`.

## 🧪 How Has This Been Tested?
- **Environment**: Windows 11 x64, dual-monitor setup (Primary: 4K 3840×2160 @ 150% DPI scale; Secondary: 1080p 1920×1080 @ 100% DPI scale).
- **Manual Verification**:
  - Ran `:examples:nucleus-demo`.
  - Moved the main window across both displays and hovered over title bar buttons (tooltips) — verified that text and borders are fully rendered without clipping on both 150% and 100% screens.
  - Opened `System Info` dialog from the title bar while on the secondary 1080p display — verified the dialog accurately centers over the parent window and is fully visible.
  - Verified no regression in popup dismissal, window moving, or rendering.

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.