### PR TITLE
feat(window): add compose Breeze context menu on KDE

### DIFF
--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/BreezeContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/BreezeContextMenu.kt
@@ -1,0 +1,78 @@
+@file:OptIn(androidx.compose.ui.text.ExperimentalTextApi::class)
+
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// Breeze kstyle/breezemetrics.h + colors/Breeze{Light,Dark}.colors
+private val BreezeUiFont = FontFamily("Noto Sans")
+
+private val BreezeAccent = Color(red = 61, green = 174, blue = 233)
+
+internal val BreezeMenuTheme =
+    ContextMenuFlyoutTheme(
+        menuShape = RoundedCornerShape(5.dp),
+        itemShape = RoundedCornerShape(5.dp),
+        uiFont = BreezeUiFont,
+        iconFont = BreezeUiFont,
+        chevron = "›",
+        chevronSize = 14.sp,
+        chevronAlpha = 1f,
+        minWidth = 128.dp,
+        maxWidth = Dp.Unspecified,
+        menuPadding = PaddingValues(4.dp),
+        itemHeight = 30.dp,
+        itemHorizontalPadding = 12.dp,
+        itemOuterHorizontalPadding = 0.dp,
+        separatorPadding = PaddingValues(horizontal = 4.dp, vertical = 4.dp),
+        iconSize = 16.dp,
+        iconGap = 4.dp,
+        shadowElevation = 10.dp,
+        shadowPad = 12.dp,
+        ambientShadow = Color.Black.copy(alpha = 0.18f),
+        spotShadow = Color.Black.copy(alpha = 0.10f),
+        showIcons = true,
+        shortcutGap = 16.dp,
+        shortcutSize = 14.sp,
+        shortcutAlpha = 0.70f,
+        colors = ::breezeColors,
+        glyph = ContextMenuIcon::toBreezeGlyph,
+    )
+
+private fun breezeColors(dark: Boolean): ContextMenuFlyoutColors =
+    if (dark) {
+        ContextMenuFlyoutColors(
+            surface = Color(red = 32, green = 35, blue = 38),
+            text = Color(red = 252, green = 252, blue = 252),
+            textDisabled = Color(red = 161, green = 169, blue = 177),
+            hover = BreezeAccent.copy(alpha = 0.30f),
+            separator = Color(red = 252, green = 252, blue = 252, alpha = 0x26),
+            border = Color(red = 252, green = 252, blue = 252, alpha = 0x33),
+        )
+    } else {
+        ContextMenuFlyoutColors(
+            surface = Color(red = 239, green = 240, blue = 241),
+            text = Color(red = 35, green = 38, blue = 41),
+            textDisabled = Color(red = 112, green = 125, blue = 138),
+            hover = BreezeAccent.copy(alpha = 0.30f),
+            separator = Color(red = 35, green = 38, blue = 41, alpha = 0x26),
+            border = Color(red = 35, green = 38, blue = 41, alpha = 0x33),
+        )
+    }
+
+internal fun ContextMenuIcon.toBreezeGlyph(): String? =
+    when (this) {
+        ContextMenuIcon.Cut -> "\u2702"
+        ContextMenuIcon.Copy -> "\u2398"
+        ContextMenuIcon.Paste -> "\u2399"
+        ContextMenuIcon.SelectAll -> "\u2611"
+        ContextMenuIcon.Delete -> "\u232B"
+        ContextMenuIcon.Folder -> "\u25A1"
+        is ContextMenuIcon.SfSymbol -> null
+    }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
@@ -7,9 +7,9 @@ import dev.nucleusframework.core.runtime.Platform
  * is active.
  *
  * Stock values (`Cut`, `Copy`, `Paste`, …) resolve to the OS glyph (SF Symbol
- * on macOS, Adwaita-style symbolic strokes on the Linux Compose flyout,
- * Segoe Fluent Icons on the Windows Compose flyout). [SfSymbol] is a raw
- * macOS symbol name and is ignored on Windows / Linux.
+ * on macOS, Breeze Unicode glyphs on the KDE Compose flyout, Segoe Fluent
+ * Icons on the Windows Compose flyout). Adwaita flyouts hide icons.
+ * [SfSymbol] is a raw macOS symbol name and is ignored on Windows / Linux.
  */
 public sealed class ContextMenuIcon {
     /** System cut / scissors glyph. */

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
@@ -31,8 +31,8 @@ internal val LocalContextMenuDensity: ProvidableCompositionLocal<Density?> =
 
 /**
  * Whether this process can show the opt-in OS-looking context menu:
- * macOS + `menu-macos` (`NSMenu`), Linux (Compose Adwaita flyout), or
- * Windows (Compose Fluent flyout).
+ * macOS + `menu-macos` (`NSMenu`), Linux (Compose Adwaita or Breeze
+ * flyout), or Windows (Compose Fluent flyout).
  */
 public val isNativeContextMenuSupported: Boolean
     get() =
@@ -48,7 +48,7 @@ public val isNativeContextMenuSupported: Boolean
  * Installs [NativeTextContextMenu] (so Cut / Copy / Paste carry
  * [ContextMenuIcon] stock tags and platform accelerators) and
  * [NativeContextMenuRepresentation] (`NSMenu` on macOS, Compose Adwaita
- * flyout on Linux, Compose Fluent flyout on Windows).
+ * or Breeze flyout on Linux, Compose Fluent flyout on Windows).
  *
  * No-op when [enabled] is `false` or when [isNativeContextMenuSupported] is
  * `false` (missing macOS native lib). Compose / Jewel chrome stays.

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.ContextMenuState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import dev.nucleusframework.application.spellcheck.LocalSpellcheckMenuSeparator
+import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.menu.macos.NativePopupMenuItem
 import dev.nucleusframework.menu.macos.NsMenuItemImage
@@ -15,7 +16,8 @@ import dev.nucleusframework.menu.macos.popUpNativeMenu
 
 /**
  * OS-looking context menu: `NSMenu` on macOS, a Compose Fluent flyout on
- * Windows, a Compose Adwaita flyout on Linux.
+ * Windows, a Compose Adwaita flyout on GNOME-like Linux desktops, a
+ * Compose Breeze flyout on KDE Plasma.
  *
  * Calling [Representation] off a supported OS closes the menu immediately
  * so a stray install cannot leave Compose in `Open`.
@@ -38,7 +40,7 @@ public object NativeContextMenuRepresentation : ContextMenuRepresentation {
         }
         when (Platform.Current) {
             Platform.Windows -> ContextMenuFlyout(status, entries, FluentMenuTheme, onDismiss)
-            Platform.Linux -> ContextMenuFlyout(status, entries, AdwaitaMenuTheme, onDismiss)
+            Platform.Linux -> ContextMenuFlyout(status, entries, linuxContextMenuTheme(), onDismiss)
             Platform.MacOS -> {
                 LaunchedEffect(status) {
                     try {
@@ -52,6 +54,12 @@ public object NativeContextMenuRepresentation : ContextMenuRepresentation {
         }
     }
 }
+
+internal fun linuxContextMenuTheme(): ContextMenuFlyoutTheme =
+    when (LinuxDesktopEnvironment.Current) {
+        LinuxDesktopEnvironment.KDE -> BreezeMenuTheme
+        else -> AdwaitaMenuTheme
+    }
 
 internal fun ContextMenuEntry.toMacPopupItem(): NativePopupMenuItem =
     when (this) {

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.text.TextContextMenu
 import androidx.compose.ui.text.AnnotatedString
 import dev.nucleusframework.application.spellcheck.SpellcheckContextMenuSeparator
+import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.menu.macos.NsMenuItemImage
 import org.junit.Assert.assertEquals
@@ -146,6 +147,27 @@ class ContextMenuInterpreterTest {
         assertEquals("\uE74D", ContextMenuIcon.Delete.toFluentGlyph())
         assertEquals("\uE8B7", ContextMenuIcon.Folder.toFluentGlyph())
         assertNull(ContextMenuIcon.SfSymbol("square.and.arrow.up").toFluentGlyph())
+    }
+
+    @Test
+    fun `stock icons map to breeze glyphs and sf symbols are ignored`() {
+        assertEquals("\u2702", ContextMenuIcon.Cut.toBreezeGlyph())
+        assertEquals("\u2398", ContextMenuIcon.Copy.toBreezeGlyph())
+        assertEquals("\u2399", ContextMenuIcon.Paste.toBreezeGlyph())
+        assertEquals("\u2611", ContextMenuIcon.SelectAll.toBreezeGlyph())
+        assertEquals("\u232B", ContextMenuIcon.Delete.toBreezeGlyph())
+        assertEquals("\u25A1", ContextMenuIcon.Folder.toBreezeGlyph())
+        assertNull(ContextMenuIcon.SfSymbol("square.and.arrow.up").toBreezeGlyph())
+    }
+
+    @Test
+    fun `linux flyout uses breeze on kde and adwaita otherwise`() {
+        val theme = linuxContextMenuTheme()
+        if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
+            assertSame(BreezeMenuTheme, theme)
+        } else {
+            assertSame(AdwaitaMenuTheme, theme)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Linux native context menu now picks Breeze when `LinuxDesktopEnvironment` is KDE (metrics and colors from Breeze `breezemetrics.h` + official Light/Dark schemes).
- GNOME-like desktops keep the Adwaita flyout.
- Stacked on #544 (shortcuts). Retarget to `nucleus-2.5` after that merges.

## Type

feat

## Test plan

- [ ] On Plasma, right-click a text field: 5dp corners, `#EFF0F1`/`#202326` surface, accent-blue hover, Noto Sans, icons + `Ctrl+C` hints.
- [ ] On GNOME, the menu stays Adwaita.
- [ ] `./gradlew :nucleus-application:test --tests ContextMenuInterpreterTest`