### PR TITLE
feat(spellcheck): let apps override the check language with Locale

### DIFF
--- a/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/SpellcheckTab.kt
+++ b/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/SpellcheckTab.kt
@@ -2,8 +2,10 @@ package dev.nucleusframework.sampletao
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -34,6 +36,7 @@ import dev.nucleusframework.application.spellcheck.SpellcheckContextMenu
 import dev.nucleusframework.spellcheck.SpellChecker
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.Locale
 
 @Composable
 internal fun SpellcheckTab(modifier: Modifier = Modifier) {
@@ -42,16 +45,20 @@ internal fun SpellcheckTab(modifier: Modifier = Modifier) {
         mutableStateOf("I recieve the teh package tommorow.\nPlease chek the adress.")
     }
     var material by remember { mutableStateOf("helo material") }
+    var locale by remember { mutableStateOf(SpellChecker.locale) }
     var available by remember { mutableStateOf(SpellChecker.isAvailable) }
     var dictionary by remember { mutableStateOf(SpellChecker.sessionIfReady?.dictionaryTag ?: "—") }
-    LaunchedEffect(Unit) {
-        val session = withContext(Dispatchers.IO) { SpellChecker.ensureSession() }
+    LaunchedEffect(locale) {
+        SpellChecker.locale = locale
+        val session = withContext(Dispatchers.IO) { SpellChecker.ensureSession(locale) }
         available = session.isAvailable
         dictionary = session.dictionaryTag ?: "—"
     }
 
     SpellcheckTabBody(
         modifier = modifier,
+        locale = locale,
+        onLocaleChange = { locale = it },
         available = available,
         dictionary = dictionary,
         singleLine = singleLine,
@@ -66,6 +73,8 @@ internal fun SpellcheckTab(modifier: Modifier = Modifier) {
 @Composable
 private fun SpellcheckTabBody(
     modifier: Modifier,
+    locale: Locale,
+    onLocaleChange: (Locale) -> Unit,
     available: Boolean,
     dictionary: String,
     singleLine: String,
@@ -86,20 +95,25 @@ private fun SpellcheckTabBody(
         BasicText(
             text =
                 if (available) {
-                    "Spellcheck ready ($dictionary). Misspellings get a red wave; " +
-                        "right-click a bad word for suggestions / add to dictionary."
+                    "Spellcheck ready (${locale.toLanguageTag()} → $dictionary). " +
+                        "Misspellings get a red wave; right-click a bad word for " +
+                        "suggestions / add to dictionary."
                 } else {
-                    "Spellcheck not available on this machine " +
-                        "(Linux Hunspell / macOS NSSpellChecker). " +
+                    "Spellcheck not available for ${locale.toLanguageTag()} " +
+                        "(Linux Hunspell / macOS NSSpellChecker / Windows ISpellChecker). " +
                         "Type anyway — the wrap is a no-op."
                 },
             style = TextStyle(color = Color(0xFFA0A4B0), fontSize = 13.sp),
         )
 
+        FieldLabel("Language")
+        LocalePicker(selected = locale, onSelected = onLocaleChange)
+
         FieldLabel("Single line")
         DemoField(
             value = singleLine,
             onValueChange = onSingleLineChange,
+            locale = locale,
             singleLine = true,
             testTag = "spellcheck-single",
         )
@@ -108,6 +122,7 @@ private fun SpellcheckTabBody(
         DemoField(
             value = multiLine,
             onValueChange = onMultiLineChange,
+            locale = locale,
             singleLine = false,
             testTag = "spellcheck-multi",
             modifier = Modifier.heightIn(min = 120.dp),
@@ -117,7 +132,41 @@ private fun SpellcheckTabBody(
         MaterialDemoField(
             value = material,
             onValueChange = onMaterialChange,
+            locale = locale,
         )
+    }
+}
+
+@Composable
+private fun LocalePicker(
+    selected: Locale,
+    onSelected: (Locale) -> Unit,
+) {
+    val system = Locale.getDefault()
+    val options =
+        listOf(
+            system to "System (${system.toLanguageTag()})",
+            Locale.US to "English",
+            Locale.FRANCE to "Français",
+            Locale.GERMANY to "Deutsch",
+        ).distinctBy { it.first }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        for ((value, label) in options) {
+            val active = value == selected
+            val accent = if (active) Color(0xFF8AB4FF) else Color(0xFFA0A4B0)
+            BasicText(
+                text = label,
+                style = TextStyle(color = accent, fontSize = 13.sp, fontWeight = FontWeight.SemiBold),
+                modifier =
+                    Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(accent.copy(alpha = if (active) 0.16f else 0.06f))
+                        .border(1.dp, accent.copy(alpha = if (active) 0.5f else 0.18f), RoundedCornerShape(6.dp))
+                        .clickable { onSelected(value) }
+                        .padding(horizontal = 10.dp, vertical = 6.dp)
+                        .testTag("spellcheck-locale-${value.toLanguageTag()}"),
+            )
+        }
     }
 }
 
@@ -133,11 +182,12 @@ private fun FieldLabel(text: String) {
 private fun DemoField(
     value: String,
     onValueChange: (String) -> Unit,
+    locale: Locale,
     singleLine: Boolean,
     testTag: String,
     modifier: Modifier = Modifier,
 ) {
-    SpellcheckContextMenu(text = value, onTextChange = onValueChange) {
+    SpellcheckContextMenu(text = value, onTextChange = onValueChange, locale = locale) {
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
@@ -160,6 +210,7 @@ private fun DemoField(
 private fun MaterialDemoField(
     value: String,
     onValueChange: (String) -> Unit,
+    locale: Locale,
 ) {
     MaterialTheme(
         colors =
@@ -172,7 +223,7 @@ private fun MaterialDemoField(
                 onBackground = Color.White,
             ),
     ) {
-        SpellcheckContextMenu(text = value, onTextChange = onValueChange) {
+        SpellcheckContextMenu(text = value, onTextChange = onValueChange, locale = locale) {
             TextField(
                 value = value,
                 onValueChange = onValueChange,

--- a/nucleus-application/api/nucleus-application.api
+++ b/nucleus-application/api/nucleus-application.api
@@ -308,8 +308,8 @@ public final class dev/nucleusframework/application/spellcheck/NucleusSpellcheck
 }
 
 public final class dev/nucleusframework/application/spellcheck/SpellcheckContextMenuKt {
-	public static final fun SpellcheckContextMenu (Landroidx/compose/foundation/text/input/TextFieldState;Ldev/nucleusframework/spellcheck/SpellcheckSession;Ldev/nucleusframework/application/spellcheck/SpellcheckMenuPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun SpellcheckContextMenu (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ldev/nucleusframework/spellcheck/SpellcheckSession;Ldev/nucleusframework/application/spellcheck/SpellcheckMenuPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SpellcheckContextMenu (Landroidx/compose/foundation/text/input/TextFieldState;Ldev/nucleusframework/spellcheck/SpellcheckSession;Ljava/util/Locale;Ldev/nucleusframework/application/spellcheck/SpellcheckMenuPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SpellcheckContextMenu (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ldev/nucleusframework/spellcheck/SpellcheckSession;Ljava/util/Locale;Ldev/nucleusframework/application/spellcheck/SpellcheckMenuPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class dev/nucleusframework/application/spellcheck/SpellcheckContextMenuSeparator : androidx/compose/foundation/ContextMenuItem {

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
@@ -64,6 +64,8 @@ public fun nucleusApplication(
     // guarantees it wins regardless of where the app sat in main(). Compose's
     // platform text menu (copy/cut/paste/select-all) reads Locale.getDefault()
     // lazily at first composition, so this must run before any UI is built.
+    // SpellChecker.locale defaults to Locale.getDefault(), so this also
+    // selects the spellcheck language unless the app overrides it.
     if (defaultLocale != null) {
         Locale.setDefault(defaultLocale)
         System.setProperty("user.language", defaultLocale.language)

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckContextMenu.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/spellcheck/SpellcheckContextMenu.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.withContext
+import java.util.Locale
 
 internal const val SPELLCHECK_IDLE_DELAY_MS: Long = 150L
 
@@ -96,6 +97,12 @@ public enum class SpellcheckMenuPlacement {
  *
  * No-op when the native spellcheck engine is unavailable.
  *
+ * Language follows [SpellChecker.locale] (itself [Locale.getDefault] until
+ * overridden). Pass [locale] to check this field in another language;
+ * pass [session] to supply a fully custom engine. [session] wins when both
+ * are set.
+ *
+ * @param locale language for this field, or `null` to use [SpellChecker.locale]
  * @param menuPlacement [SpellcheckMenuPlacement.Bottom] (default) appends
  *   after existing items; [SpellcheckMenuPlacement.Top] prepends before them.
  */
@@ -104,10 +111,11 @@ public fun SpellcheckContextMenu(
     text: String,
     onTextChange: (String) -> Unit,
     session: SpellcheckSession? = null,
+    locale: Locale? = null,
     menuPlacement: SpellcheckMenuPlacement = SpellcheckMenuPlacement.Bottom,
     content: @Composable () -> Unit,
 ) {
-    val current = rememberAvailableSession(session)
+    val current = rememberAvailableSession(session, locale)
     if (current == null) {
         content()
         return
@@ -169,12 +177,14 @@ public fun SpellcheckContextMenu(
 /**
  * [SpellcheckContextMenu] for a [TextFieldState] field.
  *
+ * @param locale See [SpellcheckContextMenu].
  * @param menuPlacement See [SpellcheckContextMenu].
  */
 @Composable
 public fun SpellcheckContextMenu(
     state: TextFieldState,
     session: SpellcheckSession? = null,
+    locale: Locale? = null,
     menuPlacement: SpellcheckMenuPlacement = SpellcheckMenuPlacement.Bottom,
     content: @Composable () -> Unit,
 ) {
@@ -184,17 +194,35 @@ public fun SpellcheckContextMenu(
             state.edit { replace(0, length, new) }
         },
         session = session,
+        locale = locale,
         menuPlacement = menuPlacement,
         content = content,
     )
 }
 
 @Composable
-private fun rememberAvailableSession(session: SpellcheckSession?): SpellcheckSession? {
-    var resolved by remember(session) { mutableStateOf(session ?: SpellChecker.sessionIfReady) }
-    LaunchedEffect(session) {
-        if (resolved?.isAvailable == true) return@LaunchedEffect
-        resolved = session ?: withContext(Dispatchers.IO) { SpellChecker.ensureSession() }
+private fun rememberAvailableSession(
+    session: SpellcheckSession?,
+    locale: Locale?,
+): SpellcheckSession? {
+    val targetLocale = locale ?: SpellChecker.locale
+    var resolved by remember(session, targetLocale) {
+        mutableStateOf(
+            session
+                ?: SpellChecker.sessionIfReady?.takeIf { it.locale == targetLocale },
+        )
+    }
+    LaunchedEffect(session, targetLocale) {
+        if (session != null) {
+            resolved = session.takeIf { it.isAvailable }
+            return@LaunchedEffect
+        }
+        if (resolved?.isAvailable == true && resolved?.locale == targetLocale) {
+            return@LaunchedEffect
+        }
+        resolved =
+            withContext(Dispatchers.IO) { SpellChecker.ensureSession(targetLocale) }
+                .takeIf { it.isAvailable }
     }
     return resolved?.takeIf { it.isAvailable }
 }

--- a/spellcheck/api/spellcheck.api
+++ b/spellcheck/api/spellcheck.api
@@ -25,10 +25,13 @@ public final class dev/nucleusframework/spellcheck/SpellChecker {
 	public final fun addToDictionary (Ljava/lang/String;)Z
 	public final fun check (Ljava/lang/String;)Z
 	public final fun ensureSession ()Ldev/nucleusframework/spellcheck/SpellcheckSession;
+	public final fun ensureSession (Ljava/util/Locale;)Ldev/nucleusframework/spellcheck/SpellcheckSession;
+	public final fun getLocale ()Ljava/util/Locale;
 	public final fun getSession ()Ldev/nucleusframework/spellcheck/SpellcheckSession;
 	public final fun getSessionIfReady ()Ldev/nucleusframework/spellcheck/SpellcheckSession;
 	public final fun isAvailable ()Z
 	public final fun misspellings (Ljava/lang/String;)Ljava/util/List;
+	public final fun setLocale (Ljava/util/Locale;)V
 	public final fun suggest (Ljava/lang/String;)Ljava/util/List;
 }
 
@@ -74,6 +77,7 @@ public final class dev/nucleusframework/spellcheck/SpellcheckSession : java/lang
 	public final fun check (Ljava/lang/String;)Z
 	public fun close ()V
 	public final fun getDictionaryTag ()Ljava/lang/String;
+	public final fun getLocale ()Ljava/util/Locale;
 	public final fun isAvailable ()Z
 	public final fun misspellings (Ljava/lang/String;)Ljava/util/List;
 	public final fun suggest (Ljava/lang/String;)Ljava/util/List;

--- a/spellcheck/src/main/kotlin/dev/nucleusframework/spellcheck/SpellChecker.kt
+++ b/spellcheck/src/main/kotlin/dev/nucleusframework/spellcheck/SpellChecker.kt
@@ -1,5 +1,7 @@
 package dev.nucleusframework.spellcheck
 
+import java.util.Locale
+
 /**
  * Process-wide spell checker used by `nucleusApplication` text fields.
  *
@@ -9,6 +11,15 @@ package dev.nucleusframework.spellcheck
  * [check], [suggest] and [addToDictionary] are no-ops (`false` / empty,
  * never thrown).
  *
+ * The language is a [Locale]. It defaults to [Locale.getDefault] — the same
+ * value `nucleusApplication(defaultLocale = …)` writes — and can be overridden
+ * without touching the JVM default:
+ *
+ * ```
+ * SpellChecker.locale = Locale.FRANCE
+ * SpellChecker.locale = Locale.forLanguageTag("de-DE")
+ * ```
+ *
  * [session] constructs the native handle on first access (dictionary load).
  * The Tao installer calls it from a background dispatcher so the UI thread
  * never waits on the native engine.
@@ -16,7 +27,33 @@ package dev.nucleusframework.spellcheck
 public object SpellChecker {
     @Volatile
     private var loaded: SpellcheckSession? = null
+
+    @Volatile
+    private var configuredLocale: Locale? = null
+    private val extras = HashMap<Locale, SpellcheckSession>()
     private val loadLock = Any()
+
+    /**
+     * Language of the process-wide session.
+     *
+     * Defaults to [Locale.getDefault] until assigned. Setting a new value
+     * drops the current process-wide session so the next [ensureSession]
+     * loads that language. Sessions requested for other locales via
+     * [ensureSession] stay cached.
+     */
+    public var locale: Locale
+        get() = configuredLocale ?: Locale.getDefault()
+        set(value) {
+            synchronized(loadLock) {
+                val previousConfigured = configuredLocale
+                configuredLocale = value
+                if (previousConfigured == value && loaded != null) return
+                if (loaded?.locale == value) return
+                val previous = loaded
+                loaded = extras.remove(value)
+                previous?.close()
+            }
+        }
 
     /**
      * Process-wide session. First access loads the native engine; prefer
@@ -40,14 +77,50 @@ public object SpellChecker {
         get() = loaded?.isAvailable == true
 
     /**
-     * Loads (or returns) the process-wide session. Safe to call from a
-     * background thread; not for the UI thread.
+     * Loads (or returns) the process-wide session for [locale]. Safe to call
+     * from a background thread; not for the UI thread.
      */
-    public fun ensureSession(): SpellcheckSession {
-        loaded?.let { return it }
-        return synchronized(loadLock) {
+    public fun ensureSession(): SpellcheckSession = ensureSession(locale)
+
+    /**
+     * Loads (or returns) a session for [locale].
+     *
+     * The process-wide [locale] uses the singleton session. Any other value
+     * is cached separately so a field can override the language without
+     * replacing the default.
+     */
+    public fun ensureSession(locale: Locale): SpellcheckSession {
+        if (locale == this.locale) {
             loaded?.let { return it }
-            SpellcheckSession().also { loaded = it }
+        } else {
+            synchronized(loadLock) {
+                extras[locale]?.let { return it }
+            }
+        }
+        return synchronized(loadLock) {
+            sessionLocked(locale)
+        }
+    }
+
+    private fun sessionLocked(locale: Locale): SpellcheckSession {
+        if (locale == this.locale) {
+            loaded?.let { return it }
+            if (configuredLocale == null) {
+                configuredLocale = locale
+            }
+            return SpellcheckSession(locale = locale).also { loaded = it }
+        }
+        extras[locale]?.let { return it }
+        return SpellcheckSession(locale = locale).also { extras[locale] = it }
+    }
+
+    internal fun resetForTests() {
+        synchronized(loadLock) {
+            loaded?.close()
+            loaded = null
+            extras.values.forEach { it.close() }
+            extras.clear()
+            configuredLocale = null
         }
     }
 

--- a/spellcheck/src/main/kotlin/dev/nucleusframework/spellcheck/SpellcheckSession.kt
+++ b/spellcheck/src/main/kotlin/dev/nucleusframework/spellcheck/SpellcheckSession.kt
@@ -29,9 +29,13 @@ import dev.nucleusframework.spellcheck.windows.NativeSpellcheckBridge as Windows
  * path.
  *
  * [SpellChecker] is the process-wide instance used by `nucleusApplication`.
+ *
+ * @property locale requested language. The loaded engine may resolve to a
+ *   close match (see [dictionaryTag]); missing dictionaries make the
+ *   session a no-op rather than substituting another language.
  */
 public class SpellcheckSession public constructor(
-    locale: Locale = Locale.getDefault(),
+    public val locale: Locale = Locale.getDefault(),
     osName: String = System.getProperty("os.name", ""),
     dictionaryDirectories: List<Path> = DictionaryLocator.defaultDirectories(),
     userDictionaryFile: Path? = defaultUserDictionaryFile(locale),

--- a/spellcheck/src/test/kotlin/dev/nucleusframework/spellcheck/SpellCheckerLocaleTest.kt
+++ b/spellcheck/src/test/kotlin/dev/nucleusframework/spellcheck/SpellCheckerLocaleTest.kt
@@ -1,0 +1,64 @@
+package dev.nucleusframework.spellcheck
+
+import java.util.Locale
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
+
+class SpellCheckerLocaleTest {
+    @AfterTest
+    fun reset() {
+        SpellChecker.resetForTests()
+    }
+
+    @Test
+    fun `locale defaults to the JVM default`() {
+        assertEquals(Locale.getDefault(), SpellChecker.locale)
+    }
+
+    @Test
+    fun `locale override is a plain Locale`() {
+        SpellChecker.locale = Locale.FRANCE
+        assertEquals(Locale.FRANCE, SpellChecker.locale)
+        SpellChecker.locale = Locale.forLanguageTag("de-DE")
+        assertEquals(Locale.GERMANY, SpellChecker.locale)
+    }
+
+    @Test
+    fun `ensureSession uses the configured locale`() {
+        SpellChecker.locale = Locale.FRANCE
+        val session = SpellChecker.ensureSession()
+        assertEquals(Locale.FRANCE, session.locale)
+        assertSame(session, SpellChecker.ensureSession())
+    }
+
+    @Test
+    fun `ensureSession for another locale does not replace the default`() {
+        SpellChecker.locale = Locale.US
+        val process = SpellChecker.ensureSession()
+        val french = SpellChecker.ensureSession(Locale.FRANCE)
+        assertEquals(Locale.US, process.locale)
+        assertEquals(Locale.FRANCE, french.locale)
+        assertSame(process, SpellChecker.ensureSession())
+        assertSame(french, SpellChecker.ensureSession(Locale.FRANCE))
+    }
+
+    @Test
+    fun `changing locale replaces the process-wide session`() {
+        SpellChecker.locale = Locale.US
+        val first = SpellChecker.ensureSession()
+        SpellChecker.locale = Locale.FRANCE
+        val second = SpellChecker.ensureSession()
+        assertEquals(Locale.FRANCE, second.locale)
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun `session stores the requested locale even when the engine is a no-op`() {
+        SpellcheckSession(locale = Locale.FRANCE, osName = "FreeBSD").use { session ->
+            assertEquals(Locale.FRANCE, session.locale)
+        }
+    }
+}

--- a/spellcheck/src/test/kotlin/dev/nucleusframework/spellcheck/SpellcheckNoopTest.kt
+++ b/spellcheck/src/test/kotlin/dev/nucleusframework/spellcheck/SpellcheckNoopTest.kt
@@ -25,6 +25,7 @@ class SpellcheckNoopTest {
     @Test
     fun `unsupported platform is a no-op`() {
         SpellcheckSession(locale = Locale.US, osName = "FreeBSD").use { session ->
+            assertEquals(Locale.US, session.locale)
             assertFalse(session.isAvailable)
             assertFalse(session.check("hello"))
             assertTrue(session.suggest("helo").isEmpty())


### PR DESCRIPTION
## Summary

- Spellcheck language is a `java.util.Locale`. It still defaults to `Locale.getDefault()`, so `nucleusApplication(defaultLocale = …)` selects the engine with no extra API.
- Apps can override the process-wide language with `SpellChecker.locale = Locale.FRANCE` (or `Locale.forLanguageTag(...)`) without changing the JVM default. Assigning a new value rebuilds the process-wide session.
- `SpellcheckContextMenu(..., locale = …)` and `SpellChecker.ensureSession(locale)` check one field in another language; extra locales are cached separately.
- Tao demo Spellcheck tab exposes a System / English / Français / Deutsch picker.

## Test plan

- [x] `:spellcheck:test` (including new `SpellCheckerLocaleTest`)
- [x] `:spellcheck:detekt` / ktlint
- [x] `:nucleus-application:detekt` / ktlint / `apiDump`
- [x] Switch language in the tao-demo Spellcheck tab and confirm underlines + suggestions follow the chosen locale when the OS/Hunspell dictionary is installed
- [x] Confirm a missing dictionary (e.g. `fr_FR` without `hunspell-fr`) stays a no-op instead of falling back to another language
- [ ] Confirm `nucleusApplication(defaultLocale = Locale.FRANCE)` still drives spellcheck when `SpellChecker.locale` is left unset