### PR TITLE
fix(spellcheck): show suggestions only for the clicked word

### DIFF
--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckContextMenu.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.InterceptPlatformTextInput
 import androidx.compose.ui.platform.PlatformTextInputInterceptor
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
+import androidx.compose.ui.text.TextRange
 import dev.nucleusframework.spellcheck.SpellChecker
 import dev.nucleusframework.spellcheck.SpellcheckMenuModel
 import dev.nucleusframework.spellcheck.SpellcheckSession
@@ -118,6 +119,7 @@ public fun SpellcheckContextMenu(
     val latestOnTextChange = rememberUpdatedState(onTextChange)
     CollectMisspellings(current, latestText, rangesState)
     var inputRequest by remember { mutableStateOf<PlatformTextInputMethodRequest?>(null) }
+    var pendingClickInRoot by remember { mutableStateOf<Offset?>(null) }
     val interceptor =
         remember {
             PlatformTextInputInterceptor { request, nextHandler ->
@@ -126,6 +128,16 @@ public fun SpellcheckContextMenu(
             }
         }
     val menuItems = {
+        val request = inputRequest
+        val clickOffset =
+            pendingClickInRoot?.let { click ->
+                request?.let { clickOffsetInField(it, click) }
+            }
+        val anchor =
+            spellcheckAnchor(
+                clickOffset = clickOffset,
+                selection = request?.value?.invoke()?.selection,
+            )
         spellcheckContextMenuItems(
             text = latestText.value,
             session = current,
@@ -133,14 +145,20 @@ public fun SpellcheckContextMenu(
             separator = separator,
             onTextChange = latestOnTextChange.value,
             placement = menuPlacement,
+            anchor = anchor,
         )
     }
     ProvideSpellcheckSeparators {
-        ProvideSpellcheckMenuItems(items = menuItems, placement = menuPlacement) {
+        ProvideSpellcheckMenuItems(
+            items = menuItems,
+            placement = menuPlacement,
+            onMenuClosed = { pendingClickInRoot = null },
+        ) {
             InterceptPlatformTextInput(interceptor) {
                 SpellcheckImeUnderlineBox(
                     inputRequest = inputRequest,
                     ranges = rangesState.value,
+                    onSecondaryClickInRoot = { pendingClickInRoot = it },
                     content = content,
                 )
             }
@@ -209,13 +227,18 @@ private fun CollectMisspellings(
 private fun SpellcheckImeUnderlineBox(
     inputRequest: PlatformTextInputMethodRequest?,
     ranges: List<SpellcheckWord>,
+    onSecondaryClickInRoot: (Offset) -> Unit,
     content: @Composable () -> Unit,
 ) {
     var boxOriginInRoot by remember { mutableStateOf(Offset.Zero) }
+    val latestClick = rememberUpdatedState(onSecondaryClickInRoot)
     Box(
         Modifier
             .onGloballyPositioned { boxOriginInRoot = it.positionInRoot() }
-            .drawWithContent {
+            .detectSecondaryClickInRoot(
+                originInRoot = { boxOriginInRoot },
+                onClick = { latestClick.value(it) },
+            ).drawWithContent {
                 drawContent()
                 val request = inputRequest ?: return@drawWithContent
                 val fieldText = request.value().text
@@ -248,24 +271,21 @@ internal fun spellcheckContextMenuItems(
     separator: ContextMenuItem,
     onTextChange: (String) -> Unit,
     placement: SpellcheckMenuPlacement = SpellcheckMenuPlacement.Bottom,
+    anchor: TextRange? = null,
 ): List<ContextMenuItem> {
-    if (ranges.isEmpty()) return emptyList()
-    val suggestions = ArrayList<ContextMenuItem>()
-    val unique = ranges.distinctBy { it.word }.take(2)
-    for (range in unique) {
-        val model = buildSpellcheckMenuModel(range.word, session, range) ?: continue
-        for (suggestion in model.suggestions) {
-            suggestions +=
-                ContextMenuItem(suggestion) {
-                    onTextChange(applySuggestion(text, model, suggestion))
-                }
+    if (ranges.isEmpty() || anchor == null) return emptyList()
+    val target = misspellingAt(ranges, anchor) ?: return emptyList()
+    val model = buildSpellcheckMenuModel(target.word, session, target) ?: return emptyList()
+    val suggestions =
+        model.suggestions.map { suggestion ->
+            ContextMenuItem(suggestion) {
+                onTextChange(applySuggestion(text, model, suggestion))
+            }
         }
-    }
-    val first = ranges.first()
     return spellcheckMenuSections(
         suggestions = suggestions,
         addToDictionaryLabel = SpellcheckMenuModel.localizedAddToDictionaryLabel(),
-        onAddToDictionary = { session.addToDictionary(first.word) },
+        onAddToDictionary = { session.addToDictionary(target.word) },
         separator = separator,
         placement = placement,
     )
@@ -336,20 +356,45 @@ public object NucleusSpellcheckInstaller {
 private fun ProvideSpellcheckMenuItems(
     items: () -> List<ContextMenuItem>,
     placement: SpellcheckMenuPlacement,
+    onMenuClosed: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    when (placement) {
-        SpellcheckMenuPlacement.Bottom ->
-            ContextMenuDataProvider(items = items, content = content)
-        SpellcheckMenuPlacement.Top -> {
-            val base = LocalTextContextMenu.current
-            val latestItems = rememberUpdatedState(items)
-            val menu =
-                remember(base) {
-                    SpellcheckTopTextContextMenu(base) { latestItems.value() }
-                }
-            CompositionLocalProvider(LocalTextContextMenu provides menu, content = content)
+    val delegate = LocalContextMenuRepresentation.current
+    val latestClosed = rememberUpdatedState(onMenuClosed)
+    val representation =
+        remember(delegate) {
+            SpellcheckMenuSessionRepresentation(delegate) { latestClosed.value() }
         }
+    CompositionLocalProvider(LocalContextMenuRepresentation provides representation) {
+        when (placement) {
+            SpellcheckMenuPlacement.Bottom ->
+                ContextMenuDataProvider(items = items, content = content)
+            SpellcheckMenuPlacement.Top -> {
+                val base = LocalTextContextMenu.current
+                val latestItems = rememberUpdatedState(items)
+                val menu =
+                    remember(base) {
+                        SpellcheckTopTextContextMenu(base) { latestItems.value() }
+                    }
+                CompositionLocalProvider(LocalTextContextMenu provides menu, content = content)
+            }
+        }
+    }
+}
+
+private class SpellcheckMenuSessionRepresentation(
+    private val delegate: ContextMenuRepresentation,
+    private val onClosed: () -> Unit,
+) : ContextMenuRepresentation {
+    @Composable
+    override fun Representation(
+        state: ContextMenuState,
+        items: () -> List<ContextMenuItem>,
+    ) {
+        if (state.status !is ContextMenuState.Status.Open) {
+            onClosed()
+        }
+        delegate.Representation(state, items)
     }
 }
 

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckMenuTarget.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckMenuTarget.kt
@@ -1,0 +1,71 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package dev.nucleusframework.application.spellcheck
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.PlatformTextInputMethodRequest
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
+import dev.nucleusframework.spellcheck.SpellcheckWord
+
+internal fun misspellingAt(
+    ranges: List<SpellcheckWord>,
+    anchor: TextRange,
+): SpellcheckWord? {
+    val start = minOf(anchor.start, anchor.end)
+    val end = maxOf(anchor.start, anchor.end)
+    if (start != end) {
+        ranges.firstOrNull { it.start == start && it.end == end }?.let { return it }
+        return ranges.firstOrNull { start >= it.start && end <= it.end }
+    }
+    return ranges.firstOrNull { start in it.start until it.end }
+}
+
+internal fun spellcheckAnchor(
+    clickOffset: Int?,
+    selection: TextRange?,
+): TextRange? = if (clickOffset != null) TextRange(clickOffset) else selection
+
+internal fun textOffsetAtRoot(
+    layout: TextLayoutResult,
+    textOriginInRoot: Offset,
+    clickInRoot: Offset,
+): Int = layout.getOffsetForPosition(clickInRoot - textOriginInRoot)
+
+internal fun clickOffsetInField(
+    request: PlatformTextInputMethodRequest,
+    clickInRoot: Offset,
+): Int? {
+    val layout = request.textLayoutResult() ?: return null
+    val origin =
+        resolveSpellcheckTextOriginInRoot(
+            request.unclippedTextOffsetInRoot(),
+            request.textClippingRectInRoot(),
+        ) ?: return null
+    return textOffsetAtRoot(layout, origin, clickInRoot)
+}
+
+internal fun Modifier.detectSecondaryClickInRoot(
+    originInRoot: () -> Offset,
+    onClick: (Offset) -> Unit,
+): Modifier =
+    pointerInput(Unit) {
+        awaitPointerEventScope {
+            while (true) {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                val local =
+                    if (event.buttons.isSecondaryPressed) {
+                        event.changes.firstOrNull()?.position
+                    } else {
+                        null
+                    }
+                if (local != null) {
+                    onClick(originInRoot() + local)
+                }
+            }
+        }
+    }

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckInstallerTest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckInstallerTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.createFontFamilyResolver
 import androidx.compose.ui.unit.Constraints
@@ -108,6 +109,7 @@ class SpellcheckInstallerTest {
                     ranges = ranges,
                     separator = SpellcheckContextMenuSeparator,
                     onTextChange = { rewritten = it },
+                    anchor = TextRange(0, 4),
                 )
             val addLabel = SpellcheckMenuModel.localizedAddToDictionaryLabel()
             val suggestions =
@@ -161,6 +163,126 @@ class SpellcheckInstallerTest {
             assertNotNull("expected a menu model for helo", model)
             assertEquals("hello world", applySuggestion("helo world", model!!, "hello"))
         }
+    }
+
+    @Test
+    fun `menu items only include suggestions for the selected misspelling`() {
+        SpellcheckSession(
+            locale = Locale.US,
+            userDictionaryFile = isolatedUserDict(),
+        ).use { session ->
+            assumeTrue("Native spellcheck + English dictionary required", session.isAvailable)
+            val text = "helo wrold"
+            val ranges = session.misspellings(text)
+            assumeTrue("expected two misspellings", ranges.size >= 2)
+            val addLabel = SpellcheckMenuModel.localizedAddToDictionaryLabel()
+            val heloItems =
+                spellcheckContextMenuItems(
+                    text = text,
+                    session = session,
+                    ranges = ranges,
+                    separator = SpellcheckContextMenuSeparator,
+                    onTextChange = {},
+                    anchor = TextRange(0, 4),
+                )
+            val heloSuggestions =
+                heloItems.filter { it !== SpellcheckContextMenuSeparator && it.label != addLabel }
+            assertTrue("expected helo suggestions", heloSuggestions.isNotEmpty())
+            assertTrue(
+                "helo menu must not list the other misspelling",
+                heloSuggestions.none { it.label == "wrold" },
+            )
+            val empty =
+                spellcheckContextMenuItems(
+                    text = text,
+                    session = session,
+                    ranges = ranges,
+                    separator = SpellcheckContextMenuSeparator,
+                    onTextChange = {},
+                    anchor = TextRange(4, 5),
+                )
+            assertTrue("whitespace must not open spellcheck items", empty.isEmpty())
+        }
+    }
+
+    @Test
+    fun `click offset wins over a stale caret selection`() {
+        SpellcheckSession(
+            locale = Locale.US,
+            userDictionaryFile = isolatedUserDict(),
+        ).use { session ->
+            assumeTrue("Native spellcheck + English dictionary required", session.isAvailable)
+            val text = "helo wrold"
+            val ranges = session.misspellings(text)
+            assumeTrue("expected two misspellings", ranges.size >= 2)
+            val addLabel = SpellcheckMenuModel.localizedAddToDictionaryLabel()
+            val anchor = spellcheckAnchor(clickOffset = 7, selection = TextRange(0, 4))
+            val items =
+                spellcheckContextMenuItems(
+                    text = text,
+                    session = session,
+                    ranges = ranges,
+                    separator = SpellcheckContextMenuSeparator,
+                    onTextChange = {},
+                    anchor = anchor,
+                )
+            val suggestions =
+                items.filter { it !== SpellcheckContextMenuSeparator && it.label != addLabel }
+            assertTrue("expected wrold suggestions", suggestions.isNotEmpty())
+            assertTrue(
+                "click on wrold must not list the helo token",
+                suggestions.none { it.label.equals("helo", ignoreCase = true) },
+            )
+        }
+    }
+
+    @Test
+    fun `selection maps onto the misspelling under the caret or highlight`() {
+        val helo = iterateWords("helo wrold").first { it.word == "helo" }
+        val wrold = iterateWords("helo wrold").first { it.word == "wrold" }
+        val ranges = listOf(helo, wrold)
+        assertEquals(helo, misspellingAt(ranges, TextRange(0, 4)))
+        assertEquals(helo, misspellingAt(ranges, TextRange(2)))
+        assertEquals(wrold, misspellingAt(ranges, TextRange(5, 10)))
+        assertEquals(null, misspellingAt(ranges, TextRange(4, 5)))
+        assertEquals(null, misspellingAt(emptyList(), TextRange(0, 4)))
+        assertEquals(TextRange(7), spellcheckAnchor(clickOffset = 7, selection = TextRange(0, 4)))
+        assertEquals(TextRange(0, 4), spellcheckAnchor(clickOffset = null, selection = TextRange(0, 4)))
+        assertEquals(null, spellcheckAnchor(clickOffset = null, selection = null))
+    }
+
+    @Test
+    fun `click in layout space maps onto the misspelled span`() {
+        val measurer =
+            TextMeasurer(
+                defaultFontFamilyResolver = createFontFamilyResolver(),
+                defaultDensity = Density(1f),
+                defaultLayoutDirection = LayoutDirection.Ltr,
+            )
+        val layout =
+            measurer.measure(
+                text = "helo wrold",
+                style = TextStyle(fontSize = 16.sp),
+                constraints = Constraints(maxWidth = 1000),
+            )
+        val helo = iterateWords("helo wrold").first { it.word == "helo" }
+        val wrold = iterateWords("helo wrold").first { it.word == "wrold" }
+        val heloBox = boundingBoxesForRange(layout, helo.start, helo.end).first()
+        val wroldBox = boundingBoxesForRange(layout, wrold.start, wrold.end).first()
+        val heloClick =
+            textOffsetAtRoot(
+                layout,
+                Offset.Zero,
+                Offset(heloBox.left + heloBox.width / 2f, heloBox.center.y),
+            )
+        val wroldClick =
+            textOffsetAtRoot(
+                layout,
+                Offset.Zero,
+                Offset(wroldBox.left + wroldBox.width / 2f, wroldBox.center.y),
+            )
+        assertEquals(helo, misspellingAt(listOf(helo, wrold), TextRange(heloClick)))
+        assertEquals(wrold, misspellingAt(listOf(helo, wrold), TextRange(wroldClick)))
     }
 
     @Test


### PR DESCRIPTION
## Summary

• Context-menu suggestions target only the misspelled word under the click, matching Chrome
• Windows/Linux resolve the word from the click (Compose does not select it there); macOS still uses the selected word
• Menu builder takes a single `TextRange` anchor — click is cleared when the menu closes

## Type

fix