### PR TITLE
fix(tao): drive Compose 1.12 frames through SingleComposeSceneRenderingScope

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeSceneContext
 import androidx.compose.ui.scene.PlatformLayersComposeScene
+import androidx.compose.ui.scene.SingleComposeSceneRenderingScope
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -23,17 +24,21 @@ import kotlin.coroutines.CoroutineContext
  * `FrameRecomposer.performFrame` + `ComposeScene.measureAndLayout` +
  * `ComposeScene.draw` — and replaced the scene factories' former
  * `coroutineContext` / `invalidate` parameters with a [FrameRecomposer] plus
- * separate `invalidateLayout` / `invalidateDraw` callbacks. (Compose Desktop's
- * own AWT path wraps the same three calls in the module-private
- * `SingleComposeSceneRenderingScope.render`, which isn't visible to external
- * backends, so the Tao hosts drive them directly here.) This type keeps the
- * scene and its recomposer together so the Tao hosts can create, render, and
- * dispose a scene with a single object.
+ * separate `invalidateLayout` / `invalidateDraw` callbacks. Compose Desktop's
+ * AWT path drives those three steps through [SingleComposeSceneRenderingScope],
+ * which swallows layout/draw invalidations raised during the in-flight frame
+ * and re-arms [requestFrame] only if the scene is still dirty afterwards.
+ * Driving the steps by hand (and wiring `invalidateLayout`/`invalidateDraw`
+ * straight to [requestFrame]) can schedule a second frame while
+ * `measureAndLayout` is still placing a tree that just remounted — Compose
+ * 1.12's [androidx.compose.ui.spatial.RectManager] then throws
+ * `LayoutNode not found in RectList` (nucleus-demo tab switches).
  */
 @OptIn(InternalComposeUiApi::class)
 internal class TaoSceneBundle(
     val scene: ComposeScene,
     val frameRecomposer: FrameRecomposer,
+    private val renderingScope: SingleComposeSceneRenderingScope,
 ) : AutoCloseable {
     /**
      * Recomposes, lays out, and draws one frame into [canvas] — the drop-in
@@ -45,9 +50,9 @@ internal class TaoSceneBundle(
         canvas: Canvas,
         nanoTime: Long,
     ) {
-        frameRecomposer.performFrame(nanoTime)
-        scene.measureAndLayout()
-        scene.draw(canvas.asComposeCanvas())
+        with(renderingScope) {
+            scene.render(frameRecomposer, canvas.asComposeCanvas(), nanoTime)
+        }
     }
 
     override fun close() {
@@ -71,6 +76,7 @@ internal fun canvasLayersSceneBundle(
     platformContext: PlatformContext,
     requestFrame: () -> Unit,
 ): TaoSceneBundle {
+    val renderingScope = SingleComposeSceneRenderingScope(requestFrame)
     val frameRecomposer = FrameRecomposer(coroutineContext) { requestFrame() }
     val scene =
         CanvasLayersComposeScene(
@@ -79,10 +85,10 @@ internal fun canvasLayersSceneBundle(
             layoutDirection = layoutDirection,
             size = size,
             platformContext = platformContext,
-            invalidateLayout = { requestFrame() },
-            invalidateDraw = { requestFrame() },
+            invalidateLayout = { renderingScope.onSceneInvalidation() },
+            invalidateDraw = { renderingScope.onSceneInvalidation() },
         )
-    return TaoSceneBundle(scene, frameRecomposer)
+    return TaoSceneBundle(scene, frameRecomposer, renderingScope)
 }
 
 /**
@@ -98,6 +104,7 @@ internal fun platformLayersSceneBundle(
     composeSceneContext: ComposeSceneContext,
     requestFrame: () -> Unit,
 ): TaoSceneBundle {
+    val renderingScope = SingleComposeSceneRenderingScope(requestFrame)
     val frameRecomposer = FrameRecomposer(coroutineContext) { requestFrame() }
     val scene =
         PlatformLayersComposeScene(
@@ -106,8 +113,8 @@ internal fun platformLayersSceneBundle(
             layoutDirection = layoutDirection,
             size = size,
             composeSceneContext = composeSceneContext,
-            invalidateLayout = { requestFrame() },
-            invalidateDraw = { requestFrame() },
+            invalidateLayout = { renderingScope.onSceneInvalidation() },
+            invalidateDraw = { renderingScope.onSceneInvalidation() },
         )
-    return TaoSceneBundle(scene, frameRecomposer)
+    return TaoSceneBundle(scene, frameRecomposer, renderingScope)
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneContentSwapTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneContentSwapTest.kt
@@ -1,0 +1,99 @@
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+
+/**
+ * Compose 1.12's RectManager throws `LayoutNode not found in RectList` when a
+ * large placed subtree is detached and a new one is placed in the same frame
+ * (nucleus-demo tab switches). These cases drive that remount through the
+ * production [TaoSceneBundle.render] path.
+ */
+class TaoSceneContentSwapTest {
+    @Test
+    fun `swapping a scrollable page of buttons does not crash RectList`() =
+        runTaoSceneTest(width = 800, height = 480) {
+            var tab by mutableStateOf(0)
+            setContent {
+                Column(Modifier.fillMaxSize()) {
+                    Row(Modifier.fillMaxWidth().height(32.dp)) {
+                        Box(Modifier.clickable { tab = 0 }.padding(8.dp)) { Text("A") }
+                        Box(Modifier.clickable { tab = 1 }.padding(8.dp)) { Text("B") }
+                    }
+                    Box(Modifier.fillMaxSize()) {
+                        when (tab) {
+                            0 -> ScrollableButtonPage("one")
+                            else -> ScrollableButtonPage("two")
+                        }
+                    }
+                }
+            }
+            tab = 1
+            frame()
+            tab = 0
+            frame()
+            tab = 1
+            frameUntilIdle()
+        }
+
+    @Test
+    fun `clicking a tab remounts the body without a RectList crash`() =
+        runTaoSceneTest(width = 800, height = 480) {
+            var tab by mutableStateOf(0)
+            setContent {
+                Column(Modifier.fillMaxSize()) {
+                    Row(Modifier.fillMaxWidth().height(32.dp)) {
+                        Box(Modifier.clickable { tab = 0 }.padding(8.dp)) { Text("A") }
+                        Box(Modifier.clickable { tab = 1 }.padding(8.dp)) { Text("B") }
+                    }
+                    Box(Modifier.fillMaxSize()) {
+                        when (tab) {
+                            0 -> ScrollableButtonPage("one")
+                            else -> ScrollableButtonPage("two")
+                        }
+                    }
+                }
+            }
+            // Second tab label is to the right of the first.
+            click(x = 40f, y = 16f)
+            frameUntilIdle()
+            click(x = 8f, y = 16f)
+            frameUntilIdle()
+        }
+}
+
+@Composable
+private fun ScrollableButtonPage(label: String) {
+    Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+        repeat(24) { index ->
+            Button(
+                onClick = {},
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp)
+                        .graphicsLayer { alpha = 1f },
+            ) {
+                Text("$label-$index")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Drive Tao Compose 1.12 frames through `SingleComposeSceneRenderingScope` instead of calling `performFrame` / `measureAndLayout` / `draw` by hand.
- Route `invalidateLayout` / `invalidateDraw` through `onSceneInvalidation()` so a remount cannot schedule a second frame mid-placement.
- Fixes `IllegalArgumentException: LayoutNode not found in RectList` when switching tabs in nucleus-demo (Compose 1.12 regression vs 2.4).
- Adds an offscreen scene test that remounts a scrollable page of buttons through the production render path.

## Test plan
- [x] `:decorated-window-tao:test --tests TaoSceneContentSwapTest --tests TaoSceneRenderTest`
- [x] Switch tabs in nucleus-demo on Windows — no RectList crash
- [ ] Switch tabs on macOS / Linux if convenient