### PR TITLE
fix(tao-linux): restore mouse wheel scrolling for discrete scroll events

### DIFF
--- a/buildSrc/src/main/kotlin/dev/nucleusframework/gradle/NativeModulePlugin.kt
+++ b/buildSrc/src/main/kotlin/dev/nucleusframework/gradle/NativeModulePlugin.kt
@@ -99,7 +99,11 @@ open class NativeModuleExtension(
                 // only the launcher script under the per-OS directory.
                 include("Cargo.toml", "Cargo.lock", "build.rs", "src/**")
                 include("${target.sourceDirName}/**")
-                exclude("target/**", "vendor/**")
+                // Vendored tao is patched in-tree (#533 discrete scroll lives
+                // there). Other vendor trees (accesskit forks, ANGLE headers)
+                // are large and rarely change independently of `src/**`.
+                include("vendor/tao/**")
+                exclude("target/**", "vendor/accesskit_*/**", "vendor/angle-headers/**")
             }
 
         val task =

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -288,6 +288,34 @@ internal object NativeTaoBridge {
     external fun nativeLinuxGtkWindow(handle: Long): Long
 
     /**
+     * Linux only, headful e2e: synthesize a `GdkEventScroll` on [handle] and
+     * deliver it through GTK's `scroll-event` signal — the same path a real
+     * mouse wheel uses.
+     *
+     * [direction] is a `GdkScrollDirection` (`0=UP`, `1=DOWN`, `2=LEFT`,
+     * `3=RIGHT`, `4=SMOOTH`). Discrete directions force `delta_x`/`delta_y`
+     * to zero (GTK 3's mouse-wheel payload). SMOOTH uses [deltaXMilli] /
+     * [deltaYMilli] as thousandths.
+     *
+     * Coordinates are widget-local logical px. The caller should first
+     * dispatch `CURSOR_MOVED` so Compose's last pointer sits over the
+     * target — this function only delivers the scroll.
+     *
+     * Must run on the Tao / GTK main thread. Returns `false` when the handle
+     * is unknown, the window is not realized, or [direction] is out of range.
+     */
+    @JvmStatic
+    external fun nativeLinuxInjectGdkScroll(
+        handle: Long,
+        direction: Int,
+        deltaXMilli: Int,
+        deltaYMilli: Int,
+        x: Int,
+        y: Int,
+    ): Boolean
+
+
+    /**
      * Linux only: origin of the content area (the child GTK allocated inside
      * any client-side decorations) in logical toplevel coordinates, packed as
      * `(x shl 32) or (y and 0xffffffff)`. `(0, 0)` for plain undecorated

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -314,7 +314,6 @@ internal object NativeTaoBridge {
         y: Int,
     ): Boolean
 
-
     /**
      * Linux only: origin of the content area (the child GTK allocated inside
      * any client-side decorations) in logical toplevel coordinates, packed as

--- a/decorated-window-tao/src/main/native/src/platform/linux/mod.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/mod.rs
@@ -3,4 +3,5 @@ pub(crate) mod decoration;
 pub(crate) mod dnd;
 pub(crate) mod handles;
 pub(crate) mod monitor;
+pub(crate) mod scroll;
 pub(crate) mod touch;

--- a/decorated-window-tao/src/main/native/src/platform/linux/scroll.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/scroll.rs
@@ -1,0 +1,128 @@
+// Headful e2e: synthesize a GdkEventScroll that matches the GTK mouse-wheel
+// shape (direction set, delta_x/delta_y left at 0). Stage-1 scene tests
+// inject TaoPointerScrollEvent past this path and cannot see the #533 drop.
+
+use glib::translate::{ToGlibPtr, ToGlibPtrMut};
+use gtk::gdk;
+use gtk::prelude::*;
+use jni::objects::JClass;
+use jni::sys::{jboolean, jint, jlong};
+use jni::JNIEnv;
+
+use crate::state::WINDOWS;
+
+/// `GdkScrollDirection` values, kept in a single match so a bad JNI argument
+/// cannot invent a direction GDK would never emit.
+fn gdk_scroll_direction(raw: jint) -> Option<i32> {
+    match raw {
+        0 => Some(gdk::ffi::GDK_SCROLL_UP),
+        1 => Some(gdk::ffi::GDK_SCROLL_DOWN),
+        2 => Some(gdk::ffi::GDK_SCROLL_LEFT),
+        3 => Some(gdk::ffi::GDK_SCROLL_RIGHT),
+        4 => Some(gdk::ffi::GDK_SCROLL_SMOOTH),
+        _ => None,
+    }
+}
+
+fn gtk_window_for(handle: jlong) -> Option<gtk::Window> {
+    use tao::platform::unix::WindowExtUnix;
+
+    let guard = WINDOWS.lock().ok()?;
+    let map = guard.as_ref()?;
+    let window = map.get(&(handle as u64))?;
+    Some(window.gtk_window().clone())
+}
+
+fn attach_pointer_device(event: &mut gdk::Event, gdk_window: &gdk::Window) {
+    use gdk::prelude::*;
+    if let Some(pointer) = gdk_window
+        .display()
+        .default_seat()
+        .and_then(|seat| seat.pointer())
+    {
+        event.set_device(Some(&pointer));
+    }
+}
+
+fn event_mut_ptr(event: &mut gdk::Event) -> *mut gdk::ffi::GdkEvent {
+    event.to_glib_none_mut().0
+}
+
+unsafe fn write_scroll_fields(
+    event: &mut gdk::Event,
+    gdk_window: &gdk::Window,
+    x: f64,
+    y: f64,
+    direction: i32,
+    delta_x: f64,
+    delta_y: f64,
+) {
+    let ptr = event_mut_ptr(event) as *mut gdk::ffi::GdkEventScroll;
+    (*ptr).window = gdk_window.to_glib_full();
+    (*ptr).send_event = 1;
+    (*ptr).x = x;
+    (*ptr).y = y;
+    (*ptr).x_root = x;
+    (*ptr).y_root = y;
+    (*ptr).direction = direction;
+    (*ptr).delta_x = delta_x;
+    (*ptr).delta_y = delta_y;
+}
+
+/// Linux only, headful e2e: deliver a synthetic `GDK_SCROLL` to the GtkWindow
+/// behind [handle], going through `connect_scroll_event` — the same path a
+/// real mouse wheel uses.
+///
+/// [direction] is a `GdkScrollDirection` (`0=UP … 4=SMOOTH`). Discrete
+/// directions force `delta_x`/`delta_y` to 0, which is the GTK 3 mouse-wheel
+/// payload (`flush_discrete_scroll_event`). SMOOTH uses
+/// [delta_x_milli]/[delta_y_milli] as thousandths.
+///
+/// Coordinates are widget-local. Compose's last pointer is positioned by
+/// the caller (CURSOR_MOVED) so this function only has to deliver the
+/// scroll. Returns JNI `true` when the signal was emitted on a realized
+/// window.
+#[no_mangle]
+pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_nativeLinuxInjectGdkScroll(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+    direction: jint,
+    delta_x_milli: jint,
+    delta_y_milli: jint,
+    x: jint,
+    y: jint,
+) -> jboolean {
+    let Some(direction) = gdk_scroll_direction(direction) else {
+        return jboolean::from(false);
+    };
+    let Some(gtk_window) = gtk_window_for(handle) else {
+        return jboolean::from(false);
+    };
+    let Some(gdk_window) = gtk_window.window() else {
+        return jboolean::from(false);
+    };
+
+    let x = x as f64;
+    let y = y as f64;
+    let (delta_x, delta_y) = if direction == gdk::ffi::GDK_SCROLL_SMOOTH {
+        (delta_x_milli as f64 / 1000.0, delta_y_milli as f64 / 1000.0)
+    } else {
+        // Discrete mouse wheel: GTK leaves the delta at zero.
+        (0.0, 0.0)
+    };
+
+    let mut scroll = gdk::Event::new(gdk::EventType::Scroll);
+    unsafe {
+        write_scroll_fields(&mut scroll, &gdk_window, x, y, direction, delta_x, delta_y);
+    }
+    attach_pointer_device(&mut scroll, &gdk_window);
+
+    // Emit the same `scroll-event` signal `connect_scroll_event` is wired
+    // to. `gtk_widget_event` / `gtk_main_do_event` can drop a send_event on
+    // Wayland (no device grab, missing SMOOTH_SCROLL_MASK); the signal is
+    // the exact handler the bug lives in.
+    let _handled: bool = glib::prelude::ObjectExt::emit_by_name(&gtk_window, "scroll-event", &[&scroll]);
+
+    jboolean::from(true)
+}

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
@@ -889,7 +889,20 @@ impl<T: 'static> EventLoop<T> {
 
             let tx_clone = event_tx.clone();
             window.connect_scroll_event(move |_, event| {
-              let (x, y) = event.delta();
+              // GDK only fills `delta_x`/`delta_y` for GDK_SCROLL_SMOOTH
+              // (trackpads). A discrete mouse wheel arrives with
+              // `direction = UP/DOWN/LEFT/RIGHT` and a zero delta, so the
+              // upstream `event.delta()` mapping drops the event entirely and
+              // the wheel never scrolls. Map the direction back onto a unit
+              // delta so discrete and smooth scrolls share one sign convention.
+              let (x, y) = match event.direction() {
+                ScrollDirection::Smooth => event.delta(),
+                ScrollDirection::Up => (0.0, -1.0),
+                ScrollDirection::Down => (0.0, 1.0),
+                ScrollDirection::Left => (-1.0, 0.0),
+                ScrollDirection::Right => (1.0, 0.0),
+                _ => (0.0, 0.0),
+              };
               if let Err(e) = tx_clone.send(Event::WindowEvent {
                 window_id: RootWindowId(id),
                 event: WindowEvent::MouseWheel {

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/LinuxDiscreteScrollHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/LinuxDiscreteScrollHeadfulCases.kt
@@ -1,0 +1,143 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import dev.nucleusframework.window.tao.TaoEventCode
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * #533 — a discrete GTK mouse-wheel event (`direction` set, delta `(0, 0)`)
+ * must scroll Compose content. A physical mouse on a modern compositor often
+ * emits `GDK_SCROLL_SMOOTH` instead, so this case synthesizes the discrete
+ * payload GTK 3 actually produces for a classic wheel
+ * (`gdkdevice-wayland.c` / `flush_discrete_scroll_event`).
+ */
+internal object LinuxDiscreteScrollHeadfulCases {
+    fun all(): List<TaoWindowTestCase> =
+        listOf(
+            discreteWheelDownScrollsColumn(),
+            smoothScrollStillWorks(),
+        )
+
+    private fun discreteWheelDownScrollsColumn(): TaoWindowTestCase {
+        val scrollPx = AtomicInteger(0)
+        val scrollMax = AtomicInteger(0)
+        return TaoWindowTestCase(
+            name = "#533 discrete GDK_SCROLL_DOWN (zero delta) scrolls a vertical column",
+            skip = { linuxOnly() },
+            // The suite's default DarkGray `fillMaxSize` Box is a Column
+            // sibling of [content]; leaving it on would give this column
+            // 0 height and the wheel would hit an unscrollable surface.
+            paintDefaultBackground = false,
+            content = { ScrollableColumn(scrollPx, scrollMax) },
+        ) {
+            awaitUntil("window mapped") { bounds() != null }
+            awaitUntil("scrollable has overflow") { scrollMax.get() > 0 }
+            settle()
+            movePointerOverContent()
+            val injected =
+                LinuxGdkScrollProbe.inject(
+                    handle = window.handle,
+                    direction = LinuxGdkScrollProbe.DOWN,
+                    x = TARGET_X,
+                    y = TARGET_Y,
+                )
+            check(injected) { "nativeLinuxInjectGdkScroll returned false (window not realized?)" }
+            awaitUntil("scroll offset advanced after discrete GDK_SCROLL_DOWN") {
+                scrollPx.get() > 0
+            }
+        }
+    }
+
+    private fun smoothScrollStillWorks(): TaoWindowTestCase {
+        val scrollPx = AtomicInteger(0)
+        val scrollMax = AtomicInteger(0)
+        return TaoWindowTestCase(
+            name = "#533 GDK_SCROLL_SMOOTH (populated delta) still scrolls",
+            skip = { linuxOnly() },
+            paintDefaultBackground = false,
+            content = { ScrollableColumn(scrollPx, scrollMax) },
+        ) {
+            awaitUntil("window mapped") { bounds() != null }
+            awaitUntil("scrollable has overflow") { scrollMax.get() > 0 }
+            settle()
+            movePointerOverContent()
+            val injected =
+                LinuxGdkScrollProbe.inject(
+                    handle = window.handle,
+                    direction = LinuxGdkScrollProbe.SMOOTH,
+                    deltaYMilli = SMOOTH_DELTA_Y_MILLI,
+                    x = TARGET_X,
+                    y = TARGET_Y,
+                )
+            check(injected) { "nativeLinuxInjectGdkScroll returned false (window not realized?)" }
+            awaitUntil("scroll offset advanced after GDK_SCROLL_SMOOTH") {
+                scrollPx.get() > 0
+            }
+        }
+    }
+
+    @Composable
+    private fun ScrollableColumn(
+        scrollPx: AtomicInteger,
+        scrollMax: AtomicInteger,
+    ) {
+        val state = rememberScrollState()
+        scrollPx.set(state.value)
+        scrollMax.set(state.maxValue)
+        Column(Modifier.fillMaxSize().verticalScroll(state)) {
+            repeat(ROW_COUNT) { i ->
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(ROW_HEIGHT_DP.dp)
+                        .background(if (i % 2 == 0) Color.DarkGray else Color.Gray),
+                )
+            }
+        }
+    }
+
+    /**
+     * Place Compose's last pointer over the scrollable, through the same
+     * CURSOR_MOVED wire the host uses for a real mouse. GTK motion injection
+     * is unreliable as a send_event on Wayland; the discrete-scroll bug is
+     * in the scroll handler, not the motion path.
+     */
+    private fun TaoWindowTestScope.movePointerOverContent() {
+        val scale = window.scaleFactor
+        val xFixed = (TARGET_X * scale * CURSOR_FIXED_SCALE).toInt()
+        val yFixed = (TARGET_Y * scale * CURSOR_FIXED_SCALE).toInt()
+        window.dispatch(TaoEventCode.CURSOR_MOVED, xFixed, yFixed)
+    }
+
+    private fun linuxOnly(): String? {
+        val os = System.getProperty("os.name", "").lowercase()
+        return if (os.contains("win") || os.contains("mac") || os.contains("darwin")) {
+            "Linux only — discrete GdkEventScroll injection"
+        } else {
+            null
+        }
+    }
+
+    private const val TARGET_X = 400
+    private const val TARGET_Y = 300
+
+    /** Must match `events.rs::CURSOR_FIXED_SCALE`. */
+    private const val CURSOR_FIXED_SCALE = 1024f
+
+    /** Thousandths: 1.0 in GDK's smooth-delta convention (positive Y = down). */
+    private const val SMOOTH_DELTA_Y_MILLI = 1000
+
+    private const val ROW_COUNT = 80
+    private const val ROW_HEIGHT_DP = 24
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/LinuxGdkScrollProbe.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/LinuxGdkScrollProbe.kt
@@ -1,0 +1,40 @@
+package dev.nucleusframework.window.tao.headful
+
+import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+
+/**
+ * Thin wrapper around the Linux headful helper that synthesizes a
+ * [GdkEventScroll](https://docs.gtk.org/gdk3/struct.EventScroll.html) and
+ * delivers it through GTK's `scroll-event` signal.
+ *
+ * A real mouse wheel on GTK 3 arrives as `direction = UP/DOWN/LEFT/RIGHT`
+ * with `delta_x = delta_y = 0`. Trackpads arrive as `SMOOTH` with a
+ * populated delta. Stage-1 [dev.nucleusframework.window.tao.scene.TaoSceneScrollTest]
+ * never sees that split because it injects a pre-shaped
+ * [dev.nucleusframework.window.tao.TaoPointerScrollEvent] past the native
+ * handler — which is why #533 was invisible to the scene battery.
+ */
+internal object LinuxGdkScrollProbe {
+    const val UP: Int = 0
+    const val DOWN: Int = 1
+    const val LEFT: Int = 2
+    const val RIGHT: Int = 3
+    const val SMOOTH: Int = 4
+
+    fun inject(
+        handle: Long,
+        direction: Int,
+        deltaXMilli: Int = 0,
+        deltaYMilli: Int = 0,
+        x: Int,
+        y: Int,
+    ): Boolean =
+        NativeTaoBridge.nativeLinuxInjectGdkScroll(
+            handle,
+            direction,
+            deltaXMilli,
+            deltaYMilli,
+            x,
+            y,
+        )
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -357,6 +357,7 @@ public object TaoHeadfulTestSuiteMain {
             },
         ) +
             UnspecifiedSizeHeadfulCases.all() +
+            LinuxDiscreteScrollHeadfulCases.all() +
             ChromeReviewHeadfulCases.all() +
             DisplayScaleHeadfulCases.all() +
             FramePacingHeadfulCases.all() +


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->
## 🚀 Description
<!-- Describe your changes in detail -->
The Tao backend's GTK scroll handler only read `GdkEventScroll.delta()`, which
GDK populates exclusively for `GDK_SCROLL_SMOOTH` (trackpad) events. A discrete
mouse wheel arrives with `direction = UP/DOWN/LEFT/RIGHT` and a `(0, 0)` delta,
so the handler emitted `MouseScrollDelta::LineDelta(0, 0)` and the wheel never
scrolled on Linux.
This PR maps the scroll `direction` back onto a unit delta when the event is not
smooth, so discrete and smooth scrolls share one sign convention:
```rust
let (x, y) = match event.direction() {
    ScrollDirection::Smooth => event.delta(),
    ScrollDirection::Up    => (0.0, -1.0),
    ScrollDirection::Down  => (0.0,  1.0),
    ScrollDirection::Left  => (-1.0, 0.0),
    ScrollDirection::Right => (1.0,  0.0),
    _ => (0.0, 0.0),
};
```
## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Mouse-wheel scrolling is completely broken in every Linux app on the Tao
backend (both X11 and Wayland). The bug is invisible to `TaoSceneScrollTest`
because that harness injects `TaoPointerScrollEvent` directly into the scene,
bypassing the native GTK → Rust path where the delta is actually lost.
Confirmed against GTK 3.24's Wayland backend (`gdkdevice-wayland.c`):
`flush_discrete_scroll_event` sets only `event->scroll.direction`, leaving
`delta_x`/`delta_y` at zero.
## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Rebuilt the native library (`libnucleus_tao.so`) via `build.sh` and ran
  `examples/tao-demo` on KDE Plasma / Wayland — the ScrollTab now scrolls with
  a mouse wheel.
- Verified an app that previously showed no scroll response now scrolls
  correctly.
- `cargo check --release --target x86_64-unknown-linux-gnu` passes with no new
  warnings; only pre-existing dead-code warnings remain.
- Trackpad (smooth) scroll is unchanged, since the `Smooth` arm still reads
  `event.delta()`.
## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
