### PR TITLE
feat(window): show keyboard shortcuts on native context menus

### DIFF
--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelContextMenuInterpreter.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelContextMenuInterpreter.kt
@@ -5,6 +5,7 @@ import dev.nucleusframework.application.contextmenu.ContextMenuEntry
 import dev.nucleusframework.application.contextmenu.ContextMenuIcon
 import dev.nucleusframework.application.contextmenu.ContextMenuItemInterpreter
 import dev.nucleusframework.application.contextmenu.DefaultContextMenuItemInterpreter
+import dev.nucleusframework.application.contextmenu.stockShortcut
 import org.jetbrains.jewel.ui.component.ContextMenuDivider
 import org.jetbrains.jewel.ui.component.ContextMenuItemOption
 import org.jetbrains.jewel.ui.component.ContextMenuItemOptionAction
@@ -13,8 +14,8 @@ import org.jetbrains.jewel.ui.component.ContextSubmenu
 /**
  * Jewel-aware [ContextMenuItemInterpreter]: maps `ContextMenuDivider` /
  * `ContextSubmenu` / `ContextMenuItemOption.actionType` onto [ContextMenuEntry]
- * so the native menu can show OS icons for Cut / Copy / Paste instead of
- * Jewel's `AllIconsKeys`.
+ * so the native menu can show OS icons and Jewel-style accelerators
+ * (`Ctrl+C` / `⌘C`) for Cut / Copy / Paste instead of Jewel's `AllIconsKeys`.
  *
  * Custom `IconKey`s on items without an [ContextMenuItemOptionAction] are
  * ignored in this version (no SVG → `NSImage` rasteriser yet). Use
@@ -33,13 +34,16 @@ public object JewelContextMenuInterpreter : ContextMenuItemInterpreter {
                     label = item.label,
                     items = item.submenu().map { child -> interpret(child, separator) },
                 )
-            is ContextMenuItemOption ->
+            is ContextMenuItemOption -> {
+                val icon = item.actionType.toStockIcon()
                 ContextMenuEntry.Item(
                     label = item.label,
                     enabled = item.enabled,
-                    icon = item.actionType.toStockIcon(),
+                    icon = icon,
                     onClick = item.onClick,
+                    shortcut = icon?.stockShortcut(),
                 )
+            }
             else -> DefaultContextMenuItemInterpreter.interpret(item, separator)
         }
 }

--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelSpellcheck.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelSpellcheck.kt
@@ -9,7 +9,7 @@ import org.jetbrains.jewel.ui.component.ContextMenuDivider
 /**
  * Provides Jewel's [ContextMenuDivider] to [LocalSpellcheckMenuSeparator] and
  * [JewelContextMenuInterpreter] so a native context menu can map Jewel
- * Cut / Copy / Paste action types to OS icons.
+ * Cut / Copy / Paste action types to OS icons and accelerators.
  *
  * Compile-time Jewel reference — no reflection. Installed automatically by
  * [JewelDecoratedWindow] and [JewelDecoratedDialog]. Apps that build their

--- a/examples/jewel-demo/src/test/kotlin/jewelsample/SpellcheckJewelTest.kt
+++ b/examples/jewel-demo/src/test/kotlin/jewelsample/SpellcheckJewelTest.kt
@@ -24,6 +24,7 @@ import dev.nucleusframework.spellcheck.SpellcheckSession
 import dev.nucleusframework.application.contextmenu.ContextMenuEntry
 import dev.nucleusframework.application.contextmenu.ContextMenuIcon
 import dev.nucleusframework.application.contextmenu.LocalContextMenuItemInterpreter
+import dev.nucleusframework.application.contextmenu.stockShortcut
 import dev.nucleusframework.window.jewel.JewelContextMenuInterpreter
 import dev.nucleusframework.window.jewel.ProvideJewelSpellcheckMenu
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
@@ -102,6 +103,7 @@ class SpellcheckJewelTest {
         val entry = JewelContextMenuInterpreter.interpret(item, ContextMenuDivider)
         val typed = entry as ContextMenuEntry.Item
         assertSame(ContextMenuIcon.Copy, typed.icon)
+        assertEquals(ContextMenuIcon.Copy.stockShortcut(), typed.shortcut)
         assertSame(
             ContextMenuEntry.Separator,
             JewelContextMenuInterpreter.interpret(ContextMenuDivider, ContextMenuDivider),

--- a/nucleus-application/api/nucleus-application.api
+++ b/nucleus-application/api/nucleus-application.api
@@ -159,11 +159,13 @@ public abstract class dev/nucleusframework/application/contextmenu/ContextMenuEn
 
 public final class dev/nucleusframework/application/contextmenu/ContextMenuEntry$Item : dev/nucleusframework/application/contextmenu/ContextMenuEntry {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Lkotlin/jvm/functions/Function0;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Lkotlin/jvm/functions/Function0;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEnabled ()Z
 	public final fun getIcon ()Ldev/nucleusframework/application/contextmenu/ContextMenuIcon;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getOnClick ()Lkotlin/jvm/functions/Function0;
+	public final fun getShortcut ()Ljava/lang/String;
 }
 
 public final class dev/nucleusframework/application/contextmenu/ContextMenuEntry$Separator : dev/nucleusframework/application/contextmenu/ContextMenuEntry {
@@ -246,6 +248,10 @@ public final class dev/nucleusframework/application/contextmenu/ContextMenuIcon$
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/nucleusframework/application/contextmenu/ContextMenuIconKt {
+	public static final fun stockShortcut (Ldev/nucleusframework/application/contextmenu/ContextMenuIcon;)Ljava/lang/String;
+}
+
 public abstract interface class dev/nucleusframework/application/contextmenu/ContextMenuItemInterpreter {
 	public abstract fun interpret (Landroidx/compose/foundation/ContextMenuItem;Landroidx/compose/foundation/ContextMenuItem;)Ldev/nucleusframework/application/contextmenu/ContextMenuEntry;
 }
@@ -282,9 +288,10 @@ public final class dev/nucleusframework/application/contextmenu/NucleusContextMe
 
 public final class dev/nucleusframework/application/contextmenu/NucleusContextMenuItem : androidx/compose/foundation/ContextMenuItem {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLdev/nucleusframework/application/contextmenu/ContextMenuIcon;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getIcon ()Ldev/nucleusframework/application/contextmenu/ContextMenuIcon;
+	public final fun getShortcut ()Ljava/lang/String;
 }
 
 public final class dev/nucleusframework/application/contextmenu/NucleusContextMenuSubmenu : androidx/compose/foundation/ContextMenuItem {

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/AdwaitaContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/AdwaitaContextMenu.kt
@@ -36,6 +36,9 @@ internal val AdwaitaMenuTheme =
         ambientShadow = Color.Black.copy(alpha = 0.09f),
         spotShadow = Color.Black.copy(alpha = 0.05f),
         showIcons = false,
+        shortcutGap = 24.dp,
+        shortcutSize = 14.sp,
+        shortcutAlpha = 0.55f,
         colors = ::adwaitaColors,
         glyph = { null },
     )

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuEntry.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuEntry.kt
@@ -17,12 +17,16 @@ public sealed class ContextMenuEntry {
      * @param enabled Whether the row can be chosen.
      * @param icon Optional native icon.
      * @param onClick Invoked when the user chooses the row.
+     * @param shortcut Accelerator shown on the right of the Linux / Windows
+     *   flyout (e.g. `Ctrl+C`). `null` or empty hides it. macOS `NSMenu` does
+     *   not use this field yet.
      */
     public class Item(
         public val label: String,
         public val enabled: Boolean,
         public val icon: ContextMenuIcon?,
         public val onClick: () -> Unit,
+        public val shortcut: String? = null,
     ) : ContextMenuEntry()
 
     /** A horizontal separator. */
@@ -84,6 +88,7 @@ public object DefaultContextMenuItemInterpreter : ContextMenuItemInterpreter {
                     enabled = item.enabled,
                     icon = item.icon,
                     onClick = item.onClick,
+                    shortcut = item.resolvedShortcut(),
                 )
             else ->
                 ContextMenuEntry.Item(

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuFlyout.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuFlyout.kt
@@ -87,6 +87,9 @@ internal class ContextMenuFlyoutTheme(
     val ambientShadow: Color,
     val spotShadow: Color,
     val showIcons: Boolean,
+    val shortcutGap: Dp,
+    val shortcutSize: TextUnit,
+    val shortcutAlpha: Float,
     val colors: (dark: Boolean) -> ContextMenuFlyoutColors,
     val glyph: (ContextMenuIcon) -> String?,
 )
@@ -160,6 +163,7 @@ private fun ContextMenuFlyoutSurface(
                             label = entry.label,
                             enabled = entry.enabled,
                             icon = entry.icon?.let(theme.glyph),
+                            shortcut = entry.shortcut,
                             reserveIcon = reserveIcon,
                             chevron = false,
                             theme = theme,
@@ -211,6 +215,7 @@ private fun ContextMenuFlyoutSubmenu(
             label = entry.label,
             enabled = true,
             icon = null,
+            shortcut = null,
             reserveIcon = reserveIcon,
             chevron = true,
             theme = theme,
@@ -247,6 +252,7 @@ private fun ContextMenuFlyoutRow(
     label: String,
     enabled: Boolean,
     icon: String?,
+    shortcut: String?,
     reserveIcon: Boolean,
     chevron: Boolean,
     theme: ContextMenuFlyoutTheme,
@@ -300,6 +306,19 @@ private fun ContextMenuFlyoutRow(
                 ),
             maxLines = 1,
         )
+        if (!shortcut.isNullOrEmpty()) {
+            Spacer(Modifier.width(theme.shortcutGap))
+            BasicText(
+                text = shortcut,
+                style =
+                    TextStyle(
+                        color = if (enabled) content.copy(alpha = theme.shortcutAlpha) else colors.textDisabled,
+                        fontSize = theme.shortcutSize,
+                        fontFamily = theme.uiFont,
+                    ),
+                maxLines = 1,
+            )
+        }
         if (chevron) {
             Spacer(Modifier.width(theme.iconGap))
             BasicText(

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
@@ -1,5 +1,7 @@
 package dev.nucleusframework.application.contextmenu
 
+import dev.nucleusframework.core.runtime.Platform
+
 /**
  * Icon shown next to a [NucleusContextMenuItem] when the native context menu
  * is active.
@@ -37,3 +39,28 @@ public sealed class ContextMenuIcon {
         public val name: String,
     ) : ContextMenuIcon()
 }
+
+/**
+ * Conventional accelerator for this stock icon, formatted like Jewel / GTK:
+ * `Ctrl+C` on Linux and Windows, `⌘C` on macOS.
+ *
+ * [ContextMenuIcon.Delete], [ContextMenuIcon.Folder], and
+ * [ContextMenuIcon.SfSymbol] have no standard shortcut and return `null`.
+ */
+public fun ContextMenuIcon.stockShortcut(): String? =
+    when (this) {
+        ContextMenuIcon.Cut -> primaryModifierShortcut("X")
+        ContextMenuIcon.Copy -> primaryModifierShortcut("C")
+        ContextMenuIcon.Paste -> primaryModifierShortcut("V")
+        ContextMenuIcon.SelectAll -> primaryModifierShortcut("A")
+        ContextMenuIcon.Delete,
+        ContextMenuIcon.Folder,
+        is ContextMenuIcon.SfSymbol,
+        -> null
+    }
+
+internal fun primaryModifierShortcut(key: String): String =
+    when (Platform.Current) {
+        Platform.MacOS -> "⌘$key"
+        else -> "Ctrl+$key"
+    }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/FluentContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/FluentContextMenu.kt
@@ -35,6 +35,9 @@ internal val FluentMenuTheme =
         ambientShadow = Color.Black.copy(alpha = 0.20f),
         spotShadow = Color.Black.copy(alpha = 0.20f),
         showIcons = true,
+        shortcutGap = 36.dp,
+        shortcutSize = 12.sp,
+        shortcutAlpha = 0.60f,
         colors = ::fluentColors,
         glyph = ContextMenuIcon::toFluentGlyph,
     )

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
@@ -46,9 +46,9 @@ public val isNativeContextMenuSupported: Boolean
 
 /**
  * Installs [NativeTextContextMenu] (so Cut / Copy / Paste carry
- * [ContextMenuIcon] stock tags) and [NativeContextMenuRepresentation]
- * (`NSMenu` on macOS, Compose Adwaita flyout on Linux, Compose Fluent
- * flyout on Windows).
+ * [ContextMenuIcon] stock tags and platform accelerators) and
+ * [NativeContextMenuRepresentation] (`NSMenu` on macOS, Compose Adwaita
+ * flyout on Linux, Compose Fluent flyout on Windows).
  *
  * No-op when [enabled] is `false` or when [isNativeContextMenuSupported] is
  * `false` (missing macOS native lib). Compose / Jewel chrome stays.

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeTextContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeTextContextMenu.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.platform.PlatformLocalization
 /**
  * Jewel-style [TextContextMenu]: rebuilds Cut / Copy / Paste / Select All as
  * [NucleusContextMenuItem]s tagged with [ContextMenuIcon] stock values so
- * [NativeContextMenuRepresentation] can attach the OS glyphs.
+ * [NativeContextMenuRepresentation] can attach the OS glyphs and accelerators.
  *
  * Disabled actions are kept (same as Compose's default and Jewel) so the menu
  * shape stays stable while the field's selection changes.

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NucleusContextMenuItem.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NucleusContextMenuItem.kt
@@ -3,23 +3,35 @@ package dev.nucleusframework.application.contextmenu
 import androidx.compose.foundation.ContextMenuItem
 
 /**
- * A [ContextMenuItem] that can carry a [ContextMenuIcon].
+ * A [ContextMenuItem] that can carry a [ContextMenuIcon] and a keyboard
+ * shortcut.
  *
  * Drop it into `ContextMenuArea` / `ContextMenuDataProvider` lists the same
  * way as a plain [ContextMenuItem]. Compose-drawn menus show the [label]
- * only; [NativeContextMenuRepresentation] also renders [icon].
+ * only; [NativeContextMenuRepresentation] also renders [icon] and [shortcut]
+ * (shortcut on the Linux / Windows flyouts).
  *
  * @param label Text shown in the menu.
  * @param enabled Whether the item can be chosen.
  * @param icon Optional stock or SF Symbol icon for the native menu.
+ * @param shortcut Accelerator shown on the right of the Linux / Windows
+ *   flyout (e.g. `Ctrl+C`). `null` falls back to [ContextMenuIcon.stockShortcut]
+ *   for Cut / Copy / Paste / Select All. Pass `""` to hide the fallback.
  * @param onClick Invoked when the user chooses the item.
  */
 public class NucleusContextMenuItem(
     label: String,
     enabled: Boolean = true,
     public val icon: ContextMenuIcon? = null,
+    public val shortcut: String? = null,
     onClick: () -> Unit,
 ) : ContextMenuItem(label, enabled, onClick)
+
+internal fun NucleusContextMenuItem.resolvedShortcut(): String? =
+    when (shortcut) {
+        null -> icon?.stockShortcut()
+        else -> shortcut.takeIf { it.isNotEmpty() }
+    }
 
 /**
  * Hairline separator for [NativeContextMenuRepresentation] and for apps that

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.text.TextContextMenu
 import androidx.compose.ui.text.AnnotatedString
 import dev.nucleusframework.application.spellcheck.SpellcheckContextMenuSeparator
+import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.menu.macos.NsMenuItemImage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -26,7 +27,60 @@ class ContextMenuInterpreterTest {
         val typed = entry as ContextMenuEntry.Item
         assertEquals("Delete", typed.label)
         assertSame(ContextMenuIcon.Delete, typed.icon)
+        assertNull(typed.shortcut)
         assertTrue(typed.enabled)
+    }
+
+    @Test
+    fun `stock edit icons get platform shortcuts`() {
+        val copy =
+            DefaultContextMenuItemInterpreter.interpret(
+                NucleusContextMenuItem("Copy", icon = ContextMenuIcon.Copy) {},
+                SpellcheckContextMenuSeparator,
+            ) as ContextMenuEntry.Item
+        val cut =
+            DefaultContextMenuItemInterpreter.interpret(
+                NucleusContextMenuItem("Cut", icon = ContextMenuIcon.Cut) {},
+                SpellcheckContextMenuSeparator,
+            ) as ContextMenuEntry.Item
+        val paste =
+            DefaultContextMenuItemInterpreter.interpret(
+                NucleusContextMenuItem("Paste", icon = ContextMenuIcon.Paste) {},
+                SpellcheckContextMenuSeparator,
+            ) as ContextMenuEntry.Item
+        val selectAll =
+            DefaultContextMenuItemInterpreter.interpret(
+                NucleusContextMenuItem("Select All", icon = ContextMenuIcon.SelectAll) {},
+                SpellcheckContextMenuSeparator,
+            ) as ContextMenuEntry.Item
+        assertEquals(expectedPrimaryShortcut("C"), copy.shortcut)
+        assertEquals(expectedPrimaryShortcut("X"), cut.shortcut)
+        assertEquals(expectedPrimaryShortcut("V"), paste.shortcut)
+        assertEquals(expectedPrimaryShortcut("A"), selectAll.shortcut)
+    }
+
+    @Test
+    fun `explicit shortcut overrides stock fallback and empty hides it`() {
+        val custom =
+            DefaultContextMenuItemInterpreter.interpret(
+                NucleusContextMenuItem(
+                    label = "Copy",
+                    icon = ContextMenuIcon.Copy,
+                    shortcut = "Ctrl+Shift+C",
+                ) {},
+                SpellcheckContextMenuSeparator,
+            ) as ContextMenuEntry.Item
+        assertEquals("Ctrl+Shift+C", custom.shortcut)
+        val hidden =
+            DefaultContextMenuItemInterpreter.interpret(
+                NucleusContextMenuItem(
+                    label = "Copy",
+                    icon = ContextMenuIcon.Copy,
+                    shortcut = "",
+                ) {},
+                SpellcheckContextMenuSeparator,
+            ) as ContextMenuEntry.Item
+        assertNull(hidden.shortcut)
     }
 
     @Test
@@ -122,7 +176,15 @@ class ContextMenuInterpreterTest {
         assertSame(ContextMenuIcon.Paste, (items[2] as NucleusContextMenuItem).icon)
         assertSame(ContextMenuIcon.SelectAll, (items[3] as NucleusContextMenuItem).icon)
         assertEquals(false, items[2].enabled)
+        val interpreted = items.map { DefaultContextMenuItemInterpreter.interpret(it, SpellcheckContextMenuSeparator) }
+        assertEquals(expectedPrimaryShortcut("X"), (interpreted[0] as ContextMenuEntry.Item).shortcut)
+        assertEquals(expectedPrimaryShortcut("C"), (interpreted[1] as ContextMenuEntry.Item).shortcut)
+        assertEquals(expectedPrimaryShortcut("V"), (interpreted[2] as ContextMenuEntry.Item).shortcut)
+        assertEquals(expectedPrimaryShortcut("A"), (interpreted[3] as ContextMenuEntry.Item).shortcut)
     }
 }
+
+private fun expectedPrimaryShortcut(key: String): String =
+    if (Platform.Current == Platform.MacOS) "⌘$key" else "Ctrl+$key"
 
 private fun symbolName(icon: ContextMenuIcon): String = (icon.toNsMenuItemImage() as NsMenuItemImage.SystemSymbol).name


### PR DESCRIPTION
## Summary

- Cut / Copy / Paste / Select All now show platform accelerators (`Ctrl+C` / `⌘C`) on the Linux Adwaita and Windows Fluent flyouts, matching Jewel.
- `NucleusContextMenuItem` and `ContextMenuEntry.Item` accept an optional `shortcut`; stock edit icons fall back to the conventional accelerator. Pass `""` to hide it.
- Jewel `ContextMenuItemOption` action types map to the same shortcuts.

## Type

feat

## Test plan

- [ ] Right-click a text field with `nativeContextMenu = true` on Linux: Cut/Copy/Paste/Select All show `Ctrl+X/C/V/A` on the right.
- [ ] Same on Windows Fluent flyout.
- [ ] Custom `NucleusContextMenuItem(..., shortcut = "Ctrl+R")` shows the explicit hint.
- [ ] `./gradlew :nucleus-application:test --tests ContextMenuInterpreterTest`