### PR TITLE
fix(tao): keep Compose 1.12 RectManager delayed dispatch off the AWT EDT

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/RectManagerEdtGuard.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/RectManagerEdtGuard.kt
@@ -1,0 +1,194 @@
+// Static access to Compose internals (same technique as TaoWindowsScrollConfig):
+// plain bytecode, so it stays GraalVM native-image compatible - no reflection.
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "KotlinRedundantDiagnosticSuppress")
+
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.spatial.RectManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Keeps Compose 1.12's `RectManager` delayed dispatch off the AWT EDT
+ * (issue #551).
+ *
+ * `RectManager` (the spatial index behind `onLayoutRectChanged` and
+ * focus-by-rect) debounces its callback dispatch with `postDelayed`, whose
+ * desktop implementation launches on skiko's `MainUIDispatcher` — a hardcoded
+ * Swing/EDT dispatcher. On the AWT backends the EDT *is* the Compose thread,
+ * so that delayed `dispatchCallbacks()` is serialized with everything else.
+ * On Tao the Compose thread is the native event-loop thread: whenever the
+ * ~16ms timer fires before the next pass cancels it (an idle gap between
+ * frames, or a layout pass longer than the debounce deadline — a large tab
+ * remount), the EDT runs `RectManager.dispatchCallbacks()` — including
+ * `RectList.defragment()`, which swaps and compacts the backing arrays —
+ * concurrently with (or without any happens-before edge to) layout running on
+ * the scene thread. The unsynchronized race corrupts the RectList and later
+ * surfaces as `IllegalArgumentException: LayoutNode not found in RectList`
+ * from `LayoutNode.detach` (or an `ArrayIndexOutOfBoundsException` from the
+ * same bookkeeping), killing the app. `TaoSceneRectManagerRaceTest`
+ * reproduces it deterministically.
+ *
+ * Compose offers no scheduling hook here, so the guard neutralizes the timer
+ * instead: it pins `ThrottledCallbacks.minDebounceDeadline` to a far-future
+ * instant while the scene is between passes. Every dispatch Compose arms then
+ * carries that unreachable deadline (`scheduleDebounceCallback` uses
+ * `max(minDebounceDeadline, now + 16)`), so the armed EDT coroutine can never
+ * fire — no RectManager code ever executes off the scene thread. The pinned
+ * value never leaks into callback bookkeeping: `triggerDebounced` returns
+ * before touching entries while the deadline is in the future, and the fire
+ * paths only ever *lower* the deadline to a real one when an actual debounced
+ * callback needs the trailing edge.
+ *
+ * The debounce feature itself is preserved by [afterFrame], which runs after
+ * every rendered frame on the scene thread: when `onLayoutRectChanged` /
+ * `onGlobalLayoutListener` entries exist it momentarily unpins the deadline
+ * and runs `dispatchCallbacks()` — firing due trailing edges exactly like the
+ * upstream timer would, only on the right thread — then re-pins and schedules
+ * a frame for the next real deadline.
+ *
+ * Residual upstream exposure (documented, not host-fixable without patching
+ * Compose): an app that registers debounced rect callbacks
+ * (`Modifier.onLayoutRectChanged` / `onFirstVisible` / `onVisibilityChanged` —
+ * nothing in stock Compose/Foundation/Material registers one by default) can
+ * still get one EDT dispatch if a pass runs >16ms past a mid-pass re-arm AND
+ * no layout/semantics notification arrives in between ([onScenePulse] re-pins
+ * on each one). Apps without such callbacks — including every current Nucleus
+ * API — never execute RectManager code off the scene thread.
+ */
+@OptIn(InternalComposeUiApi::class)
+internal class RectManagerEdtGuard(
+    private val scope: CoroutineScope,
+    private val requestFrame: () -> Unit,
+) {
+    private val rectManagers = ArrayList<RectManager>(2)
+    private var wakeupJob: Job? = null
+
+    /**
+     * Wraps [delegate] so every [SemanticsOwner] the scene announces — the
+     * main owner and each popup/dialog layer — registers its RectManager with
+     * this guard. The scene announces an owner right after constructing it,
+     * before any content is set.
+     */
+    fun wrapListener(delegate: PlatformContext.SemanticsOwnerListener?): PlatformContext.SemanticsOwnerListener =
+        object : PlatformContext.SemanticsOwnerListener {
+            override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
+                onOwnerAppended(semanticsOwner)
+                delegate?.onSemanticsOwnerAppended(semanticsOwner)
+            }
+
+            override fun onSemanticsOwnerRemoved(semanticsOwner: SemanticsOwner) {
+                onOwnerRemoved(semanticsOwner)
+                delegate?.onSemanticsOwnerRemoved(semanticsOwner)
+            }
+
+            override fun onSemanticsChange(semanticsOwner: SemanticsOwner) {
+                onScenePulse()
+                delegate?.onSemanticsChange(semanticsOwner)
+            }
+
+            override fun onLayoutChange(
+                semanticsOwner: SemanticsOwner,
+                semanticsNodeId: Int,
+            ) {
+                onScenePulse()
+                delegate?.onLayoutChange(semanticsOwner, semanticsNodeId)
+            }
+        }
+
+    /**
+     * Post-frame hook, run on the scene thread after every rendered frame:
+     * fires due debounced callbacks (when any are registered), cancels
+     * whatever dispatch the pass armed, and re-pins the deadline so anything
+     * armed until the next frame stays inert.
+     */
+    fun afterFrame() {
+        var nextWakeupDelayMillis = -1L
+        for (i in rectManagers.indices) {
+            val rectManager = rectManagers[i]
+            val throttled = rectManager.throttledCallbacks
+            val hasEntries =
+                throttled.rectChangedMap.size != 0 || throttled.globalChangeEntries != null
+            if (hasEntries) {
+                // Unpin and run one dispatch: triggerDebounced fires the due
+                // trailing edges and recomputes the real next deadline.
+                val now = System.currentTimeMillis()
+                throttled.minDebounceDeadline = 0
+                rectManager.dispatchCallbacks()
+                val deadline = throttled.minDebounceDeadline
+                if (deadline > 0) {
+                    val delayMillis = (deadline - now).coerceAtLeast(1)
+                    if (nextWakeupDelayMillis < 0 || delayMillis < nextWakeupDelayMillis) {
+                        nextWakeupDelayMillis = delayMillis
+                    }
+                }
+            }
+            disarm(rectManager)
+        }
+        if (nextWakeupDelayMillis >= 0) {
+            // A debounced trailing edge is pending: wake the frame loop when
+            // it is due so the next afterFrame fires it on the scene thread.
+            wakeupJob?.cancel()
+            wakeupJob =
+                scope.launch(start = CoroutineStart.UNDISPATCHED) {
+                    delay(nextWakeupDelayMillis)
+                    requestFrame()
+                }
+        }
+    }
+
+    /**
+     * Mid-pass check, run from the layout/semantics-change callbacks that fire
+     * on the scene thread while a pass is still running: a debounced rect
+     * callback firing during the pass lowers the pinned deadline back to a
+     * real one, and the pass then re-arms a dispatch that *can* elapse
+     * (`max(realDeadline, now + 16)`). Re-pin as soon as we can observe it, so
+     * such a dispatch only survives until the next semantics/layout
+     * notification instead of the end of the frame. No deadline information is
+     * lost: [afterFrame] recomputes the real deadline from the registered
+     * entries. When the deadline is already pinned (or there is none), this is
+     * two field reads — cheap enough for a per-node callback.
+     */
+    private fun onScenePulse() {
+        for (i in rectManagers.indices) {
+            val rectManager = rectManagers[i]
+            val deadline = rectManager.throttledCallbacks.minDebounceDeadline
+            if (deadline > 0 && deadline != INERT_DEADLINE_MILLIS) {
+                disarm(rectManager)
+            }
+        }
+    }
+
+    private fun onOwnerAppended(semanticsOwner: SemanticsOwner) {
+        val owner = semanticsOwner.rootSemanticsNode.layoutNode.owner ?: return
+        val rectManager = owner.rectManager
+        rectManagers.add(rectManager)
+        // Kill the dispatch armed while the owner attached its root, then pin.
+        disarm(rectManager)
+    }
+
+    private fun onOwnerRemoved(semanticsOwner: SemanticsOwner) {
+        val owner = semanticsOwner.rootSemanticsNode.layoutNode.owner ?: return
+        rectManagers.remove(owner.rectManager)
+    }
+
+    private fun disarm(rectManager: RectManager) {
+        rectManager.removeScheduledCallback()
+        rectManager.throttledCallbacks.minDebounceDeadline = INERT_DEADLINE_MILLIS
+    }
+
+    private companion object {
+        /**
+         * The pinned deadline: far enough that `max(deadline, now + 16)` never
+         * elapses, small enough that millisecond arithmetic on it cannot
+         * overflow. (~292 million years of uptime.)
+         */
+        const val INERT_DEADLINE_MILLIS = Long.MAX_VALUE / 1024
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
@@ -12,6 +12,9 @@ import androidx.compose.ui.scene.SingleComposeSceneRenderingScope
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import org.jetbrains.skia.Canvas
 import kotlin.coroutines.CoroutineContext
 
@@ -33,12 +36,19 @@ import kotlin.coroutines.CoroutineContext
  * `measureAndLayout` is still placing a tree that just remounted — Compose
  * 1.12's [androidx.compose.ui.spatial.RectManager] then throws
  * `LayoutNode not found in RectList` (nucleus-demo tab switches).
+ *
+ * Each bundle also carries a [RectManagerEdtGuard], which keeps the
+ * RectManager's delayed dispatch off the AWT EDT (issue #551) — see that class
+ * for the full story.
  */
 @OptIn(InternalComposeUiApi::class)
 internal class TaoSceneBundle(
     val scene: ComposeScene,
     val frameRecomposer: FrameRecomposer,
     private val renderingScope: SingleComposeSceneRenderingScope,
+    private val edtGuard: RectManagerEdtGuard,
+    /** Owns [edtGuard]'s debounce wakeups; cancelled with the scene. */
+    private val guardScope: CoroutineScope,
 ) : AutoCloseable {
     /**
      * Recomposes, lays out, and draws one frame into [canvas] — the drop-in
@@ -53,9 +63,11 @@ internal class TaoSceneBundle(
         with(renderingScope) {
             scene.render(frameRecomposer, canvas.asComposeCanvas(), nanoTime)
         }
+        edtGuard.afterFrame()
     }
 
     override fun close() {
+        guardScope.cancel()
         scene.close()
         frameRecomposer.close()
     }
@@ -78,17 +90,19 @@ internal fun canvasLayersSceneBundle(
 ): TaoSceneBundle {
     val renderingScope = SingleComposeSceneRenderingScope(requestFrame)
     val frameRecomposer = FrameRecomposer(coroutineContext) { requestFrame() }
+    val guardScope = CoroutineScope(coroutineContext + SupervisorJob())
+    val edtGuard = RectManagerEdtGuard(guardScope, requestFrame)
     val scene =
         CanvasLayersComposeScene(
             frameRecomposer = frameRecomposer,
             density = density,
             layoutDirection = layoutDirection,
             size = size,
-            platformContext = platformContext,
+            platformContext = platformContext.withEdtGuard(edtGuard),
             invalidateLayout = { renderingScope.onSceneInvalidation() },
             invalidateDraw = { renderingScope.onSceneInvalidation() },
         )
-    return TaoSceneBundle(scene, frameRecomposer, renderingScope)
+    return TaoSceneBundle(scene, frameRecomposer, renderingScope, edtGuard, guardScope)
 }
 
 /**
@@ -106,15 +120,32 @@ internal fun platformLayersSceneBundle(
 ): TaoSceneBundle {
     val renderingScope = SingleComposeSceneRenderingScope(requestFrame)
     val frameRecomposer = FrameRecomposer(coroutineContext) { requestFrame() }
+    val guardScope = CoroutineScope(coroutineContext + SupervisorJob())
+    val edtGuard = RectManagerEdtGuard(guardScope, requestFrame)
     val scene =
         PlatformLayersComposeScene(
             frameRecomposer = frameRecomposer,
             density = density,
             layoutDirection = layoutDirection,
             size = size,
-            composeSceneContext = composeSceneContext,
+            composeSceneContext =
+                object : ComposeSceneContext by composeSceneContext {
+                    override val platformContext: PlatformContext =
+                        composeSceneContext.platformContext.withEdtGuard(edtGuard)
+                },
             invalidateLayout = { renderingScope.onSceneInvalidation() },
             invalidateDraw = { renderingScope.onSceneInvalidation() },
         )
-    return TaoSceneBundle(scene, frameRecomposer, renderingScope)
+    return TaoSceneBundle(scene, frameRecomposer, renderingScope, edtGuard, guardScope)
 }
+
+/**
+ * Returns a [PlatformContext] view whose [PlatformContext.semanticsOwnerListener]
+ * additionally registers every announced owner with [edtGuard].
+ */
+@OptIn(InternalComposeUiApi::class)
+private fun PlatformContext.withEdtGuard(edtGuard: RectManagerEdtGuard): PlatformContext =
+    object : PlatformContext by this {
+        override val semanticsOwnerListener: PlatformContext.SemanticsOwnerListener =
+            edtGuard.wrapListener(this@withEdtGuard.semanticsOwnerListener)
+    }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -9,6 +9,7 @@ import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
 import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
+import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneKeyboardTest
 import dev.nucleusframework.window.tao.scene.TaoSceneOuterLocalsBridgeTest
 import dev.nucleusframework.window.tao.scene.TaoScenePointerTest
@@ -280,6 +281,13 @@ public object TaoSceneTestBattery {
         }
         run("TaoSceneSemanticsTest: clickable nodes expose an onClick action") {
             TaoSceneSemanticsTest().`clickable nodes expose an onClick action`()
+        }
+
+        run("TaoSceneContentSwapTest: swapping a scrollable page of buttons does not crash RectList") {
+            TaoSceneContentSwapTest().`swapping a scrollable page of buttons does not crash RectList`()
+        }
+        run("TaoSceneContentSwapTest: clicking a tab remounts the body without a RectList crash") {
+            TaoSceneContentSwapTest().`clicking a tab remounts the body without a RectList crash`()
         }
 
         run("TaoA11yProjectionTest: compose semantics are projected into the a11y node snapshot") {

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -9,10 +9,12 @@ import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
 import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
+import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneKeyboardTest
 import dev.nucleusframework.window.tao.scene.TaoSceneOuterLocalsBridgeTest
 import dev.nucleusframework.window.tao.scene.TaoScenePointerTest
 import dev.nucleusframework.window.tao.scene.TaoScenePopupTest
+import dev.nucleusframework.window.tao.scene.TaoSceneRectManagerRaceTest
 import dev.nucleusframework.window.tao.scene.TaoSceneRenderTest
 import dev.nucleusframework.window.tao.scene.TaoSceneScrollTest
 import dev.nucleusframework.window.tao.scene.TaoSceneSemanticsTest
@@ -51,6 +53,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoScenePopupTest::class.java,
             TaoSceneOuterLocalsBridgeTest::class.java,
             TaoSceneAnimationTest::class.java,
+            TaoSceneContentSwapTest::class.java,
             TaoSceneSemanticsTest::class.java,
             TaoA11yProjectionTest::class.java,
             TitleBarHitTestTest::class.java,
@@ -70,6 +73,8 @@ class TaoSceneTestBatteryDriftTest {
             TaoMetalMissingPoolE2ETest::class.java to
                 "opt-in headful e2e (NUCLEUS_TAO_SMOKE=1); spawns a child JVM",
             TaoSyntheticDndTest::class.java to "pins an AWT DropTarget; the no-AWT image never initialises AWT",
+            TaoSceneRectManagerRaceTest::class.java to
+                "races the real AWT EDT against wall-clock frames; the no-AWT image never initialises AWT",
             TaoTransferableAccessGuardTest::class.java to "Compose interop ABI guard, not a scene behaviour",
             TaoSceneTestBatteryDriftTest::class.java to "meta-test for the battery itself",
         )

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneRectManagerRaceTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneRectManagerRaceTest.kt
@@ -1,0 +1,145 @@
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onLayoutRectChanged
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Issue #551: Compose 1.12's RectManager schedules its debounce dispatch via
+ * desktop `postDelayed`, which runs on skiko's `MainUIDispatcher` — the AWT
+ * EDT. On AWT hosts the EDT *is* the Compose thread, so the dispatch is
+ * serialized with layout. On Tao the Compose thread is the native event-loop
+ * thread, so the ~16ms-delayed `RectManager.dispatchCallbacks()` (including
+ * `RectList.defragment()`) executes on the EDT concurrently with layout
+ * running on the scene thread — corrupting the RectList and later throwing
+ * `IllegalArgumentException: LayoutNode not found in RectList` from
+ * `LayoutNode.detach`.
+ *
+ * This test forces the overlap deterministically: every tab switch detaches a
+ * tree (making the RectList fragmented) and mounts a new one whose placement
+ * takes well over 16ms (per-node busy spins), so the timer armed by the first
+ * placement fires mid-layout on the EDT while inserts are still running.
+ */
+class TaoSceneRectManagerRaceTest {
+    @Test
+    fun `EDT-delayed RectManager dispatch must not race scene-thread layout`() =
+        runTaoSceneTest(width = 600, height = 400) {
+            var tab by mutableStateOf(0)
+
+            setContent {
+                Column(Modifier.fillMaxSize()) {
+                    when (tab) {
+                        0 -> SlowBody(Color.Red)
+                        else -> SlowBody(Color.Blue)
+                    }
+                }
+            }
+
+            repeat(60) {
+                tab = (tab + 1) % 2
+                // The remount frame: applyChanges detaches the old tree
+                // (fragmenting the RectList) and the new tree's slow placement
+                // keeps the scene thread inserting rects for >16ms, straddling
+                // the debounce timer deadline.
+                frame()
+                // Give the EDT a moment so a timer that survived the frame can
+                // fire between frames too (visibility-race variant).
+                Thread.sleep(2)
+            }
+            frameUntilIdle()
+        }
+
+    /**
+     * The guard pins the debounce deadline to keep the EDT out — this checks
+     * the debounce *feature* still works: `onLayoutRectChanged` trailing edges
+     * must keep firing, now from the scene-thread post-frame hook instead of
+     * the upstream EDT timer.
+     */
+    @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+    @Test
+    fun `debounced onLayoutRectChanged trailing edge still fires with the guard pinned`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            var offset by mutableStateOf(0)
+            var callbacks = 0
+
+            setContent {
+                Column(Modifier.fillMaxSize()) {
+                    Box(Modifier.height(offset.dp))
+                    Box(
+                        Modifier
+                            .size(40.dp)
+                            .background(Color.Red)
+                            .onLayoutRectChanged(
+                                throttleMillis = 0,
+                                debounceMillis = 64,
+                            ) { callbacks++ },
+                    )
+                }
+            }
+            // The debounce compares real wall-clock millis; let it elapse for
+            // the initial fire, then frame so the post-frame hook dispatches.
+            frameUntilIdle()
+            Thread.sleep(DEBOUNCE_ELAPSE_MS)
+            frame()
+            val baseline = callbacks
+
+            // Move the observed box, then let the 64ms debounce elapse again.
+            offset = 60
+            frame()
+            Thread.sleep(DEBOUNCE_ELAPSE_MS)
+            frame()
+            assertTrue(
+                callbacks > baseline,
+                "debounced onLayoutRectChanged must still fire (got $callbacks, baseline $baseline)",
+            )
+        }
+
+    private companion object {
+        /** Comfortably past the 64ms `onLayoutRectChanged` debounce. */
+        const val DEBOUNCE_ELAPSE_MS = 150L
+    }
+
+    @Suppress("FunctionNaming")
+    @androidx.compose.runtime.Composable
+    private fun SlowBody(color: Color) {
+        Column(Modifier.fillMaxSize()) {
+            repeat(15) { row ->
+                Row {
+                    repeat(10) { col ->
+                        Box(
+                            Modifier
+                                .layout { measurable, constraints ->
+                                    val placeable = measurable.measure(constraints)
+                                    layout(placeable.width, placeable.height) {
+                                        // ~0.2ms per node: ~30ms of placement per
+                                        // remount, guaranteeing the frame overlaps
+                                        // the 16ms debounce deadline.
+                                        val end = System.nanoTime() + 200_000L
+                                        while (System.nanoTime() < end) {
+                                            Thread.onSpinWait()
+                                        }
+                                        placeable.place(0, 0)
+                                    }
+                                }.size(8.dp)
+                                .background(if ((row + col) % 2 == 0) color else Color.Gray),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #551 — the `IllegalArgumentException: LayoutNode N not found in RectList` crash (followed by `LayoutNode should be attached to an owner`) on nucleus-demo tab switches, and on any Tao app remounting a large tree.

**Root cause (upstream Compose 1.12 bug, not a Tao frame-ordering issue).** `RectManager` debounces its callback dispatch through the desktop `postDelayed` actual, which launches on skiko's `MainUIDispatcher` — the hardcoded Swing EDT (the implementation carries JetBrains' own `TODO CMP-7153`). On AWT backends the EDT *is* the Compose thread, so the dispatch is serialized. On Tao the Compose thread is the native event-loop thread: whenever the ~16 ms timer fires before a frame cancels it (idle gap between frames, or a layout pass longer than the deadline — a big tab remount), the EDT runs `RectManager.dispatchCallbacks()` — including `RectList.defragment()`, which swaps and compacts the backing arrays — concurrently with layout on the scene thread. The unsynchronized race corrupts the RectList; the crash surfaces later, at the next `detach`, which is why #550's frame ordering and #553's skip/catch attempts could not help.

**Fix — `RectManagerEdtGuard`** (no reflection, GraalVM native-image safe; static internal access like `TaoWindowsScrollConfig`):
- Pins `ThrottledCallbacks.minDebounceDeadline` to an unreachable instant between passes, so every dispatch Compose arms (`max(minDebounceDeadline, now + 16)`) is inert — no RectManager code ever executes off the scene thread, even during >16 ms passes.
- Preserves debounce semantics: a post-frame hook unpins and runs `dispatchCallbacks()` on the scene thread when `onLayoutRectChanged`/`onGlobalLayout` entries exist, then re-pins and schedules a frame for the next real deadline.
- Re-pins from layout/semantics notifications when a mid-pass fire lowered the deadline.
- Installed per `RootNodeOwner` (main owner + every popup/dialog layer) via the scene factories in `TaoSceneBundle` — covers all hosts, popups and overlays.

Documented residual (upstream-only): an app explicitly registering debounced rect callbacks (`Modifier.onLayoutRectChanged` / `onFirstVisible` / `onVisibilityChanged` — nothing in stock Compose/Foundation/Material registers one by default) can still get one EDT dispatch if a pass runs >16 ms past a mid-pass re-arm with no layout/semantics notification in between. Follow-up issue tracks an opt-in reflective closure; a standalone no-framework reproducer has been prepared for a JetBrains YouTrack report.

Also registers `TaoSceneContentSwapTest` (added in #550) in the scene test battery — it had been left out, failing the drift test.

## Test plan

- [x] `TaoSceneRectManagerRaceTest` — deterministic repro: fails on `nucleus-2.5` without the guard with the exact #551 stack (`RectManager.remove → LayoutNode.detach`), passes with it (3/3 runs)
- [x] `debounced onLayoutRectChanged trailing edge still fires with the guard pinned` — debounce feature preserved on the scene thread
- [x] Full `:decorated-window-tao:test` suite green (114 tests) + ktlint
- [x] Standalone pure-Compose reproducer (no Nucleus): crashes 3/3 on a non-EDT scene thread, never on the EDT — confirms root cause and AWT parity
- [x] Headful `:examples:nucleus-demo:run` session: no exception in logs
- [x] Manual: hammer nucleus-demo title-bar tabs (drag + click) on Windows
