### PR TITLE
fix(window): pick Linux context menu by GTK/Qt toolkit

### DIFF
--- a/core-runtime/api/core-runtime.api
+++ b/core-runtime/api/core-runtime.api
@@ -85,6 +85,19 @@ public final class dev/nucleusframework/core/runtime/LinuxDesktopEnvironment$Com
 	public final fun getCurrent ()Ldev/nucleusframework/core/runtime/LinuxDesktopEnvironment;
 }
 
+public final class dev/nucleusframework/core/runtime/LinuxUiToolkit : java/lang/Enum {
+	public static final field Companion Ldev/nucleusframework/core/runtime/LinuxUiToolkit$Companion;
+	public static final field Gtk Ldev/nucleusframework/core/runtime/LinuxUiToolkit;
+	public static final field Qt Ldev/nucleusframework/core/runtime/LinuxUiToolkit;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/nucleusframework/core/runtime/LinuxUiToolkit;
+	public static fun values ()[Ldev/nucleusframework/core/runtime/LinuxUiToolkit;
+}
+
+public final class dev/nucleusframework/core/runtime/LinuxUiToolkit$Companion {
+	public final fun getCurrent ()Ldev/nucleusframework/core/runtime/LinuxUiToolkit;
+}
+
 public final class dev/nucleusframework/core/runtime/NativeLibraryLoader {
 	public static final field INSTANCE Ldev/nucleusframework/core/runtime/NativeLibraryLoader;
 	public final fun load (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;Ljava/util/List;)Z

--- a/core-runtime/src/main/kotlin/dev/nucleusframework/core/runtime/LinuxDesktopEnvironment.kt
+++ b/core-runtime/src/main/kotlin/dev/nucleusframework/core/runtime/LinuxDesktopEnvironment.kt
@@ -26,3 +26,115 @@ public enum class LinuxDesktopEnvironment {
         }
     }
 }
+
+/**
+ * Widget toolkit the Linux session is built on. Distinct from
+ * [LinuxDesktopEnvironment]: LXQt and Deepin are not Plasma but they are
+ * still Qt shells, while GNOME / XFCE / Cinnamon / MATE are GTK.
+ *
+ * Used to pick matching chrome such as the context-menu flyout (Adwaita vs
+ * Breeze).
+ */
+public enum class LinuxUiToolkit {
+    /** GTK shells: GNOME, XFCE, Cinnamon, MATE, Budgie, Pantheon, … */
+    Gtk,
+
+    /** Qt shells: KDE Plasma, LXQt, Deepin, Trinity, … */
+    Qt,
+    ;
+
+    /** Resolves [Current] from the process environment. */
+    public companion object {
+        /**
+         * Toolkit of the current session, from `XDG_CURRENT_DESKTOP` /
+         * `DESKTOP_SESSION` / `XDG_SESSION_DESKTOP`, then `KDE_FULL_SESSION`
+         * and `QT_QPA_PLATFORMTHEME`. Defaults to [Gtk] when nothing matches
+         * (tiling WMs, unknown DEs).
+         */
+        public val Current: LinuxUiToolkit by lazy {
+            linuxUiToolkit(
+                xdgCurrentDesktop = System.getenv("XDG_CURRENT_DESKTOP"),
+                desktopSession = System.getenv("DESKTOP_SESSION"),
+                xdgSessionDesktop = System.getenv("XDG_SESSION_DESKTOP"),
+                kdeFullSession = System.getenv("KDE_FULL_SESSION"),
+                qtPlatformTheme = System.getenv("QT_QPA_PLATFORMTHEME"),
+            )
+        }
+    }
+}
+
+private val QtDesktopIds =
+    setOf(
+        "kde",
+        "plasma",
+        "plasmawayland",
+        "lxqt",
+        "deepin",
+        "dde",
+        "trinity",
+        "tde",
+        "lumina",
+        "ukui",
+        "cutefish",
+        "lingmo",
+    )
+
+private val GtkDesktopIds =
+    setOf(
+        "gnome",
+        "ubuntu",
+        "unity",
+        "xfce",
+        "x-cinnamon",
+        "cinnamon",
+        "mate",
+        "budgie",
+        "pantheon",
+        "lxde",
+        "enlightenment",
+        "pop",
+        "cosmic",
+        "phosh",
+    )
+
+internal fun linuxUiToolkit(
+    xdgCurrentDesktop: String?,
+    desktopSession: String?,
+    xdgSessionDesktop: String?,
+    kdeFullSession: String?,
+    qtPlatformTheme: String?,
+): LinuxUiToolkit {
+    val tokens =
+        buildList {
+            addDesktopTokens(xdgCurrentDesktop)
+            addDesktopTokens(desktopSession)
+            addDesktopTokens(xdgSessionDesktop)
+        }
+    for (token in tokens) {
+        if (token.matchesAnyDesktopId(QtDesktopIds)) return LinuxUiToolkit.Qt
+        if (token.matchesAnyDesktopId(GtkDesktopIds)) return LinuxUiToolkit.Gtk
+    }
+    if (kdeFullSession.equals("true", ignoreCase = true)) return LinuxUiToolkit.Qt
+    return when (qtPlatformTheme?.trim()?.lowercase(Locale.ENGLISH)) {
+        "kde",
+        "lxqt",
+        "qt5ct",
+        "qt6ct",
+        "kvantum",
+        "plasma",
+        -> LinuxUiToolkit.Qt
+        else -> LinuxUiToolkit.Gtk
+    }
+}
+
+private fun MutableList<String>.addDesktopTokens(value: String?) {
+    if (value.isNullOrBlank()) return
+    value.split(':', ';', ',', ' ').mapNotNullTo(this) { token ->
+        token.trim().lowercase(Locale.ENGLISH).ifEmpty { null }
+    }
+}
+
+private fun String.matchesAnyDesktopId(ids: Set<String>): Boolean =
+    ids.any { id ->
+        this == id || startsWith("$id-") || startsWith("${id}_")
+    }

--- a/core-runtime/src/test/kotlin/dev/nucleusframework/core/runtime/LinuxUiToolkitTest.kt
+++ b/core-runtime/src/test/kotlin/dev/nucleusframework/core/runtime/LinuxUiToolkitTest.kt
@@ -1,0 +1,70 @@
+package dev.nucleusframework.core.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class LinuxUiToolkitTest(
+    private val desktop: String?,
+    private val session: String?,
+    private val sessionDesktop: String?,
+    private val kdeFullSession: String?,
+    private val qtTheme: String?,
+    private val expected: LinuxUiToolkit,
+) {
+    @Test
+    fun `classifies gtk vs qt from session hints`() {
+        assertEquals(
+            expected,
+            linuxUiToolkit(
+                xdgCurrentDesktop = desktop,
+                desktopSession = session,
+                xdgSessionDesktop = sessionDesktop,
+                kdeFullSession = kdeFullSession,
+                qtPlatformTheme = qtTheme,
+            ),
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0} / {1} / {2} / kde={3} qt={4} → {5}")
+        fun data(): Collection<Array<Any?>> =
+            listOf(
+                row("GNOME", null, null, null, null, LinuxUiToolkit.Gtk),
+                row("ubuntu:GNOME", null, null, null, null, LinuxUiToolkit.Gtk),
+                row("Budgie:GNOME", null, null, null, null, LinuxUiToolkit.Gtk),
+                row("XFCE", null, null, null, null, LinuxUiToolkit.Gtk),
+                row("X-Cinnamon", null, null, null, null, LinuxUiToolkit.Gtk),
+                row("MATE", null, null, null, null, LinuxUiToolkit.Gtk),
+                row("Pantheon", null, null, null, null, LinuxUiToolkit.Gtk),
+                row("pop:GNOME", null, null, null, null, LinuxUiToolkit.Gtk),
+                row("KDE", null, null, null, null, LinuxUiToolkit.Qt),
+                row(null, "plasma", null, null, null, LinuxUiToolkit.Qt),
+                row(null, "plasmawayland", null, null, null, LinuxUiToolkit.Qt),
+                row("LXQt", null, null, null, null, LinuxUiToolkit.Qt),
+                row("lxqt:LXQt", null, null, null, null, LinuxUiToolkit.Qt),
+                row("Deepin", null, null, null, null, LinuxUiToolkit.Qt),
+                row("UKUI", null, null, null, null, LinuxUiToolkit.Qt),
+                row(null, null, null, "true", null, LinuxUiToolkit.Qt),
+                row(null, null, null, null, "qt6ct", LinuxUiToolkit.Qt),
+                row(null, null, null, null, "kde", LinuxUiToolkit.Qt),
+                row("Hyprland", null, null, null, "kvantum", LinuxUiToolkit.Qt),
+                row("Hyprland", null, null, null, null, LinuxUiToolkit.Gtk),
+                row("sway", null, null, null, "gtk3", LinuxUiToolkit.Gtk),
+                row(null, null, null, null, null, LinuxUiToolkit.Gtk),
+                row("KDE:GNOME", null, null, null, null, LinuxUiToolkit.Qt),
+            )
+
+        private fun row(
+            desktop: String?,
+            session: String?,
+            sessionDesktop: String?,
+            kdeFullSession: String?,
+            qtTheme: String?,
+            expected: LinuxUiToolkit,
+        ): Array<Any?> = arrayOf(desktop, session, sessionDesktop, kdeFullSession, qtTheme, expected)
+    }
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/AdwaitaContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/AdwaitaContextMenu.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -23,7 +22,7 @@ internal val AdwaitaMenuTheme =
         chevronSize = 16.sp,
         chevronAlpha = 0.30f,
         minWidth = 120.dp,
-        maxWidth = Dp.Unspecified,
+        maxWidth = 280.dp,
         menuPadding = PaddingValues(6.dp),
         itemHeight = 32.dp,
         itemHorizontalPadding = 12.dp,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/BreezeContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/BreezeContextMenu.kt
@@ -1,17 +1,16 @@
-@file:OptIn(androidx.compose.ui.text.ExperimentalTextApi::class)
-
 package dev.nucleusframework.application.contextmenu
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 // Breeze kstyle/breezemetrics.h + colors/Breeze{Light,Dark}.colors
-private val BreezeUiFont = FontFamily("Noto Sans")
+// SansSerif (not FontFamily("Noto Sans")): the named-family constructor is
+// ExperimentalTextApi and can throw during BasicText place on Compose 1.12.
+private val BreezeUiFont = FontFamily.SansSerif
 
 private val BreezeAccent = Color(red = 61, green = 174, blue = 233)
 
@@ -25,7 +24,7 @@ internal val BreezeMenuTheme =
         chevronSize = 14.sp,
         chevronAlpha = 1f,
         minWidth = 128.dp,
-        maxWidth = Dp.Unspecified,
+        maxWidth = 320.dp,
         menuPadding = PaddingValues(4.dp),
         itemHeight = 30.dp,
         itemHorizontalPadding = 12.dp,
@@ -42,7 +41,8 @@ internal val BreezeMenuTheme =
         shortcutSize = 14.sp,
         shortcutAlpha = 0.70f,
         colors = ::breezeColors,
-        glyph = ContextMenuIcon::toBreezeGlyph,
+        glyph = { null },
+        vector = ContextMenuIcon::toBreezeVector,
     )
 
 private fun breezeColors(dark: Boolean): ContextMenuFlyoutColors =
@@ -64,15 +64,4 @@ private fun breezeColors(dark: Boolean): ContextMenuFlyoutColors =
             separator = Color(red = 35, green = 38, blue = 41, alpha = 0x26),
             border = Color(red = 35, green = 38, blue = 41, alpha = 0x33),
         )
-    }
-
-internal fun ContextMenuIcon.toBreezeGlyph(): String? =
-    when (this) {
-        ContextMenuIcon.Cut -> "\u2702"
-        ContextMenuIcon.Copy -> "\u2398"
-        ContextMenuIcon.Paste -> "\u2399"
-        ContextMenuIcon.SelectAll -> "\u2611"
-        ContextMenuIcon.Delete -> "\u232B"
-        ContextMenuIcon.Folder -> "\u25A1"
-        is ContextMenuIcon.SfSymbol -> null
     }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/BreezeContextMenuIcons.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/BreezeContextMenuIcons.kt
@@ -1,0 +1,113 @@
+package dev.nucleusframework.application.contextmenu
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.PathParser
+import androidx.compose.ui.unit.dp
+
+/**
+ * 16×16 monochrome Breeze action icons. Unicode fallbacks (✂ / ⎘ / ☑)
+ * pick different fonts and emoji presentation, so they never share a size.
+ */
+internal fun ContextMenuIcon.toBreezeVector(): ImageVector? =
+    when (this) {
+        ContextMenuIcon.Cut -> BreezeMenuIcons.Cut
+        ContextMenuIcon.Copy -> BreezeMenuIcons.Copy
+        ContextMenuIcon.Paste -> BreezeMenuIcons.Paste
+        ContextMenuIcon.SelectAll -> BreezeMenuIcons.SelectAll
+        ContextMenuIcon.Delete -> BreezeMenuIcons.Delete
+        ContextMenuIcon.Folder -> BreezeMenuIcons.Folder
+        is ContextMenuIcon.SfSymbol -> null
+    }
+
+private object BreezeMenuIcons {
+    val Cut: ImageVector by lazy {
+        breezeMenuIcon(
+            "Cut",
+            "M 5 2 C 4.567 2.75 4.34825 2.75 4.78125 3.5 L 7.40625 8 L 5.90625 10.21875 " +
+                "C 5.63425 10.08075 5.325 10 5 10 C 3.895 10 3 10.895 3 12 C 3 13.105 " +
+                "3.895 14 5 14 C 6.105 14 7 13.105 7 12 C 7 11.595 6.86325 11.22125 " +
+                "6.65625 10.90625 C 6.65125 10.89825 6.66125 10.882 6.65625 10.875 " +
+                "L 7.09375 10.25 C 7.89575 10.225 8.008 9.65725 8.5 9.65625 C 8.511 " +
+                "9.65625 8.52025 9.65525 8.53125 9.65625 L 8.5625 9.71875 L 9.34375 " +
+                "10.875 L 9.34375 10.90625 C 9.13775 11.22125 8.9980469 11.595 " +
+                "8.9980469 12 C 8.9980469 13.105 9.8930469 14 10.998047 14 C 12.103047 " +
+                "14 12.998047 13.105 12.998047 12 C 12.998047 10.895 12.103047 10 " +
+                "10.998047 10 C 10.673047 10 10.36475 10.08075 10.09375 10.21875 " +
+                "L 8.59375 8 C 8.59375 8 11.22875 3.492 11.21875 3.5 C 11.65175 2.75 " +
+                "11.431047 2.75 10.998047 2 L 7.9980469 7.125 L 5 2 z M 7.9980469 8 " +
+                "L 8 8 C 8.276 8 8.5 8.224 8.5 8.5 C 8.5 8.754 8.3075 8.968 8.0625 9 " +
+                "L 7.9375 9 C 7.6925 8.968 7.4980469 8.754 7.4980469 8.5 C 7.4980469 " +
+                "8.224 7.7220469 8 7.9980469 8 z M 4.9980469 11 C 5.5500469 11 " +
+                "5.9980469 11.448 5.9980469 12 C 5.9980469 12.552 5.5500469 13 " +
+                "4.9980469 13 C 4.4460469 13 3.9980469 12.552 3.9980469 12 C 3.9980469 " +
+                "11.448 4.4460469 11 4.9980469 11 z M 10.998047 11 C 11.550047 11 " +
+                "11.998047 11.448 11.998047 12 C 11.998047 12.552 11.550047 13 " +
+                "10.998047 13 C 10.446047 13 9.9980469 12.552 9.9980469 12 C 9.9980469 " +
+                "11.448 10.446047 11 10.998047 11 z",
+        )
+    }
+    val Copy: ImageVector by lazy {
+        breezeMenuIcon(
+            "Copy",
+            "M 3 2 L 3 12 L 6 12 L 6 14 L 14 14 L 14 7 L 11 4 L 10 4 L 8 2 L 3 2 Z " +
+                "M 4 3 L 7 3 L 7 4 L 6 4 L 6 11 L 4 11 L 4 3 Z M 7 5 L 10 5 L 10 8 " +
+                "L 13 8 L 13 13 L 7 13 L 7 5 Z",
+        )
+    }
+    val Paste: ImageVector by lazy {
+        breezeMenuIcon(
+            "Paste",
+            "M 5 2 L 5 3 L 3 3 L 3 14 L 7 14 L 8 14 L 12 14 L 13 14 L 13 13 L 13 9 " +
+                "L 13 3 L 11 3 L 11 2 L 5 2 z M 4 4 L 5 4 L 5 5 L 11 5 L 11 4 L 12 4 " +
+                "L 12 6 L 12 12 L 12 13 L 8 13 L 7 13 L 4 13 L 4 12 L 4 6 L 4 4 z " +
+                "M 5 7 L 5 8 L 10 8 L 10 7 L 5 7 z M 5 10 L 5 11 L 8 11 L 8 10 L 5 10 z",
+        )
+    }
+    val SelectAll: ImageVector by lazy {
+        breezeMenuIcon(
+            "SelectAll",
+            "M 2 2 L 2 5 L 3 5 L 3 3 L 5 3 L 5 2 L 3 2 L 2 2 z M 11 2 L 11 3 L 13 3 " +
+                "L 13 4 L 13 5 L 14 5 L 14 3 L 14 2 L 11 2 z M 4 4 L 4 7 L 7 7 L 7 4 " +
+                "L 4 4 z M 9 4 L 9 7 L 12 7 L 12 4 L 9 4 z M 4 9 L 4 12 L 7 12 L 7 9 " +
+                "L 4 9 z M 9 9 L 9 12 L 12 12 L 12 9 L 9 9 z M 2 11 L 2 12 L 2 13 " +
+                "L 2 14 L 5 14 L 5 13 L 3 13 L 3 12 L 3 11 L 2 11 z M 13 11 L 13 12 " +
+                "L 13 13 L 12 13 L 11 13 L 11 14 L 12 14 L 13 14 L 14 14 L 14 12 " +
+                "L 14 11 L 13 11 z",
+        )
+    }
+    val Delete: ImageVector by lazy {
+        breezeMenuIcon(
+            "Delete",
+            "m5 2v2h1v-1h4v1h1v-2h-5zm-3 3v1h2v8h8v-8h2v-1zm3 1h6v7h-6z",
+        )
+    }
+    val Folder: ImageVector by lazy {
+        breezeMenuIcon(
+            "Folder",
+            "M 2 2 L 2 3 L 2 6 L 2 7 L 2 13 L 2 14 L 14 14 L 14 13 L 14 6 L 14 5 " +
+                "L 14 4 L 9 4 L 7 2 L 7 2 L 7 2 L 3 2 L 2 2 z M 3 3 L 6.6 3 L 7.6 4 " +
+                "L 7 4 L 7 4 L 7 4 L 5 6 L 3 6 L 3 3 z M 3 7 L 13 7 L 13 13 L 3 13 L 3 7 z",
+        )
+    }
+}
+
+private fun breezeMenuIcon(
+    name: String,
+    pathData: String,
+): ImageVector {
+    val builder =
+        ImageVector.Builder(
+            name = "BreezeMenu$name",
+            defaultWidth = 16.dp,
+            defaultHeight = 16.dp,
+            viewportWidth = 16f,
+            viewportHeight = 16f,
+        )
+    builder.addPath(
+        pathData = PathParser().parsePathString(pathData).toNodes(),
+        fill = SolidColor(Color.Black),
+    )
+    return builder.build()
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuFlyout.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuFlyout.kt
@@ -23,7 +23,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -38,16 +38,23 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.paint
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.takeOrElse
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
@@ -92,7 +99,13 @@ internal class ContextMenuFlyoutTheme(
     val shortcutAlpha: Float,
     val colors: (dark: Boolean) -> ContextMenuFlyoutColors,
     val glyph: (ContextMenuIcon) -> String?,
-)
+    val vector: (ContextMenuIcon) -> ImageVector? = { null },
+) {
+    internal fun hasIcon(icon: ContextMenuIcon?): Boolean {
+        if (icon == null) return false
+        return vector(icon) != null || glyph(icon) != null
+    }
+}
 
 @Composable
 internal fun ContextMenuFlyout(
@@ -130,11 +143,13 @@ private fun ContextMenuFlyoutSurface(
     val reserveIcon =
         theme.showIcons &&
             entries.any { entry ->
-                entry is ContextMenuEntry.Item && theme.glyph(entry.icon ?: return@any false) != null
+                entry is ContextMenuEntry.Item && theme.hasIcon(entry.icon)
             }
+    val maxWidth = theme.maxWidth.takeOrElse { 320.dp }
     Box(Modifier.padding(theme.shadowPad)) {
         Column(
             Modifier
+                .widthIn(min = theme.minWidth, max = maxWidth)
                 .shadow(
                     elevation = theme.shadowElevation,
                     shape = theme.menuShape,
@@ -142,7 +157,6 @@ private fun ContextMenuFlyoutSurface(
                     ambientColor = theme.ambientShadow,
                     spotColor = theme.spotShadow,
                 ).width(IntrinsicSize.Max)
-                .widthIn(min = theme.minWidth, max = theme.maxWidth)
                 .clip(theme.menuShape)
                 .border(1.dp, colors.border, theme.menuShape)
                 .background(colors.surface)
@@ -162,7 +176,7 @@ private fun ContextMenuFlyoutSurface(
                         ContextMenuFlyoutRow(
                             label = entry.label,
                             enabled = entry.enabled,
-                            icon = entry.icon?.let(theme.glyph),
+                            icon = entry.icon,
                             shortcut = entry.shortcut,
                             reserveIcon = reserveIcon,
                             chevron = false,
@@ -251,7 +265,7 @@ private fun ContextMenuFlyoutSubmenu(
 private fun ContextMenuFlyoutRow(
     label: String,
     enabled: Boolean,
-    icon: String?,
+    icon: ContextMenuIcon?,
     shortcut: String?,
     reserveIcon: Boolean,
     chevron: Boolean,
@@ -262,6 +276,7 @@ private fun ContextMenuFlyoutRow(
 ) {
     val hovered by interactionSource.collectIsHoveredAsState()
     val content = if (enabled) colors.text else colors.textDisabled
+    val iconSp = with(LocalDensity.current) { theme.iconSize.toSp() }
     Row(
         Modifier
             .fillMaxWidth()
@@ -279,19 +294,12 @@ private fun ContextMenuFlyoutRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (reserveIcon) {
-            if (icon != null) {
-                BasicText(
-                    text = icon,
-                    style =
-                        TextStyle(
-                            color = content,
-                            fontSize = 16.sp,
-                            fontFamily = theme.iconFont,
-                        ),
-                )
-            } else {
-                Spacer(Modifier.size(theme.iconSize))
-            }
+            ContextMenuFlyoutIcon(
+                icon = icon,
+                content = content,
+                iconSp = iconSp,
+                theme = theme,
+            )
             Spacer(Modifier.width(theme.iconGap))
         }
         BasicText(
@@ -331,5 +339,41 @@ private fun ContextMenuFlyoutRow(
                     ),
             )
         }
+    }
+}
+
+@Composable
+private fun ContextMenuFlyoutIcon(
+    icon: ContextMenuIcon?,
+    content: Color,
+    iconSp: TextUnit,
+    theme: ContextMenuFlyoutTheme,
+) {
+    val vector = icon?.let(theme.vector)
+    val glyph = icon?.let(theme.glyph)
+    val iconModifier = Modifier.requiredSize(theme.iconSize)
+    if (vector != null) {
+        Box(
+            iconModifier.paint(
+                painter = rememberVectorPainter(vector),
+                contentScale = ContentScale.Fit,
+                colorFilter = ColorFilter.tint(content),
+            ),
+        )
+    } else if (glyph != null) {
+        Box(iconModifier, contentAlignment = Alignment.Center) {
+            BasicText(
+                text = glyph,
+                style =
+                    TextStyle(
+                        color = content,
+                        fontSize = iconSp,
+                        fontFamily = theme.iconFont,
+                        textAlign = TextAlign.Center,
+                    ),
+            )
+        }
+    } else {
+        Spacer(iconModifier)
     }
 }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuIcon.kt
@@ -7,8 +7,8 @@ import dev.nucleusframework.core.runtime.Platform
  * is active.
  *
  * Stock values (`Cut`, `Copy`, `Paste`, …) resolve to the OS glyph (SF Symbol
- * on macOS, Breeze Unicode glyphs on the KDE Compose flyout, Segoe Fluent
- * Icons on the Windows Compose flyout). Adwaita flyouts hide icons.
+ * on macOS, 16 dp Breeze vectors on the Qt/KDE Compose flyout, Segoe Fluent
+ * Icons on the Windows Compose flyout). Adwaita (GTK) flyouts hide icons.
  * [SfSymbol] is a raw macOS symbol name and is ignored on Windows / Linux.
  */
 public sealed class ContextMenuIcon {

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuProvider.kt
@@ -31,8 +31,8 @@ internal val LocalContextMenuDensity: ProvidableCompositionLocal<Density?> =
 
 /**
  * Whether this process can show the opt-in OS-looking context menu:
- * macOS + `menu-macos` (`NSMenu`), Linux (Compose Adwaita or Breeze
- * flyout), or Windows (Compose Fluent flyout).
+ * macOS + `menu-macos` (`NSMenu`), Linux (Compose Adwaita on GTK
+ * desktops, Breeze on Qt desktops), or Windows (Compose Fluent flyout).
  */
 public val isNativeContextMenuSupported: Boolean
     get() =
@@ -48,7 +48,8 @@ public val isNativeContextMenuSupported: Boolean
  * Installs [NativeTextContextMenu] (so Cut / Copy / Paste carry
  * [ContextMenuIcon] stock tags and platform accelerators) and
  * [NativeContextMenuRepresentation] (`NSMenu` on macOS, Compose Adwaita
- * or Breeze flyout on Linux, Compose Fluent flyout on Windows).
+ * flyout on GTK Linux / Breeze on Qt Linux, Compose Fluent flyout on
+ * Windows).
  *
  * No-op when [enabled] is `false` or when [isNativeContextMenuSupported] is
  * `false` (missing macOS native lib). Compose / Jewel chrome stays.

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/contextmenu/NativeContextMenuRepresentation.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.ContextMenuState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import dev.nucleusframework.application.spellcheck.LocalSpellcheckMenuSeparator
-import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
+import dev.nucleusframework.core.runtime.LinuxUiToolkit
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.menu.macos.NativePopupMenuItem
 import dev.nucleusframework.menu.macos.NsMenuItemImage
@@ -16,8 +16,9 @@ import dev.nucleusframework.menu.macos.popUpNativeMenu
 
 /**
  * OS-looking context menu: `NSMenu` on macOS, a Compose Fluent flyout on
- * Windows, a Compose Adwaita flyout on GNOME-like Linux desktops, a
- * Compose Breeze flyout on KDE Plasma.
+ * Windows, a Compose Adwaita flyout on GTK Linux desktops (GNOME, XFCE,
+ * Cinnamon, MATE, …), a Compose Breeze flyout on Qt Linux desktops (KDE
+ * Plasma, LXQt, Deepin, …).
  *
  * Calling [Representation] off a supported OS closes the menu immediately
  * so a stray install cannot leave Compose in `Open`.
@@ -56,9 +57,9 @@ public object NativeContextMenuRepresentation : ContextMenuRepresentation {
 }
 
 internal fun linuxContextMenuTheme(): ContextMenuFlyoutTheme =
-    when (LinuxDesktopEnvironment.Current) {
-        LinuxDesktopEnvironment.KDE -> BreezeMenuTheme
-        else -> AdwaitaMenuTheme
+    when (LinuxUiToolkit.Current) {
+        LinuxUiToolkit.Qt -> BreezeMenuTheme
+        LinuxUiToolkit.Gtk -> AdwaitaMenuTheme
     }
 
 internal fun ContextMenuEntry.toMacPopupItem(): NativePopupMenuItem =

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/contextmenu/ContextMenuInterpreterTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.text.TextContextMenu
 import androidx.compose.ui.text.AnnotatedString
 import dev.nucleusframework.application.spellcheck.SpellcheckContextMenuSeparator
-import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
+import dev.nucleusframework.core.runtime.LinuxUiToolkit
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.menu.macos.NsMenuItemImage
 import org.junit.Assert.assertEquals
@@ -150,20 +150,28 @@ class ContextMenuInterpreterTest {
     }
 
     @Test
-    fun `stock icons map to breeze glyphs and sf symbols are ignored`() {
-        assertEquals("\u2702", ContextMenuIcon.Cut.toBreezeGlyph())
-        assertEquals("\u2398", ContextMenuIcon.Copy.toBreezeGlyph())
-        assertEquals("\u2399", ContextMenuIcon.Paste.toBreezeGlyph())
-        assertEquals("\u2611", ContextMenuIcon.SelectAll.toBreezeGlyph())
-        assertEquals("\u232B", ContextMenuIcon.Delete.toBreezeGlyph())
-        assertEquals("\u25A1", ContextMenuIcon.Folder.toBreezeGlyph())
-        assertNull(ContextMenuIcon.SfSymbol("square.and.arrow.up").toBreezeGlyph())
+    fun `stock icons map to breeze vectors and sf symbols are ignored`() {
+        listOf(
+            ContextMenuIcon.Cut,
+            ContextMenuIcon.Copy,
+            ContextMenuIcon.Paste,
+            ContextMenuIcon.SelectAll,
+            ContextMenuIcon.Delete,
+            ContextMenuIcon.Folder,
+        ).forEach { icon ->
+            val vector = icon.toBreezeVector()!!
+            assertEquals("width of $icon", 16f, vector.defaultWidth.value, 0f)
+            assertEquals("height of $icon", 16f, vector.defaultHeight.value, 0f)
+            assertEquals("viewport width of $icon", 16f, vector.viewportWidth, 0f)
+            assertEquals("viewport height of $icon", 16f, vector.viewportHeight, 0f)
+        }
+        assertNull(ContextMenuIcon.SfSymbol("square.and.arrow.up").toBreezeVector())
     }
 
     @Test
-    fun `linux flyout uses breeze on kde and adwaita otherwise`() {
+    fun `linux flyout uses breeze on qt desktops and adwaita on gtk`() {
         val theme = linuxContextMenuTheme()
-        if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
+        if (LinuxUiToolkit.Current == LinuxUiToolkit.Qt) {
             assertSame(BreezeMenuTheme, theme)
         } else {
             assertSame(AdwaitaMenuTheme, theme)


### PR DESCRIPTION
## Summary

- Introduce `LinuxUiToolkit` so the Linux context-menu flyout follows the session toolkit, not just `LinuxDesktopEnvironment == KDE`: Adwaita on GTK shells (GNOME, XFCE, Cinnamon, MATE, …) and Breeze on Qt shells (Plasma, LXQt, Deepin, …). Detection reads `XDG_CURRENT_DESKTOP` / `DESKTOP_SESSION` / `XDG_SESSION_DESKTOP`, then `KDE_FULL_SESSION` and `QT_QPA_PLATFORMTHEME`.
- Replace mixed-metric Breeze Unicode glyphs (some of which render as emoji) with 16 dp monochrome vectors painted into a fixed slot.
- Cap flyout width and stop using `FontFamily("Noto Sans")` so Compose 1.12 no longer crashes with `LayoutNode not found in RectList` when the Breeze menu measures.

## Test plan

- [x] On KDE / another Qt session, right-click a text field: Breeze flyout, icons all 16 dp, shortcuts still aligned.
- [x] On GNOME / XFCE / Cinnamon, the same gesture shows the Adwaita flyout (no icons).
- [x] `./gradlew :core-runtime:test :nucleus-application:test --tests dev.nucleusframework.application.contextmenu.ContextMenuInterpreterTest`
- [x] `./gradlew :examples:nucleus-demo:run` stays up; opening the context menu does not throw `RectList`.