### PR TITLE
feat(window): opt-in native context menu

### DIFF
--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelContextMenuInterpreter.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelContextMenuInterpreter.kt
@@ -1,0 +1,54 @@
+package dev.nucleusframework.window.jewel
+
+import androidx.compose.foundation.ContextMenuItem
+import dev.nucleusframework.application.contextmenu.ContextMenuEntry
+import dev.nucleusframework.application.contextmenu.ContextMenuIcon
+import dev.nucleusframework.application.contextmenu.ContextMenuItemInterpreter
+import dev.nucleusframework.application.contextmenu.DefaultContextMenuItemInterpreter
+import org.jetbrains.jewel.ui.component.ContextMenuDivider
+import org.jetbrains.jewel.ui.component.ContextMenuItemOption
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
+import org.jetbrains.jewel.ui.component.ContextSubmenu
+
+/**
+ * Jewel-aware [ContextMenuItemInterpreter]: maps `ContextMenuDivider` /
+ * `ContextSubmenu` / `ContextMenuItemOption.actionType` onto [ContextMenuEntry]
+ * so the native menu can show OS icons for Cut / Copy / Paste instead of
+ * Jewel's `AllIconsKeys`.
+ *
+ * Custom `IconKey`s on items without an [ContextMenuItemOptionAction] are
+ * ignored in this version (no SVG → `NSImage` rasteriser yet). Use
+ * [dev.nucleusframework.application.contextmenu.NucleusContextMenuItem] with
+ * a [ContextMenuIcon] for those.
+ */
+public object JewelContextMenuInterpreter : ContextMenuItemInterpreter {
+    override fun interpret(
+        item: ContextMenuItem,
+        separator: ContextMenuItem,
+    ): ContextMenuEntry =
+        when (item) {
+            ContextMenuDivider -> ContextMenuEntry.Separator
+            is ContextSubmenu ->
+                ContextMenuEntry.Submenu(
+                    label = item.label,
+                    items = item.submenu().map { child -> interpret(child, separator) },
+                )
+            is ContextMenuItemOption ->
+                ContextMenuEntry.Item(
+                    label = item.label,
+                    enabled = item.enabled,
+                    icon = item.actionType.toStockIcon(),
+                    onClick = item.onClick,
+                )
+            else -> DefaultContextMenuItemInterpreter.interpret(item, separator)
+        }
+}
+
+private fun ContextMenuItemOptionAction?.toStockIcon(): ContextMenuIcon? =
+    when (this) {
+        ContextMenuItemOptionAction.CutMenuItemOptionAction -> ContextMenuIcon.Cut
+        ContextMenuItemOptionAction.CopyMenuItemOptionAction -> ContextMenuIcon.Copy
+        ContextMenuItemOptionAction.PasteMenuItemOptionAction -> ContextMenuIcon.Paste
+        ContextMenuItemOptionAction.SelectAllMenuItemOptionAction -> ContextMenuIcon.SelectAll
+        null -> null
+    }

--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
@@ -99,6 +99,9 @@ public fun NucleusApplicationScope.JewelDecoratedWindow(
     // of the parent, the only client-positionable window kind under xdg-shell
     // (parent-relative coordinates). For drag ghosts. Ignored elsewhere.
     popupFor: NucleusWindow? = null,
+    // Replace Compose-drawn context menus with the OS menu. Tao + macOS
+    // only; no-op on Windows, Linux, and AWT.
+    nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (Tao backend; on Linux effective on X11/XWayland only).
     // No-op on AWT.
@@ -131,6 +134,7 @@ public fun NucleusApplicationScope.JewelDecoratedWindow(
             alwaysOnTop = alwaysOnTop,
             undecorated = undecorated,
             popupFor = popupFor,
+            nativeContextMenu = nativeContextMenu,
             hiddenFromDock = hiddenFromDock,
             minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,

--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
@@ -100,7 +100,8 @@ public fun NucleusApplicationScope.JewelDecoratedWindow(
     // (parent-relative coordinates). For drag ghosts. Ignored elsewhere.
     popupFor: NucleusWindow? = null,
     // Replace Compose-drawn context menus with the OS-looking menu. Tao +
-    // macOS (`NSMenu`) or Tao + Windows (Fluent flyout); no-op on Linux and AWT.
+    // macOS (`NSMenu`), or a Compose flyout on Linux (Adwaita) / Windows
+    // (Fluent). No-op on AWT.
     nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (Tao backend; on Linux effective on X11/XWayland only).

--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
@@ -99,8 +99,8 @@ public fun NucleusApplicationScope.JewelDecoratedWindow(
     // of the parent, the only client-positionable window kind under xdg-shell
     // (parent-relative coordinates). For drag ghosts. Ignored elsewhere.
     popupFor: NucleusWindow? = null,
-    // Replace Compose-drawn context menus with the OS menu. Tao + macOS
-    // only; no-op on Windows, Linux, and AWT.
+    // Replace Compose-drawn context menus with the OS-looking menu. Tao +
+    // macOS (`NSMenu`) or Tao + Windows (Fluent flyout); no-op on Linux and AWT.
     nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (Tao backend; on Linux effective on X11/XWayland only).

--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelSpellcheck.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelSpellcheck.kt
@@ -2,11 +2,14 @@ package dev.nucleusframework.window.jewel
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import dev.nucleusframework.application.contextmenu.LocalContextMenuItemInterpreter
 import dev.nucleusframework.application.spellcheck.LocalSpellcheckMenuSeparator
 import org.jetbrains.jewel.ui.component.ContextMenuDivider
 
 /**
- * Provides Jewel's [ContextMenuDivider] to [LocalSpellcheckMenuSeparator].
+ * Provides Jewel's [ContextMenuDivider] to [LocalSpellcheckMenuSeparator] and
+ * [JewelContextMenuInterpreter] so a native context menu can map Jewel
+ * Cut / Copy / Paste action types to OS icons.
  *
  * Compile-time Jewel reference — no reflection. Installed automatically by
  * [JewelDecoratedWindow] and [JewelDecoratedDialog]. Apps that build their
@@ -16,6 +19,7 @@ import org.jetbrains.jewel.ui.component.ContextMenuDivider
 public fun ProvideJewelSpellcheckMenu(content: @Composable () -> Unit) {
     CompositionLocalProvider(
         LocalSpellcheckMenuSeparator provides ContextMenuDivider,
+        LocalContextMenuItemInterpreter provides JewelContextMenuInterpreter,
         content = content,
     )
 }

--- a/decorated-window-material2/api/decorated-window-material2.api
+++ b/decorated-window-material2/api/decorated-window-material2.api
@@ -17,7 +17,7 @@ public final class dev/nucleusframework/window/material2/MaterialDecoratedDialog
 
 public final class dev/nucleusframework/window/material2/MaterialDecoratedWindowKt {
 	public static final fun MaterialDecoratedWindow-CL87EUo (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ldev/nucleusframework/window/styling/TitleBarStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
-	public static final fun MaterialDecoratedWindow-ZKw2RcA (Ldev/nucleusframework/application/NucleusApplicationScope;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ldev/nucleusframework/window/styling/TitleBarStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun MaterialDecoratedWindow-fsutTYA (Ldev/nucleusframework/application/NucleusApplicationScope;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ldev/nucleusframework/window/styling/TitleBarStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class dev/nucleusframework/window/material2/MaterialDialogTitleBarKt {

--- a/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
+++ b/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
@@ -82,7 +82,8 @@ public fun NucleusApplicationScope.MaterialDecoratedWindow(
     // extend past the window bounds. Honoured by the Tao backend; ignored by AWT.
     nativePopupLayers: Boolean = false,
     // Replace Compose-drawn context menus with the OS-looking menu. Tao +
-    // macOS (`NSMenu`) or Tao + Windows (Fluent flyout); no-op on Linux and AWT.
+    // macOS (`NSMenu`), or a Compose flyout on Linux (Adwaita) / Windows
+    // (Fluent). No-op on AWT.
     nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (Tao backend; on Linux effective on X11/XWayland only).

--- a/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
+++ b/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
@@ -81,6 +81,9 @@ public fun NucleusApplicationScope.MaterialDecoratedWindow(
     // (NSPanel / WS_POPUP HWND / Tao popup window on Linux) so menus can
     // extend past the window bounds. Honoured by the Tao backend; ignored by AWT.
     nativePopupLayers: Boolean = false,
+    // Replace Compose-drawn context menus with the OS menu. Tao + macOS
+    // only; no-op on Windows, Linux, and AWT.
+    nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (Tao backend; on Linux effective on X11/XWayland only).
     // No-op on AWT.
@@ -114,6 +117,7 @@ public fun NucleusApplicationScope.MaterialDecoratedWindow(
             focusable = focusable,
             alwaysOnTop = alwaysOnTop,
             nativePopupLayers = nativePopupLayers,
+            nativeContextMenu = nativeContextMenu,
             hiddenFromDock = hiddenFromDock,
             minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,

--- a/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
+++ b/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
@@ -81,8 +81,8 @@ public fun NucleusApplicationScope.MaterialDecoratedWindow(
     // (NSPanel / WS_POPUP HWND / Tao popup window on Linux) so menus can
     // extend past the window bounds. Honoured by the Tao backend; ignored by AWT.
     nativePopupLayers: Boolean = false,
-    // Replace Compose-drawn context menus with the OS menu. Tao + macOS
-    // only; no-op on Windows, Linux, and AWT.
+    // Replace Compose-drawn context menus with the OS-looking menu. Tao +
+    // macOS (`NSMenu`) or Tao + Windows (Fluent flyout); no-op on Linux and AWT.
     nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (Tao backend; on Linux effective on X11/XWayland only).

--- a/decorated-window-material3/api/decorated-window-material3.api
+++ b/decorated-window-material3/api/decorated-window-material3.api
@@ -23,7 +23,7 @@ public final class dev/nucleusframework/window/material/MaterialDecoratedDialogK
 
 public final class dev/nucleusframework/window/material/MaterialDecoratedWindowKt {
 	public static final fun MaterialDecoratedWindow-2nA36Wk (Landroidx/compose/ui/window/ApplicationScope;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ldev/nucleusframework/window/styling/TitleBarStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
-	public static final fun MaterialDecoratedWindow-ZKw2RcA (Ldev/nucleusframework/application/NucleusApplicationScope;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ldev/nucleusframework/window/styling/TitleBarStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun MaterialDecoratedWindow-fsutTYA (Ldev/nucleusframework/application/NucleusApplicationScope;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ldev/nucleusframework/window/styling/TitleBarStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class dev/nucleusframework/window/material/MaterialDialogTitleBarKt {

--- a/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
+++ b/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
@@ -100,6 +100,9 @@ public fun NucleusApplicationScope.MaterialDecoratedWindow(
     // (NSPanel / WS_POPUP HWND / Tao popup window on Linux) so menus can
     // extend past the window bounds. Honoured by the Tao backend; ignored by AWT.
     nativePopupLayers: Boolean = false,
+    // Replace Compose-drawn context menus with the OS menu. Tao + macOS
+    // only; no-op on Windows, Linux, and AWT.
+    nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (Tao backend; on Linux effective on X11/XWayland only).
     // No-op on AWT.
@@ -133,6 +136,7 @@ public fun NucleusApplicationScope.MaterialDecoratedWindow(
             focusable = focusable,
             alwaysOnTop = alwaysOnTop,
             nativePopupLayers = nativePopupLayers,
+            nativeContextMenu = nativeContextMenu,
             hiddenFromDock = hiddenFromDock,
             minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,

--- a/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
+++ b/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
@@ -101,7 +101,8 @@ public fun NucleusApplicationScope.MaterialDecoratedWindow(
     // extend past the window bounds. Honoured by the Tao backend; ignored by AWT.
     nativePopupLayers: Boolean = false,
     // Replace Compose-drawn context menus with the OS-looking menu. Tao +
-    // macOS (`NSMenu`) or Tao + Windows (Fluent flyout); no-op on Linux and AWT.
+    // macOS (`NSMenu`), or a Compose flyout on Linux (Adwaita) / Windows
+    // (Fluent). No-op on AWT.
     nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (Tao backend; on Linux effective on X11/XWayland only).

--- a/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
+++ b/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
@@ -100,8 +100,8 @@ public fun NucleusApplicationScope.MaterialDecoratedWindow(
     // (NSPanel / WS_POPUP HWND / Tao popup window on Linux) so menus can
     // extend past the window bounds. Honoured by the Tao backend; ignored by AWT.
     nativePopupLayers: Boolean = false,
-    // Replace Compose-drawn context menus with the OS menu. Tao + macOS
-    // only; no-op on Windows, Linux, and AWT.
+    // Replace Compose-drawn context menus with the OS-looking menu. Tao +
+    // macOS (`NSMenu`) or Tao + Windows (Fluent flyout); no-op on Linux and AWT.
     nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (Tao backend; on Linux effective on X11/XWayland only).

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.LocalDensity
-
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeScenePointer
 import androidx.compose.ui.unit.Density
@@ -173,7 +172,6 @@ internal class TaoComposeSceneHostWindows(
 
     private var sceneBundle: TaoSceneBundle? = null
     private val scene: ComposeScene? get() = sceneBundle?.scene
-
 
     /** Parent locals bridged via [setSceneCompositionLocalContext]; applied to the scene once created. */
     private var pendingCompositionLocalContext: androidx.compose.runtime.CompositionLocalContext? = null

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneOuterLocalsBridgeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneOuterLocalsBridgeTest.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.PlatformContext
-
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
@@ -148,7 +147,7 @@ private fun captureOuterLocals(layoutDirection: LayoutDirection = GlobalLayoutDi
     var captured: CompositionLocalContext? = null
     val outer =
         canvasLayersSceneBundle(
-            coroutineContext = kotlin.coroutines.EmptyCoroutineContext,
+            coroutineContext = kotlinx.coroutines.Dispatchers.Unconfined,
             density = Density(1f),
             layoutDirection = GlobalLayoutDirection,
             size = IntSize(1, 1),

--- a/examples/jewel-demo/src/test/kotlin/jewelsample/SpellcheckJewelTest.kt
+++ b/examples/jewel-demo/src/test/kotlin/jewelsample/SpellcheckJewelTest.kt
@@ -19,6 +19,7 @@ import dev.nucleusframework.application.spellcheck.LocalSpellcheckMenuSeparator
 import dev.nucleusframework.application.spellcheck.NucleusSpellcheckInstaller
 import dev.nucleusframework.application.spellcheck.SpellcheckContextMenu
 import dev.nucleusframework.application.spellcheck.SpellcheckMenuPlacement
+import dev.nucleusframework.spellcheck.SpellcheckMenuModel
 import dev.nucleusframework.spellcheck.SpellcheckSession
 import dev.nucleusframework.application.contextmenu.ContextMenuEntry
 import dev.nucleusframework.application.contextmenu.ContextMenuIcon
@@ -141,9 +142,10 @@ class SpellcheckJewelTest {
             assertTrue("expected menu items", items.isNotEmpty())
             assertSame(ContextMenuDivider, items.first())
             assertSame(ContextMenuDivider, items[items.lastIndex - 1])
-            val suggestions = items.filter { it !== ContextMenuDivider && it.label != "Add to dictionary" }
+            val addLabel = SpellcheckMenuModel.localizedAddToDictionaryLabel()
+            val suggestions = items.filter { it !== ContextMenuDivider && it.label != addLabel }
             assertTrue("expected suggestions, got ${items.map { it.label }}", suggestions.isNotEmpty())
-            assertEquals("Add to dictionary", items.last().label)
+            assertEquals(addLabel, items.last().label)
         }
     }
 

--- a/examples/jewel-demo/src/test/kotlin/jewelsample/SpellcheckJewelTest.kt
+++ b/examples/jewel-demo/src/test/kotlin/jewelsample/SpellcheckJewelTest.kt
@@ -20,9 +20,15 @@ import dev.nucleusframework.application.spellcheck.NucleusSpellcheckInstaller
 import dev.nucleusframework.application.spellcheck.SpellcheckContextMenu
 import dev.nucleusframework.application.spellcheck.SpellcheckMenuPlacement
 import dev.nucleusframework.spellcheck.SpellcheckSession
+import dev.nucleusframework.application.contextmenu.ContextMenuEntry
+import dev.nucleusframework.application.contextmenu.ContextMenuIcon
+import dev.nucleusframework.application.contextmenu.LocalContextMenuItemInterpreter
+import dev.nucleusframework.window.jewel.JewelContextMenuInterpreter
 import dev.nucleusframework.window.jewel.ProvideJewelSpellcheckMenu
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.ui.component.ContextMenuDivider
+import org.jetbrains.jewel.ui.component.ContextMenuItemOption
+import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
 import org.jetbrains.jewel.ui.component.ContextMenuRepresentation
 import org.jetbrains.jewel.ui.component.TextField
 import org.junit.Assert.assertEquals
@@ -43,6 +49,10 @@ class SpellcheckJewelTest {
                     CompositionLocalProvider(LocalContextMenuRepresentation provides ContextMenuRepresentation) {
                         ProvideJewelSpellcheckMenu {
                             assertSame(ContextMenuDivider, LocalSpellcheckMenuSeparator.current)
+                            assertSame(
+                                JewelContextMenuInterpreter,
+                                LocalContextMenuItemInterpreter.current,
+                            )
                             SpellcheckContextMenu(text = "helo", onTextChange = {}) {
                                 assertSame(
                                     ContextMenuRepresentation,
@@ -78,6 +88,23 @@ class SpellcheckJewelTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `Jewel cut action type maps to native stock icon`() {
+        val item =
+            ContextMenuItemOption(
+                actionType = ContextMenuItemOptionAction.CopyMenuItemOptionAction,
+                label = "Copy",
+                action = {},
+            )
+        val entry = JewelContextMenuInterpreter.interpret(item, ContextMenuDivider)
+        val typed = entry as ContextMenuEntry.Item
+        assertSame(ContextMenuIcon.Copy, typed.icon)
+        assertSame(
+            ContextMenuEntry.Separator,
+            JewelContextMenuInterpreter.interpret(ContextMenuDivider, ContextMenuDivider),
+        )
     }
 
     @Test

--- a/examples/nucleus-demo/src/main/kotlin/com/example/demo/Main.kt
+++ b/examples/nucleus-demo/src/main/kotlin/com/example/demo/Main.kt
@@ -147,7 +147,7 @@ fun main(args: Array<String>) =
                 onCloseRequest = ::exitApplication,
                 title = "Nucleus Demo",
                 minimumSize = DpSize(1300.dp, 480.dp),
-                nativeContextMenu = true
+                nativeContextMenu = true,
             ) {
                 CompositionLocalProvider(
                     LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr,

--- a/examples/nucleus-demo/src/main/kotlin/com/example/demo/Main.kt
+++ b/examples/nucleus-demo/src/main/kotlin/com/example/demo/Main.kt
@@ -147,7 +147,7 @@ fun main(args: Array<String>) =
                 onCloseRequest = ::exitApplication,
                 title = "Nucleus Demo",
                 minimumSize = DpSize(1300.dp, 480.dp),
-                nativePopupLayers = true,
+                nativeContextMenu = true
             ) {
                 CompositionLocalProvider(
                     LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr,

--- a/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/Main.kt
+++ b/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/Main.kt
@@ -269,6 +269,7 @@ private fun runApp() =
                     }
                     false
                 },
+                nativeContextMenu = true,
             ) {
                 val taoWindow = nucleusWindow.unsafe.taoWindow!!
                 var clicks by remember { mutableStateOf(0) }

--- a/menu-macos/api/menu-macos.api
+++ b/menu-macos/api/menu-macos.api
@@ -232,7 +232,7 @@ public final class dev/nucleusframework/menu/macos/NativePopupMenuItem$Submenu :
 	public final fun getTitle ()Ljava/lang/String;
 }
 
-public final class dev/nucleusframework/menu/macos/NativePopupMenuKt {
+public final class dev/nucleusframework/menu/macos/NativePopupMenuItemKt {
 	public static final fun isNativePopupMenuAvailable ()Z
 	public static final fun popUpNativeMenu (Ljava/util/List;)Z
 }

--- a/menu-macos/api/menu-macos.api
+++ b/menu-macos/api/menu-macos.api
@@ -206,6 +206,37 @@ public final class dev/nucleusframework/menu/macos/NativeMenuScope {
 	public final fun getEntries ()Ljava/util/List;
 }
 
+public abstract class dev/nucleusframework/menu/macos/NativePopupMenuItem {
+	public static final field $stable I
+}
+
+public final class dev/nucleusframework/menu/macos/NativePopupMenuItem$Entry : dev/nucleusframework/menu/macos/NativePopupMenuItem {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;ZLdev/nucleusframework/menu/macos/NsMenuItemImage;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLdev/nucleusframework/menu/macos/NsMenuItemImage;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getEnabled ()Z
+	public final fun getIcon ()Ldev/nucleusframework/menu/macos/NsMenuItemImage;
+	public final fun getOnClick ()Lkotlin/jvm/functions/Function0;
+	public final fun getTitle ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/menu/macos/NativePopupMenuItem$Separator : dev/nucleusframework/menu/macos/NativePopupMenuItem {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/menu/macos/NativePopupMenuItem$Separator;
+}
+
+public final class dev/nucleusframework/menu/macos/NativePopupMenuItem$Submenu : dev/nucleusframework/menu/macos/NativePopupMenuItem {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun getItems ()Ljava/util/List;
+	public final fun getTitle ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/menu/macos/NativePopupMenuKt {
+	public static final fun isNativePopupMenuAvailable ()Z
+	public static final fun popUpNativeMenu (Ljava/util/List;)Z
+}
+
 public abstract class dev/nucleusframework/menu/macos/NsMenuItemBadge {
 	public static final field $stable I
 	public static final field Companion Ldev/nucleusframework/menu/macos/NsMenuItemBadge$Companion;

--- a/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativeNsMenuBridge.kt
+++ b/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativeNsMenuBridge.kt
@@ -302,6 +302,8 @@ internal object NativeNsMenuBridge {
         y: Float,
     ): Boolean
 
+    @JvmStatic external fun nativeMenuPopUpAtCursor(menuHandle: Long): Boolean
+
     // ---- Menu bar ----
 
     @JvmStatic external fun nativeMenuBarIsVisible(): Boolean

--- a/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativePopupMenuItem.kt
+++ b/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativePopupMenuItem.kt
@@ -1,0 +1,96 @@
+package dev.nucleusframework.menu.macos
+
+/**
+ * One row in a [popUpNativeMenu] tree: a clickable item, a separator, or a
+ * submenu. Used by the Tao native context-menu representation.
+ */
+public sealed class NativePopupMenuItem {
+    /**
+     * A clickable item.
+     *
+     * @param title Label shown in the menu.
+     * @param enabled Whether the item can be chosen.
+     * @param icon Optional native image (SF Symbol, named image, or file).
+     * @param onClick Invoked on the UI thread after the menu dismisses if the
+     *   user chose this item.
+     */
+    public class Entry(
+        public val title: String,
+        public val enabled: Boolean = true,
+        public val icon: NsMenuItemImage? = null,
+        public val onClick: () -> Unit = {},
+    ) : NativePopupMenuItem()
+
+    /** A horizontal separator. */
+    public object Separator : NativePopupMenuItem()
+
+    /**
+     * A nested submenu.
+     *
+     * @param title Label of the submenu item.
+     * @param items Children shown when the submenu opens.
+     */
+    public class Submenu(
+        public val title: String,
+        public val items: List<NativePopupMenuItem>,
+    ) : NativePopupMenuItem()
+}
+
+/** Whether [popUpNativeMenu] can show an AppKit menu on this process. */
+public val isNativePopupMenuAvailable: Boolean
+    get() = NsMenu.isAvailable
+
+/**
+ * Pops a native `NSMenu` at the current cursor location.
+ *
+ * Blocks the calling thread (AppKit nested tracking loop) until the user
+ * chooses an item or dismisses the menu. No-op and returns `false` when the
+ * native library is not loaded.
+ *
+ * @return `true` if the user selected an item, `false` if dismissed or
+ *   unavailable.
+ */
+public fun popUpNativeMenu(items: List<NativePopupMenuItem>): Boolean {
+    if (!NsMenu.isAvailable || items.isEmpty()) return false
+    val menu = NsMenu()
+    menu.autoenablesItems = false
+    try {
+        materializePopupItems(menu, items)
+        return menu.popUpAtCursor()
+    } finally {
+        menu.close()
+    }
+}
+
+private fun materializePopupItems(
+    menu: NsMenu,
+    items: List<NativePopupMenuItem>,
+) {
+    for (item in items) {
+        when (item) {
+            is NativePopupMenuItem.Separator -> {
+                val sep = NsMenuItem.separator()
+                menu.addItem(sep)
+                sep.close()
+            }
+            is NativePopupMenuItem.Submenu -> {
+                val menuItem = NsMenuItem(item.title)
+                val submenu = NsMenu(item.title)
+                submenu.autoenablesItems = false
+                materializePopupItems(submenu, item.items)
+                menuItem.submenu = submenu
+                menu.addItem(menuItem)
+                menuItem.close()
+                submenu.close()
+            }
+            is NativePopupMenuItem.Entry -> {
+                val menuItem = NsMenuItem(item.title)
+                if (!item.enabled) menuItem.isEnabled = false
+                item.icon?.let { menuItem.image = it }
+                menuItem.onAction = item.onClick
+                menu.addItem(menuItem)
+                menuItem.close()
+            }
+        }
+    }
+}

--- a/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NsMenu.kt
+++ b/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NsMenu.kt
@@ -273,6 +273,9 @@ internal class NsMenu internal constructor(
         atY: Float,
     ): Boolean = NativeNsMenuBridge.nativeMenuPopUp(handle, positioningItem?.handle ?: 0L, atX, atY)
 
+    /** Pops the menu at the current mouse location (`NSEvent.mouseLocation`). */
+    fun popUpAtCursor(): Boolean = NativeNsMenuBridge.nativeMenuPopUpAtCursor(handle)
+
     // ---- Delegate ----
 
     var delegate: NsMenuDelegate?

--- a/menu-macos/src/main/native/macos/nucleus_menu_macos.m
+++ b/menu-macos/src/main/native/macos/nucleus_menu_macos.m
@@ -925,6 +925,19 @@ JNIEXPORT jboolean JNICALL JNI_FN(nativeMenuPopUp)(JNIEnv *env, jclass clazz,
     return result ? JNI_TRUE : JNI_FALSE;
 }
 
+JNIEXPORT jboolean JNICALL JNI_FN(nativeMenuPopUpAtCursor)(JNIEnv *env, jclass clazz,
+                                                            jlong menuHandle) {
+    (void)env; (void)clazz;
+    NSMenu *menu = HANDLE_TO_MENU(menuHandle);
+    __block BOOL result = NO;
+    runOnMain(^{
+        result = [menu popUpMenuPositioningItem:nil
+                                     atLocation:[NSEvent mouseLocation]
+                                         inView:nil];
+    });
+    return result ? JNI_TRUE : JNI_FALSE;
+}
+
 // ============================================================================
 // SECTION: Menu bar
 // ============================================================================

--- a/nucleus-application/api/nucleus-application.api
+++ b/nucleus-application/api/nucleus-application.api
@@ -9,8 +9,8 @@ public final class dev/nucleusframework/application/DecoratedDialogKt {
 }
 
 public final class dev/nucleusframework/application/DecoratedWindowKt {
-	public static final fun DecoratedWindow-TQdphew (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DecoratedWindow-ghhko4k (Ldev/nucleusframework/application/NucleusApplicationScope;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DecoratedWindow-ghhko4k (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DecoratedWindow-sr2hWdk (Ldev/nucleusframework/application/NucleusApplicationScope;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class dev/nucleusframework/application/DefaultNucleusDialogHost : dev/nucleusframework/application/NucleusDialogHost {
@@ -22,7 +22,7 @@ public final class dev/nucleusframework/application/DefaultNucleusDialogHost : d
 public final class dev/nucleusframework/application/DefaultNucleusWindowHost : dev/nucleusframework/application/NucleusWindowHost {
 	public static final field $stable I
 	public static final field INSTANCE Ldev/nucleusframework/application/DefaultNucleusWindowHost;
-	public fun Window-wgn-j6Y (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public fun Window-iZYZsq0 (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class dev/nucleusframework/application/NucleusApplicationKt {
@@ -121,12 +121,12 @@ public final class dev/nucleusframework/application/NucleusWindowBounds {
 }
 
 public abstract interface class dev/nucleusframework/application/NucleusWindowHost {
-	public abstract fun Window-wgn-j6Y (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public abstract fun Window-iZYZsq0 (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class dev/nucleusframework/application/NucleusWindowHostKt {
 	public static final fun HostedDialog (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/DialogState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
-	public static final fun HostedWindow-TQdphew (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun HostedWindow-ghhko4k (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZZLdev/nucleusframework/application/NucleusWindow;ZZZLandroidx/compose/ui/unit/DpSize;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 	public static final fun getLocalNucleusDialogHost ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun getLocalNucleusWindowHost ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
@@ -151,6 +151,146 @@ public final class dev/nucleusframework/application/NucleusWindowUnsafe$DefaultI
 
 public final class dev/nucleusframework/application/SingleInstanceRestoreBusKt {
 	public static final fun SingleInstanceRestoreEffect (Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+}
+
+public abstract class dev/nucleusframework/application/contextmenu/ContextMenuEntry {
+	public static final field $stable I
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuEntry$Item : dev/nucleusframework/application/contextmenu/ContextMenuEntry {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Lkotlin/jvm/functions/Function0;)V
+	public final fun getEnabled ()Z
+	public final fun getIcon ()Ldev/nucleusframework/application/contextmenu/ContextMenuIcon;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getOnClick ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuEntry$Separator : dev/nucleusframework/application/contextmenu/ContextMenuEntry {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/ContextMenuEntry$Separator;
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuEntry$Submenu : dev/nucleusframework/application/contextmenu/ContextMenuEntry {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun getItems ()Ljava/util/List;
+	public final fun getLabel ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuEntryKt {
+	public static final fun getLocalContextMenuItemInterpreter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract class dev/nucleusframework/application/contextmenu/ContextMenuIcon {
+	public static final field $stable I
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuIcon$Copy : dev/nucleusframework/application/contextmenu/ContextMenuIcon {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/ContextMenuIcon$Copy;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuIcon$Cut : dev/nucleusframework/application/contextmenu/ContextMenuIcon {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/ContextMenuIcon$Cut;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuIcon$Delete : dev/nucleusframework/application/contextmenu/ContextMenuIcon {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/ContextMenuIcon$Delete;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuIcon$Folder : dev/nucleusframework/application/contextmenu/ContextMenuIcon {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/ContextMenuIcon$Folder;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuIcon$Paste : dev/nucleusframework/application/contextmenu/ContextMenuIcon {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/ContextMenuIcon$Paste;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuIcon$SelectAll : dev/nucleusframework/application/contextmenu/ContextMenuIcon {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/ContextMenuIcon$SelectAll;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/nucleusframework/application/contextmenu/ContextMenuIcon$SfSymbol : dev/nucleusframework/application/contextmenu/ContextMenuIcon {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/nucleusframework/application/contextmenu/ContextMenuIcon$SfSymbol;
+	public static synthetic fun copy$default (Ldev/nucleusframework/application/contextmenu/ContextMenuIcon$SfSymbol;Ljava/lang/String;ILjava/lang/Object;)Ldev/nucleusframework/application/contextmenu/ContextMenuIcon$SfSymbol;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/nucleusframework/application/contextmenu/ContextMenuItemInterpreter {
+	public abstract fun interpret (Landroidx/compose/foundation/ContextMenuItem;Landroidx/compose/foundation/ContextMenuItem;)Ldev/nucleusframework/application/contextmenu/ContextMenuEntry;
+}
+
+public final class dev/nucleusframework/application/contextmenu/DefaultContextMenuItemInterpreter : dev/nucleusframework/application/contextmenu/ContextMenuItemInterpreter {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/DefaultContextMenuItemInterpreter;
+	public fun interpret (Landroidx/compose/foundation/ContextMenuItem;Landroidx/compose/foundation/ContextMenuItem;)Ldev/nucleusframework/application/contextmenu/ContextMenuEntry;
+}
+
+public final class dev/nucleusframework/application/contextmenu/NativeContextMenuProviderKt {
+	public static final fun NativeContextMenuProvider (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun getLocalNativeContextMenu ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun isNativeContextMenuSupported ()Z
+}
+
+public final class dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation : androidx/compose/foundation/ContextMenuRepresentation {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation;
+	public fun Representation (Landroidx/compose/foundation/ContextMenuState;Ljava/util/List;Landroidx/compose/runtime/Composer;I)V
+	public fun Representation (Landroidx/compose/foundation/ContextMenuState;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class dev/nucleusframework/application/contextmenu/NativeTextContextMenu : androidx/compose/foundation/text/TextContextMenu {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/NativeTextContextMenu;
+	public fun Area (Landroidx/compose/foundation/text/TextContextMenu$TextManager;Landroidx/compose/foundation/ContextMenuState;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class dev/nucleusframework/application/contextmenu/NucleusContextMenuDivider : androidx/compose/foundation/ContextMenuItem {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/application/contextmenu/NucleusContextMenuDivider;
+}
+
+public final class dev/nucleusframework/application/contextmenu/NucleusContextMenuItem : androidx/compose/foundation/ContextMenuItem {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getIcon ()Ldev/nucleusframework/application/contextmenu/ContextMenuIcon;
+}
+
+public final class dev/nucleusframework/application/contextmenu/NucleusContextMenuSubmenu : androidx/compose/foundation/ContextMenuItem {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final fun getItems ()Lkotlin/jvm/functions/Function0;
 }
 
 public final class dev/nucleusframework/application/spellcheck/NucleusSpellcheckInstaller {

--- a/nucleus-application/build.gradle.kts
+++ b/nucleus-application/build.gradle.kts
@@ -24,8 +24,9 @@ dependencies {
     api(project(":darkmode-detector"))
     implementation(project(":core-runtime"))
     implementation(project(":graalvm-runtime"))
-    // Native context menu: NSMenu on macOS. Windows is a Compose Fluent
-    // flyout (no JNI). The macOS library no-ops when the dylib is missing.
+    // Native context menu: NSMenu on macOS. Windows and Linux are Compose
+    // flyouts (Fluent / Adwaita). The macOS library no-ops when the dylib
+    // is missing.
     implementation(project(":menu-macos"))
     // Spellcheck (Linux Hunspell, macOS NSSpellChecker, Windows ISpellChecker).
     // `api` because SpellcheckContextMenu / NucleusSpellcheckInstaller expose SpellcheckSession.

--- a/nucleus-application/build.gradle.kts
+++ b/nucleus-application/build.gradle.kts
@@ -24,8 +24,8 @@ dependencies {
     api(project(":darkmode-detector"))
     implementation(project(":core-runtime"))
     implementation(project(":graalvm-runtime"))
-    // Native context menu (NSMenu pop-up). The library no-ops when the
-    // macOS dylib is missing, so Windows / Linux consumers just skip the pop.
+    // Native context menu: NSMenu on macOS. Windows is a Compose Fluent
+    // flyout (no JNI). The macOS library no-ops when the dylib is missing.
     implementation(project(":menu-macos"))
     // Spellcheck (Linux Hunspell, macOS NSSpellChecker, Windows ISpellChecker).
     // `api` because SpellcheckContextMenu / NucleusSpellcheckInstaller expose SpellcheckSession.

--- a/nucleus-application/build.gradle.kts
+++ b/nucleus-application/build.gradle.kts
@@ -24,6 +24,9 @@ dependencies {
     api(project(":darkmode-detector"))
     implementation(project(":core-runtime"))
     implementation(project(":graalvm-runtime"))
+    // Native context menu (NSMenu pop-up). The library no-ops when the
+    // macOS dylib is missing, so Windows / Linux consumers just skip the pop.
+    implementation(project(":menu-macos"))
     // Spellcheck (Linux Hunspell, macOS NSSpellChecker, Windows ISpellChecker).
     // `api` because SpellcheckContextMenu / NucleusSpellcheckInstaller expose SpellcheckSession.
     api(project(":spellcheck"))

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -44,6 +44,11 @@ public fun NucleusApplicationScope.DecoratedWindow(
     // window's render target. Honoured by the Tao backend on all three
     // platforms; ignored by AWT.
     nativePopupLayers: Boolean = false,
+    // Replace Compose-drawn context menus (ContextMenuArea, text
+    // Cut/Copy/Paste, spellcheck items) with the OS menu. Tao + macOS
+    // only (`NSMenu`); no-op on Windows, Linux, and AWT. Independent of
+    // [nativePopupLayers].
+    nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (macOS: NSApplication accessory policy, app-wide; Windows:
     // WS_EX_TOOLWINDOW, per-window; Linux: GTK skip-taskbar hint, per-window,
@@ -103,6 +108,7 @@ public fun NucleusApplicationScope.DecoratedWindow(
                 undecorated = undecorated,
                 popupFor = popupFor,
                 nativePopupLayers = nativePopupLayers,
+                nativeContextMenu = nativeContextMenu,
                 hiddenFromDock = hiddenFromDock,
                 minimumSize = minimumSize,
                 onPreviewKeyEvent = onPreviewKeyEvent,
@@ -137,6 +143,7 @@ public fun DecoratedWindow(
     undecorated: Boolean = false,
     popupFor: NucleusWindow? = null,
     nativePopupLayers: Boolean = false,
+    nativeContextMenu: Boolean = false,
     hiddenFromDock: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -156,6 +163,7 @@ public fun DecoratedWindow(
         undecorated = undecorated,
         popupFor = popupFor,
         nativePopupLayers = nativePopupLayers,
+        nativeContextMenu = nativeContextMenu,
         hiddenFromDock = hiddenFromDock,
         minimumSize = minimumSize,
         onPreviewKeyEvent = onPreviewKeyEvent,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -45,9 +45,10 @@ public fun NucleusApplicationScope.DecoratedWindow(
     // platforms; ignored by AWT.
     nativePopupLayers: Boolean = false,
     // Replace Compose-drawn context menus (ContextMenuArea, text
-    // Cut/Copy/Paste, spellcheck items) with the OS menu. Tao + macOS
-    // only (`NSMenu`); no-op on Windows, Linux, and AWT. Independent of
-    // [nativePopupLayers].
+    // Cut/Copy/Paste, spellcheck items) with the OS-looking menu. Tao +
+    // macOS (`NSMenu`) or Tao + Windows (Compose Fluent flyout). No-op on
+    // Linux and AWT.
+    // Independent of [nativePopupLayers].
     nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and
     // focusable (macOS: NSApplication accessory policy, app-wide; Windows:

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -46,8 +46,8 @@ public fun NucleusApplicationScope.DecoratedWindow(
     nativePopupLayers: Boolean = false,
     // Replace Compose-drawn context menus (ContextMenuArea, text
     // Cut/Copy/Paste, spellcheck items) with the OS-looking menu. Tao +
-    // macOS (`NSMenu`) or Tao + Windows (Compose Fluent flyout). No-op on
-    // Linux and AWT.
+    // macOS (`NSMenu`), or a Compose flyout on Linux (Adwaita) / Windows
+    // (Fluent). No-op on AWT.
     // Independent of [nativePopupLayers].
     nativeContextMenu: Boolean = false,
     // Hide this window from the OS taskbar/Dock while it stays visible and

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindowHost.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindowHost.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.window.rememberWindowState
  * ```
  *
  * Parameter surface matches [DecoratedWindow] (including Tao-only knobs such
- * as [popupFor], [nativePopupLayers], [hiddenFromDock]).
+ * as [popupFor], [nativePopupLayers], [nativeContextMenu], [hiddenFromDock]).
  */
 public fun interface NucleusWindowHost {
     @Composable
@@ -60,6 +60,7 @@ public fun interface NucleusWindowHost {
         undecorated: Boolean,
         popupFor: NucleusWindow?,
         nativePopupLayers: Boolean,
+        nativeContextMenu: Boolean,
         hiddenFromDock: Boolean,
         minimumSize: DpSize?,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
@@ -143,6 +144,7 @@ public object DefaultNucleusWindowHost : NucleusWindowHost {
         undecorated: Boolean,
         popupFor: NucleusWindow?,
         nativePopupLayers: Boolean,
+        nativeContextMenu: Boolean,
         hiddenFromDock: Boolean,
         minimumSize: DpSize?,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
@@ -162,6 +164,7 @@ public object DefaultNucleusWindowHost : NucleusWindowHost {
             undecorated = undecorated,
             popupFor = popupFor,
             nativePopupLayers = nativePopupLayers,
+            nativeContextMenu = nativeContextMenu,
             hiddenFromDock = hiddenFromDock,
             minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,
@@ -230,6 +233,7 @@ public fun HostedWindow(
     undecorated: Boolean = false,
     popupFor: NucleusWindow? = null,
     nativePopupLayers: Boolean = false,
+    nativeContextMenu: Boolean = false,
     hiddenFromDock: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -249,6 +253,7 @@ public fun HostedWindow(
         undecorated = undecorated,
         popupFor = popupFor,
         nativePopupLayers = nativePopupLayers,
+        nativeContextMenu = nativeContextMenu,
         hiddenFromDock = hiddenFromDock,
         minimumSize = minimumSize,
         onPreviewKeyEvent = onPreviewKeyEvent,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/AdwaitaContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/AdwaitaContextMenu.kt
@@ -1,0 +1,62 @@
+@file:OptIn(androidx.compose.ui.text.ExperimentalTextApi::class)
+
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// libadwaita _common.scss / _menus.scss / _popovers.scss
+private val AdwaitaUiFont = FontFamily("Adwaita Sans")
+
+internal val AdwaitaMenuTheme =
+    ContextMenuFlyoutTheme(
+        menuShape = RoundedCornerShape(15.dp),
+        itemShape = RoundedCornerShape(9.dp),
+        uiFont = AdwaitaUiFont,
+        iconFont = AdwaitaUiFont,
+        chevron = "›",
+        chevronSize = 16.sp,
+        chevronAlpha = 0.30f,
+        minWidth = 120.dp,
+        maxWidth = Dp.Unspecified,
+        menuPadding = PaddingValues(6.dp),
+        itemHeight = 32.dp,
+        itemHorizontalPadding = 12.dp,
+        itemOuterHorizontalPadding = 0.dp,
+        separatorPadding = PaddingValues(vertical = 6.dp),
+        iconSize = 16.dp,
+        iconGap = 6.dp,
+        shadowElevation = 8.dp,
+        shadowPad = 16.dp,
+        ambientShadow = Color.Black.copy(alpha = 0.09f),
+        spotShadow = Color.Black.copy(alpha = 0.05f),
+        showIcons = false,
+        colors = ::adwaitaColors,
+        glyph = { null },
+    )
+
+private fun adwaitaColors(dark: Boolean): ContextMenuFlyoutColors =
+    if (dark) {
+        ContextMenuFlyoutColors(
+            surface = Color(red = 54, green = 54, blue = 58),
+            text = Color.White,
+            textDisabled = Color.White.copy(alpha = 0.50f),
+            hover = Color.White.copy(alpha = 0.10f),
+            separator = Color(red = 0, green = 0, blue = 6, alpha = 0x40),
+            border = Color.Black.copy(alpha = 0.05f),
+        )
+    } else {
+        ContextMenuFlyoutColors(
+            surface = Color.White,
+            text = Color(red = 0, green = 0, blue = 6, alpha = 0xCC),
+            textDisabled = Color(red = 0, green = 0, blue = 6, alpha = 0x66),
+            hover = Color(red = 0, green = 0, blue = 6, alpha = 0x1A),
+            separator = Color(red = 0, green = 0, blue = 6, alpha = 0x12),
+            border = Color.Black.copy(alpha = 0.05f),
+        )
+    }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuEntry.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuEntry.kt
@@ -1,0 +1,96 @@
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import dev.nucleusframework.application.spellcheck.SpellcheckContextMenuSeparator
+
+/**
+ * Platform-neutral description of one context-menu row, after an
+ * [ContextMenuItemInterpreter] has looked at the Compose [ContextMenuItem].
+ */
+public sealed class ContextMenuEntry {
+    /**
+     * A clickable row.
+     *
+     * @param label Text shown in the menu.
+     * @param enabled Whether the row can be chosen.
+     * @param icon Optional native icon.
+     * @param onClick Invoked when the user chooses the row.
+     */
+    public class Item(
+        public val label: String,
+        public val enabled: Boolean,
+        public val icon: ContextMenuIcon?,
+        public val onClick: () -> Unit,
+    ) : ContextMenuEntry()
+
+    /** A horizontal separator. */
+    public object Separator : ContextMenuEntry()
+
+    /**
+     * A nested submenu.
+     *
+     * @param label Title of the submenu item.
+     * @param items Children, already interpreted.
+     */
+    public class Submenu(
+        public val label: String,
+        public val items: List<ContextMenuEntry>,
+    ) : ContextMenuEntry()
+}
+
+/**
+ * Turns a Compose [ContextMenuItem] into a [ContextMenuEntry].
+ *
+ * The default understands [NucleusContextMenuItem], [NucleusContextMenuDivider],
+ * [NucleusContextMenuSubmenu], and the spellcheck separator sentinels. Jewel
+ * installs a richer interpreter (action types → stock icons, `ContextMenuDivider`,
+ * submenus) from `decorated-window-jewel`.
+ */
+public fun interface ContextMenuItemInterpreter {
+    /** Interprets [item]. [separator] is the ambient spellcheck separator sentinel. */
+    public fun interpret(
+        item: ContextMenuItem,
+        separator: ContextMenuItem,
+    ): ContextMenuEntry
+}
+
+/** Ambient [ContextMenuItemInterpreter]. Defaults to [DefaultContextMenuItemInterpreter]. */
+public val LocalContextMenuItemInterpreter: ProvidableCompositionLocal<ContextMenuItemInterpreter> =
+    staticCompositionLocalOf { DefaultContextMenuItemInterpreter }
+
+/**
+ * Default interpreter: Nucleus item types, the spellcheck / Nucleus dividers,
+ * everything else as a label-only row.
+ */
+public object DefaultContextMenuItemInterpreter : ContextMenuItemInterpreter {
+    override fun interpret(
+        item: ContextMenuItem,
+        separator: ContextMenuItem,
+    ): ContextMenuEntry =
+        when {
+            item === separator -> ContextMenuEntry.Separator
+            item === NucleusContextMenuDivider -> ContextMenuEntry.Separator
+            item === SpellcheckContextMenuSeparator -> ContextMenuEntry.Separator
+            item is NucleusContextMenuSubmenu ->
+                ContextMenuEntry.Submenu(
+                    label = item.label,
+                    items = item.items().map { child -> interpret(child, separator) },
+                )
+            item is NucleusContextMenuItem ->
+                ContextMenuEntry.Item(
+                    label = item.label,
+                    enabled = item.enabled,
+                    icon = item.icon,
+                    onClick = item.onClick,
+                )
+            else ->
+                ContextMenuEntry.Item(
+                    label = item.label,
+                    enabled = item.enabled,
+                    icon = null,
+                    onClick = item.onClick,
+                )
+        }
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuFlyout.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuFlyout.kt
@@ -1,0 +1,316 @@
+@file:OptIn(
+    androidx.compose.foundation.ExperimentalFoundationApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+    androidx.compose.ui.text.ExperimentalTextApi::class,
+)
+
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.ContextMenuState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
+import kotlinx.coroutines.delay
+
+private const val SUBMENU_OPEN_DELAY_MS = 200L
+private const val SUBMENU_CLOSE_DELAY_MS = 160L
+
+internal class ContextMenuFlyoutColors(
+    val surface: Color,
+    val text: Color,
+    val textDisabled: Color,
+    val hover: Color,
+    val separator: Color,
+    val border: Color,
+)
+
+internal class ContextMenuFlyoutTheme(
+    val menuShape: RoundedCornerShape,
+    val itemShape: RoundedCornerShape,
+    val uiFont: FontFamily,
+    val iconFont: FontFamily,
+    val chevron: String,
+    val chevronSize: TextUnit,
+    val chevronAlpha: Float,
+    val minWidth: Dp,
+    val maxWidth: Dp,
+    val menuPadding: PaddingValues,
+    val itemHeight: Dp,
+    val itemHorizontalPadding: Dp,
+    val itemOuterHorizontalPadding: Dp,
+    val separatorPadding: PaddingValues,
+    val iconSize: Dp,
+    val iconGap: Dp,
+    val shadowElevation: Dp,
+    val shadowPad: Dp,
+    val ambientShadow: Color,
+    val spotShadow: Color,
+    val showIcons: Boolean,
+    val colors: (dark: Boolean) -> ContextMenuFlyoutColors,
+    val glyph: (ContextMenuIcon) -> String?,
+)
+
+@Composable
+internal fun ContextMenuFlyout(
+    status: ContextMenuState.Status.Open,
+    entries: List<ContextMenuEntry>,
+    theme: ContextMenuFlyoutTheme,
+    onDismiss: () -> Unit,
+) {
+    val dark = isSystemInDarkTheme()
+    val menuDensity = LocalContextMenuDensity.current ?: LocalDensity.current
+    Popup(
+        popupPositionProvider = rememberPopupPositionProviderAtPosition(status.rect.center),
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        CompositionLocalProvider(LocalDensity provides menuDensity) {
+            ContextMenuFlyoutSurface(
+                entries = entries,
+                theme = theme,
+                dark = dark,
+                onDismiss = onDismiss,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContextMenuFlyoutSurface(
+    entries: List<ContextMenuEntry>,
+    theme: ContextMenuFlyoutTheme,
+    dark: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val colors = theme.colors(dark)
+    val reserveIcon =
+        theme.showIcons &&
+            entries.any { entry ->
+                entry is ContextMenuEntry.Item && theme.glyph(entry.icon ?: return@any false) != null
+            }
+    Box(Modifier.padding(theme.shadowPad)) {
+        Column(
+            Modifier
+                .shadow(
+                    elevation = theme.shadowElevation,
+                    shape = theme.menuShape,
+                    clip = false,
+                    ambientColor = theme.ambientShadow,
+                    spotColor = theme.spotShadow,
+                ).width(IntrinsicSize.Max)
+                .widthIn(min = theme.minWidth, max = theme.maxWidth)
+                .clip(theme.menuShape)
+                .border(1.dp, colors.border, theme.menuShape)
+                .background(colors.surface)
+                .padding(theme.menuPadding),
+        ) {
+            entries.forEach { entry ->
+                when (entry) {
+                    is ContextMenuEntry.Separator ->
+                        Box(
+                            Modifier
+                                .padding(theme.separatorPadding)
+                                .fillMaxWidth()
+                                .height(1.dp)
+                                .background(colors.separator),
+                        )
+                    is ContextMenuEntry.Item ->
+                        ContextMenuFlyoutRow(
+                            label = entry.label,
+                            enabled = entry.enabled,
+                            icon = entry.icon?.let(theme.glyph),
+                            reserveIcon = reserveIcon,
+                            chevron = false,
+                            theme = theme,
+                            colors = colors,
+                            onClick = {
+                                onDismiss()
+                                entry.onClick()
+                            },
+                        )
+                    is ContextMenuEntry.Submenu ->
+                        ContextMenuFlyoutSubmenu(
+                            entry = entry,
+                            reserveIcon = reserveIcon,
+                            theme = theme,
+                            dark = dark,
+                            colors = colors,
+                            onDismiss = onDismiss,
+                        )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContextMenuFlyoutSubmenu(
+    entry: ContextMenuEntry.Submenu,
+    reserveIcon: Boolean,
+    theme: ContextMenuFlyoutTheme,
+    dark: Boolean,
+    colors: ContextMenuFlyoutColors,
+    onDismiss: () -> Unit,
+) {
+    val rowInteraction = remember { MutableInteractionSource() }
+    val rowHovered by rowInteraction.collectIsHoveredAsState()
+    var flyoutHovered by remember { mutableStateOf(false) }
+    var showFlyout by remember { mutableStateOf(false) }
+    LaunchedEffect(rowHovered, flyoutHovered) {
+        if (rowHovered || flyoutHovered) {
+            delay(SUBMENU_OPEN_DELAY_MS)
+            showFlyout = true
+        } else {
+            delay(SUBMENU_CLOSE_DELAY_MS)
+            showFlyout = false
+        }
+    }
+    Box {
+        ContextMenuFlyoutRow(
+            label = entry.label,
+            enabled = true,
+            icon = null,
+            reserveIcon = reserveIcon,
+            chevron = true,
+            theme = theme,
+            colors = colors,
+            interactionSource = rowInteraction,
+            onClick = { showFlyout = true },
+        )
+        if (showFlyout) {
+            Popup(
+                alignment = Alignment.TopEnd,
+                offset = IntOffset(0, 0),
+                properties = PopupProperties(focusable = false),
+            ) {
+                val flyoutInteraction = remember { MutableInteractionSource() }
+                val hoveringFlyout by flyoutInteraction.collectIsHoveredAsState()
+                LaunchedEffect(hoveringFlyout) {
+                    flyoutHovered = hoveringFlyout
+                }
+                Box(Modifier.hoverable(flyoutInteraction)) {
+                    ContextMenuFlyoutSurface(
+                        entries = entry.items,
+                        theme = theme,
+                        dark = dark,
+                        onDismiss = onDismiss,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContextMenuFlyoutRow(
+    label: String,
+    enabled: Boolean,
+    icon: String?,
+    reserveIcon: Boolean,
+    chevron: Boolean,
+    theme: ContextMenuFlyoutTheme,
+    colors: ContextMenuFlyoutColors,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    onClick: () -> Unit,
+) {
+    val hovered by interactionSource.collectIsHoveredAsState()
+    val content = if (enabled) colors.text else colors.textDisabled
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = theme.itemOuterHorizontalPadding)
+            .clip(theme.itemShape)
+            .hoverable(interactionSource, enabled = enabled)
+            .background(if (hovered && enabled) colors.hover else Color.Transparent)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = enabled,
+                onClick = onClick,
+            ).height(theme.itemHeight)
+            .padding(horizontal = theme.itemHorizontalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (reserveIcon) {
+            if (icon != null) {
+                BasicText(
+                    text = icon,
+                    style =
+                        TextStyle(
+                            color = content,
+                            fontSize = 16.sp,
+                            fontFamily = theme.iconFont,
+                        ),
+                )
+            } else {
+                Spacer(Modifier.size(theme.iconSize))
+            }
+            Spacer(Modifier.width(theme.iconGap))
+        }
+        BasicText(
+            text = label,
+            modifier = Modifier.weight(1f),
+            style =
+                TextStyle(
+                    color = content,
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                    fontFamily = theme.uiFont,
+                ),
+            maxLines = 1,
+        )
+        if (chevron) {
+            Spacer(Modifier.width(theme.iconGap))
+            BasicText(
+                text = theme.chevron,
+                style =
+                    TextStyle(
+                        color = content.copy(alpha = theme.chevronAlpha),
+                        fontSize = theme.chevronSize,
+                        fontFamily = theme.iconFont,
+                    ),
+            )
+        }
+    }
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
@@ -5,8 +5,9 @@ package dev.nucleusframework.application.contextmenu
  * is active.
  *
  * Stock values (`Cut`, `Copy`, `Paste`, …) resolve to the OS glyph (SF Symbol
- * on macOS, Segoe Fluent Icons on the Windows Compose flyout). [SfSymbol] is
- * a raw macOS symbol name for custom items and is ignored on Windows / Linux.
+ * on macOS, Adwaita-style symbolic strokes on the Linux Compose flyout,
+ * Segoe Fluent Icons on the Windows Compose flyout). [SfSymbol] is a raw
+ * macOS symbol name and is ignored on Windows / Linux.
  */
 public sealed class ContextMenuIcon {
     /** System cut / scissors glyph. */

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
@@ -5,8 +5,8 @@ package dev.nucleusframework.application.contextmenu
  * is active.
  *
  * Stock values (`Cut`, `Copy`, `Paste`, …) resolve to the OS glyph (SF Symbol
- * on macOS). [SfSymbol] is a raw macOS symbol name for custom items. Windows
- * and Linux ignore icons until those backends land.
+ * on macOS, Segoe Fluent Icons on the Windows Compose flyout). [SfSymbol] is
+ * a raw macOS symbol name for custom items and is ignored on Windows / Linux.
  */
 public sealed class ContextMenuIcon {
     /** System cut / scissors glyph. */
@@ -30,7 +30,7 @@ public sealed class ContextMenuIcon {
     /**
      * A raw SF Symbol name (macOS 11+), e.g. `"square.and.arrow.up"`.
      *
-     * Ignored on Windows / Linux.
+     * Ignored on Windows and Linux.
      */
     public data class SfSymbol(
         public val name: String,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
@@ -1,0 +1,38 @@
+package dev.nucleusframework.application.contextmenu
+
+/**
+ * Icon shown next to a [NucleusContextMenuItem] when the native context menu
+ * is active.
+ *
+ * Stock values (`Cut`, `Copy`, `Paste`, …) resolve to the OS glyph (SF Symbol
+ * on macOS). [SfSymbol] is a raw macOS symbol name for custom items. Windows
+ * and Linux ignore icons until those backends land.
+ */
+public sealed class ContextMenuIcon {
+    /** System cut / scissors glyph. */
+    public data object Cut : ContextMenuIcon()
+
+    /** System copy glyph. */
+    public data object Copy : ContextMenuIcon()
+
+    /** System paste / clipboard glyph. */
+    public data object Paste : ContextMenuIcon()
+
+    /** System select-all glyph. Often omitted on macOS. */
+    public data object SelectAll : ContextMenuIcon()
+
+    /** System delete / trash glyph. */
+    public data object Delete : ContextMenuIcon()
+
+    /** System folder glyph. */
+    public data object Folder : ContextMenuIcon()
+
+    /**
+     * A raw SF Symbol name (macOS 11+), e.g. `"square.and.arrow.up"`.
+     *
+     * Ignored on Windows / Linux.
+     */
+    public data class SfSymbol(
+        public val name: String,
+    ) : ContextMenuIcon()
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/FluentContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/FluentContextMenu.kt
@@ -1,0 +1,321 @@
+@file:OptIn(
+    androidx.compose.foundation.ExperimentalFoundationApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+    androidx.compose.ui.text.ExperimentalTextApi::class,
+)
+
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.ContextMenuState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
+import dev.nucleusframework.application.spellcheck.LocalSpellcheckMenuSeparator
+import kotlinx.coroutines.delay
+
+private val MenuShape = RoundedCornerShape(8.dp)
+private val ItemShape = RoundedCornerShape(4.dp)
+private val UiFont = FontFamily("Segoe UI Variable Text")
+private val IconFont = FontFamily("Segoe Fluent Icons")
+
+private const val CHEVRON_GLYPH = "\uE76C"
+private const val SUBMENU_OPEN_DELAY_MS = 200L
+private const val SUBMENU_CLOSE_DELAY_MS = 160L
+
+private class FluentColors(
+    val surface: Color,
+    val text: Color,
+    val textDisabled: Color,
+    val hover: Color,
+    val separator: Color,
+    val border: Color,
+) {
+    companion object {
+        fun of(dark: Boolean): FluentColors =
+            if (dark) {
+                FluentColors(
+                    surface = Color(red = 44, green = 44, blue = 44),
+                    text = Color.White,
+                    textDisabled = Color(red = 115, green = 115, blue = 115),
+                    hover = Color.White.copy(alpha = 0.12f),
+                    separator = Color(red = 61, green = 61, blue = 61),
+                    border = Color(red = 61, green = 61, blue = 61),
+                )
+            } else {
+                FluentColors(
+                    surface = Color(red = 249, green = 249, blue = 249),
+                    text = Color(red = 26, green = 26, blue = 26),
+                    textDisabled = Color(red = 154, green = 154, blue = 154),
+                    hover = Color.Black.copy(alpha = 0.08f),
+                    separator = Color(red = 229, green = 229, blue = 229),
+                    border = Color(red = 229, green = 229, blue = 229),
+                )
+            }
+    }
+}
+
+@Composable
+internal fun FluentContextMenuPopup(
+    state: ContextMenuState,
+    items: () -> List<ContextMenuItem>,
+) {
+    val status = state.status
+    if (status !is ContextMenuState.Status.Open) return
+    val interpreter = LocalContextMenuItemInterpreter.current
+    val separator = LocalSpellcheckMenuSeparator.current
+    val entries = items().map { item -> interpreter.interpret(item, separator) }
+    if (entries.isEmpty()) {
+        LaunchedEffect(status) {
+            state.status = ContextMenuState.Status.Closed
+        }
+        return
+    }
+    val dark = isSystemInDarkTheme()
+    // Click rect is already in pixels. Paint at window density so a subtree
+    // zoom (Gallery 75%) does not scale the flyout.
+    val menuDensity = LocalContextMenuDensity.current ?: LocalDensity.current
+    Popup(
+        popupPositionProvider = rememberPopupPositionProviderAtPosition(status.rect.center),
+        onDismissRequest = { state.status = ContextMenuState.Status.Closed },
+        properties = PopupProperties(focusable = true),
+    ) {
+        CompositionLocalProvider(LocalDensity provides menuDensity) {
+            FluentMenuSurface(
+                entries = entries,
+                dark = dark,
+                onDismiss = { state.status = ContextMenuState.Status.Closed },
+            )
+        }
+    }
+}
+
+@Composable
+private fun FluentMenuSurface(
+    entries: List<ContextMenuEntry>,
+    dark: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val colors = FluentColors.of(dark)
+    val reserveIcon = entries.any { entry -> entry is ContextMenuEntry.Item && entry.icon != null }
+    Column(
+        Modifier
+            .shadow(elevation = 16.dp, shape = MenuShape, clip = false)
+            .width(IntrinsicSize.Max)
+            .widthIn(min = 168.dp, max = 448.dp)
+            .clip(MenuShape)
+            .border(1.dp, colors.border, MenuShape)
+            .background(colors.surface)
+            .padding(vertical = 4.dp),
+    ) {
+        entries.forEach { entry ->
+            when (entry) {
+                is ContextMenuEntry.Separator ->
+                    Box(
+                        Modifier
+                            .padding(horizontal = 12.dp, vertical = 4.dp)
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(colors.separator),
+                    )
+                is ContextMenuEntry.Item ->
+                    FluentMenuRow(
+                        label = entry.label,
+                        enabled = entry.enabled,
+                        icon = entry.icon?.toFluentGlyph(),
+                        reserveIcon = reserveIcon,
+                        chevron = false,
+                        colors = colors,
+                        onClick = {
+                            onDismiss()
+                            entry.onClick()
+                        },
+                    )
+                is ContextMenuEntry.Submenu ->
+                    FluentSubmenuRow(
+                        entry = entry,
+                        reserveIcon = reserveIcon,
+                        dark = dark,
+                        colors = colors,
+                        onDismiss = onDismiss,
+                    )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FluentSubmenuRow(
+    entry: ContextMenuEntry.Submenu,
+    reserveIcon: Boolean,
+    dark: Boolean,
+    colors: FluentColors,
+    onDismiss: () -> Unit,
+) {
+    val rowInteraction = remember { MutableInteractionSource() }
+    val rowHovered by rowInteraction.collectIsHoveredAsState()
+    var flyoutHovered by remember { mutableStateOf(false) }
+    var showFlyout by remember { mutableStateOf(false) }
+    LaunchedEffect(rowHovered, flyoutHovered) {
+        if (rowHovered || flyoutHovered) {
+            delay(SUBMENU_OPEN_DELAY_MS)
+            showFlyout = true
+        } else {
+            delay(SUBMENU_CLOSE_DELAY_MS)
+            showFlyout = false
+        }
+    }
+    Box {
+        FluentMenuRow(
+            label = entry.label,
+            enabled = true,
+            icon = null,
+            reserveIcon = reserveIcon,
+            chevron = true,
+            colors = colors,
+            interactionSource = rowInteraction,
+            onClick = { showFlyout = true },
+        )
+        if (showFlyout) {
+            Popup(
+                alignment = Alignment.TopEnd,
+                offset = IntOffset(0, 0),
+                properties = PopupProperties(focusable = false),
+            ) {
+                val flyoutInteraction = remember { MutableInteractionSource() }
+                val hoveringFlyout by flyoutInteraction.collectIsHoveredAsState()
+                LaunchedEffect(hoveringFlyout) {
+                    flyoutHovered = hoveringFlyout
+                }
+                Box(Modifier.hoverable(flyoutInteraction)) {
+                    FluentMenuSurface(
+                        entries = entry.items,
+                        dark = dark,
+                        onDismiss = onDismiss,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FluentMenuRow(
+    label: String,
+    enabled: Boolean,
+    icon: String?,
+    reserveIcon: Boolean,
+    chevron: Boolean,
+    colors: FluentColors,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    onClick: () -> Unit,
+) {
+    val hovered by interactionSource.collectIsHoveredAsState()
+    val content = if (enabled) colors.text else colors.textDisabled
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp)
+            .clip(ItemShape)
+            .hoverable(interactionSource, enabled = enabled)
+            .background(if (hovered && enabled) colors.hover else Color.Transparent)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = enabled,
+                onClick = onClick,
+            ).height(36.dp)
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (reserveIcon) {
+            if (icon != null) {
+                BasicText(
+                    text = icon,
+                    style =
+                        TextStyle(
+                            color = content,
+                            fontSize = 16.sp,
+                            fontFamily = IconFont,
+                        ),
+                )
+            } else {
+                Spacer(Modifier.size(16.dp))
+            }
+            Spacer(Modifier.width(12.dp))
+        }
+        BasicText(
+            text = label,
+            modifier = Modifier.weight(1f),
+            style =
+                TextStyle(
+                    color = content,
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                    fontFamily = UiFont,
+                ),
+            maxLines = 1,
+        )
+        if (chevron) {
+            Spacer(Modifier.width(12.dp))
+            BasicText(
+                text = CHEVRON_GLYPH,
+                style =
+                    TextStyle(
+                        color = content,
+                        fontSize = 12.sp,
+                        fontFamily = IconFont,
+                    ),
+            )
+        }
+    }
+}
+
+internal fun ContextMenuIcon.toFluentGlyph(): String? =
+    when (this) {
+        ContextMenuIcon.Cut -> "\uE8C6"
+        ContextMenuIcon.Copy -> "\uE8C8"
+        ContextMenuIcon.Paste -> "\uE77F"
+        ContextMenuIcon.SelectAll -> "\uE8B3"
+        ContextMenuIcon.Delete -> "\uE74D"
+        ContextMenuIcon.Folder -> "\uE8B7"
+        is ContextMenuIcon.SfSymbol -> null
+    }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/FluentContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/FluentContextMenu.kt
@@ -1,313 +1,64 @@
-@file:OptIn(
-    androidx.compose.foundation.ExperimentalFoundationApi::class,
-    androidx.compose.ui.ExperimentalComposeUiApi::class,
-    androidx.compose.ui.text.ExperimentalTextApi::class,
-)
+@file:OptIn(androidx.compose.ui.text.ExperimentalTextApi::class)
 
 package dev.nucleusframework.application.contextmenu
 
-import androidx.compose.foundation.ContextMenuItem
-import androidx.compose.foundation.ContextMenuState
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.hoverable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupProperties
-import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
-import dev.nucleusframework.application.spellcheck.LocalSpellcheckMenuSeparator
-import kotlinx.coroutines.delay
 
-private val MenuShape = RoundedCornerShape(8.dp)
-private val ItemShape = RoundedCornerShape(4.dp)
-private val UiFont = FontFamily("Segoe UI Variable Text")
-private val IconFont = FontFamily("Segoe Fluent Icons")
+private val FluentUiFont = FontFamily("Segoe UI Variable Text")
+private val FluentIconFont = FontFamily("Segoe Fluent Icons")
 
-private const val CHEVRON_GLYPH = "\uE76C"
-private const val SUBMENU_OPEN_DELAY_MS = 200L
-private const val SUBMENU_CLOSE_DELAY_MS = 160L
+internal val FluentMenuTheme =
+    ContextMenuFlyoutTheme(
+        menuShape = RoundedCornerShape(8.dp),
+        itemShape = RoundedCornerShape(4.dp),
+        uiFont = FluentUiFont,
+        iconFont = FluentIconFont,
+        chevron = "\uE76C",
+        chevronSize = 12.sp,
+        chevronAlpha = 1f,
+        minWidth = 168.dp,
+        maxWidth = 448.dp,
+        menuPadding = PaddingValues(vertical = 4.dp),
+        itemHeight = 36.dp,
+        itemHorizontalPadding = 12.dp,
+        itemOuterHorizontalPadding = 4.dp,
+        separatorPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+        iconSize = 16.dp,
+        iconGap = 12.dp,
+        shadowElevation = 16.dp,
+        shadowPad = 0.dp,
+        ambientShadow = Color.Black.copy(alpha = 0.20f),
+        spotShadow = Color.Black.copy(alpha = 0.20f),
+        showIcons = true,
+        colors = ::fluentColors,
+        glyph = ContextMenuIcon::toFluentGlyph,
+    )
 
-private class FluentColors(
-    val surface: Color,
-    val text: Color,
-    val textDisabled: Color,
-    val hover: Color,
-    val separator: Color,
-    val border: Color,
-) {
-    companion object {
-        fun of(dark: Boolean): FluentColors =
-            if (dark) {
-                FluentColors(
-                    surface = Color(red = 44, green = 44, blue = 44),
-                    text = Color.White,
-                    textDisabled = Color(red = 115, green = 115, blue = 115),
-                    hover = Color.White.copy(alpha = 0.12f),
-                    separator = Color(red = 61, green = 61, blue = 61),
-                    border = Color(red = 61, green = 61, blue = 61),
-                )
-            } else {
-                FluentColors(
-                    surface = Color(red = 249, green = 249, blue = 249),
-                    text = Color(red = 26, green = 26, blue = 26),
-                    textDisabled = Color(red = 154, green = 154, blue = 154),
-                    hover = Color.Black.copy(alpha = 0.08f),
-                    separator = Color(red = 229, green = 229, blue = 229),
-                    border = Color(red = 229, green = 229, blue = 229),
-                )
-            }
-    }
-}
-
-@Composable
-internal fun FluentContextMenuPopup(
-    state: ContextMenuState,
-    items: () -> List<ContextMenuItem>,
-) {
-    val status = state.status
-    if (status !is ContextMenuState.Status.Open) return
-    val interpreter = LocalContextMenuItemInterpreter.current
-    val separator = LocalSpellcheckMenuSeparator.current
-    val entries = items().map { item -> interpreter.interpret(item, separator) }
-    if (entries.isEmpty()) {
-        LaunchedEffect(status) {
-            state.status = ContextMenuState.Status.Closed
-        }
-        return
-    }
-    val dark = isSystemInDarkTheme()
-    // Click rect is already in pixels. Paint at window density so a subtree
-    // zoom (Gallery 75%) does not scale the flyout.
-    val menuDensity = LocalContextMenuDensity.current ?: LocalDensity.current
-    Popup(
-        popupPositionProvider = rememberPopupPositionProviderAtPosition(status.rect.center),
-        onDismissRequest = { state.status = ContextMenuState.Status.Closed },
-        properties = PopupProperties(focusable = true),
-    ) {
-        CompositionLocalProvider(LocalDensity provides menuDensity) {
-            FluentMenuSurface(
-                entries = entries,
-                dark = dark,
-                onDismiss = { state.status = ContextMenuState.Status.Closed },
-            )
-        }
-    }
-}
-
-@Composable
-private fun FluentMenuSurface(
-    entries: List<ContextMenuEntry>,
-    dark: Boolean,
-    onDismiss: () -> Unit,
-) {
-    val colors = FluentColors.of(dark)
-    val reserveIcon = entries.any { entry -> entry is ContextMenuEntry.Item && entry.icon != null }
-    Column(
-        Modifier
-            .shadow(elevation = 16.dp, shape = MenuShape, clip = false)
-            .width(IntrinsicSize.Max)
-            .widthIn(min = 168.dp, max = 448.dp)
-            .clip(MenuShape)
-            .border(1.dp, colors.border, MenuShape)
-            .background(colors.surface)
-            .padding(vertical = 4.dp),
-    ) {
-        entries.forEach { entry ->
-            when (entry) {
-                is ContextMenuEntry.Separator ->
-                    Box(
-                        Modifier
-                            .padding(horizontal = 12.dp, vertical = 4.dp)
-                            .fillMaxWidth()
-                            .height(1.dp)
-                            .background(colors.separator),
-                    )
-                is ContextMenuEntry.Item ->
-                    FluentMenuRow(
-                        label = entry.label,
-                        enabled = entry.enabled,
-                        icon = entry.icon?.toFluentGlyph(),
-                        reserveIcon = reserveIcon,
-                        chevron = false,
-                        colors = colors,
-                        onClick = {
-                            onDismiss()
-                            entry.onClick()
-                        },
-                    )
-                is ContextMenuEntry.Submenu ->
-                    FluentSubmenuRow(
-                        entry = entry,
-                        reserveIcon = reserveIcon,
-                        dark = dark,
-                        colors = colors,
-                        onDismiss = onDismiss,
-                    )
-            }
-        }
-    }
-}
-
-@Composable
-private fun FluentSubmenuRow(
-    entry: ContextMenuEntry.Submenu,
-    reserveIcon: Boolean,
-    dark: Boolean,
-    colors: FluentColors,
-    onDismiss: () -> Unit,
-) {
-    val rowInteraction = remember { MutableInteractionSource() }
-    val rowHovered by rowInteraction.collectIsHoveredAsState()
-    var flyoutHovered by remember { mutableStateOf(false) }
-    var showFlyout by remember { mutableStateOf(false) }
-    LaunchedEffect(rowHovered, flyoutHovered) {
-        if (rowHovered || flyoutHovered) {
-            delay(SUBMENU_OPEN_DELAY_MS)
-            showFlyout = true
-        } else {
-            delay(SUBMENU_CLOSE_DELAY_MS)
-            showFlyout = false
-        }
-    }
-    Box {
-        FluentMenuRow(
-            label = entry.label,
-            enabled = true,
-            icon = null,
-            reserveIcon = reserveIcon,
-            chevron = true,
-            colors = colors,
-            interactionSource = rowInteraction,
-            onClick = { showFlyout = true },
+private fun fluentColors(dark: Boolean): ContextMenuFlyoutColors =
+    if (dark) {
+        ContextMenuFlyoutColors(
+            surface = Color(red = 44, green = 44, blue = 44),
+            text = Color.White,
+            textDisabled = Color(red = 115, green = 115, blue = 115),
+            hover = Color.White.copy(alpha = 0.12f),
+            separator = Color(red = 61, green = 61, blue = 61),
+            border = Color(red = 61, green = 61, blue = 61),
         )
-        if (showFlyout) {
-            Popup(
-                alignment = Alignment.TopEnd,
-                offset = IntOffset(0, 0),
-                properties = PopupProperties(focusable = false),
-            ) {
-                val flyoutInteraction = remember { MutableInteractionSource() }
-                val hoveringFlyout by flyoutInteraction.collectIsHoveredAsState()
-                LaunchedEffect(hoveringFlyout) {
-                    flyoutHovered = hoveringFlyout
-                }
-                Box(Modifier.hoverable(flyoutInteraction)) {
-                    FluentMenuSurface(
-                        entries = entry.items,
-                        dark = dark,
-                        onDismiss = onDismiss,
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun FluentMenuRow(
-    label: String,
-    enabled: Boolean,
-    icon: String?,
-    reserveIcon: Boolean,
-    chevron: Boolean,
-    colors: FluentColors,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    onClick: () -> Unit,
-) {
-    val hovered by interactionSource.collectIsHoveredAsState()
-    val content = if (enabled) colors.text else colors.textDisabled
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 4.dp)
-            .clip(ItemShape)
-            .hoverable(interactionSource, enabled = enabled)
-            .background(if (hovered && enabled) colors.hover else Color.Transparent)
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                enabled = enabled,
-                onClick = onClick,
-            ).height(36.dp)
-            .padding(horizontal = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (reserveIcon) {
-            if (icon != null) {
-                BasicText(
-                    text = icon,
-                    style =
-                        TextStyle(
-                            color = content,
-                            fontSize = 16.sp,
-                            fontFamily = IconFont,
-                        ),
-                )
-            } else {
-                Spacer(Modifier.size(16.dp))
-            }
-            Spacer(Modifier.width(12.dp))
-        }
-        BasicText(
-            text = label,
-            modifier = Modifier.weight(1f),
-            style =
-                TextStyle(
-                    color = content,
-                    fontSize = 14.sp,
-                    lineHeight = 20.sp,
-                    fontFamily = UiFont,
-                ),
-            maxLines = 1,
+    } else {
+        ContextMenuFlyoutColors(
+            surface = Color(red = 249, green = 249, blue = 249),
+            text = Color(red = 26, green = 26, blue = 26),
+            textDisabled = Color(red = 154, green = 154, blue = 154),
+            hover = Color.Black.copy(alpha = 0.08f),
+            separator = Color(red = 229, green = 229, blue = 229),
+            border = Color(red = 229, green = 229, blue = 229),
         )
-        if (chevron) {
-            Spacer(Modifier.width(12.dp))
-            BasicText(
-                text = CHEVRON_GLYPH,
-                style =
-                    TextStyle(
-                        color = content,
-                        fontSize = 12.sp,
-                        fontFamily = IconFont,
-                    ),
-            )
-        }
     }
-}
 
 internal fun ContextMenuIcon.toFluentGlyph(): String? =
     when (this) {

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
@@ -8,8 +8,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import dev.nucleusframework.core.runtime.Platform
-import dev.nucleusframework.menu.macos.isNativePopupMenuAvailable
+import dev.nucleusframework.menu.macos.isNativePopupMenuAvailable as isMacOsNativePopupMenuAvailable
 
 /**
  * `true` when [NativeContextMenuProvider] has installed the native
@@ -20,19 +22,34 @@ public val LocalNativeContextMenu: ProvidableCompositionLocal<Boolean> =
     staticCompositionLocalOf { false }
 
 /**
- * Whether this process can show an AppKit context menu: macOS + `menu-macos`
- * native library loaded. Windows and Linux are always `false`.
+ * Window density captured by [NativeContextMenuProvider], above any
+ * subtree [LocalDensity] override (e.g. the demo Gallery at 75%).
+ * The Windows Compose flyout uses this so it stays at OS scale.
+ */
+internal val LocalContextMenuDensity: ProvidableCompositionLocal<Density?> =
+    staticCompositionLocalOf { null }
+
+/**
+ * Whether this process can show the opt-in native-looking context menu:
+ * macOS + `menu-macos`, or Windows (Compose Fluent flyout). Linux is
+ * always `false`.
  */
 public val isNativeContextMenuSupported: Boolean
-    get() = Platform.Current == Platform.MacOS && isNativePopupMenuAvailable
+    get() =
+        when (Platform.Current) {
+            Platform.MacOS -> isMacOsNativePopupMenuAvailable
+            Platform.Windows -> true
+            else -> false
+        }
 
 /**
  * Jewel-style context-menu provider: installs [NativeTextContextMenu] (so
  * Cut / Copy / Paste carry [ContextMenuIcon] stock tags) and
- * [NativeContextMenuRepresentation] (so the menu is an `NSMenu`).
+ * [NativeContextMenuRepresentation] (`NSMenu` on macOS, Compose Fluent
+ * flyout on Windows).
  *
  * No-op when [enabled] is `false` or when [isNativeContextMenuSupported] is
- * `false` (Windows, Linux, missing native lib). Compose / Jewel chrome stays.
+ * `false` (Linux, missing macOS native lib). Compose / Jewel chrome stays.
  *
  * @param enabled Caller opt-in, typically [DecoratedWindow]'s
  *   `nativeContextMenu` flag.
@@ -48,8 +65,10 @@ public fun NativeContextMenuProvider(
         content()
         return
     }
+    val windowDensity = LocalDensity.current
     CompositionLocalProvider(
         LocalNativeContextMenu provides true,
+        LocalContextMenuDensity provides windowDensity,
         LocalContextMenuRepresentation provides NativeContextMenuRepresentation,
         LocalTextContextMenu provides NativeTextContextMenu,
         content = content,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
@@ -14,9 +14,9 @@ import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.menu.macos.isNativePopupMenuAvailable as isMacOsNativePopupMenuAvailable
 
 /**
- * `true` when [NativeContextMenuProvider] has installed the native
+ * `true` when [NativeContextMenuProvider] has installed the OS-looking
  * representation in this subtree. Spellcheck uses this to stop drawing its
- * own Compose popup (separators are native rows instead).
+ * own Compose popup (separators are handled by the OS-looking renderer).
  */
 public val LocalNativeContextMenu: ProvidableCompositionLocal<Boolean> =
     staticCompositionLocalOf { false }
@@ -24,36 +24,38 @@ public val LocalNativeContextMenu: ProvidableCompositionLocal<Boolean> =
 /**
  * Window density captured by [NativeContextMenuProvider], above any
  * subtree [LocalDensity] override (e.g. the demo Gallery at 75%).
- * The Windows Compose flyout uses this so it stays at OS scale.
+ * The Windows / Linux Compose flyouts use this so they stay at OS scale.
  */
 internal val LocalContextMenuDensity: ProvidableCompositionLocal<Density?> =
     staticCompositionLocalOf { null }
 
 /**
- * Whether this process can show the opt-in native-looking context menu:
- * macOS + `menu-macos`, or Windows (Compose Fluent flyout). Linux is
- * always `false`.
+ * Whether this process can show the opt-in OS-looking context menu:
+ * macOS + `menu-macos` (`NSMenu`), Linux (Compose Adwaita flyout), or
+ * Windows (Compose Fluent flyout).
  */
 public val isNativeContextMenuSupported: Boolean
     get() =
         when (Platform.Current) {
             Platform.MacOS -> isMacOsNativePopupMenuAvailable
-            Platform.Windows -> true
+            Platform.Linux,
+            Platform.Windows,
+            -> true
             else -> false
         }
 
 /**
- * Jewel-style context-menu provider: installs [NativeTextContextMenu] (so
- * Cut / Copy / Paste carry [ContextMenuIcon] stock tags) and
- * [NativeContextMenuRepresentation] (`NSMenu` on macOS, Compose Fluent
+ * Installs [NativeTextContextMenu] (so Cut / Copy / Paste carry
+ * [ContextMenuIcon] stock tags) and [NativeContextMenuRepresentation]
+ * (`NSMenu` on macOS, Compose Adwaita flyout on Linux, Compose Fluent
  * flyout on Windows).
  *
  * No-op when [enabled] is `false` or when [isNativeContextMenuSupported] is
- * `false` (Linux, missing macOS native lib). Compose / Jewel chrome stays.
+ * `false` (missing macOS native lib). Compose / Jewel chrome stays.
  *
  * @param enabled Caller opt-in, typically [DecoratedWindow]'s
  *   `nativeContextMenu` flag.
- * @param content Window content that should use the native menu.
+ * @param content Window content that should use the OS-looking menu.
  */
 @Suppress("FunctionNaming")
 @Composable

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
@@ -1,0 +1,57 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.LocalContextMenuRepresentation
+import androidx.compose.foundation.text.LocalTextContextMenu
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import dev.nucleusframework.core.runtime.Platform
+import dev.nucleusframework.menu.macos.isNativePopupMenuAvailable
+
+/**
+ * `true` when [NativeContextMenuProvider] has installed the native
+ * representation in this subtree. Spellcheck uses this to stop drawing its
+ * own Compose popup (separators are native rows instead).
+ */
+public val LocalNativeContextMenu: ProvidableCompositionLocal<Boolean> =
+    staticCompositionLocalOf { false }
+
+/**
+ * Whether this process can show an AppKit context menu: macOS + `menu-macos`
+ * native library loaded. Windows and Linux are always `false`.
+ */
+public val isNativeContextMenuSupported: Boolean
+    get() = Platform.Current == Platform.MacOS && isNativePopupMenuAvailable
+
+/**
+ * Jewel-style context-menu provider: installs [NativeTextContextMenu] (so
+ * Cut / Copy / Paste carry [ContextMenuIcon] stock tags) and
+ * [NativeContextMenuRepresentation] (so the menu is an `NSMenu`).
+ *
+ * No-op when [enabled] is `false` or when [isNativeContextMenuSupported] is
+ * `false` (Windows, Linux, missing native lib). Compose / Jewel chrome stays.
+ *
+ * @param enabled Caller opt-in, typically [DecoratedWindow]'s
+ *   `nativeContextMenu` flag.
+ * @param content Window content that should use the native menu.
+ */
+@Suppress("FunctionNaming")
+@Composable
+public fun NativeContextMenuProvider(
+    enabled: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    if (!enabled || !isNativeContextMenuSupported) {
+        content()
+        return
+    }
+    CompositionLocalProvider(
+        LocalNativeContextMenu provides true,
+        LocalContextMenuRepresentation provides NativeContextMenuRepresentation,
+        LocalTextContextMenu provides NativeTextContextMenu,
+        content = content,
+    )
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
@@ -1,0 +1,80 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.ContextMenuRepresentation
+import androidx.compose.foundation.ContextMenuState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import dev.nucleusframework.application.spellcheck.LocalSpellcheckMenuSeparator
+import dev.nucleusframework.menu.macos.NativePopupMenuItem
+import dev.nucleusframework.menu.macos.NsMenuItemImage
+import dev.nucleusframework.menu.macos.popUpNativeMenu
+
+/**
+ * Renders the context menu as a native `NSMenu` on macOS.
+ *
+ * On Windows / Linux this object is never installed ([NativeContextMenuProvider]
+ * is a no-op there). Calling [Representation] off macOS closes the menu
+ * immediately so a stray install cannot leave Compose in `Open`.
+ */
+public object NativeContextMenuRepresentation : ContextMenuRepresentation {
+    @Composable
+    override fun Representation(
+        state: ContextMenuState,
+        items: () -> List<ContextMenuItem>,
+    ) {
+        val status = state.status
+        if (status !is ContextMenuState.Status.Open) return
+        val interpreter = LocalContextMenuItemInterpreter.current
+        val separator = LocalSpellcheckMenuSeparator.current
+        LaunchedEffect(status) {
+            val resolved = items()
+            if (resolved.isEmpty() || !isNativeContextMenuSupported) {
+                state.status = ContextMenuState.Status.Closed
+                return@LaunchedEffect
+            }
+            val popupItems =
+                resolved.map { item ->
+                    interpreter.interpret(item, separator).toPopupItem()
+                }
+            try {
+                popUpNativeMenu(popupItems)
+            } finally {
+                state.status = ContextMenuState.Status.Closed
+            }
+        }
+    }
+}
+
+internal fun ContextMenuEntry.toPopupItem(): NativePopupMenuItem =
+    when (this) {
+        is ContextMenuEntry.Separator -> NativePopupMenuItem.Separator
+        is ContextMenuEntry.Submenu ->
+            NativePopupMenuItem.Submenu(
+                title = label,
+                items = items.map { child -> child.toPopupItem() },
+            )
+        is ContextMenuEntry.Item ->
+            NativePopupMenuItem.Entry(
+                title = label,
+                enabled = enabled,
+                icon = icon?.toNsMenuItemImage(),
+                onClick = onClick,
+            )
+    }
+
+internal fun ContextMenuIcon.toNsMenuItemImage(): NsMenuItemImage? {
+    val symbol =
+        when (this) {
+            ContextMenuIcon.Cut -> "scissors"
+            ContextMenuIcon.Copy -> "doc.on.doc"
+            ContextMenuIcon.Paste -> "doc.on.clipboard"
+            ContextMenuIcon.SelectAll -> return null
+            ContextMenuIcon.Delete -> "trash"
+            ContextMenuIcon.Folder -> "folder"
+            is ContextMenuIcon.SfSymbol -> name
+        }
+    return NsMenuItemImage.SystemSymbol(symbol)
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
@@ -14,12 +14,11 @@ import dev.nucleusframework.menu.macos.NsMenuItemImage
 import dev.nucleusframework.menu.macos.popUpNativeMenu
 
 /**
- * Renders the context menu as a native `NSMenu` on macOS, or as a Compose
- * Fluent flyout (WinUI 3 MenuFlyout metrics) on Windows.
+ * OS-looking context menu: `NSMenu` on macOS, a Compose Fluent flyout on
+ * Windows, a Compose Adwaita flyout on Linux.
  *
- * On Linux this object is never installed ([NativeContextMenuProvider] is a
- * no-op there). Calling [Representation] off a supported OS closes the menu
- * immediately so a stray install cannot leave Compose in `Open`.
+ * Calling [Representation] off a supported OS closes the menu immediately
+ * so a stray install cannot leave Compose in `Open`.
  */
 public object NativeContextMenuRepresentation : ContextMenuRepresentation {
     @Composable
@@ -29,27 +28,27 @@ public object NativeContextMenuRepresentation : ContextMenuRepresentation {
     ) {
         val status = state.status
         if (status !is ContextMenuState.Status.Open) return
-        if (Platform.Current == Platform.Windows) {
-            FluentContextMenuPopup(state, items)
-            return
-        }
         val interpreter = LocalContextMenuItemInterpreter.current
         val separator = LocalSpellcheckMenuSeparator.current
-        LaunchedEffect(status) {
-            val resolved = items()
-            if (resolved.isEmpty() || !isNativeContextMenuSupported) {
-                state.status = ContextMenuState.Status.Closed
-                return@LaunchedEffect
-            }
-            val popupItems =
-                resolved.map { item ->
-                    interpreter.interpret(item, separator).toMacPopupItem()
+        val entries = items().map { item -> interpreter.interpret(item, separator) }
+        val onDismiss = { state.status = ContextMenuState.Status.Closed }
+        if (entries.isEmpty()) {
+            LaunchedEffect(status) { onDismiss() }
+            return
+        }
+        when (Platform.Current) {
+            Platform.Windows -> ContextMenuFlyout(status, entries, FluentMenuTheme, onDismiss)
+            Platform.Linux -> ContextMenuFlyout(status, entries, AdwaitaMenuTheme, onDismiss)
+            Platform.MacOS -> {
+                LaunchedEffect(status) {
+                    try {
+                        popUpNativeMenu(entries.map { it.toMacPopupItem() })
+                    } finally {
+                        onDismiss()
+                    }
                 }
-            try {
-                popUpNativeMenu(popupItems)
-            } finally {
-                state.status = ContextMenuState.Status.Closed
             }
+            else -> LaunchedEffect(status) { onDismiss() }
         }
     }
 }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
@@ -8,15 +8,17 @@ import androidx.compose.foundation.ContextMenuState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import dev.nucleusframework.application.spellcheck.LocalSpellcheckMenuSeparator
+import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.menu.macos.NativePopupMenuItem
 import dev.nucleusframework.menu.macos.NsMenuItemImage
 import dev.nucleusframework.menu.macos.popUpNativeMenu
 
 /**
- * Renders the context menu as a native `NSMenu` on macOS.
+ * Renders the context menu as a native `NSMenu` on macOS, or as a Compose
+ * Fluent flyout (WinUI 3 MenuFlyout metrics) on Windows.
  *
- * On Windows / Linux this object is never installed ([NativeContextMenuProvider]
- * is a no-op there). Calling [Representation] off macOS closes the menu
+ * On Linux this object is never installed ([NativeContextMenuProvider] is a
+ * no-op there). Calling [Representation] off a supported OS closes the menu
  * immediately so a stray install cannot leave Compose in `Open`.
  */
 public object NativeContextMenuRepresentation : ContextMenuRepresentation {
@@ -27,6 +29,10 @@ public object NativeContextMenuRepresentation : ContextMenuRepresentation {
     ) {
         val status = state.status
         if (status !is ContextMenuState.Status.Open) return
+        if (Platform.Current == Platform.Windows) {
+            FluentContextMenuPopup(state, items)
+            return
+        }
         val interpreter = LocalContextMenuItemInterpreter.current
         val separator = LocalSpellcheckMenuSeparator.current
         LaunchedEffect(status) {
@@ -37,7 +43,7 @@ public object NativeContextMenuRepresentation : ContextMenuRepresentation {
             }
             val popupItems =
                 resolved.map { item ->
-                    interpreter.interpret(item, separator).toPopupItem()
+                    interpreter.interpret(item, separator).toMacPopupItem()
                 }
             try {
                 popUpNativeMenu(popupItems)
@@ -48,13 +54,13 @@ public object NativeContextMenuRepresentation : ContextMenuRepresentation {
     }
 }
 
-internal fun ContextMenuEntry.toPopupItem(): NativePopupMenuItem =
+internal fun ContextMenuEntry.toMacPopupItem(): NativePopupMenuItem =
     when (this) {
         is ContextMenuEntry.Separator -> NativePopupMenuItem.Separator
         is ContextMenuEntry.Submenu ->
             NativePopupMenuItem.Submenu(
                 title = label,
-                items = items.map { child -> child.toPopupItem() },
+                items = items.map { child -> child.toMacPopupItem() },
             )
         is ContextMenuEntry.Item ->
             NativePopupMenuItem.Entry(

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeTextContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeTextContextMenu.kt
@@ -1,0 +1,86 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.ContextMenuState
+import androidx.compose.foundation.text.TextContextMenu
+import androidx.compose.foundation.text.TextContextMenuArea
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalLocalization
+import androidx.compose.ui.platform.PlatformLocalization
+
+/**
+ * Jewel-style [TextContextMenu]: rebuilds Cut / Copy / Paste / Select All as
+ * [NucleusContextMenuItem]s tagged with [ContextMenuIcon] stock values so
+ * [NativeContextMenuRepresentation] can attach the OS glyphs.
+ *
+ * Disabled actions are kept (same as Compose's default and Jewel) so the menu
+ * shape stays stable while the field's selection changes.
+ */
+public object NativeTextContextMenu : TextContextMenu {
+    @Composable
+    override fun Area(
+        textManager: TextContextMenu.TextManager,
+        state: ContextMenuState,
+        content: @Composable () -> Unit,
+    ) {
+        val localization = LocalLocalization.current
+        val items = {
+            nativeTextContextMenuItems(localization, textManager)
+        }
+        TextContextMenuArea(
+            textManager = textManager,
+            items = items,
+            state = state,
+            content = content,
+        )
+    }
+}
+
+internal fun nativeTextContextMenuItems(
+    localization: PlatformLocalization,
+    textManager: TextContextMenu.TextManager,
+): List<ContextMenuItem> =
+    buildList {
+        textManager.cut?.let { action ->
+            add(
+                NucleusContextMenuItem(
+                    label = localization.cut,
+                    enabled = action.enabled,
+                    icon = ContextMenuIcon.Cut,
+                    onClick = action.execute,
+                ),
+            )
+        }
+        textManager.copy?.let { action ->
+            add(
+                NucleusContextMenuItem(
+                    label = localization.copy,
+                    enabled = action.enabled,
+                    icon = ContextMenuIcon.Copy,
+                    onClick = action.execute,
+                ),
+            )
+        }
+        textManager.paste?.let { action ->
+            add(
+                NucleusContextMenuItem(
+                    label = localization.paste,
+                    enabled = action.enabled,
+                    icon = ContextMenuIcon.Paste,
+                    onClick = action.execute,
+                ),
+            )
+        }
+        textManager.selectAll?.let { action ->
+            add(
+                NucleusContextMenuItem(
+                    label = localization.selectAll,
+                    enabled = action.enabled,
+                    icon = ContextMenuIcon.SelectAll,
+                    onClick = action.execute,
+                ),
+            )
+        }
+    }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NucleusContextMenuItem.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NucleusContextMenuItem.kt
@@ -1,0 +1,46 @@
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.ContextMenuItem
+
+/**
+ * A [ContextMenuItem] that can carry a [ContextMenuIcon].
+ *
+ * Drop it into `ContextMenuArea` / `ContextMenuDataProvider` lists the same
+ * way as a plain [ContextMenuItem]. Compose-drawn menus show the [label]
+ * only; [NativeContextMenuRepresentation] also renders [icon].
+ *
+ * @param label Text shown in the menu.
+ * @param enabled Whether the item can be chosen.
+ * @param icon Optional stock or SF Symbol icon for the native menu.
+ * @param onClick Invoked when the user chooses the item.
+ */
+public class NucleusContextMenuItem(
+    label: String,
+    enabled: Boolean = true,
+    public val icon: ContextMenuIcon? = null,
+    onClick: () -> Unit,
+) : ContextMenuItem(label, enabled, onClick)
+
+/**
+ * Hairline separator for [NativeContextMenuRepresentation] and for apps that
+ * build the item list themselves.
+ *
+ * Prefer this over an empty [ContextMenuItem] so every renderer (native,
+ * Jewel `ContextMenuDivider`, spellcheck) can recognise it.
+ */
+public object NucleusContextMenuDivider : ContextMenuItem(
+    label = "---",
+    enabled = false,
+    onClick = {},
+)
+
+/**
+ * A nested submenu. [items] is evaluated when the native menu is materialised.
+ *
+ * Compose-drawn representations that do not understand this type show [label]
+ * as a disabled row.
+ */
+public class NucleusContextMenuSubmenu(
+    label: String,
+    public val items: () -> List<ContextMenuItem>,
+) : ContextMenuItem(label, enabled = false, onClick = {})

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -19,6 +19,7 @@ import dev.nucleusframework.application.NucleusWindow
 import dev.nucleusframework.application.ObserveSingleInstanceRestore
 import dev.nucleusframework.application.TaoNucleusApplicationScope
 import dev.nucleusframework.application.TaoNucleusWindow
+import dev.nucleusframework.application.contextmenu.NativeContextMenuProvider
 import dev.nucleusframework.window.DecoratedWindowState
 import dev.nucleusframework.window.LocalTitleBarInfo
 import dev.nucleusframework.window.tao.LocalTaoCompositionLocalContextBridge
@@ -49,6 +50,7 @@ internal object TaoDecoratedWindowAdapter {
         undecorated: Boolean,
         popupFor: NucleusWindow?,
         nativePopupLayers: Boolean,
+        nativeContextMenu: Boolean,
         hiddenFromDock: Boolean,
         minimumSize: DpSize?,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
@@ -163,7 +165,9 @@ internal object TaoDecoratedWindowAdapter {
                     LocalTitleBarInfo provides sceneTitleBarInfo,
                 ) {
                     TaoTextSelectionAccessibility {
-                        nucleusScope.content()
+                        NativeContextMenuProvider(enabled = nativeContextMenu) {
+                            nucleusScope.content()
+                        }
                     }
                 }
             }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckContextMenu.kt
@@ -264,7 +264,7 @@ internal fun spellcheckContextMenuItems(
     val first = ranges.first()
     return spellcheckMenuSections(
         suggestions = suggestions,
-        addToDictionaryLabel = SpellcheckMenuModel.DEFAULT_ADD_TO_DICTIONARY_LABEL,
+        addToDictionaryLabel = SpellcheckMenuModel.localizedAddToDictionaryLabel(),
         onAddToDictionary = { session.addToDictionary(first.word) },
         separator = separator,
         placement = placement,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckContextMenuSeparator.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckContextMenuSeparator.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
+import dev.nucleusframework.application.contextmenu.LocalNativeContextMenu
 
 /**
  * Hairline sentinel for Compose's default context menu. Jewel apps provide
@@ -60,6 +61,10 @@ public val LocalSpellcheckMenuSeparator: ProvidableCompositionLocal<ContextMenuI
  */
 @Composable
 internal fun ProvideSpellcheckSeparators(content: @Composable () -> Unit) {
+    if (LocalNativeContextMenu.current) {
+        content()
+        return
+    }
     if (LocalSpellcheckMenuSeparator.current !== SpellcheckContextMenuSeparator) {
         content()
         return

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
@@ -1,0 +1,117 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.text.TextContextMenu
+import androidx.compose.ui.text.AnnotatedString
+import dev.nucleusframework.application.spellcheck.SpellcheckContextMenuSeparator
+import dev.nucleusframework.menu.macos.NsMenuItemImage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContextMenuInterpreterTest {
+    @Test
+    fun `nucleus item keeps icon`() {
+        val item =
+            NucleusContextMenuItem(
+                label = "Delete",
+                icon = ContextMenuIcon.Delete,
+                onClick = {},
+            )
+        val entry = DefaultContextMenuItemInterpreter.interpret(item, SpellcheckContextMenuSeparator)
+        val typed = entry as ContextMenuEntry.Item
+        assertEquals("Delete", typed.label)
+        assertSame(ContextMenuIcon.Delete, typed.icon)
+        assertTrue(typed.enabled)
+    }
+
+    @Test
+    fun `dividers become separators`() {
+        val interpreter = DefaultContextMenuItemInterpreter
+        assertSame(
+            ContextMenuEntry.Separator,
+            interpreter.interpret(NucleusContextMenuDivider, SpellcheckContextMenuSeparator),
+        )
+        assertSame(
+            ContextMenuEntry.Separator,
+            interpreter.interpret(SpellcheckContextMenuSeparator, SpellcheckContextMenuSeparator),
+        )
+        val custom = ContextMenuItem("---") {}
+        assertSame(
+            ContextMenuEntry.Separator,
+            interpreter.interpret(custom, custom),
+        )
+    }
+
+    @Test
+    fun `plain compose item has no icon`() {
+        val item = ContextMenuItem("Copy") {}
+        val entry = DefaultContextMenuItemInterpreter.interpret(item, SpellcheckContextMenuSeparator)
+        val typed = entry as ContextMenuEntry.Item
+        assertEquals("Copy", typed.label)
+        assertNull(typed.icon)
+    }
+
+    @Test
+    fun `submenu interprets children`() {
+        val submenu =
+            NucleusContextMenuSubmenu("More") {
+                listOf(
+                    NucleusContextMenuItem("Nested", icon = ContextMenuIcon.Folder) {},
+                    NucleusContextMenuDivider,
+                )
+            }
+        val entry = DefaultContextMenuItemInterpreter.interpret(submenu, SpellcheckContextMenuSeparator)
+        val typed = entry as ContextMenuEntry.Submenu
+        assertEquals("More", typed.label)
+        assertEquals(2, typed.items.size)
+        assertSame(ContextMenuIcon.Folder, (typed.items[0] as ContextMenuEntry.Item).icon)
+        assertSame(ContextMenuEntry.Separator, typed.items[1])
+    }
+
+    @Test
+    fun `stock icons map to sf symbols except select all`() {
+        assertEquals("scissors", symbolName(ContextMenuIcon.Cut))
+        assertEquals("doc.on.doc", symbolName(ContextMenuIcon.Copy))
+        assertEquals("doc.on.clipboard", symbolName(ContextMenuIcon.Paste))
+        assertNull(ContextMenuIcon.SelectAll.toNsMenuItemImage())
+        assertEquals("folder", symbolName(ContextMenuIcon.Folder))
+        assertEquals("square.and.arrow.up", symbolName(ContextMenuIcon.SfSymbol("square.and.arrow.up")))
+    }
+
+    @Test
+    fun `native text menu tags cut copy paste`() {
+        val manager =
+            object : TextContextMenu.TextManager {
+                override val selectedText: AnnotatedString = AnnotatedString("hi")
+                override val cut: TextContextMenu.Action = TextContextMenu.Action(enabled = true) {}
+                override val copy: TextContextMenu.Action = TextContextMenu.Action(enabled = true) {}
+                override val paste: TextContextMenu.Action = TextContextMenu.Action(enabled = false) {}
+                override val selectAll: TextContextMenu.Action = TextContextMenu.Action(enabled = true) {}
+
+                override fun selectWordAtPositionIfNotAlreadySelected(offset: androidx.compose.ui.geometry.Offset) {
+                    // Not exercised — TextManager contract only.
+                }
+            }
+        val localization =
+            object : androidx.compose.ui.platform.PlatformLocalization {
+                override val cut: String = "Cut"
+                override val copy: String = "Copy"
+                override val paste: String = "Paste"
+                override val selectAll: String = "Select All"
+            }
+        val items = nativeTextContextMenuItems(localization, manager)
+        assertEquals(4, items.size)
+        assertSame(ContextMenuIcon.Cut, (items[0] as NucleusContextMenuItem).icon)
+        assertSame(ContextMenuIcon.Copy, (items[1] as NucleusContextMenuItem).icon)
+        assertSame(ContextMenuIcon.Paste, (items[2] as NucleusContextMenuItem).icon)
+        assertSame(ContextMenuIcon.SelectAll, (items[3] as NucleusContextMenuItem).icon)
+        assertEquals(false, items[2].enabled)
+    }
+}
+
+private fun symbolName(icon: ContextMenuIcon): String = (icon.toNsMenuItemImage() as NsMenuItemImage.SystemSymbol).name

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
@@ -84,6 +84,17 @@ class ContextMenuInterpreterTest {
     }
 
     @Test
+    fun `stock icons map to fluent glyphs and sf symbols are ignored`() {
+        assertEquals("\uE8C6", ContextMenuIcon.Cut.toFluentGlyph())
+        assertEquals("\uE8C8", ContextMenuIcon.Copy.toFluentGlyph())
+        assertEquals("\uE77F", ContextMenuIcon.Paste.toFluentGlyph())
+        assertEquals("\uE8B3", ContextMenuIcon.SelectAll.toFluentGlyph())
+        assertEquals("\uE74D", ContextMenuIcon.Delete.toFluentGlyph())
+        assertEquals("\uE8B7", ContextMenuIcon.Folder.toFluentGlyph())
+        assertNull(ContextMenuIcon.SfSymbol("square.and.arrow.up").toFluentGlyph())
+    }
+
+    @Test
     fun `native text menu tags cut copy paste`() {
         val manager =
             object : TextContextMenu.TextManager {

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckInstallerTest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckInstallerTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.sp
+import dev.nucleusframework.spellcheck.SpellcheckMenuModel
 import dev.nucleusframework.spellcheck.SpellcheckSession
 import dev.nucleusframework.spellcheck.applySuggestion
 import dev.nucleusframework.spellcheck.buildSpellcheckMenuModel
@@ -108,10 +109,11 @@ class SpellcheckInstallerTest {
                     separator = SpellcheckContextMenuSeparator,
                     onTextChange = { rewritten = it },
                 )
+            val addLabel = SpellcheckMenuModel.localizedAddToDictionaryLabel()
             val suggestions =
-                items.filter { it !== SpellcheckContextMenuSeparator && it.label != "Add to dictionary" }
+                items.filter { it !== SpellcheckContextMenuSeparator && it.label != addLabel }
             assertTrue("expected suggestion items", suggestions.isNotEmpty())
-            assertTrue("expected Add to dictionary", items.any { it.label == "Add to dictionary" })
+            assertTrue("expected Add to dictionary", items.any { it.label == addLabel })
             suggestions.first().onClick()
             val result = rewritten ?: error("suggestion must rewrite the field")
             assertTrue("suggestion must keep world", result.contains("world"))
@@ -136,13 +138,14 @@ class SpellcheckInstallerTest {
                     onAddToDictionary = { added = true },
                 )
             assertTrue("expected spellcheck menu items", items.isNotEmpty())
+            val addLabel = SpellcheckMenuModel.localizedAddToDictionaryLabel()
             val suggestionItems =
-                items.filter { it !== SpellcheckContextMenuSeparator && it.label != "Add to dictionary" }
+                items.filter { it !== SpellcheckContextMenuSeparator && it.label != addLabel }
             assertTrue("expected suggestion items, got ${items.map { it.label }}", suggestionItems.isNotEmpty())
-            assertTrue("expected Add to dictionary", items.any { it.label == "Add to dictionary" })
+            assertTrue("expected Add to dictionary", items.any { it.label == addLabel })
             suggestionItems.first().onClick()
             assertEquals(suggestionItems.first().label, applied)
-            items.first { it.label == "Add to dictionary" }.onClick()
+            items.first { it.label == addLabel }.onClick()
             assertTrue(added)
         }
     }

--- a/scripts/ci/a11y-goldens/a11y-tab.atspi.json
+++ b/scripts/ci/a11y-goldens/a11y-tab.atspi.json
@@ -12,7 +12,8 @@
     { "name": "Events", "role": "page tab", "actionsAll": ["click"] },
     { "name": "WebView", "role": "page tab", "actionsAll": ["click"] },
     { "name": "SwiftUI", "role": "page tab", "actionsAll": ["click"] },
-    { "name": "Texture", "role": "page tab", "actionsAll": ["click"] }
+    { "name": "Texture", "role": "page tab", "actionsAll": ["click"] },
+    { "name": "Spellcheck", "role": "page tab", "actionsAll": ["click"] }
   ],
   "nodes": [
     {

--- a/scripts/ci/a11y-goldens/complex-tab.atspi.json
+++ b/scripts/ci/a11y-goldens/complex-tab.atspi.json
@@ -12,7 +12,8 @@
     { "name": "Events", "role": "page tab", "actionsAll": ["click"] },
     { "name": "WebView", "role": "page tab", "actionsAll": ["click"] },
     { "name": "SwiftUI", "role": "page tab", "actionsAll": ["click"] },
-    { "name": "Texture", "role": "page tab", "actionsAll": ["click"] }
+    { "name": "Texture", "role": "page tab", "actionsAll": ["click"] },
+    { "name": "Spellcheck", "role": "page tab", "actionsAll": ["click"] }
   ],
   "nodes": [
     {

--- a/spellcheck/api/spellcheck.api
+++ b/spellcheck/api/spellcheck.api
@@ -53,6 +53,8 @@ public final class dev/nucleusframework/spellcheck/SpellcheckMenuModel {
 }
 
 public final class dev/nucleusframework/spellcheck/SpellcheckMenuModel$Companion {
+	public final fun localizedAddToDictionaryLabel (Ljava/util/Locale;)Ljava/lang/String;
+	public static synthetic fun localizedAddToDictionaryLabel$default (Ldev/nucleusframework/spellcheck/SpellcheckMenuModel$Companion;Ljava/util/Locale;ILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class dev/nucleusframework/spellcheck/SpellcheckMenuModelKt {

--- a/spellcheck/src/main/kotlin/dev/nucleusframework/spellcheck/SpellcheckMenuModel.kt
+++ b/spellcheck/src/main/kotlin/dev/nucleusframework/spellcheck/SpellcheckMenuModel.kt
@@ -1,5 +1,7 @@
 package dev.nucleusframework.spellcheck
 
+import java.util.Locale
+
 /**
  * Payload used to overload a text-field context menu for one target word.
  *
@@ -12,7 +14,7 @@ public data class SpellcheckMenuModel(
     public val word: String,
     public val range: SpellcheckWord?,
     public val suggestions: List<String>,
-    public val addToDictionaryLabel: String = DEFAULT_ADD_TO_DICTIONARY_LABEL,
+    public val addToDictionaryLabel: String = localizedAddToDictionaryLabel(),
 ) {
     /** Holds the default "Add to dictionary" label. */
     public companion object {
@@ -20,8 +22,81 @@ public data class SpellcheckMenuModel(
          * Default English label matching Electron/Chrome's "Add to dictionary".
          */
         public const val DEFAULT_ADD_TO_DICTIONARY_LABEL: String = "Add to dictionary"
+
+        /**
+         * Persist-word label in [locale], matching how Compose localizes
+         * Cut / Copy / Paste from the JVM default locale.
+         *
+         * Unknown locales fall back to [DEFAULT_ADD_TO_DICTIONARY_LABEL].
+         */
+        public fun localizedAddToDictionaryLabel(locale: Locale = Locale.getDefault()): String {
+            val language = locale.language.lowercase(Locale.ROOT)
+            val country = locale.country.uppercase(Locale.ROOT)
+            val tag = if (country.isEmpty()) language else "${language}_$country"
+            return ADD_TO_DICTIONARY_LABELS[tag]
+                ?: ADD_TO_DICTIONARY_LABELS[canonicalLanguage(language)]
+                ?: DEFAULT_ADD_TO_DICTIONARY_LABEL
+        }
+
+        private fun canonicalLanguage(language: String): String =
+            when (language) {
+                "in" -> "id"
+                "iw" -> "he"
+                else -> language
+            }
     }
 }
+
+// Chrome / Electron "Add to dictionary" phrasing, keyed by Java locale
+// (`language` or `language_COUNTRY`). Country tags override the language.
+private val ADD_TO_DICTIONARY_LABELS: Map<String, String> =
+    mapOf(
+        "ar" to "إضافة إلى القاموس",
+        "bg" to "Добавяне към речника",
+        "ca" to "Afegeix al diccionari",
+        "cs" to "Přidat do slovníku",
+        "da" to "Føj til ordbog",
+        "de" to "Zum Wörterbuch hinzufügen",
+        "el" to "Προσθήκη στο λεξικό",
+        "en" to SpellcheckMenuModel.DEFAULT_ADD_TO_DICTIONARY_LABEL,
+        "es" to "Añadir al diccionario",
+        "es_MX" to "Agregar al diccionario",
+        "es_US" to "Agregar al diccionario",
+        "es_419" to "Agregar al diccionario",
+        "fi" to "Lisää sanakirjaan",
+        "fr" to "Ajouter au dictionnaire",
+        "he" to "הוסף למילון",
+        "hi" to "शब्दकोश में जोड़ें",
+        "hr" to "Dodaj u rječnik",
+        "hu" to "Hozzáadás a szótárhoz",
+        "id" to "Tambahkan ke kamus",
+        "it" to "Aggiungi al dizionario",
+        "ja" to "辞書に追加",
+        "ko" to "사전에 추가",
+        "ms" to "Tambah ke kamus",
+        "nb" to "Legg til i ordliste",
+        "nl" to "Toevoegen aan woordenboek",
+        "nn" to "Legg til i ordliste",
+        "no" to "Legg til i ordliste",
+        "pl" to "Dodaj do słownika",
+        "pt" to "Adicionar ao dicionário",
+        "pt_BR" to "Adicionar ao dicionário",
+        "pt_PT" to "Adicionar ao dicionário",
+        "ro" to "Adaugă în dicționar",
+        "ru" to "Добавить в словарь",
+        "sk" to "Pridať do slovníka",
+        "sl" to "Dodaj v slovar",
+        "sv" to "Lägg till i ordlista",
+        "th" to "เพิ่มในพจนานุกรม",
+        "tr" to "Sözlüğe ekle",
+        "uk" to "Додати до словника",
+        "vi" to "Thêm vào từ điển",
+        "zh" to "添加到字典",
+        "zh_CN" to "添加到字典",
+        "zh_SG" to "添加到字典",
+        "zh_TW" to "加入字典",
+        "zh_HK" to "加入字典",
+    )
 
 private const val DEFAULT_MAX_SUGGESTIONS = 5
 
@@ -44,6 +119,7 @@ public fun buildSpellcheckMenuModel(
         word = word,
         range = range,
         suggestions = suggestions,
+        addToDictionaryLabel = SpellcheckMenuModel.localizedAddToDictionaryLabel(),
     )
 }
 

--- a/spellcheck/src/test/kotlin/dev/nucleusframework/spellcheck/SpellcheckLabelTest.kt
+++ b/spellcheck/src/test/kotlin/dev/nucleusframework/spellcheck/SpellcheckLabelTest.kt
@@ -1,0 +1,59 @@
+package dev.nucleusframework.spellcheck
+
+import java.util.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SpellcheckLabelTest {
+    @Test
+    fun `add to dictionary follows the requested locale`() {
+        assertEquals(
+            "Add to dictionary",
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.US),
+        )
+        assertEquals(
+            "Ajouter au dictionnaire",
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.FRANCE),
+        )
+        assertEquals(
+            "Zum Wörterbuch hinzufügen",
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.GERMANY),
+        )
+        assertEquals(
+            "Añadir al diccionario",
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.forLanguageTag("es-ES")),
+        )
+        assertEquals(
+            "Agregar al diccionario",
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.forLanguageTag("es-MX")),
+        )
+        assertEquals(
+            "加入字典",
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.TAIWAN),
+        )
+        assertEquals(
+            "添加到字典",
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.CHINA),
+        )
+    }
+
+    @Test
+    fun `unknown locale falls back to English`() {
+        assertEquals(
+            SpellcheckMenuModel.DEFAULT_ADD_TO_DICTIONARY_LABEL,
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.forLanguageTag("xx")),
+        )
+    }
+
+    @Test
+    fun `legacy language codes map onto the modern tags`() {
+        assertEquals(
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.forLanguageTag("id")),
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.forLanguageTag("in")),
+        )
+        assertEquals(
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.forLanguageTag("he")),
+            SpellcheckMenuModel.localizedAddToDictionaryLabel(Locale.forLanguageTag("iw")),
+        )
+    }
+}

--- a/spellcheck/src/test/kotlin/dev/nucleusframework/spellcheck/SpellcheckMenuTest.kt
+++ b/spellcheck/src/test/kotlin/dev/nucleusframework/spellcheck/SpellcheckMenuTest.kt
@@ -22,7 +22,7 @@ class SpellcheckMenuTest {
             assertNotNull(model)
             assertEquals("helo", model.word)
             assertTrue(model.suggestions.isNotEmpty(), "expected suggestions, got ${model.suggestions}")
-            assertEquals(SpellcheckMenuModel.DEFAULT_ADD_TO_DICTIONARY_LABEL, model.addToDictionaryLabel)
+            assertEquals(SpellcheckMenuModel.localizedAddToDictionaryLabel(), model.addToDictionaryLabel)
             val applied = applySuggestion("helo world", model, model.suggestions.first())
             assertEquals("${model.suggestions.first()} world", applied)
             assertEquals("hello world", applySuggestion("helo world", model, "hello"))


### PR DESCRIPTION
## 🚀 Description

Opt-in `nativeContextMenu` on `DecoratedWindow` (and the Jewel / Material 2 / Material 3 / `HostedWindow` wrappers) that replaces Compose-drawn context menus with the OS-looking menu:

- **Tao + macOS** — native `NSMenu` at the cursor (`NSEvent.mouseLocation`)
- **Tao + Windows** — Compose Fluent flyout (WinUI 3 MenuFlyout metrics). No JNI / `TrackPopupMenu`.
- **Tao + Linux** — Compose Adwaita flyout (libadwaita `GtkPopoverMenu` metrics). No GTK / JNI. Same shared flyout as Windows, themed separately.

Windows and Linux flyouts are painted at window density so a subtree `LocalDensity` zoom (e.g. nucleus-demo Gallery at 75%) does not shrink the menu.

Same shape as Jewel: a provider installs both `LocalTextContextMenu` and `LocalContextMenuRepresentation`.

- `NativeTextContextMenu` rebuilds Cut / Copy / Paste / Select All as `NucleusContextMenuItem`s tagged with `ContextMenuIcon` stock values.
- Stock icons resolve to SF Symbols on macOS (`scissors`, `doc.on.doc`, `doc.on.clipboard`) and Segoe Fluent Icons on Windows. Linux follows Adwaita and does not draw menu icons. Custom rows use `NucleusContextMenuItem` + `ContextMenuIcon.SfSymbol` / `Delete` / `Folder` (`SfSymbol` is ignored on Windows / Linux).
- Jewel's `ContextMenuItemOption.actionType` maps to those same OS glyphs (not `AllIconsKeys`).
- Spellcheck (#536) keeps injecting suggestions / “Add to dictionary”; it no longer draws its own Compose popup when the OS-looking menu is on.

```kotlin
DecoratedWindow(
    nativeContextMenu = true,
    onCloseRequest = { … },
) { … }

ContextMenuDataProvider({
    listOf(
        NucleusContextMenuItem("Delete", icon = ContextMenuIcon.Delete) { … },
        NucleusContextMenuDivider,
    )
}) { … }
```

The flag is a **no-op on AWT**, and on macOS if `menu-macos` is missing. Compose / Jewel chrome stays.

A screen that re-provides `LocalContextMenuRepresentation` (e.g. a custom color-picker menu) still wins over the window-level provider.

## 📄 Motivation and Context

Compose and Jewel draw the right-click menu in Skia. Apps that want the OS look (Liquid Glass / SF Symbols on macOS, Fluent MenuFlyout on Windows, Adwaita popover on Linux) had no hook. Same item list on all three (`ContextMenuItem` / spellcheck / Jewel action types).

Windows and Linux are Compose-only on purpose: classic `HMENU` / `TrackPopupMenu` is the old GDI menu, not Chrome or WinUI 3; GTK3 `GtkMenu` looks dated next to libadwaita and cannot share a process with a future GTK4 window.

## 🧪 How Has This Been Tested?

- `./gradlew :nucleus-application:test --tests 'dev.nucleusframework.application.contextmenu.*' --tests 'dev.nucleusframework.application.spellcheck.*'`
- `./gradlew :examples:jewel-demo:test --tests jewelsample.SpellcheckJewelTest`
- `./gradlew :nucleus-application:detekt :nucleus-application:ktlintCheck :menu-macos:detekt :menu-macos:ktlintCheck`
- `apiDump` for `nucleus-application`, `menu-macos`, `decorated-window-material2`, `decorated-window-material3`
- `menu-macos` native dylib rebuilt (`nativeMenuPopUpAtCursor`)
- tao-demo and nucleus-demo enable the flag; TextField / Gallery right-click checked on macOS (NSMenu), Windows (Fluent flyout), and Linux (Adwaita flyout)

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

`NucleusWindowHost.Window` gains a `nativeContextMenu` parameter (same ABI shape as `nativePopupLayers`). Custom hosts must add the argument.

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
