### PR TITLE
fix(tao): show the macOS press-and-hold accent picker

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -1536,10 +1536,11 @@ private class TaoPlatformContext(
     override suspend fun startInputMethod(
         request: androidx.compose.ui.platform.PlatformTextInputMethodRequest,
     ): Nothing {
-        // Keep TaoView as firstResponder, matching Compose AWT's single
-        // component model. Making a hidden NSTextView firstResponder causes
-        // AppKit to push an I-beam cursor for the whole window before the
-        // first pointer interaction on macOS.
+        // Keep TaoView as firstResponder. Activating its NSTextInputContext
+        // (and swizzling selectedRange / validAttributes / firstRect) is
+        // what lets AppKit's PressAndHold accent picker engage; a hidden
+        // NSTextView overlay was tried and rejected because it forced an
+        // I-beam cursor for the whole window.
         NativeTaoBridge.nativeActivateInputContext(windowHandle)
         coroutineScope {
             launch {

--- a/decorated-window-tao/src/main/native/macos/main_thread_dispatch.m
+++ b/decorated-window-tao/src/main/native/macos/main_thread_dispatch.m
@@ -65,11 +65,12 @@ void nucleus_tao_install_cmd_q_handler(void) {
 // `ApplePressAndHoldEnabled` user default. We set it everywhere we can — App
 // domain, Argument volatile domain, CFPreferences, registration domain — both
 // from `+load` (= dyld load time, before any Compose/AWT static init) and at
-// runtime. Note: empirically this is **insufficient** for Tao's bare NSView;
-// AppKit's `_NSKeyBindingManager` has additional internal checks tied to
-// NSTextView/NSTextField subclasses that we cannot satisfy from outside.
-// The flag plumbing is kept anyway since it's harmless and required for any
-// future native-image/sub-process scenario.
+// runtime. The picker itself is an input method: it only engages when
+// `interpretKeyEvents:` sees the *repeat* keyDown after the initial press.
+// Tao used to skip those repeats (see vendored `view.rs`); that was the
+// actual blocker, not the NSView class hierarchy. These defaults stay
+// required so a user-level `defaults write -g ApplePressAndHoldEnabled -bool
+// false` cannot silently disable the picker for Nucleus apps.
 static void nucleus_tao_force_press_and_hold(void) {
     @autoreleasepool {
         [[NSUserDefaults standardUserDefaults]
@@ -145,11 +146,83 @@ static NSArray<NSAttributedStringKey> *tao_view_valid_attributes_for_marked_text
     ];
 }
 
+// PressAndHold inserts the base character first (`insertText:@"e"`), then
+// on the first repeat marks it (`setMarkedText:@"e"`) and shows the picker.
+// Picking an accent calls `insertText:@"é"`. Compose has no composition
+// range, so without a delete the field would read "eé". We remember the
+// last committed scalar count and emit that many backspaces before the
+// replacement insert.
+static NSUInteger g_last_inserted_scalars = 0;
+static BOOL g_pending_ime_replace = NO;
+static IMP g_orig_set_marked_text = NULL;
+static IMP g_orig_insert_text = NULL;
+static IMP g_orig_unmark_text = NULL;
+static void (*g_ime_delete_previous)(long ns_view, int count) = NULL;
+
+void nucleus_tao_register_ime_delete_callback(void (*cb)(long, int)) {
+    g_ime_delete_previous = cb;
+}
+
+static NSString *nucleus_string_from_ime_arg(id string) {
+    if ([string isKindOfClass:[NSAttributedString class]]) {
+        return [(NSAttributedString *)string string];
+    }
+    return (NSString *)string;
+}
+
+static NSUInteger nucleus_utf16_scalar_count(NSString *s) {
+    if (!s) return 0;
+    NSUInteger count = 0;
+    NSUInteger len = s.length;
+    for (NSUInteger i = 0; i < len; ) {
+        unichar c = [s characterAtIndex:i];
+        if (CFStringIsSurrogateHighCharacter(c) && i + 1 < len) {
+            i += 2;
+        } else {
+            i += 1;
+        }
+        count++;
+    }
+    return count;
+}
+
+static void nucleus_set_marked_text(
+    id self, SEL sel, id string, NSRange selected, NSRange replacement
+) {
+    if (g_last_inserted_scalars > 0) {
+        g_pending_ime_replace = YES;
+    }
+    if (g_orig_set_marked_text) {
+        ((void (*)(id, SEL, id, NSRange, NSRange))g_orig_set_marked_text)(
+            self, sel, string, selected, replacement
+        );
+    }
+}
+
+static void nucleus_insert_text(id self, SEL sel, id string, NSRange replacement) {
+    if (g_pending_ime_replace && g_last_inserted_scalars > 0 && g_ime_delete_previous) {
+        g_ime_delete_previous((long)(__bridge void *)self, (int)g_last_inserted_scalars);
+        g_last_inserted_scalars = 0;
+    }
+    g_pending_ime_replace = NO;
+    if (g_orig_insert_text) {
+        ((void (*)(id, SEL, id, NSRange))g_orig_insert_text)(self, sel, string, replacement);
+    }
+    g_last_inserted_scalars = nucleus_utf16_scalar_count(nucleus_string_from_ime_arg(string));
+}
+
+static void nucleus_unmark_text(id self, SEL sel) {
+    g_pending_ime_replace = NO;
+    if (g_orig_unmark_text) {
+        ((void (*)(id, SEL))g_orig_unmark_text)(self, sel);
+    }
+}
+
 static void nucleus_tao_swizzle_view_methods_once(void) {
+    Class taoViewClass = objc_getClass("TaoView");
+    if (!taoViewClass) return;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        Class taoViewClass = objc_getClass("TaoView");
-        if (!taoViewClass) return;
         class_replaceMethod(taoViewClass,
                             @selector(selectedRange),
                             (IMP)tao_view_selected_range,
@@ -162,6 +235,22 @@ static void nucleus_tao_swizzle_view_methods_once(void) {
                             @selector(validAttributesForMarkedText),
                             (IMP)tao_view_valid_attributes_for_marked_text,
                             "@@:");
+        Method setMarked = class_getInstanceMethod(
+            taoViewClass, @selector(setMarkedText:selectedRange:replacementRange:)
+        );
+        if (setMarked) {
+            g_orig_set_marked_text = method_setImplementation(setMarked, (IMP)nucleus_set_marked_text);
+        }
+        Method insertText = class_getInstanceMethod(
+            taoViewClass, @selector(insertText:replacementRange:)
+        );
+        if (insertText) {
+            g_orig_insert_text = method_setImplementation(insertText, (IMP)nucleus_insert_text);
+        }
+        Method unmark = class_getInstanceMethod(taoViewClass, @selector(unmarkText));
+        if (unmark) {
+            g_orig_unmark_text = method_setImplementation(unmark, (IMP)nucleus_unmark_text);
+        }
     });
 }
 

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -145,6 +145,9 @@ pub(crate) fn run_event_loop_blocking() {
     unsafe {
         crate::platform::macos::ffi::nucleus_tao_install_cmd_q_handler();
         crate::platform::macos::ffi::nucleus_tao_enable_press_and_hold();
+        crate::platform::macos::ffi::nucleus_tao_register_ime_delete_callback(
+            crate::platform::macos::ime::ime_delete_previous_callback,
+        );
         crate::platform::macos::ffi::nucleus_tao_install_drag_monitor();
         crate::platform::macos::ffi::nucleus_tao_register_trackpad_gesture_callback(
             crate::platform::macos::trackpad_gesture_callback,

--- a/decorated-window-tao/src/main/native/src/platform/macos/ffi.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/ffi.rs
@@ -13,6 +13,7 @@ extern "C" {
     pub(crate) fn nucleus_tao_is_main_thread() -> i32;
     pub(crate) fn nucleus_tao_install_cmd_q_handler();
     pub(crate) fn nucleus_tao_enable_press_and_hold();
+    pub(crate) fn nucleus_tao_register_ime_delete_callback(cb: extern "C" fn(i64, i32));
     pub(crate) fn nucleus_tao_activate_input_context(ns_view_handle: i64);
     pub(crate) fn nucleus_tao_set_ime_local_rect(
         ns_view_handle: i64,

--- a/decorated-window-tao/src/main/native/src/platform/macos/ime.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/ime.rs
@@ -6,10 +6,52 @@ use jni::JNIEnv;
 
 use tao::platform::macos::WindowExtMacOS;
 
+use crate::events::{dispatch_key, EVENT_KEY_DOWN, EVENT_KEY_UP};
+use crate::keymap;
 use crate::platform::macos::ffi::{
     nucleus_tao_activate_input_context, nucleus_tao_set_ime_local_rect,
 };
 use crate::state::WINDOWS;
+
+fn handle_for_ns_view(ns_view_ptr: i64) -> Option<u64> {
+    if ns_view_ptr == 0 {
+        return None;
+    }
+    let target = ns_view_ptr as usize;
+    let guard = WINDOWS.lock().ok()?;
+    let map = guard.as_ref()?;
+    map.iter()
+        .find(|(_, w)| w.ns_view() as usize == target)
+        .map(|(h, _)| *h)
+}
+
+/// Called from the ObjC `insertText:` swizzle when PressAndHold replaces a
+/// previously committed character (e → é). Emits Backspace to Compose so
+/// the next `ReceivedImeText` overwrites instead of appending.
+pub(crate) extern "C" fn ime_delete_previous_callback(ns_view: i64, count: i32) {
+    let Some(handle) = handle_for_ns_view(ns_view) else {
+        return;
+    };
+    let n = count.clamp(0, 16);
+    for _ in 0..n {
+        dispatch_key(
+            handle,
+            EVENT_KEY_DOWN,
+            8, // AWT VK_BACK_SPACE
+            keymap::LOC_STANDARD,
+            0,
+            0,
+        );
+        dispatch_key(
+            handle,
+            EVENT_KEY_UP,
+            8,
+            keymap::LOC_STANDARD,
+            0,
+            0,
+        );
+    }
+}
 
 #[no_mangle]
 pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_nativeActivateInputContext(

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/macos/view.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/macos/view.rs
@@ -680,38 +680,41 @@ extern "C" fn key_down(this: &mut Object, _sel: Sel, event: &NSEvent) {
 
     update_potentially_stale_modifiers(state, event);
 
-    let pass_along = !is_repeat || !state.is_key_down;
-    if pass_along {
-      // See below for why we do this.
+    // Always feed the event to the input context — including key-repeat
+    // events. AppKit's PressAndHold (long-press a letter → accent picker)
+    // is an input method that only engages on the first *repeat* after the
+    // initial keyDown. The previous `!is_repeat` skip was a leftover from
+    // when characters were synthesized both here and in `insertText:`;
+    // Nucleus inserts solely via `ReceivedImeText`, so repeats no longer
+    // double-type. They either start PressAndHold or produce genuine
+    // key-repeat `insertText:` calls (eeee).
+    //
+    // During an active preedit (dead key or the accent picker) we must
+    // keep `hasMarkedText == YES`. Clearing the ivar made a follow-up
+    // key (e.g. "2" to pick é) look like a regular insert.
+    if !state.in_ime_preedit {
       let marked_text_ref: &mut *mut NSMutableAttributedString = this.get_mut_ivar("markedText");
       let () = msg_send![(*marked_text_ref), release];
       *marked_text_ref = Retained::into_raw(NSMutableAttributedString::new());
-      state.key_triggered_ime = false;
-
-      // Some keys (and only *some*, with no known reason) don't trigger `insertText`, while others do...
-      // So, we don't give repeats the opportunity to trigger that, since otherwise our hack will cause some
-      // keys to generate twice as many characters.
-      let array: id = msg_send![class!(NSArray), arrayWithObject: event];
-      let () = msg_send![&*this, interpretKeyEvents: array];
     }
-    // The `interpretKeyEvents` above, may invoke `set_marked_text` or `insert_text`,
-    // if the event corresponds to an IME event.
+    state.key_triggered_ime = false;
+
+    let array: id = msg_send![class!(NSArray), arrayWithObject: event];
+    let () = msg_send![&*this, interpretKeyEvents: array];
+
+    // The `interpretKeyEvents` above may invoke `set_marked_text` or `insert_text`.
     let in_ime = state.key_triggered_ime;
     let key_event = create_key_event(event, true, is_repeat, in_ime, None);
     let is_arrow_key = is_arrow_key(key_event.physical_key);
-    if pass_along {
-      // The `interpretKeyEvents` above, may invoke `set_marked_text` or `insert_text`,
-      // if the event corresponds to an IME event.
-      // If `set_marked_text` or `insert_text` were not invoked, then the IME was deactivated,
-      // and we should cancel the IME session.
-      // When using arrow keys in an IME window, the input context won't invoke the
-      // IME related methods, so in that case we shouldn't cancel the IME session.
-      let is_preediting: bool = state.in_ime_preedit;
-      if is_preediting && !state.key_triggered_ime && !is_arrow_key {
-        // In this case we should cancel the IME session.
-        let () = msg_send![this, unmarkText];
-        state.in_ime_preedit = false;
-      }
+    // If `set_marked_text` or `insert_text` were not invoked, then the IME
+    // was deactivated, and we should cancel the IME session. Arrow keys
+    // inside an IME window don't invoke those methods — don't cancel then.
+    // Repeat keyDowns while PressAndHold is showing the picker also don't
+    // re-enter those methods; cancelling on them would dismiss the picker.
+    let is_preediting: bool = state.in_ime_preedit;
+    if is_preediting && !state.key_triggered_ime && !is_arrow_key && !is_repeat {
+      let () = msg_send![this, unmarkText];
+      state.in_ime_preedit = false;
     }
     let window_event = Event::WindowEvent {
       window_id,


### PR DESCRIPTION
## 🚀 Description

Long-pressing a letter in a Compose `BasicTextField` on macOS (tao backend) never showed the system accent picker. Dead keys (`'` then `e`) already worked.

Tao's `keyDown:` skipped `interpretKeyEvents:` on key-repeat. PressAndHold is an input method that only engages on the first *repeat* after the initial press, so the picker never started.

This change:

- Feeds every keyDown — including repeats — to `interpretKeyEvents:`
- Leaves marked text in place during an active preedit so choosing an accent with `2` / click is not treated as a fresh insert
- Does not cancel the IME session on later repeats (that would dismiss the picker)
- Replaces the already-committed base character (`e` → `é`) instead of appending (`eé`)

A previous NSTextView overlay that made the picker work was reverted because it forced an I-beam cursor on the whole window. This keeps TaoView as firstResponder.

## 📄 Motivation and Context

Reported against OfflineTranslator (tao + `BasicTextField`). Holding `e` did nothing after the first character; `' + e` produced `é`. Same path as Chrome/WebKit: the picker is PressAndHold, not a dead key.

Natives are built in CI from `src/main/native/**` (`libnucleus_tao.dylib` is gitignored).

## 🧪 How Has This Been Tested?

- [x] `cargo build --release --target aarch64-apple-darwin` for `decorated-window-tao` natives
- [ ] Manual: focus a `BasicTextField`, long-press `e` — picker appears under the caret
- [ ] Manual: pick `é` with `2` or a click — field contains `é`, not `eé`
- [ ] Manual: release without picking — field keeps `e`
- [ ] Manual: dead key `' + e` still inserts `é`
- [ ] Manual: hold a letter with no variants (or PressAndHold disabled) — key repeat (`eeee`)
- [ ] Manual: CJK / dead-key composition still commits a single replacement, no extra backspaces

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.