### PR TITLE
fix(tao): honor Dp.Unspecified wrap-content window size

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
@@ -8,16 +8,15 @@ import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberDialogState
 import androidx.compose.ui.window.rememberWindowState
 import dev.nucleusframework.core.runtime.Platform
@@ -94,9 +93,8 @@ public fun ApplicationScope.DecoratedDialog(
             val explicit = state.position
             if (explicit is WindowPosition.Absolute) return@remember explicit
             // Wrap-content dialogs (#532) don't know their height yet — a
-            // centre computed against Dp.Unspecified (NaN / 0) is wrong and
-            // on macOS would be locked in by addChildWindow:. Defer to the
-            // size-ready effect below.
+            // centre computed against Dp.Unspecified is wrong. The size
+            // bridge below recentres once the measured size is specified.
             if (!sizeSpecified) return@remember explicit
             val centered =
                 when (Platform.Current) {
@@ -172,20 +170,11 @@ public fun ApplicationScope.DecoratedDialog(
     )
 
     // Bidirectional bridge between DialogState and the WindowState plumbed
-    // into the underlying DecoratedWindow. After wrap-content resolves, the
-    // deferred parent-centre runs once with the real size.
-    val pendingParentCenter = remember { mutableStateOf(autoCenterRequested && !sizeSpecified) }
+    // into the underlying DecoratedWindow. After wrap-content resolves,
+    // position is still not Absolute — centre on the parent once.
     LaunchedEffect(windowState.size) {
         if (state.size != windowState.size) state.size = windowState.size
-        val centered =
-            takePendingParentCenter(
-                pending = pendingParentCenter.value,
-                parent = parent,
-                size = windowState.size,
-            ) ?: return@LaunchedEffect
-        pendingParentCenter.value = false
-        windowState.position = centered
-        state.position = centered
+        recenterAfterWrapContent(autoCenterRequested, parent, windowState, state)
     }
     LaunchedEffect(windowState.position) {
         val p = windowState.position
@@ -223,17 +212,24 @@ public fun ApplicationScope.DecoratedDialog(
  *
  * No-op when the relevant bridge or the parent is unavailable.
  */
-private fun takePendingParentCenter(
-    pending: Boolean,
+private fun recenterAfterWrapContent(
+    autoCenterRequested: Boolean,
     parent: TaoWindow?,
-    size: DpSize,
-): WindowPosition.Absolute? {
-    if (!pending || !size.width.isSpecified || !size.height.isSpecified) return null
-    return when (Platform.Current) {
-        Platform.Windows -> centerOnParentWindows(parent, size.width.value, size.height.value)
-        Platform.Linux -> centerOnParentLinux(parent, size.width.value, size.height.value)
-        else -> null
-    }
+    windowState: WindowState,
+    state: DialogState,
+) {
+    if (!autoCenterRequested || state.position is WindowPosition.Absolute) return
+    if (!windowState.size.width.isSpecified || !windowState.size.height.isSpecified) return
+    val centered =
+        when (Platform.Current) {
+            Platform.Windows ->
+                centerOnParentWindows(parent, windowState.size.width.value, windowState.size.height.value)
+            Platform.Linux ->
+                centerOnParentLinux(parent, windowState.size.width.value, windowState.size.height.value)
+            else -> null
+        } ?: return
+    windowState.position = centered
+    state.position = centered
 }
 
 private fun applyDialogOwnerRelationship(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
@@ -8,11 +8,14 @@ import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberDialogState
@@ -85,10 +88,16 @@ public fun ApplicationScope.DecoratedDialog(
     // native bridge centres atomically right before `addChildWindow:` to
     // avoid the flash, so we don't pre-compute a position here.
     val autoCenterRequested = state.position !is WindowPosition.Absolute
+    val sizeSpecified = state.size.width.isSpecified && state.size.height.isSpecified
     val initialPosition =
         remember(parent) {
             val explicit = state.position
             if (explicit is WindowPosition.Absolute) return@remember explicit
+            // Wrap-content dialogs (#532) don't know their height yet — a
+            // centre computed against Dp.Unspecified (NaN / 0) is wrong and
+            // on macOS would be locked in by addChildWindow:. Defer to the
+            // size-ready effect below.
+            if (!sizeSpecified) return@remember explicit
             val centered =
                 when (Platform.Current) {
                     Platform.Windows ->
@@ -146,11 +155,14 @@ public fun ApplicationScope.DecoratedDialog(
             // Native owner relationship. Runs inside the dialog's composition,
             // so `windowScope.window` is the dialog's TaoWindow and its HWND
             // is already resolvable via [TaoWindow.nativeHandle].
+            // Do not wait for wrap-content size: on Wayland a hidden dialog
+            // without an owner never receives a configure, so setContent
+            // never runs and wrap-content deadlocks (#532).
             DisposableEffect(windowScope.window, parent) {
                 applyDialogOwnerRelationship(
                     dialog = windowScope.window,
                     parent = parent,
-                    autoCenter = autoCenterRequested,
+                    autoCenter = autoCenterRequested && sizeSpecified,
                 )
                 onDispose { /* native handle destruction restores focus to owner */ }
             }
@@ -160,9 +172,20 @@ public fun ApplicationScope.DecoratedDialog(
     )
 
     // Bidirectional bridge between DialogState and the WindowState plumbed
-    // into the underlying DecoratedWindow.
+    // into the underlying DecoratedWindow. After wrap-content resolves, the
+    // deferred parent-centre runs once with the real size.
+    val pendingParentCenter = remember { mutableStateOf(autoCenterRequested && !sizeSpecified) }
     LaunchedEffect(windowState.size) {
         if (state.size != windowState.size) state.size = windowState.size
+        val centered =
+            takePendingParentCenter(
+                pending = pendingParentCenter.value,
+                parent = parent,
+                size = windowState.size,
+            ) ?: return@LaunchedEffect
+        pendingParentCenter.value = false
+        windowState.position = centered
+        state.position = centered
     }
     LaunchedEffect(windowState.position) {
         val p = windowState.position
@@ -200,6 +223,19 @@ public fun ApplicationScope.DecoratedDialog(
  *
  * No-op when the relevant bridge or the parent is unavailable.
  */
+private fun takePendingParentCenter(
+    pending: Boolean,
+    parent: TaoWindow?,
+    size: DpSize,
+): WindowPosition.Absolute? {
+    if (!pending || !size.width.isSpecified || !size.height.isSpecified) return null
+    return when (Platform.Current) {
+        Platform.Windows -> centerOnParentWindows(parent, size.width.value, size.height.value)
+        Platform.Linux -> centerOnParentLinux(parent, size.width.value, size.height.value)
+        else -> null
+    }
+}
+
 private fun applyDialogOwnerRelationship(
     dialog: TaoWindow,
     parent: TaoWindow?,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -262,6 +262,7 @@ internal fun ApplicationScope.openDecoratedWindow(
     // parent window's theme/user locals from the first composition without
     // hijacking popup positioning. See [LocalTaoCompositionLocalContextBridge].
     initialCompositionLocalContext: CompositionLocalContext? = null,
+    sizePolicy: WindowSizePolicy = WindowSizePolicy(),
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     // hiddenFromDock rides on the GTK skip-taskbar/skip-pager hint, which
@@ -352,6 +353,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             initialCompositionLocalContext,
             nativePopupLayers,
             transparent,
+            sizePolicy,
             hotReloadContent,
         )
     }
@@ -375,6 +377,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             initialCompositionLocalContext,
             nativePopupLayers,
             transparent,
+            sizePolicy,
             hotReloadContent,
         )
     }
@@ -511,8 +514,10 @@ internal fun ApplicationScope.openDecoratedWindow(
                         }
                     }
                 }
-                Column(modifier = Modifier.fillMaxSize()) {
-                    scopeFactory().hotReloadContent()
+                WindowContentRoot(sizePolicy) {
+                    Column {
+                        scopeFactory().hotReloadContent()
+                    }
                 }
             }
         }
@@ -625,6 +630,7 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     initialCompositionLocalContext: CompositionLocalContext?,
     nativePopupLayers: Boolean,
     transparent: Boolean,
+    sizePolicy: WindowSizePolicy,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     val host = TaoComposeSceneHostLinux(window, fullyTransparent = transparent)
@@ -735,8 +741,10 @@ private fun ApplicationScope.openDecoratedWindowLinux(
                             isFullscreen = stateHolder.value.isFullscreen,
                             modifier = Modifier.fillMaxSize().then(border),
                         ) {
-                            Column(modifier = Modifier.fillMaxSize()) {
-                                scopeFactory().content()
+                            WindowContentRoot(sizePolicy) {
+                                Column {
+                                    scopeFactory().content()
+                                }
                             }
                         }
                         if (modalCount.value > 0 || (!isDialog && GlobalModalDialogCount.value > 0)) {
@@ -1029,6 +1037,7 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     initialCompositionLocalContext: CompositionLocalContext?,
     nativePopupLayers: Boolean,
     transparent: Boolean,
+    sizePolicy: WindowSizePolicy,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     val host =
@@ -1178,8 +1187,10 @@ private fun ApplicationScope.openDecoratedWindowWindows(
                             isFullscreen = stateHolder.value.isFullscreen,
                             modifier = Modifier.fillMaxSize().then(border),
                         ) {
-                            Column(modifier = Modifier.fillMaxSize()) {
-                                scopeFactory().content()
+                            WindowContentRoot(sizePolicy) {
+                                Column {
+                                    scopeFactory().content()
+                                }
                             }
                         }
                         if (modalCount.value > 0 || (!isDialog && GlobalModalDialogCount.value > 0)) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -5,7 +5,6 @@ package dev.nucleusframework.window.tao
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -262,7 +261,6 @@ internal fun ApplicationScope.openDecoratedWindow(
     // parent window's theme/user locals from the first composition without
     // hijacking popup positioning. See [LocalTaoCompositionLocalContextBridge].
     initialCompositionLocalContext: CompositionLocalContext? = null,
-    sizePolicy: WindowSizePolicy = WindowSizePolicy(),
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     // hiddenFromDock rides on the GTK skip-taskbar/skip-pager hint, which
@@ -353,7 +351,6 @@ internal fun ApplicationScope.openDecoratedWindow(
             initialCompositionLocalContext,
             nativePopupLayers,
             transparent,
-            sizePolicy,
             hotReloadContent,
         )
     }
@@ -377,7 +374,6 @@ internal fun ApplicationScope.openDecoratedWindow(
             initialCompositionLocalContext,
             nativePopupLayers,
             transparent,
-            sizePolicy,
             hotReloadContent,
         )
     }
@@ -514,10 +510,8 @@ internal fun ApplicationScope.openDecoratedWindow(
                         }
                     }
                 }
-                WindowContentRoot(sizePolicy) {
-                    Column {
-                        scopeFactory().hotReloadContent()
-                    }
+                WindowSceneColumn {
+                    scopeFactory().hotReloadContent()
                 }
             }
         }
@@ -630,7 +624,6 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     initialCompositionLocalContext: CompositionLocalContext?,
     nativePopupLayers: Boolean,
     transparent: Boolean,
-    sizePolicy: WindowSizePolicy,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     val host = TaoComposeSceneHostLinux(window, fullyTransparent = transparent)
@@ -741,10 +734,8 @@ private fun ApplicationScope.openDecoratedWindowLinux(
                             isFullscreen = stateHolder.value.isFullscreen,
                             modifier = Modifier.fillMaxSize().then(border),
                         ) {
-                            WindowContentRoot(sizePolicy) {
-                                Column {
-                                    scopeFactory().content()
-                                }
+                            WindowSceneColumn {
+                                scopeFactory().content()
                             }
                         }
                         if (modalCount.value > 0 || (!isDialog && GlobalModalDialogCount.value > 0)) {
@@ -1037,7 +1028,6 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     initialCompositionLocalContext: CompositionLocalContext?,
     nativePopupLayers: Boolean,
     transparent: Boolean,
-    sizePolicy: WindowSizePolicy,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     val host =
@@ -1187,10 +1177,8 @@ private fun ApplicationScope.openDecoratedWindowWindows(
                             isFullscreen = stateHolder.value.isFullscreen,
                             modifier = Modifier.fillMaxSize().then(border),
                         ) {
-                            WindowContentRoot(sizePolicy) {
-                                Column {
-                                    scopeFactory().content()
-                                }
+                            WindowSceneColumn {
+                                scopeFactory().content()
                             }
                         }
                         if (modalCount.value > 0 || (!isDialog && GlobalModalDialogCount.value > 0)) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.graphics.painter.Painter
@@ -146,11 +147,11 @@ public fun ApplicationScope.DecoratedWindow(
     state.applyMacOsInitialMaximizedSize()
 
     // Compose Desktop wrap-content: an unspecified axis is measured from
-    // the first composition, then applied as a real inner size before show
-    // (#532). Creating the native surface at NaN/0 makes Metal/EGL drop
-    // the drawable (`CAMetalLayer ignoring invalid setDrawableSize … height=0`).
+    // content and applied via setInnerSize (#532). Creating the native
+    // surface at NaN/0 makes Metal/EGL drop the drawable.
     val wrapWidth = !state.size.width.isSpecified
     val wrapHeight = !state.size.height.isSpecified
+    val measuredContent = remember { mutableStateOf<IntSize?>(null) }
 
     // Mirrors Compose Desktop's `appliedState` pattern: tracks the last value
     // we wrote to the window so the native→state listeners can ignore echoes.
@@ -161,7 +162,7 @@ public fun ApplicationScope.DecoratedWindow(
                 var position: WindowPosition? = null
                 var placement: WindowPlacement? = null
                 var isMinimized: Boolean? = null
-                var wrapApplied: Boolean = false
+                var wrapSettled: Boolean = !wrapWidth && !wrapHeight
             }
         }
 
@@ -174,44 +175,6 @@ public fun ApplicationScope.DecoratedWindow(
             // applies the initial state.position (Absolute, Aligned, …) on first
             // composition. Pre-stamping it would short-circuit Aligned positions
             // because the LaunchedEffect bails when `pos == applied.position`.
-
-            val created = arrayOfNulls<TaoWindow>(1)
-            val sizePolicy =
-                WindowSizePolicy(
-                    wrapWidth = wrapWidth,
-                    wrapHeight = wrapHeight,
-                    onContentMeasured = measure@{ wPx, hPx ->
-                        val target = created[0] ?: return@measure
-                        val scale =
-                            (NativeTaoBridge.nativeScaleFactor(target.handle).coerceAtLeast(1)) / 1000f
-                        val newSize =
-                            resolveWrapContentSize(
-                                wrapWidth = wrapWidth,
-                                wrapHeight = wrapHeight,
-                                requested = latestState.size,
-                                minimumSize = minimumSize,
-                                widthPx = wPx,
-                                heightPx = hPx,
-                                scale = scale,
-                            ) ?: return@measure
-                        if (applied.size == newSize) return@measure
-                        val previous = applied.size
-                        if (applied.wrapApplied &&
-                            previous != null &&
-                            newSize.width <= previous.width &&
-                            newSize.height <= previous.height
-                        ) {
-                            return@measure
-                        }
-                        applied.wrapApplied = true
-                        target.setInnerSize(
-                            newSize.width.value.toDouble(),
-                            newSize.height.value.toDouble(),
-                        )
-                        applied.size = newSize
-                        latestState.size = newSize
-                    },
-                )
 
             val w =
                 openDecoratedWindow(
@@ -241,7 +204,6 @@ public fun ApplicationScope.DecoratedWindow(
                     macOSStyle = macOSStyle,
                     hiddenFromDock = hiddenFromDock,
                     initialCompositionLocalContext = compositionLocalContext,
-                    sizePolicy = sizePolicy,
                     content = {
                         val backgroundArgb = latestWindowBackgroundArgb.value
                         val clearColorLayers = LocalWindowClearColorLayers.current
@@ -258,7 +220,15 @@ public fun ApplicationScope.DecoratedWindow(
                     },
                 )
 
-            created[0] = w
+            w.installSizePolicy(
+                WindowSizePolicy(
+                    wrapWidth = wrapWidth,
+                    wrapHeight = wrapHeight,
+                    onContentMeasured = { size ->
+                        if (measuredContent.value != size) measuredContent.value = size
+                    },
+                ),
+            )
 
             // Initial placement / minimised flag are applied imperatively here
             // (Maximized is handled at builder time, above).
@@ -287,7 +257,7 @@ public fun ApplicationScope.DecoratedWindow(
                     // measurement writes the real size; otherwise the first
                     // native configure (creation fallback) would freeze the
                     // requested wrap axis at 600dp.
-                    if (applied.wrapApplied || (!wrapWidth && !wrapHeight)) {
+                    if (applied.wrapSettled) {
                         latestState.size = newSize
                     }
                 }
@@ -328,7 +298,10 @@ public fun ApplicationScope.DecoratedWindow(
         }
 
     DisposableEffect(window) {
-        onDispose { window.requestClose() }
+        onDispose {
+            window.clearSizePolicy()
+            window.requestClose()
+        }
     }
 
     // ── State → window sync ──
@@ -338,6 +311,27 @@ public fun ApplicationScope.DecoratedWindow(
         if (window.isResizable != resizable) {
             window.setResizable(resizable)
         }
+    }
+    LaunchedEffect(window, measuredContent.value) {
+        if (applied.wrapSettled) return@LaunchedEffect
+        val measured = measuredContent.value ?: return@LaunchedEffect
+        val scale = (NativeTaoBridge.nativeScaleFactor(window.handle).coerceAtLeast(1)) / 1000f
+        val resolved =
+            resolveWrapContentSize(
+                wrapWidth = wrapWidth,
+                wrapHeight = wrapHeight,
+                requested = latestState.size,
+                minimumSize = minimumSize,
+                measured = measured,
+                scale = scale,
+            ) ?: return@LaunchedEffect
+        window.setInnerSize(
+            resolved.width.value.toDouble(),
+            resolved.height.value.toDouble(),
+        )
+        applied.size = resolved
+        latestState.size = resolved
+        applied.wrapSettled = true
     }
     LaunchedEffect(window, state.size, state.placement) {
         // Maximized / Fullscreen windows derive their size from the
@@ -704,45 +698,4 @@ private fun actualWindowSizeDp(
     val h = (rect[3] / scale).toInt()
     if (w <= 0 || h <= 0) return null
     return w to h
-}
-
-internal const val DEFAULT_WINDOW_WIDTH_DP = 800.0
-internal const val DEFAULT_WINDOW_HEIGHT_DP = 600.0
-
-/**
- * Builds the first real [DpSize] for a wrap-content window from the
- * content's measured pixels. Specified axes keep the requested value;
- * unspecified axes take the measured size (floored by [minimumSize]).
- * Returns `null` when the wrap axes have not produced a positive size yet.
- */
-internal fun resolveWrapContentSize(
-    wrapWidth: Boolean,
-    wrapHeight: Boolean,
-    requested: DpSize,
-    minimumSize: DpSize?,
-    widthPx: Int,
-    heightPx: Int,
-    scale: Float,
-): DpSize? {
-    if (scale <= 0f) return null
-    val measuredW = (widthPx / scale).dp
-    val measuredH = (heightPx / scale).dp
-    val width =
-        when {
-            !wrapWidth && requested.width.isSpecified -> requested.width
-            widthPx > 0 -> measuredW
-            else -> return null
-        }
-    val height =
-        when {
-            !wrapHeight && requested.height.isSpecified -> requested.height
-            heightPx > 0 -> measuredH
-            else -> return null
-        }
-    val minW = minimumSize?.width
-    val minH = minimumSize?.height
-    val flooredW = if (minW != null && minW.isSpecified && width < minW) minW else width
-    val flooredH = if (minH != null && minH.isSpecified && height < minH) minH else height
-    if (flooredW.value <= 0f || flooredH.value <= 0f) return null
-    return DpSize(flooredW, flooredH)
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
@@ -144,6 +145,13 @@ public fun ApplicationScope.DecoratedWindow(
     state.inflateToMinimumSize(minimumSize)
     state.applyMacOsInitialMaximizedSize()
 
+    // Compose Desktop wrap-content: an unspecified axis is measured from
+    // the first composition, then applied as a real inner size before show
+    // (#532). Creating the native surface at NaN/0 makes Metal/EGL drop
+    // the drawable (`CAMetalLayer ignoring invalid setDrawableSize … height=0`).
+    val wrapWidth = !state.size.width.isSpecified
+    val wrapHeight = !state.size.height.isSpecified
+
     // Mirrors Compose Desktop's `appliedState` pattern: tracks the last value
     // we wrote to the window so the native→state listeners can ignore echoes.
     val applied =
@@ -153,6 +161,7 @@ public fun ApplicationScope.DecoratedWindow(
                 var position: WindowPosition? = null
                 var placement: WindowPlacement? = null
                 var isMinimized: Boolean? = null
+                var wrapApplied: Boolean = false
             }
         }
 
@@ -166,17 +175,51 @@ public fun ApplicationScope.DecoratedWindow(
             // composition. Pre-stamping it would short-circuit Aligned positions
             // because the LaunchedEffect bails when `pos == applied.position`.
 
+            val created = arrayOfNulls<TaoWindow>(1)
+            val sizePolicy =
+                WindowSizePolicy(
+                    wrapWidth = wrapWidth,
+                    wrapHeight = wrapHeight,
+                    onContentMeasured = measure@{ wPx, hPx ->
+                        val target = created[0] ?: return@measure
+                        val scale =
+                            (NativeTaoBridge.nativeScaleFactor(target.handle).coerceAtLeast(1)) / 1000f
+                        val newSize =
+                            resolveWrapContentSize(
+                                wrapWidth = wrapWidth,
+                                wrapHeight = wrapHeight,
+                                requested = latestState.size,
+                                minimumSize = minimumSize,
+                                widthPx = wPx,
+                                heightPx = hPx,
+                                scale = scale,
+                            ) ?: return@measure
+                        if (applied.size == newSize) return@measure
+                        val previous = applied.size
+                        if (applied.wrapApplied &&
+                            previous != null &&
+                            newSize.width <= previous.width &&
+                            newSize.height <= previous.height
+                        ) {
+                            return@measure
+                        }
+                        applied.wrapApplied = true
+                        target.setInnerSize(
+                            newSize.width.value.toDouble(),
+                            newSize.height.value.toDouble(),
+                        )
+                        applied.size = newSize
+                        latestState.size = newSize
+                    },
+                )
+
             val w =
                 openDecoratedWindow(
                     onCloseRequest = { latestOnClose() },
                     title = title,
                     icon = icon,
-                    width =
-                        state.size.width.value
-                            .toDouble(),
-                    height =
-                        state.size.height.value
-                            .toDouble(),
+                    width = state.size.width.toWindowCreationDp(DEFAULT_WINDOW_WIDTH_DP),
+                    height = state.size.height.toWindowCreationDp(DEFAULT_WINDOW_HEIGHT_DP),
                     minimumSize = minimumSize,
                     visible = false,
                     resizable = resizable,
@@ -198,6 +241,7 @@ public fun ApplicationScope.DecoratedWindow(
                     macOSStyle = macOSStyle,
                     hiddenFromDock = hiddenFromDock,
                     initialCompositionLocalContext = compositionLocalContext,
+                    sizePolicy = sizePolicy,
                     content = {
                         val backgroundArgb = latestWindowBackgroundArgb.value
                         val clearColorLayers = LocalWindowClearColorLayers.current
@@ -213,6 +257,8 @@ public fun ApplicationScope.DecoratedWindow(
                         latestContent.invoke(this)
                     },
                 )
+
+            created[0] = w
 
             // Initial placement / minimised flag are applied imperatively here
             // (Maximized is handled at builder time, above).
@@ -237,7 +283,13 @@ public fun ApplicationScope.DecoratedWindow(
                 val newSize = DpSize((wPx / scale).dp, (hPx / scale).dp)
                 if (newSize != applied.size) {
                     applied.size = newSize
-                    latestState.size = newSize
+                    // Keep Unspecified in WindowState until wrap-content
+                    // measurement writes the real size; otherwise the first
+                    // native configure (creation fallback) would freeze the
+                    // requested wrap axis at 600dp.
+                    if (applied.wrapApplied || (!wrapWidth && !wrapHeight)) {
+                        latestState.size = newSize
+                    }
                 }
                 // Tao doesn't emit a dedicated "placement changed" event, but
                 // every fullscreen / maximize / restore transition resizes the
@@ -294,6 +346,7 @@ public fun ApplicationScope.DecoratedWindow(
         // requested logical size while Win32/Wayland think it should
         // fill the monitor.
         if (state.placement != WindowPlacement.Floating) return@LaunchedEffect
+        if (!state.size.width.isSpecified || !state.size.height.isSpecified) return@LaunchedEffect
         if (state.size != applied.size) {
             window.setInnerSize(
                 state.size.width.value
@@ -651,4 +704,45 @@ private fun actualWindowSizeDp(
     val h = (rect[3] / scale).toInt()
     if (w <= 0 || h <= 0) return null
     return w to h
+}
+
+internal const val DEFAULT_WINDOW_WIDTH_DP = 800.0
+internal const val DEFAULT_WINDOW_HEIGHT_DP = 600.0
+
+/**
+ * Builds the first real [DpSize] for a wrap-content window from the
+ * content's measured pixels. Specified axes keep the requested value;
+ * unspecified axes take the measured size (floored by [minimumSize]).
+ * Returns `null` when the wrap axes have not produced a positive size yet.
+ */
+internal fun resolveWrapContentSize(
+    wrapWidth: Boolean,
+    wrapHeight: Boolean,
+    requested: DpSize,
+    minimumSize: DpSize?,
+    widthPx: Int,
+    heightPx: Int,
+    scale: Float,
+): DpSize? {
+    if (scale <= 0f) return null
+    val measuredW = (widthPx / scale).dp
+    val measuredH = (heightPx / scale).dp
+    val width =
+        when {
+            !wrapWidth && requested.width.isSpecified -> requested.width
+            widthPx > 0 -> measuredW
+            else -> return null
+        }
+    val height =
+        when {
+            !wrapHeight && requested.height.isSpecified -> requested.height
+            heightPx > 0 -> measuredH
+            else -> return null
+        }
+    val minW = minimumSize?.width
+    val minH = minimumSize?.height
+    val flooredW = if (minW != null && minW.isSpecified && width < minW) minW else width
+    val flooredH = if (minH != null && minH.isSpecified && height < minH) minH else height
+    if (flooredW.value <= 0f || flooredH.value <= 0f) return null
+    return DpSize(flooredW, flooredH)
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -100,11 +100,13 @@ public object TaoApplication {
                 popupParentHandle = popupOf?.handle ?: 0L,
             )
         windows[handle] = window
+        val safeWidth = if (width.isFinite() && width > 0.0) width else DEFAULT_WINDOW_WIDTH_DP
+        val safeHeight = if (height.isFinite() && height > 0.0) height else DEFAULT_WINDOW_HEIGHT_DP
         NativeTaoBridge.nativeCreateWindow(
             handle,
             title,
-            width,
-            height,
+            safeWidth,
+            safeHeight,
             decorations,
             resizable,
             visible,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowSizePolicy.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowSizePolicy.kt
@@ -1,26 +1,45 @@
 package dev.nucleusframework.window.tao
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
-import androidx.compose.ui.util.fastForEach
-import androidx.compose.ui.util.fastMap
-import androidx.compose.ui.util.fastMaxOfOrDefault
+import java.util.concurrent.ConcurrentHashMap
+
+internal const val DEFAULT_WINDOW_WIDTH_DP = 800.0
+internal const val DEFAULT_WINDOW_HEIGHT_DP = 600.0
+
+private val sizePolicies = ConcurrentHashMap<Long, WindowSizePolicy>()
+
+internal fun TaoWindow.installSizePolicy(policy: WindowSizePolicy) {
+    sizePolicies[handle] = policy
+}
+
+internal fun TaoWindow.clearSizePolicy() {
+    sizePolicies.remove(handle)
+}
+
+internal fun TaoWindow.resolvedSizePolicy(): WindowSizePolicy = sizePolicies[handle] ?: WindowSizePolicy()
 
 /**
- * How a [DecoratedWindow] resolves [androidx.compose.ui.window.WindowState.size]
- * when one or both axes are [Dp.Unspecified] (Compose Desktop wrap-content).
+ * Wrap-content axes for a [DecoratedWindow] whose [androidx.compose.ui.window.WindowState.size]
+ * has [Dp.Unspecified] on one or both dimensions (#532).
  */
 internal class WindowSizePolicy(
     val wrapWidth: Boolean = false,
     val wrapHeight: Boolean = false,
-    val onContentMeasured: ((widthPx: Int, heightPx: Int) -> Unit)? = null,
+    val onContentMeasured: ((IntSize) -> Unit)? = null,
 ) {
     val wraps: Boolean get() = wrapWidth || wrapHeight
 }
@@ -29,60 +48,62 @@ internal fun Dp.toWindowCreationDp(fallback: Double): Double =
     if (isSpecified && value.isFinite() && value > 0f) value.toDouble() else fallback
 
 /**
- * Root of the window scene. Specified axes fill the window; wrap-content
- * axes measure children with an unbounded max so `fillMaxSize` chrome
- * outside this node cannot collapse [Dp.Unspecified] to the placeholder
- * creation size.
+ * Scene column: [fillMaxSize] when both axes are specified (the 99% path),
+ * wrap-content modifiers + [onSizeChanged] when an axis is [Dp.Unspecified].
+ *
+ * Reads the policy installed on [LocalTaoWindow] so [openDecoratedWindow]
+ * does not grow another parameter.
  */
 @Composable
-internal fun WindowContentRoot(
-    policy: WindowSizePolicy,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    if (!policy.wraps) {
-        Layout(
-            content = content,
-            modifier = modifier.fillMaxWidth().fillMaxHeight(),
-        ) { measurables, constraints ->
-            val placeables = measurables.fastMap { it.measure(constraints) }
-            layout(constraints.maxWidth, constraints.maxHeight) {
-                placeables.fastForEach { it.place(0, 0) }
-            }
-        }
-        return
-    }
-    Layout(
-        content = content,
-        modifier =
-            modifier.onSizeChanged { size ->
-                if (size.width > 0 && size.height > 0) {
-                    policy.onContentMeasured?.invoke(size.width, size.height)
+internal fun WindowSceneColumn(content: @Composable ColumnScope.() -> Unit) {
+    val policy = LocalTaoWindow.current?.resolvedSizePolicy() ?: WindowSizePolicy()
+    val modifier =
+        if (!policy.wraps) {
+            Modifier.fillMaxSize()
+        } else {
+            Modifier
+                .then(if (policy.wrapWidth) Modifier.wrapContentWidth(unbounded = true) else Modifier.fillMaxWidth())
+                .then(if (policy.wrapHeight) Modifier.wrapContentHeight(unbounded = true) else Modifier.fillMaxHeight())
+                .onSizeChanged { size ->
+                    if (size.width > 0 && size.height > 0) policy.onContentMeasured?.invoke(size)
                 }
-            },
-    ) { measurables, constraints ->
-        val childConstraints =
-            Constraints(
-                minWidth = 0,
-                maxWidth = if (policy.wrapWidth) Constraints.Infinity else constraints.maxWidth,
-                minHeight = 0,
-                maxHeight = if (policy.wrapHeight) Constraints.Infinity else constraints.maxHeight,
-            )
-        val placeables = measurables.fastMap { it.measure(childConstraints) }
-        val width =
-            if (policy.wrapWidth) {
-                placeables.fastMaxOfOrDefault(0) { it.width }
-            } else {
-                constraints.maxWidth
-            }
-        val height =
-            if (policy.wrapHeight) {
-                placeables.fastMaxOfOrDefault(0) { it.height }
-            } else {
-                constraints.maxHeight
-            }
-        layout(width.coerceAtLeast(0), height.coerceAtLeast(0)) {
-            placeables.fastForEach { it.place(0, 0) }
         }
-    }
+    Column(modifier = modifier, content = content)
+}
+
+/**
+ * Builds the first real [DpSize] for a wrap-content window from the
+ * content's measured pixels. Specified axes keep the requested value;
+ * unspecified axes take the measured size (floored by [minimumSize]).
+ * Returns `null` when the wrap axes have not produced a positive size yet.
+ */
+internal fun resolveWrapContentSize(
+    wrapWidth: Boolean,
+    wrapHeight: Boolean,
+    requested: DpSize,
+    minimumSize: DpSize?,
+    measured: IntSize,
+    scale: Float,
+): DpSize? {
+    if (scale <= 0f) return null
+    val measuredW = (measured.width / scale).dp
+    val measuredH = (measured.height / scale).dp
+    val width =
+        when {
+            !wrapWidth && requested.width.isSpecified -> requested.width
+            measured.width > 0 -> measuredW
+            else -> return null
+        }
+    val height =
+        when {
+            !wrapHeight && requested.height.isSpecified -> requested.height
+            measured.height > 0 -> measuredH
+            else -> return null
+        }
+    val minW = minimumSize?.width
+    val minH = minimumSize?.height
+    val flooredW = if (minW != null && minW.isSpecified && width < minW) minW else width
+    val flooredH = if (minH != null && minH.isSpecified && height < minH) minH else height
+    if (flooredW.value <= 0f || flooredH.value <= 0f) return null
+    return DpSize(flooredW, flooredH)
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowSizePolicy.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowSizePolicy.kt
@@ -1,0 +1,88 @@
+package dev.nucleusframework.window.tao
+
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxOfOrDefault
+
+/**
+ * How a [DecoratedWindow] resolves [androidx.compose.ui.window.WindowState.size]
+ * when one or both axes are [Dp.Unspecified] (Compose Desktop wrap-content).
+ */
+internal class WindowSizePolicy(
+    val wrapWidth: Boolean = false,
+    val wrapHeight: Boolean = false,
+    val onContentMeasured: ((widthPx: Int, heightPx: Int) -> Unit)? = null,
+) {
+    val wraps: Boolean get() = wrapWidth || wrapHeight
+}
+
+internal fun Dp.toWindowCreationDp(fallback: Double): Double =
+    if (isSpecified && value.isFinite() && value > 0f) value.toDouble() else fallback
+
+/**
+ * Root of the window scene. Specified axes fill the window; wrap-content
+ * axes measure children with an unbounded max so `fillMaxSize` chrome
+ * outside this node cannot collapse [Dp.Unspecified] to the placeholder
+ * creation size.
+ */
+@Composable
+internal fun WindowContentRoot(
+    policy: WindowSizePolicy,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    if (!policy.wraps) {
+        Layout(
+            content = content,
+            modifier = modifier.fillMaxWidth().fillMaxHeight(),
+        ) { measurables, constraints ->
+            val placeables = measurables.fastMap { it.measure(constraints) }
+            layout(constraints.maxWidth, constraints.maxHeight) {
+                placeables.fastForEach { it.place(0, 0) }
+            }
+        }
+        return
+    }
+    Layout(
+        content = content,
+        modifier =
+            modifier.onSizeChanged { size ->
+                if (size.width > 0 && size.height > 0) {
+                    policy.onContentMeasured?.invoke(size.width, size.height)
+                }
+            },
+    ) { measurables, constraints ->
+        val childConstraints =
+            Constraints(
+                minWidth = 0,
+                maxWidth = if (policy.wrapWidth) Constraints.Infinity else constraints.maxWidth,
+                minHeight = 0,
+                maxHeight = if (policy.wrapHeight) Constraints.Infinity else constraints.maxHeight,
+            )
+        val placeables = measurables.fastMap { it.measure(childConstraints) }
+        val width =
+            if (policy.wrapWidth) {
+                placeables.fastMaxOfOrDefault(0) { it.width }
+            } else {
+                constraints.maxWidth
+            }
+        val height =
+            if (policy.wrapHeight) {
+                placeables.fastMaxOfOrDefault(0) { it.height }
+            } else {
+                constraints.maxHeight
+            }
+        layout(width.coerceAtLeast(0), height.coerceAtLeast(0)) {
+            placeables.fastForEach { it.place(0, 0) }
+        }
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -107,6 +107,21 @@ public object TaoSceneTestBattery {
             TaoWindowScrollTest().pixelScrollMirrorsMacOsAwtPreciseWheelRotationScale()
         }
         run("TaoWindowResizableTest: reflectsCreationFlag") { TaoWindowResizableTest().reflectsCreationFlag() }
+        run("WindowWrapContentTest: creationSizeUsesSpecifiedAxis") {
+            WindowWrapContentTest().creationSizeUsesSpecifiedAxis()
+        }
+        run("WindowWrapContentTest: wrapHeightKeepsRequestedWidth") {
+            WindowWrapContentTest().wrapHeightKeepsRequestedWidth()
+        }
+        run("WindowWrapContentTest: wrapBothUsesMeasuredPixels") {
+            WindowWrapContentTest().wrapBothUsesMeasuredPixels()
+        }
+        run("WindowWrapContentTest: wrapWaitsForPositiveMeasuredAxis") {
+            WindowWrapContentTest().wrapWaitsForPositiveMeasuredAxis()
+        }
+        run("WindowWrapContentTest: wrapHonoursMinimumSizeFloor") {
+            WindowWrapContentTest().wrapHonoursMinimumSizeFloor()
+        }
         run("TaoSceneRenderTest: solid background fills the whole frame") {
             TaoSceneRenderTest().`solid background fills the whole frame`()
         }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -43,6 +43,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoWheelPinchZoomTest::class.java,
             TaoWindowScrollTest::class.java,
             TaoWindowResizableTest::class.java,
+            WindowWrapContentTest::class.java,
             TaoSceneRenderTest::class.java,
             TaoSceneKeyboardTest::class.java,
             TaoScenePointerTest::class.java,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/WindowWrapContentTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/WindowWrapContentTest.kt
@@ -1,0 +1,87 @@
+package dev.nucleusframework.window.tao
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WindowWrapContentTest {
+    @Test
+    fun creationSizeUsesSpecifiedAxis() {
+        assertEquals(300.0, 300.dp.toWindowCreationDp(800.0))
+        assertEquals(800.0, Dp.Unspecified.toWindowCreationDp(800.0))
+        assertEquals(600.0, 0.dp.toWindowCreationDp(600.0))
+    }
+
+    @Test
+    fun wrapHeightKeepsRequestedWidth() {
+        val size =
+            resolveWrapContentSize(
+                wrapWidth = false,
+                wrapHeight = true,
+                requested = DpSize(300.dp, Dp.Unspecified),
+                minimumSize = null,
+                widthPx = 12,
+                heightPx = 160,
+                scale = 2f,
+            )
+        assertEquals(DpSize(300.dp, 80.dp), size)
+    }
+
+    @Test
+    fun wrapBothUsesMeasuredPixels() {
+        val size =
+            resolveWrapContentSize(
+                wrapWidth = true,
+                wrapHeight = true,
+                requested = DpSize(Dp.Unspecified, Dp.Unspecified),
+                minimumSize = null,
+                widthPx = 200,
+                heightPx = 100,
+                scale = 1f,
+            )
+        assertEquals(DpSize(200.dp, 100.dp), size)
+    }
+
+    @Test
+    fun wrapWaitsForPositiveMeasuredAxis() {
+        assertNull(
+            resolveWrapContentSize(
+                wrapWidth = false,
+                wrapHeight = true,
+                requested = DpSize(300.dp, Dp.Unspecified),
+                minimumSize = null,
+                widthPx = 300,
+                heightPx = 0,
+                scale = 1f,
+            ),
+        )
+    }
+
+    @Test
+    fun wrapHonoursMinimumSizeFloor() {
+        val size =
+            resolveWrapContentSize(
+                wrapWidth = false,
+                wrapHeight = true,
+                requested = DpSize(300.dp, Dp.Unspecified),
+                minimumSize = DpSize(200.dp, 120.dp),
+                widthPx = 300,
+                heightPx = 40,
+                scale = 1f,
+            )
+        assertEquals(DpSize(300.dp, 120.dp), size)
+    }
+
+    @Test
+    fun unspecifiedHeightIsDetected() {
+        val size = DpSize(300.dp, Dp.Unspecified)
+        assertTrue(size.width.isSpecified)
+        assertFalse(size.height.isSpecified)
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/WindowWrapContentTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/WindowWrapContentTest.kt
@@ -2,13 +2,11 @@ package dev.nucleusframework.window.tao
 
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.isSpecified
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class WindowWrapContentTest {
     @Test
@@ -26,8 +24,7 @@ class WindowWrapContentTest {
                 wrapHeight = true,
                 requested = DpSize(300.dp, Dp.Unspecified),
                 minimumSize = null,
-                widthPx = 12,
-                heightPx = 160,
+                measured = IntSize(12, 160),
                 scale = 2f,
             )
         assertEquals(DpSize(300.dp, 80.dp), size)
@@ -41,8 +38,7 @@ class WindowWrapContentTest {
                 wrapHeight = true,
                 requested = DpSize(Dp.Unspecified, Dp.Unspecified),
                 minimumSize = null,
-                widthPx = 200,
-                heightPx = 100,
+                measured = IntSize(200, 100),
                 scale = 1f,
             )
         assertEquals(DpSize(200.dp, 100.dp), size)
@@ -56,8 +52,7 @@ class WindowWrapContentTest {
                 wrapHeight = true,
                 requested = DpSize(300.dp, Dp.Unspecified),
                 minimumSize = null,
-                widthPx = 300,
-                heightPx = 0,
+                measured = IntSize(300, 0),
                 scale = 1f,
             ),
         )
@@ -71,17 +66,9 @@ class WindowWrapContentTest {
                 wrapHeight = true,
                 requested = DpSize(300.dp, Dp.Unspecified),
                 minimumSize = DpSize(200.dp, 120.dp),
-                widthPx = 300,
-                heightPx = 40,
+                measured = IntSize(300, 40),
                 scale = 1f,
             )
         assertEquals(DpSize(300.dp, 120.dp), size)
-    }
-
-    @Test
-    fun unspecifiedHeightIsDetected() {
-        val size = DpSize(300.dp, Dp.Unspecified)
-        assertTrue(size.width.isSpecified)
-        assertFalse(size.height.isSpecified)
     }
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -11,7 +12,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.rememberDialogState
+import androidx.compose.ui.window.rememberWindowState
+import dev.nucleusframework.window.tao.DecoratedDialog
 import dev.nucleusframework.window.tao.DecoratedWindow
+import dev.nucleusframework.window.tao.TaoWindow
 import dev.nucleusframework.window.tao.XdgPortalParent
 import dev.nucleusframework.window.tao.taoApplication
 import java.util.concurrent.atomic.AtomicBoolean
@@ -348,8 +355,13 @@ public object TaoHeadfulTestSuiteMain {
                         "nsView=0x${nsView.toString(16)} probe=OK",
                 )
             },
-        ) + ChromeReviewHeadfulCases.all() + DisplayScaleHeadfulCases.all() + FramePacingHeadfulCases.all() +
-            MacWindowChromeStateHeadfulCases.all() + PopupScaleHeadfulCases.all()
+        ) +
+            UnspecifiedSizeHeadfulCases.all() +
+            ChromeReviewHeadfulCases.all() +
+            DisplayScaleHeadfulCases.all() +
+            FramePacingHeadfulCases.all() +
+            MacWindowChromeStateHeadfulCases.all() +
+            PopupScaleHeadfulCases.all()
 
     private val cases: List<TaoWindowTestCase> =
         allCases.filter { nameFilter == null || it.name.contains(nameFilter, ignoreCase = true) }
@@ -396,11 +408,16 @@ public object TaoHeadfulTestSuiteMain {
             // Published by the window content; the driver runs at APPLICATION
             // level so it survives the window scene's attach/re-composition.
             val windowHolder = remember(current) { mutableStateOf<dev.nucleusframework.window.tao.TaoWindow?>(null) }
+            val dialogHolder = remember(current) { mutableStateOf<dev.nucleusframework.window.tao.TaoWindow?>(null) }
 
             if (skipReason == null) {
                 androidx.compose.runtime.key(current) {
                     DecoratedWindow(
                         onCloseRequest = { /* cases drive their own lifecycle */ },
+                        state =
+                            rememberWindowState(
+                                size = case.size ?: DpSize(800.dp, 600.dp),
+                            ),
                         title = "tao-headful: ${case.name}",
                         transparent = case.transparent,
                         nativePopupLayers = case.nativePopupLayers,
@@ -416,6 +433,21 @@ public object TaoHeadfulTestSuiteMain {
                         val w = window
                         LaunchedEffect(w) { windowHolder.value = w }
                     }
+                    val dialogContent = case.dialogContent
+                    if (dialogContent != null) {
+                        DecoratedDialog(
+                            onCloseRequest = { /* cases drive their own lifecycle */ },
+                            state =
+                                rememberDialogState(
+                                    size = case.dialogSize ?: DpSize(400.dp, 300.dp),
+                                ),
+                            title = "tao-headful-dialog: ${case.name}",
+                        ) {
+                            dialogContent()
+                            val w = window
+                            LaunchedEffect(w) { dialogHolder.value = w }
+                        }
+                    }
                 }
             }
 
@@ -430,13 +462,13 @@ public object TaoHeadfulTestSuiteMain {
                 val start = System.currentTimeMillis()
                 val failure =
                     try {
-                        // Wait for the window content to publish its TaoWindow.
-                        val deadline = System.currentTimeMillis() + WINDOW_PUBLISH_TIMEOUT_MILLIS
-                        while (windowHolder.value == null) {
-                            check(System.currentTimeMillis() < deadline) { "window never published its handle" }
-                            kotlinx.coroutines.delay(WINDOW_PUBLISH_POLL_MILLIS)
-                        }
-                        running.driver(TaoWindowTestScope(windowHolder.value!!))
+                        val published =
+                            awaitPublishedWindows(
+                                windowHolder = windowHolder,
+                                dialogHolder = dialogHolder,
+                                waitForDialog = running.dialogContent != null,
+                            )
+                        running.driver(published)
                         null
                     } catch (c: kotlinx.coroutines.CancellationException) {
                         throw c // app teardown — never record as a test failure
@@ -496,6 +528,28 @@ public object TaoHeadfulTestSuiteMain {
         System.getProperty("os.name", "").lowercase().let { os ->
             !os.contains("win") && !os.contains("mac") && !os.contains("darwin")
         }
+
+    private suspend fun awaitPublishedWindows(
+        windowHolder: MutableState<TaoWindow?>,
+        dialogHolder: MutableState<TaoWindow?>,
+        waitForDialog: Boolean,
+    ): TaoWindowTestScope {
+        val deadline = System.currentTimeMillis() + WINDOW_PUBLISH_TIMEOUT_MILLIS
+        while (windowHolder.value == null) {
+            check(System.currentTimeMillis() < deadline) { "window never published its handle" }
+            kotlinx.coroutines.delay(WINDOW_PUBLISH_POLL_MILLIS)
+        }
+        if (waitForDialog) {
+            while (dialogHolder.value == null) {
+                check(System.currentTimeMillis() < deadline) { "dialog never published its handle" }
+                kotlinx.coroutines.delay(WINDOW_PUBLISH_POLL_MILLIS)
+            }
+        }
+        return TaoWindowTestScope(
+            window = windowHolder.value!!,
+            dialogWindow = dialogHolder.value,
+        )
+    }
 
     /**
      * True when the process was launched with an X11-forcing env var. The native

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
@@ -1,6 +1,8 @@
 package dev.nucleusframework.window.tao.headful
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpSize
+import dev.nucleusframework.window.tao.TaoDecoratedDialogScope
 import dev.nucleusframework.window.tao.TaoDecoratedWindowScope
 import dev.nucleusframework.window.tao.TaoWindow
 import kotlinx.coroutines.delay
@@ -42,6 +44,21 @@ internal class TaoWindowTestCase(
      * window instead of being drawn inline. Creation-time only.
      */
     val nativePopupLayers: Boolean = false,
+    /**
+     * Initial [androidx.compose.ui.window.WindowState.size] for this case's
+     * [dev.nucleusframework.window.tao.DecoratedWindow]. `null` keeps the
+     * Compose Desktop default (800×600). Pass a [DpSize] with
+     * [androidx.compose.ui.unit.Dp.Unspecified] on one or both axes to
+     * exercise wrap-content sizing (#532).
+     */
+    val size: DpSize? = null,
+    /**
+     * When non-null, the suite also composes a [dev.nucleusframework.window.tao.DecoratedDialog]
+     * at application scope (parented to this case's window). [dialogSize]
+     * is its [androidx.compose.ui.window.DialogState.size].
+     */
+    val dialogSize: DpSize? = null,
+    val dialogContent: (@Composable TaoDecoratedDialogScope.() -> Unit)? = null,
     /** Optional extra window content composed inside the DecoratedWindow. */
     val content: @Composable TaoDecoratedWindowScope.() -> Unit = {},
     val driver: suspend TaoWindowTestScope.() -> Unit,
@@ -53,6 +70,7 @@ internal class TaoWindowTestCase(
 
 internal class TaoWindowTestScope(
     val window: TaoWindow,
+    val dialogWindow: TaoWindow? = null,
 ) {
     /**
      * Polls [predicate] on the composition dispatcher (the Tao main thread)
@@ -75,6 +93,9 @@ internal class TaoWindowTestScope(
 
     /** Outer bounds as [x, y, w, h] physical px, or null before the window is mapped. */
     fun bounds(): LongArray? = window.outerBoundsPx()
+
+    /** [dialogWindow] outer bounds, or null if no dialog is open / not yet mapped. */
+    fun dialogBounds(): LongArray? = dialogWindow?.outerBoundsPx()
 
     private companion object {
         const val AWAIT_TIMEOUT_MILLIS = 15_000L

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
@@ -94,9 +94,6 @@ internal class TaoWindowTestScope(
     /** Outer bounds as [x, y, w, h] physical px, or null before the window is mapped. */
     fun bounds(): LongArray? = window.outerBoundsPx()
 
-    /** [dialogWindow] outer bounds, or null if no dialog is open / not yet mapped. */
-    fun dialogBounds(): LongArray? = dialogWindow?.outerBoundsPx()
-
     private companion object {
         const val AWAIT_TIMEOUT_MILLIS = 15_000L
         const val POLL_MILLIS = 25L

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/UnspecifiedSizeHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/UnspecifiedSizeHeadfulCases.kt
@@ -1,0 +1,94 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import dev.nucleusframework.window.DialogTitleBar
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * #532 — `Dp.Unspecified` on a window/dialog axis must wrap content, not
+ * create a 0-tall (or NaN) native surface that Metal/EGL refuses to draw.
+ */
+internal object UnspecifiedSizeHeadfulCases {
+    fun all(): List<TaoWindowTestCase> =
+        listOf(
+            windowWrapContentHeight(),
+            dialogWrapContentHeight(),
+        )
+
+    private fun windowWrapContentHeight(): TaoWindowTestCase =
+        TaoWindowTestCase(
+            name = "#532 window wrap-content height maps with non-zero size",
+            paintDefaultBackground = false,
+            size = DpSize(WRAP_WIDTH_DP.dp, Dp.Unspecified),
+            content = {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(WRAP_WIDTH_DP.dp, CONTENT_HEIGHT_DP.dp)
+                            .background(Color.Red),
+                )
+            },
+        ) {
+            awaitUntil("window mapped with wrap-content height") {
+                val b = bounds() ?: return@awaitUntil false
+                if (b[2] <= 0 || b[3] <= 0) return@awaitUntil false
+                val heightDp = b[3] / window.scaleFactor
+                heightDp in CONTENT_HEIGHT_DP..(CONTENT_HEIGHT_DP + MAX_CHROME_DP)
+            }
+            val b = checkNotNull(bounds())
+            val heightDp = b[3] / window.scaleFactor
+            check(heightDp in CONTENT_HEIGHT_DP..(CONTENT_HEIGHT_DP + MAX_CHROME_DP)) {
+                "expected wrap-content height around ${CONTENT_HEIGHT_DP}dp, got ${heightDp}dp"
+            }
+        }
+
+    private fun dialogWrapContentHeight(): TaoWindowTestCase {
+        val dialogRef = AtomicReference<dev.nucleusframework.window.tao.TaoWindow?>(null)
+        return TaoWindowTestCase(
+            name = "#532 dialog wrap-content height maps with non-zero size",
+            paintDefaultBackground = false,
+            dialogSize = DpSize(WRAP_WIDTH_DP.dp, Dp.Unspecified),
+            dialogContent = {
+                DialogTitleBar { }
+                Box(
+                    modifier =
+                        Modifier
+                            .size(WRAP_WIDTH_DP.dp, CONTENT_HEIGHT_DP.dp)
+                            .background(Color.Red),
+                )
+                val w = window
+                SideEffect { dialogRef.set(w) }
+            },
+        ) {
+            val dialog =
+                dialogWindow
+                    ?: dialogRef.get()
+                    ?: run {
+                        awaitUntil("dialog window published") {
+                            dialogRef.get() != null
+                        }
+                        checkNotNull(dialogRef.get())
+                    }
+            awaitUntil("dialog mapped with wrap-content height") {
+                val b = dialog.outerBoundsPx() ?: return@awaitUntil false
+                if (b[2] <= 0 || b[3] <= 0) return@awaitUntil false
+                val heightDp = b[3] / dialog.scaleFactor
+                heightDp in CONTENT_HEIGHT_DP..(CONTENT_HEIGHT_DP + MAX_CHROME_DP)
+            }
+        }
+    }
+
+    private const val WRAP_WIDTH_DP = 300f
+    private const val CONTENT_HEIGHT_DP = 137f
+
+    // Title bar + Linux CSD shadow / macOS traffic-light chrome.
+    private const val MAX_CHROME_DP = 220f
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/UnspecifiedSizeHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/UnspecifiedSizeHeadfulCases.kt
@@ -3,14 +3,12 @@ package dev.nucleusframework.window.tao.headful
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import dev.nucleusframework.window.DialogTitleBar
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * #532 — `Dp.Unspecified` on a window/dialog axis must wrap content, not
@@ -50,9 +48,8 @@ internal object UnspecifiedSizeHeadfulCases {
             }
         }
 
-    private fun dialogWrapContentHeight(): TaoWindowTestCase {
-        val dialogRef = AtomicReference<dev.nucleusframework.window.tao.TaoWindow?>(null)
-        return TaoWindowTestCase(
+    private fun dialogWrapContentHeight(): TaoWindowTestCase =
+        TaoWindowTestCase(
             name = "#532 dialog wrap-content height maps with non-zero size",
             paintDefaultBackground = false,
             dialogSize = DpSize(WRAP_WIDTH_DP.dp, Dp.Unspecified),
@@ -64,19 +61,9 @@ internal object UnspecifiedSizeHeadfulCases {
                             .size(WRAP_WIDTH_DP.dp, CONTENT_HEIGHT_DP.dp)
                             .background(Color.Red),
                 )
-                val w = window
-                SideEffect { dialogRef.set(w) }
             },
         ) {
-            val dialog =
-                dialogWindow
-                    ?: dialogRef.get()
-                    ?: run {
-                        awaitUntil("dialog window published") {
-                            dialogRef.get() != null
-                        }
-                        checkNotNull(dialogRef.get())
-                    }
+            val dialog = checkNotNull(dialogWindow) { "dialog window never published" }
             awaitUntil("dialog mapped with wrap-content height") {
                 val b = dialog.outerBoundsPx() ?: return@awaitUntil false
                 if (b[2] <= 0 || b[3] <= 0) return@awaitUntil false
@@ -84,7 +71,6 @@ internal object UnspecifiedSizeHeadfulCases {
                 heightDp in CONTENT_HEIGHT_DP..(CONTENT_HEIGHT_DP + MAX_CHROME_DP)
             }
         }
-    }
 
     private const val WRAP_WIDTH_DP = 300f
     private const val CONTENT_HEIGHT_DP = 137f


### PR DESCRIPTION
## Summary

- Fixes [#532](https://github.com/NucleusFramework/Nucleus/issues/532): `DecoratedWindow` / `DecoratedDialog` stayed blank when `WindowState` / `DialogState` used `Dp.Unspecified` for wrap-content size.
- Tao forwarded `NaN` as the native inner size, so Metal dropped the drawable (`CAMetalLayer ignoring invalid setDrawableSize … height=0`) and GTK rejected `height > 0`.
- Unspecified axes are now measured from content (same idea as Compose Desktop’s `setSizeSafely`) and applied via `setInnerSize`. Specified axes are unchanged.
- Dialogs no longer pre-center on a NaN height; they re-center on the parent once the real size is known.

## Test plan

- [x] `./gradlew :decorated-window-tao:test --tests dev.nucleusframework.window.tao.WindowWrapContentTest`
- [x] `./gradlew :decorated-window-tao:taoHeadfulTest -Dnucleus.tao.headful.filter=#532` (window + dialog, 3 consecutive runs)
- [x] `:decorated-window-tao:ktlintCheck` and `:decorated-window-tao:detekt`
- [x] Confirm on macOS that `DecoratedDialog(state = rememberDialogState(size = DpSize(300.dp, Dp.Unspecified)))` paints (no `CAMetalLayer … height=0`)
- [x] Confirm wrap-content still works if only width is `Dp.Unspecified`, and that a normal `800×600` window is unchanged