### PR TITLE
fix(window): match Win11 caption-button hover fade

### DIFF
--- a/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/WindowsWindowControlArea.kt
+++ b/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/WindowsWindowControlArea.kt
@@ -24,6 +24,9 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
+import dev.nucleusframework.window.internal.WindowsCaptionButtonStyle
+import dev.nucleusframework.window.internal.animateWindowsCaptionColor
+import dev.nucleusframework.window.internal.windowsCaptionButtonBackground
 import dev.nucleusframework.window.styling.TitleBarStyle
 import dev.nucleusframework.window.utils.windows.windowsTitleBarIcons
 import java.awt.Frame
@@ -31,24 +34,7 @@ import java.awt.event.WindowEvent
 
 private val WINDOWS_BUTTON_WIDTH = 46.dp
 
-// Fixed Windows-native button colors — never theme-dependent
-@Suppress("MagicNumber")
-private val WindowsButtonHoveredLight = Color(0x1A000000)
-
-@Suppress("MagicNumber")
-private val WindowsButtonHoveredDark = Color(0x1AFFFFFF)
-
-@Suppress("MagicNumber")
-private val WindowsButtonPressedLight = Color(0x33000000)
-
-@Suppress("MagicNumber")
-private val WindowsButtonPressedDark = Color(0x33FFFFFF)
-
-@Suppress("MagicNumber")
-private val WindowsCloseButtonHovered = Color(0xFFE81123)
-
-@Suppress("MagicNumber")
-private val WindowsCloseButtonPressed = Color(0xFFF1707A)
+private const val CLOSE_HOVER_ALPHA_EPSILON = 0.02f
 
 @Suppress("FunctionNaming")
 @Composable
@@ -163,18 +149,28 @@ private fun TitleBarScope.WindowsCaptionButton(
 ) {
     var hovered by remember { mutableStateOf(false) }
     var pressed by remember { mutableStateOf(false) }
+    val appearing = hovered || pressed
 
     val isDark = LocalIsDarkTheme.current
-    val backgroundColor =
-        captionButtonBackground(
+    val targetBackground =
+        windowsCaptionButtonBackground(
             hovered = hovered,
             pressed = pressed,
             isCloseButton = isCloseButton,
             isDark = isDark,
-            style = style,
+            customHover = style.colors.iconButtonHoveredBackground,
+            customPressed = style.colors.iconButtonPressedBackground,
+        )
+    val backgroundColor =
+        animateWindowsCaptionColor(
+            targetBackground,
+            appearing = appearing,
+            durationMillis = WindowsCaptionButtonStyle.BackgroundFadeOutMillis,
         )
 
-    val isCloseHovered = (hovered || pressed) && isCloseButton
+    val isCloseHovered =
+        isCloseButton &&
+            (appearing || backgroundColor.alpha > CLOSE_HOVER_ALPHA_EPSILON)
     val currentIcon =
         when {
             isCloseHovered && iconHover != null -> iconHover
@@ -215,30 +211,6 @@ private fun TitleBarScope.WindowsCaptionButton(
             contentDescription = contentDescription,
             colorFilter = colorFilter,
         )
-    }
-}
-
-private fun captionButtonBackground(
-    hovered: Boolean,
-    pressed: Boolean,
-    isCloseButton: Boolean,
-    isDark: Boolean,
-    style: TitleBarStyle,
-): Color {
-    val customHover = style.colors.iconButtonHoveredBackground
-    val customPressed = style.colors.iconButtonPressedBackground
-    val pressedColor =
-        customPressed.takeUnless { it == Color.Transparent }
-            ?: if (isDark) WindowsButtonPressedDark else WindowsButtonPressedLight
-    val hoveredColor =
-        customHover.takeUnless { it == Color.Transparent }
-            ?: if (isDark) WindowsButtonHoveredDark else WindowsButtonHoveredLight
-    return when {
-        pressed && isCloseButton -> WindowsCloseButtonPressed
-        pressed -> pressedColor
-        hovered && isCloseButton -> WindowsCloseButtonHovered
-        hovered -> hoveredColor
-        else -> Color.Transparent
     }
 }
 

--- a/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/WindowsWindowControlArea.kt
+++ b/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/WindowsWindowControlArea.kt
@@ -165,7 +165,7 @@ private fun TitleBarScope.WindowsCaptionButton(
         animateWindowsCaptionColor(
             targetBackground,
             appearing = appearing,
-            durationMillis = WindowsCaptionButtonStyle.BackgroundFadeOutMillis,
+            durationMillis = WindowsCaptionButtonStyle.BACKGROUND_FADE_OUT_MILLIS,
         )
 
     val isCloseHovered =

--- a/decorated-window-core/api/decorated-window-core.api
+++ b/decorated-window-core/api/decorated-window-core.api
@@ -668,6 +668,25 @@ public final class dev/nucleusframework/window/internal/InsideBorderModifierKt {
 	public static synthetic fun insideBorder-xT4_qwU$default (Landroidx/compose/ui/Modifier;FJLandroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 }
 
+public final class dev/nucleusframework/window/internal/WindowsCaptionButtonStyle {
+	public static final field $stable I
+	public static final field BackgroundFadeOutMillis I
+	public static final field ForegroundFadeOutMillis I
+	public static final field INSTANCE Ldev/nucleusframework/window/internal/WindowsCaptionButtonStyle;
+	public final fun getCloseHovered-0d7_KjU ()J
+	public final fun getCloseIdle-0d7_KjU ()J
+	public final fun getClosePressed-0d7_KjU ()J
+	public final fun getHoveredDark-0d7_KjU ()J
+	public final fun getHoveredLight-0d7_KjU ()J
+	public final fun getPressedDark-0d7_KjU ()J
+	public final fun getPressedLight-0d7_KjU ()J
+}
+
+public final class dev/nucleusframework/window/internal/WindowsCaptionButtonStyleKt {
+	public static final fun animateWindowsCaptionColor-3J-VO9M (JZILandroidx/compose/runtime/Composer;I)J
+	public static final fun windowsCaptionButtonBackground-VT9Kpxs (ZZZZJJ)J
+}
+
 public final class dev/nucleusframework/window/styling/DecoratedWindowColors {
 	public static final field $stable I
 	public synthetic fun <init> (JJJILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/decorated-window-core/api/decorated-window-core.api
+++ b/decorated-window-core/api/decorated-window-core.api
@@ -670,8 +670,8 @@ public final class dev/nucleusframework/window/internal/InsideBorderModifierKt {
 
 public final class dev/nucleusframework/window/internal/WindowsCaptionButtonStyle {
 	public static final field $stable I
-	public static final field BackgroundFadeOutMillis I
-	public static final field ForegroundFadeOutMillis I
+	public static final field BACKGROUND_FADE_OUT_MILLIS I
+	public static final field FOREGROUND_FADE_OUT_MILLIS I
 	public static final field INSTANCE Ldev/nucleusframework/window/internal/WindowsCaptionButtonStyle;
 	public final fun getCloseHovered-0d7_KjU ()J
 	public final fun getCloseIdle-0d7_KjU ()J

--- a/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/NucleusDecoratedWindowTheme.kt
+++ b/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/NucleusDecoratedWindowTheme.kt
@@ -55,8 +55,8 @@ public object DecoratedWindowDefaults {
         DecoratedWindowStyle(
             colors =
                 DecoratedWindowColors(
-                    border = Color(0x12FFFFFF),
-                    borderInactive = Color(0x12FFFFFF),
+                    border = Color(0x0F000000),
+                    borderInactive = Color(0x0F000000),
                     background = Color.White,
                 ),
             metrics = DecoratedWindowMetrics(borderWidth = 1.dp),

--- a/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/internal/WindowsCaptionButtonStyle.kt
+++ b/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/internal/WindowsCaptionButtonStyle.kt
@@ -47,10 +47,10 @@ public object WindowsCaptionButtonStyle {
     public val CloseIdle: Color = Color(0x00C42B1C)
 
     /** `MinMaxCloseControl.xaml` PointerOver → Normal background duration. */
-    public const val BackgroundFadeOutMillis: Int = 150
+    public const val BACKGROUND_FADE_OUT_MILLIS: Int = 150
 
     /** `MinMaxCloseControl.xaml` PointerOver → Normal glyph duration. */
-    public const val ForegroundFadeOutMillis: Int = 100
+    public const val FOREGROUND_FADE_OUT_MILLIS: Int = 100
 }
 
 /**

--- a/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/internal/WindowsCaptionButtonStyle.kt
+++ b/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/internal/WindowsCaptionButtonStyle.kt
@@ -1,0 +1,124 @@
+@file:Suppress("MagicNumber")
+
+package dev.nucleusframework.window.internal
+
+import androidx.compose.animation.core.AnimationVector4D
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.TwoWayConverter
+import androidx.compose.animation.core.animateValueAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Native Win11 caption-button tokens, taken from WinUI
+ * `Common_themeresources_any.xaml` and Windows Terminal
+ * `MinMaxCloseControl.xaml` (the Microsoft control that matches Notepad).
+ *
+ * Hover-in is instantaneous. Hover-out fades the fill in 150ms and the glyph
+ * in 100ms. Colors interpolate in sRGB so the close button stays on
+ * `#C42B1C` instead of flashing gray (microsoft/terminal#9762).
+ */
+public object WindowsCaptionButtonStyle {
+    /** WinUI `SubtleFillColorSecondary` (light). */
+    public val HoveredLight: Color = Color(0x09000000)
+
+    /** WinUI `SubtleFillColorSecondary` (dark). */
+    public val HoveredDark: Color = Color(0x0FFFFFFF)
+
+    /** WinUI `SubtleFillColorTertiary` (light). */
+    public val PressedLight: Color = Color(0x06000000)
+
+    /** WinUI `SubtleFillColorTertiary` (dark). */
+    public val PressedDark: Color = Color(0x0AFFFFFF)
+
+    /** Win11 / WinUI `SystemFillColorCritical` close hover. */
+    public val CloseHovered: Color = Color(0xFFC42B1C)
+
+    /** Terminal close-pressed: the same red at 90% opacity. */
+    public val ClosePressed: Color = Color(0xE6C42B1C)
+
+    /**
+     * Idle close fill: `#C42B1C` at alpha 0. ColorAnimation from this to
+     * [CloseHovered] only changes alpha, so the fade never goes through gray.
+     */
+    public val CloseIdle: Color = Color(0x00C42B1C)
+
+    /** `MinMaxCloseControl.xaml` PointerOver → Normal background duration. */
+    public const val BackgroundFadeOutMillis: Int = 150
+
+    /** `MinMaxCloseControl.xaml` PointerOver → Normal glyph duration. */
+    public const val ForegroundFadeOutMillis: Int = 100
+}
+
+/**
+ * Caption-button fill for the current pointer state.
+ *
+ * [customHover] / [customPressed] override the min/max overlay when they are
+ * not [Color.Transparent]. Close hover/pressed always use the system red,
+ * matching WinUI `AppWindowTitleBar` (the button background color is not
+ * applied to the close button hover and pressed states).
+ */
+public fun windowsCaptionButtonBackground(
+    hovered: Boolean,
+    pressed: Boolean,
+    isCloseButton: Boolean,
+    isDark: Boolean,
+    customHover: Color,
+    customPressed: Color,
+): Color {
+    val pressedColor =
+        customPressed.takeUnless { it == Color.Transparent }
+            ?: if (isDark) WindowsCaptionButtonStyle.PressedDark else WindowsCaptionButtonStyle.PressedLight
+    val hoveredColor =
+        customHover.takeUnless { it == Color.Transparent }
+            ?: if (isDark) WindowsCaptionButtonStyle.HoveredDark else WindowsCaptionButtonStyle.HoveredLight
+    return when {
+        pressed && isCloseButton -> WindowsCaptionButtonStyle.ClosePressed
+        pressed -> pressedColor
+        hovered && isCloseButton -> WindowsCaptionButtonStyle.CloseHovered
+        hovered -> hoveredColor
+        isCloseButton -> WindowsCaptionButtonStyle.CloseIdle
+        else -> hoveredColor.copy(alpha = 0f)
+    }
+}
+
+/**
+ * Animates a caption-button color the way native Win32 / Terminal does:
+ * snap when the overlay appears, linear sRGB fade when it disappears.
+ */
+@Composable
+public fun animateWindowsCaptionColor(
+    target: Color,
+    appearing: Boolean,
+    durationMillis: Int,
+): Color {
+    val spec =
+        if (appearing) {
+            snap()
+        } else {
+            tween<Color>(durationMillis = durationMillis, easing = LinearEasing)
+        }
+    val animated by animateValueAsState(
+        targetValue = target,
+        typeConverter = WindowsCaptionColorConverter,
+        animationSpec = spec,
+        label = "windowsCaptionColor",
+    )
+    return animated
+}
+
+// sRGB component interpolation — not Oklab — so `#C42B1C` ↔ `#00C42B1C`
+// only changes alpha. Compose's default Color converter would fade through
+// a neutral gray, which is the Terminal #9762 bug.
+private val WindowsCaptionColorConverter =
+    TwoWayConverter<Color, AnimationVector4D>(
+        convertToVector = { color ->
+            AnimationVector4D(color.red, color.green, color.blue, color.alpha)
+        },
+        convertFromVector = { vector ->
+            Color(vector.v1, vector.v2, vector.v3, vector.v4)
+        },
+    )

--- a/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/styling/TitleBarStyling.kt
+++ b/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/styling/TitleBarStyling.kt
@@ -22,7 +22,16 @@ public data class TitleBarColors(
     val content: Color,
     val border: Color,
     val fullscreenControlButtonsBackground: Color = Color.Unspecified,
+    /**
+     * Hover fill for Windows min/max caption buttons. [Color.Transparent]
+     * (the default) keeps the Win11 SubtleFill overlay. The close button
+     * always uses the system red — WinUI does not apply this color there.
+     */
     val iconButtonHoveredBackground: Color = Color.Transparent,
+    /**
+     * Pressed fill for Windows min/max caption buttons. [Color.Transparent]
+     * (the default) keeps the Win11 SubtleFill overlay. Close stays system red.
+     */
     val iconButtonPressedBackground: Color = Color.Transparent,
     val controlButtonIconColor: Color = Color.Unspecified,
     val controlButtonIconHoverColor: Color = Color.Unspecified,

--- a/decorated-window-core/src/test/kotlin/dev/nucleusframework/window/internal/WindowsCaptionButtonStyleTest.kt
+++ b/decorated-window-core/src/test/kotlin/dev/nucleusframework/window/internal/WindowsCaptionButtonStyleTest.kt
@@ -24,8 +24,8 @@ class WindowsCaptionButtonStyleTest {
 
     @Test
     fun fadeOutDurationsMatchTerminalCaptionButtons() {
-        assertEquals(150, WindowsCaptionButtonStyle.BackgroundFadeOutMillis)
-        assertEquals(100, WindowsCaptionButtonStyle.ForegroundFadeOutMillis)
+        assertEquals(150, WindowsCaptionButtonStyle.BACKGROUND_FADE_OUT_MILLIS)
+        assertEquals(100, WindowsCaptionButtonStyle.FOREGROUND_FADE_OUT_MILLIS)
     }
 
     @Test

--- a/decorated-window-core/src/test/kotlin/dev/nucleusframework/window/internal/WindowsCaptionButtonStyleTest.kt
+++ b/decorated-window-core/src/test/kotlin/dev/nucleusframework/window/internal/WindowsCaptionButtonStyleTest.kt
@@ -1,0 +1,88 @@
+package dev.nucleusframework.window.internal
+
+import androidx.compose.ui.graphics.Color
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WindowsCaptionButtonStyleTest {
+    @Test
+    fun closeIdleSharesHueWithHoveredSoFadeDoesNotGoGray() {
+        val idle = WindowsCaptionButtonStyle.CloseIdle
+        val hovered = WindowsCaptionButtonStyle.CloseHovered
+        assertEquals(hovered.red, idle.red, 0.001f)
+        assertEquals(hovered.green, idle.green, 0.001f)
+        assertEquals(hovered.blue, idle.blue, 0.001f)
+        assertEquals(0f, idle.alpha, 0.001f)
+        assertEquals(1f, hovered.alpha, 0.001f)
+    }
+
+    @Test
+    fun closeHoveredIsWin11CriticalRed() {
+        assertEquals(Color(0xFFC42B1C), WindowsCaptionButtonStyle.CloseHovered)
+    }
+
+    @Test
+    fun fadeOutDurationsMatchTerminalCaptionButtons() {
+        assertEquals(150, WindowsCaptionButtonStyle.BackgroundFadeOutMillis)
+        assertEquals(100, WindowsCaptionButtonStyle.ForegroundFadeOutMillis)
+    }
+
+    @Test
+    fun customHoverAppliesToMinMaxButNotClose() {
+        val custom = Color(0xFF336699)
+        val minHover =
+            windowsCaptionButtonBackground(
+                hovered = true,
+                pressed = false,
+                isCloseButton = false,
+                isDark = true,
+                customHover = custom,
+                customPressed = Color.Transparent,
+            )
+        val closeHover =
+            windowsCaptionButtonBackground(
+                hovered = true,
+                pressed = false,
+                isCloseButton = true,
+                isDark = true,
+                customHover = custom,
+                customPressed = Color.Transparent,
+            )
+        assertEquals(custom, minHover)
+        assertEquals(WindowsCaptionButtonStyle.CloseHovered, closeHover)
+    }
+
+    @Test
+    fun idleMinMaxKeepsHoverHueAtZeroAlpha() {
+        val idle =
+            windowsCaptionButtonBackground(
+                hovered = false,
+                pressed = false,
+                isCloseButton = false,
+                isDark = true,
+                customHover = Color.Transparent,
+                customPressed = Color.Transparent,
+            )
+        val hover = WindowsCaptionButtonStyle.HoveredDark
+        assertEquals(hover.red, idle.red, 0.001f)
+        assertEquals(hover.green, idle.green, 0.001f)
+        assertEquals(hover.blue, idle.blue, 0.001f)
+        assertEquals(0f, idle.alpha, 0.001f)
+    }
+
+    @Test
+    fun defaultDarkHoverIsWinuiSubtleFillSecondary() {
+        val hover =
+            windowsCaptionButtonBackground(
+                hovered = true,
+                pressed = false,
+                isCloseButton = false,
+                isDark = true,
+                customHover = Color.Transparent,
+                customPressed = Color.Transparent,
+            )
+        assertEquals(WindowsCaptionButtonStyle.HoveredDark, hover)
+        assertTrue(hover.alpha in 0.05f..0.07f)
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/WindowControlsWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/WindowControlsWindows.kt
@@ -276,7 +276,7 @@ private fun WindowsCaptionButton(
         animateWindowsCaptionColor(
             targetBackground,
             appearing = appearing,
-            durationMillis = WindowsCaptionButtonStyle.BackgroundFadeOutMillis,
+            durationMillis = WindowsCaptionButtonStyle.BACKGROUND_FADE_OUT_MILLIS,
         )
 
     // Keep the white close glyph while the red fill is still fading out so

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/WindowControlsWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/WindowControlsWindows.kt
@@ -57,33 +57,20 @@ import dev.nucleusframework.window.icons.windows.RestoreDark
 import dev.nucleusframework.window.icons.windows.RestoreInactive
 import dev.nucleusframework.window.icons.windows.RestoreInactiveDark
 import dev.nucleusframework.window.icons.windows.WindowsControlButtonIcons
+import dev.nucleusframework.window.internal.WindowsCaptionButtonStyle
+import dev.nucleusframework.window.internal.animateWindowsCaptionColor
+import dev.nucleusframework.window.internal.windowsCaptionButtonBackground
 import dev.nucleusframework.window.resolveWindowControl
 import dev.nucleusframework.window.styling.TitleBarStyle
 import dev.nucleusframework.window.tao.LocalTaoWindow
 import dev.nucleusframework.window.tao.TaoWindow
 
-// Mirrors `decorated-window-core/WindowsWindowControlArea.kt` so the visual
+// Mirrors `decorated-window-awt/WindowsWindowControlArea.kt` so the visual
 // output is identical between the AWT-based backend and the Tao backend.
 
 private val WINDOWS_BUTTON_WIDTH = 46.dp
 
-@Suppress("MagicNumber")
-private val WindowsButtonHoveredLight = Color(0x1A000000)
-
-@Suppress("MagicNumber")
-private val WindowsButtonHoveredDark = Color(0x1AFFFFFF)
-
-@Suppress("MagicNumber")
-private val WindowsButtonPressedLight = Color(0x33000000)
-
-@Suppress("MagicNumber")
-private val WindowsButtonPressedDark = Color(0x33FFFFFF)
-
-@Suppress("MagicNumber")
-private val WindowsCloseButtonHovered = Color(0xFFE81123)
-
-@Suppress("MagicNumber")
-private val WindowsCloseButtonPressed = Color(0xFFF1707A)
+private const val CLOSE_HOVER_ALPHA_EPSILON = 0.02f
 
 /**
  * Windows-style window controls (minimize / maximize-restore / close).
@@ -274,17 +261,29 @@ private fun WindowsCaptionButton(
 ) {
     var hovered by remember { mutableStateOf(false) }
     var pressed by remember { mutableStateOf(false) }
+    val appearing = hovered || pressed
 
-    val backgroundColor =
-        captionButtonBackground(
+    val targetBackground =
+        windowsCaptionButtonBackground(
             hovered = hovered,
             pressed = pressed,
             isCloseButton = isCloseButton,
             isDark = isDark,
-            style = style,
+            customHover = style.colors.iconButtonHoveredBackground,
+            customPressed = style.colors.iconButtonPressedBackground,
+        )
+    val backgroundColor =
+        animateWindowsCaptionColor(
+            targetBackground,
+            appearing = appearing,
+            durationMillis = WindowsCaptionButtonStyle.BackgroundFadeOutMillis,
         )
 
-    val isCloseHovered = (hovered || pressed) && isCloseButton
+    // Keep the white close glyph while the red fill is still fading out so
+    // the X does not snap back to gray on a still-red background.
+    val isCloseHovered =
+        isCloseButton &&
+            (appearing || backgroundColor.alpha > CLOSE_HOVER_ALPHA_EPSILON)
     val currentIcon: Painter =
         rememberVectorPainter(
             if (isCloseHovered && iconHover != null) iconHover else icon,
@@ -319,33 +318,6 @@ private fun WindowsCaptionButton(
         contentAlignment = Alignment.Center,
     ) {
         Image(painter = currentIcon, contentDescription = contentDescription, colorFilter = colorFilter)
-    }
-}
-
-// Mirrors `decorated-window-core/WindowsWindowControlArea.kt` so custom
-// [TitleBarStyle] colors apply identically on the Tao backend. Close-button
-// hover/pressed always use the fixed Windows red — matching AWT.
-private fun captionButtonBackground(
-    hovered: Boolean,
-    pressed: Boolean,
-    isCloseButton: Boolean,
-    isDark: Boolean,
-    style: TitleBarStyle,
-): Color {
-    val customHover = style.colors.iconButtonHoveredBackground
-    val customPressed = style.colors.iconButtonPressedBackground
-    val pressedColor =
-        customPressed.takeUnless { it == Color.Transparent }
-            ?: if (isDark) WindowsButtonPressedDark else WindowsButtonPressedLight
-    val hoveredColor =
-        customHover.takeUnless { it == Color.Transparent }
-            ?: if (isDark) WindowsButtonHoveredDark else WindowsButtonHoveredLight
-    return when {
-        pressed && isCloseButton -> WindowsCloseButtonPressed
-        pressed -> pressedColor
-        hovered && isCloseButton -> WindowsCloseButtonHovered
-        hovered -> hoveredColor
-        else -> Color.Transparent
     }
 }
 


### PR DESCRIPTION
Closes #517

## Summary
- Animate Windows caption buttons like native Win32 / Terminal `MinMaxCloseControl`: instant hover-in, 150ms linear sRGB fade-out.
- Use Win11 tokens: SubtleFill overlays for min/max, close `#C42B1C`. Idle close keeps the same hue at alpha 0 so the fade never flashes gray (microsoft/terminal#9762).
- `TitleBarColors.iconButtonHoveredBackground` / `iconButtonPressedBackground` customize min/max. Close stays system red, matching WinUI `AppWindowTitleBar`.
- Share the tokens and animation between Tao and AWT.
- Light default window border uses WinUI `ControlStrokeColorDefault` (`#0F000000`) instead of a near-invisible white-on-white stroke.
- Does **not** redraw a Compose CSD contour on Windows — the DWM `DWMWA_BORDER_COLOR` path from #527 is unchanged.

## Test plan
- [x] `./gradlew :examples:nucleus-demo:run` on Windows 11
- [x] Hover and leave minimize / maximize / close — overlay snaps in, fades out
- [x] Close fade stays on red (no gray intermediate)
- [ ] Set `iconButtonHoveredBackground` — min/max pick it up, close stays red
- [x] No extra inner frame around the window (no #527 regression)
- [x] Light theme default window border is a faint dark line