### PR TITLE
feat(tao): wire Modifier.keepScreenOn to EnergyManager

### DIFF
--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -21,6 +21,10 @@ val publishVersion =
 dependencies {
     api(project(":decorated-window-core"))
     implementation(project(":core-runtime"))
+    // Compose `Modifier.keepScreenOn()` is a no-op on desktop unless the
+    // scene's PlatformContext implements `isKeepScreenOnEnabled`. Tao owns
+    // that context and forwards it to EnergyManager.
+    implementation(project(":energy-manager"))
     implementation(libs.compose.desktop.common)
     // Compose Hot Reload interop (TaoHotReloadBridge). compileOnly: these
     // artifacts are only referenced when running under the hot-reload agent,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayController.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayController.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.Density
@@ -31,6 +30,7 @@ import dev.nucleusframework.window.tao.scene.LocalTaoMetalTextureHost
 import dev.nucleusframework.window.tao.scene.MetalTextureHostCache
 import dev.nucleusframework.window.tao.scene.TaoComposeSceneContext
 import dev.nucleusframework.window.tao.scene.TaoMetalTextureHost
+import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoRecordedSurface
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.platformLayersSceneBundle
@@ -391,7 +391,7 @@ internal class NativeViewOverlayController(
                 )
             }
         val ourPlatformContext =
-            object : PlatformContext.Empty() {
+            object : TaoPlatformContextBase() {
                 override val windowInfo: WindowInfo get() = overlayWindowInfo
 
                 override fun setPointerIcon(pointerIcon: PointerIcon) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayControllerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayControllerWindows.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.Density
@@ -27,6 +26,7 @@ import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.popup.TaoPopupHostWindows
 import dev.nucleusframework.window.tao.popup.TaoPopupSceneLayerWindows
 import dev.nucleusframework.window.tao.scene.TaoComposeSceneContext
+import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.platformLayersSceneBundle
 import dev.nucleusframework.window.tao.scene.renderGlFrame
@@ -436,7 +436,7 @@ internal class NativeViewOverlayControllerWindows(
             // GL state cache for the new framebuffer.
 
             val ourPlatformContext =
-                object : PlatformContext.Empty() {
+                object : TaoPlatformContextBase() {
                     override val windowInfo: WindowInfo get() = overlayWindowInfo
 
                     override fun setPointerIcon(pointerIcon: PointerIcon) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeSceneLayer
 import androidx.compose.ui.unit.Density
@@ -28,6 +27,7 @@ import dev.nucleusframework.window.tao.ffi.PopupNativeBridge
 import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.scene.LocalTaoMetalTextureHost
 import dev.nucleusframework.window.tao.scene.TaoMetalTextureHost
+import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoRecordedSurface
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
@@ -204,7 +204,7 @@ internal class TaoPopupSceneLayer(
             layoutDirection = _layoutDirection,
             size = sceneLayoutSize,
             platformContext =
-                object : PlatformContext.Empty() {
+                object : TaoPlatformContextBase() {
                     override val windowInfo: androidx.compose.ui.platform.WindowInfo
                         get() = popupWindowInfo
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeSceneLayer
 import androidx.compose.ui.unit.Density
@@ -33,6 +32,7 @@ import dev.nucleusframework.window.tao.ffi.NativeTaoEglBridge
 import dev.nucleusframework.window.tao.releaseGlTextureImports
 import dev.nucleusframework.window.tao.scene.LocalTaoGlTextureHost
 import dev.nucleusframework.window.tao.scene.TaoGlTextureHost
+import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.alignToBufferScale
 import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
@@ -179,7 +179,7 @@ internal class TaoPopupSceneLayerLinux(
             layoutDirection = _layoutDirection,
             size = sceneLayoutSize,
             platformContext =
-                object : PlatformContext.Empty() {
+                object : TaoPlatformContextBase() {
                     override val windowInfo: androidx.compose.ui.platform.WindowInfo
                         get() = popupWindowInfo
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeSceneLayer
 import androidx.compose.ui.unit.Density
@@ -26,6 +25,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeWindows
 import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
+import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
 import dev.nucleusframework.window.tao.scene.renderGlFrame
@@ -169,7 +169,7 @@ internal class TaoPopupSceneLayerWindows(
             layoutDirection = _layoutDirection,
             size = sceneLayoutSize,
             platformContext =
-                object : PlatformContext.Empty() {
+                object : TaoPlatformContextBase() {
                     override val windowInfo: androidx.compose.ui.platform.WindowInfo
                         get() = popupWindowInfo
                 },

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.Density
@@ -27,6 +26,7 @@ import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.releaseWindowsTextureImports
 import dev.nucleusframework.window.tao.scene.LocalTaoWindowsTextureHost
 import dev.nucleusframework.window.tao.scene.TaoComposeSceneHostWindows
+import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.TaoWindowsTextureHost
 import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
@@ -466,7 +466,7 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
 
     // ── Platform plumbing ─────────────────────────────────────────────────
 
-    private inner class StandalonePopupPlatformContext : PlatformContext.Empty() {
+    private inner class StandalonePopupPlatformContext : TaoPlatformContextBase() {
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHost.windowInfo
 
         override fun setPointerIcon(pointerIcon: PointerIcon) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.Density
@@ -27,6 +26,7 @@ import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.releaseGlTextureImports
 import dev.nucleusframework.window.tao.scene.LocalTaoGlTextureHost
 import dev.nucleusframework.window.tao.scene.TaoGlTextureHost
+import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
 import dev.nucleusframework.window.tao.scene.preservingEglBinding
@@ -473,7 +473,7 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
 
     // ── Platform plumbing ─────────────────────────────────────────────────
 
-    private inner class StandalonePopupPlatformContext : PlatformContext.Empty() {
+    private inner class StandalonePopupPlatformContext : TaoPlatformContextBase() {
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostLinux.windowInfo
 
         override fun setPointerIcon(pointerIcon: PointerIcon) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.Density
@@ -26,6 +25,7 @@ import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.scene.LocalTaoMetalTextureHost
 import dev.nucleusframework.window.tao.scene.MetalTextureHostCache
 import dev.nucleusframework.window.tao.scene.TaoMetalTextureHost
+import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
 import dev.nucleusframework.window.tao.scene.newMetalRenderExecutor
@@ -451,7 +451,7 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
 
     // ── Platform plumbing ─────────────────────────────────────────────────
 
-    private inner class StandalonePopupPlatformContext : PlatformContext.Empty() {
+    private inner class StandalonePopupPlatformContext : TaoPlatformContextBase() {
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostMac.windowInfo
 
         override fun setPointerIcon(pointerIcon: PointerIcon) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -1528,7 +1528,7 @@ private class TaoPlatformContext(
     override val dragAndDropManager: androidx.compose.ui.platform.PlatformDragAndDropManager,
     override val textToolbar: androidx.compose.ui.platform.TextToolbar,
     private val onInputSession: (androidx.compose.ui.platform.PlatformTextInputMethodRequest?) -> Unit,
-) : PlatformContext.Empty() {
+) : TaoPlatformContextBase() {
     // Compose's Popup framework reads `LocalPlatformWindowInsets.current.systemBars`
     // when `usePlatformInsets = true` (the default). The popup positioning logic
     // then operates inside `windowSize - insets`, so a `top` inset matching our

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -2442,7 +2442,7 @@ private class LinuxTaoPlatformContext(
     override val semanticsOwnerListener: androidx.compose.ui.platform.PlatformContext.SemanticsOwnerListener?,
     override val dragAndDropManager: androidx.compose.ui.platform.PlatformDragAndDropManager,
     override val textToolbar: androidx.compose.ui.platform.TextToolbar,
-) : androidx.compose.ui.platform.PlatformContext.Empty() {
+) : TaoPlatformContextBase() {
     override val windowInsets: androidx.compose.ui.platform.PlatformWindowInsets =
         object : androidx.compose.ui.platform.PlatformWindowInsets {
             override val systemBars: androidx.compose.ui.platform.PlatformInsets =

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -1798,7 +1798,7 @@ private class WindowsTaoPlatformContext(
     override val semanticsOwnerListener: androidx.compose.ui.platform.PlatformContext.SemanticsOwnerListener? = null,
     override val dragAndDropManager: androidx.compose.ui.platform.PlatformDragAndDropManager,
     override val textToolbar: androidx.compose.ui.platform.TextToolbar,
-) : androidx.compose.ui.platform.PlatformContext.Empty() {
+) : TaoPlatformContextBase() {
     override val windowInsets: androidx.compose.ui.platform.PlatformWindowInsets =
         object : androidx.compose.ui.platform.PlatformWindowInsets {
             override val systemBars: androidx.compose.ui.platform.PlatformInsets =

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoKeepScreenOn.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoKeepScreenOn.kt
@@ -1,0 +1,69 @@
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.platform.PlatformContext
+import dev.nucleusframework.energymanager.AwakeHandle
+import dev.nucleusframework.energymanager.AwakeMode
+import dev.nucleusframework.energymanager.EnergyManager
+import java.util.logging.Logger
+
+/**
+ * Process-wide refcount for Compose `Modifier.keepScreenOn()` on the Tao
+ * backend.
+ *
+ * Each [TaoPlatformContextBase] reports 0↔1; this object turns that into a
+ * single [EnergyManager.acquireAwake] handle so several windows/popups can
+ * request the screen on without releasing each other, and without dropping
+ * an app-owned [EnergyManager.keepAwake] slot.
+ */
+internal object TaoKeepScreenOn {
+    private val logger = Logger.getLogger(TaoKeepScreenOn::class.java.name)
+    private val lock = Any()
+    private var count = 0
+    private var handle: AwakeHandle? = null
+
+    fun setEnabled(enabled: Boolean) {
+        synchronized(lock) {
+            if (enabled) {
+                if (++count == 1) {
+                    handle = EnergyManager.acquireAwake(AwakeMode.SYSTEM_AND_DISPLAY)
+                    if (!EnergyManager.isAwakeActive()) {
+                        logger.fine("keepScreenOn requested but EnergyManager could not keep the display awake")
+                    }
+                }
+            } else if (count > 0 && --count == 0) {
+                handle?.close()
+                handle = null
+            }
+        }
+    }
+
+    internal fun resetForTests() {
+        synchronized(lock) {
+            count = 0
+            handle?.close()
+            handle = null
+        }
+    }
+}
+
+/**
+ * [PlatformContext] that forwards Compose's `isKeepScreenOnEnabled` to
+ * [TaoKeepScreenOn] / [EnergyManager].
+ *
+ * Every Tao scene (window, popup, overlay) must extend this instead of
+ * [PlatformContext.Empty] so `Modifier.keepScreenOn()` actually keeps the
+ * display awake.
+ */
+@OptIn(InternalComposeUiApi::class)
+internal abstract class TaoPlatformContextBase : PlatformContext.Empty() {
+    private var keepScreenOn = false
+
+    override var isKeepScreenOnEnabled: Boolean
+        get() = keepScreenOn
+        set(value) {
+            if (keepScreenOn == value) return
+            keepScreenOn = value
+            TaoKeepScreenOn.setEnabled(value)
+        }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoKeepScreenOnTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoKeepScreenOnTest.kt
@@ -1,0 +1,77 @@
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.keepScreenOn
+import dev.nucleusframework.energymanager.AwakeMode
+import dev.nucleusframework.energymanager.EnergyManager
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TaoKeepScreenOnTest {
+    @After
+    fun tearDown() {
+        TaoKeepScreenOn.resetForTests()
+        EnergyManager.releaseAwake()
+    }
+
+    @Test
+    fun `PlatformContext setter refcounts across scenes`() {
+        assumeAvailable()
+        val first = TestContext()
+        val second = TestContext()
+
+        first.isKeepScreenOnEnabled = true
+        assertTrue(EnergyManager.isAwakeActive())
+
+        second.isKeepScreenOnEnabled = true
+        first.isKeepScreenOnEnabled = false
+        assertTrue(EnergyManager.isAwakeActive(), "second scene must keep the request")
+
+        second.isKeepScreenOnEnabled = false
+        assertFalse(EnergyManager.isAwakeActive())
+    }
+
+    @Test
+    fun `idempotent setter does not double-acquire`() {
+        assumeAvailable()
+        val context = TestContext()
+        context.isKeepScreenOnEnabled = true
+        context.isKeepScreenOnEnabled = true
+        context.isKeepScreenOnEnabled = false
+        assertFalse(EnergyManager.isAwakeActive())
+    }
+
+    @Test
+    fun `keepScreenOn does not drop an explicit keepAwake slot`() {
+        assumeAvailable()
+        EnergyManager.keepAwake(AwakeMode.SYSTEM_AND_DISPLAY)
+        val context = TestContext()
+        context.isKeepScreenOnEnabled = true
+        context.isKeepScreenOnEnabled = false
+        assertTrue(EnergyManager.isAwakeActive(), "app-owned keepAwake must survive")
+        EnergyManager.releaseAwake()
+        assertFalse(EnergyManager.isAwakeActive())
+    }
+
+    @Test
+    fun `Modifier keepScreenOn attaches and detaches through the scene`() {
+        assumeAvailable()
+        runTaoSceneTest {
+            setContent {
+                Box(Modifier.keepScreenOn())
+            }
+            assertTrue(EnergyManager.isAwakeActive())
+        }
+        assertFalse(EnergyManager.isAwakeActive())
+    }
+
+    private fun assumeAvailable() {
+        assumeTrue("Energy manager not available", EnergyManager.isAvailable())
+    }
+
+    private class TestContext : TaoPlatformContextBase()
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneTestHarness.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneTestHarness.kt
@@ -204,7 +204,7 @@ internal class TaoSceneTestScope(
         }
 
     private val platformContext =
-        object : PlatformContext.Empty() {
+        object : TaoPlatformContextBase() {
             override val windowInfo: TaoWindowInfo = this@TaoSceneTestScope.windowInfo
 
             override val semanticsOwnerListener =

--- a/energy-manager/api/energy-manager.api
+++ b/energy-manager/api/energy-manager.api
@@ -1,3 +1,9 @@
+public final class dev/nucleusframework/energymanager/AwakeHandle : java/lang/AutoCloseable {
+	public fun close ()V
+	public final fun getMode ()Ldev/nucleusframework/energymanager/AwakeMode;
+	public final fun isActive ()Z
+}
+
 public final class dev/nucleusframework/energymanager/AwakeMode : java/lang/Enum {
 	public static final field SYSTEM_AND_DISPLAY Ldev/nucleusframework/energymanager/AwakeMode;
 	public static final field SYSTEM_ONLY Ldev/nucleusframework/energymanager/AwakeMode;
@@ -8,6 +14,8 @@ public final class dev/nucleusframework/energymanager/AwakeMode : java/lang/Enum
 
 public final class dev/nucleusframework/energymanager/EnergyManager {
 	public static final field INSTANCE Ldev/nucleusframework/energymanager/EnergyManager;
+	public final fun acquireAwake (Ldev/nucleusframework/energymanager/AwakeMode;)Ldev/nucleusframework/energymanager/AwakeHandle;
+	public static synthetic fun acquireAwake$default (Ldev/nucleusframework/energymanager/EnergyManager;Ldev/nucleusframework/energymanager/AwakeMode;ILjava/lang/Object;)Ldev/nucleusframework/energymanager/AwakeHandle;
 	public final fun disableEfficiencyMode ()Ldev/nucleusframework/energymanager/EnergyManager$Result;
 	public final fun disableLightEfficiencyMode ()Ldev/nucleusframework/energymanager/EnergyManager$Result;
 	public final fun disableThreadEfficiencyMode ()Ldev/nucleusframework/energymanager/EnergyManager$Result;

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/AwakeHandle.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/AwakeHandle.kt
@@ -1,0 +1,33 @@
+package dev.nucleusframework.energymanager
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * An acquired [EnergyManager] awake request.
+ *
+ * Closing the handle drops this request. The process stays awake while any
+ * other handle, or an unmatched [EnergyManager.keepAwake] call, is still
+ * active. [close] is idempotent and thread-safe.
+ */
+public class AwakeHandle internal constructor(
+    /** Mode this handle requested. */
+    public val mode: AwakeMode,
+    private val onClose: (AwakeHandle) -> Unit,
+) : AutoCloseable {
+    private val active = AtomicBoolean(true)
+
+    /** `false` after [close]. */
+    public val isActive: Boolean
+        get() = active.get()
+
+    /** Drops this request. Idempotent. */
+    override fun close() {
+        if (active.compareAndSet(true, false)) {
+            onClose(this)
+        }
+    }
+
+    internal fun markInactive() {
+        active.set(false)
+    }
+}

--- a/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
+++ b/energy-manager/src/main/kotlin/dev/nucleusframework/energymanager/EnergyManager.kt
@@ -26,6 +26,11 @@ import java.util.concurrent.Executors
  *   Linux:   GNOME SessionManager / freedesktop PowerManagement / systemd-logind /
  *            X11 inhibitors — [AwakeMode.SYSTEM_ONLY] drops the idle bits and skips
  *            the X11 screen-saver backend.
+ *
+ * [keepAwake] / [releaseAwake] own a single explicit slot (last writer wins
+ * for that slot). [acquireAwake] returns independent handles that coexist
+ * with it; the OS request uses the strongest live [AwakeMode] and is dropped
+ * only when the explicit slot and every handle are gone.
  */
 @Suppress("TooManyFunctions")
 public object EnergyManager {
@@ -36,6 +41,11 @@ public object EnergyManager {
     )
 
     private val unsupported = Result(false, -1, "Not supported on this platform")
+
+    private val lock = Any()
+    private var explicitMode: AwakeMode? = null
+    private val holders = mutableListOf<AwakeHandle>()
+    private var appliedMode: AwakeMode? = null
 
     private val delegate: PlatformEnergyManager? =
         when (Platform.Current) {
@@ -102,19 +112,49 @@ public object EnergyManager {
      * [AwakeMode.SYSTEM_ONLY] lets the screen saver and display sleep behave normally
      * while long background work keeps running.
      *
-     * Calling this while a request is already active replaces it with [mode].
+     * Calling this while a previous [keepAwake] request is already active replaces
+     * that slot with [mode]. Handles from [acquireAwake] are independent: the OS
+     * request uses the strongest live mode and stays held until this slot and
+     * every handle are gone.
      *
      * The request is held by a dedicated internal thread, so it stays active
      * regardless of which thread calls this function — including short-lived
      * coroutine dispatcher workers.
      */
     public fun keepAwake(mode: AwakeMode = AwakeMode.SYSTEM_AND_DISPLAY): Result =
-        delegate?.keepAwake(mode) ?: unsupported
+        synchronized(lock) {
+            explicitMode = mode
+            applyLocked()
+        }
 
     /**
-     * Releases the awake state, allowing the OS to sleep normally.
+     * Acquires an awake request that stays held until [AwakeHandle.close].
+     *
+     * Multiple handles can be active at once and coexist with [keepAwake].
+     * The OS request uses the strongest requested [AwakeMode] and is released
+     * only when every handle (and any unmatched [keepAwake]) is gone.
+     *
+     * Prefer this over [keepAwake] when several independent features (a video
+     * player, a Compose `Modifier.keepScreenOn()`, a download) need the
+     * machine awake without stepping on each other.
      */
-    public fun releaseAwake(): Result = delegate?.releaseAwake() ?: unsupported
+    public fun acquireAwake(mode: AwakeMode = AwakeMode.SYSTEM_AND_DISPLAY): AwakeHandle =
+        synchronized(lock) {
+            val handle = AwakeHandle(mode, ::releaseHandle)
+            holders += handle
+            applyLocked()
+            handle
+        }
+
+    /**
+     * Releases the [keepAwake] slot, allowing the OS to sleep normally if no
+     * [acquireAwake] handle is still live.
+     */
+    public fun releaseAwake(): Result =
+        synchronized(lock) {
+            explicitMode = null
+            applyLocked()
+        }
 
     /**
      * Returns true if an awake request is currently held.
@@ -141,6 +181,60 @@ public object EnergyManager {
      */
     @Deprecated("Renamed to isAwakeActive()", ReplaceWith("isAwakeActive()"))
     public fun isScreenAwakeActive(): Boolean = isAwakeActive()
+
+    private fun releaseHandle(handle: AwakeHandle) {
+        synchronized(lock) {
+            if (!holders.remove(handle)) return
+            applyLocked()
+        }
+    }
+
+    private fun applyLocked(): Result {
+        val strongest = strongestModeLocked()
+        if (strongest == appliedMode) {
+            return Result(true)
+        }
+        val result =
+            if (strongest == null) {
+                delegate?.releaseAwake() ?: unsupported
+            } else {
+                delegate?.keepAwake(strongest) ?: unsupported
+            }
+        if (result.success) {
+            appliedMode = strongest
+        }
+        return result
+    }
+
+    private fun strongestModeLocked(): AwakeMode? {
+        var display = explicitMode == AwakeMode.SYSTEM_AND_DISPLAY
+        var system = explicitMode == AwakeMode.SYSTEM_ONLY
+        for (handle in holders) {
+            when (handle.mode) {
+                AwakeMode.SYSTEM_AND_DISPLAY -> display = true
+                AwakeMode.SYSTEM_ONLY -> system = true
+            }
+        }
+        return when {
+            display -> AwakeMode.SYSTEM_AND_DISPLAY
+            system -> AwakeMode.SYSTEM_ONLY
+            else -> null
+        }
+    }
+
+    /**
+     * Drops every handle and the explicit slot. Test-only: production
+     * callers must close their own [AwakeHandle]s.
+     */
+    internal fun resetAwakeForTests() {
+        synchronized(lock) {
+            val snapshot = holders.toList()
+            holders.clear()
+            explicitMode = null
+            applyLocked()
+            snapshot.forEach { it.markInactive() }
+        }
+    }
 
     /**
      * Executes [block] on a dedicated thread with efficiency mode enabled.

--- a/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerAwakeHandleTest.kt
+++ b/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerAwakeHandleTest.kt
@@ -1,0 +1,102 @@
+package dev.nucleusframework.energymanager
+
+import dev.nucleusframework.energymanager.windows.NativeWindowsEnergyBridge
+import dev.nucleusframework.energymanager.windows.WindowsEnergyManager
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EnergyManagerAwakeHandleTest {
+    @After
+    fun tearDown() {
+        EnergyManager.resetAwakeForTests()
+    }
+
+    @Test
+    fun `acquireAwake round trips`() {
+        assumeAvailable()
+        val handle = EnergyManager.acquireAwake()
+        try {
+            assertTrue(handle.isActive)
+            assertTrue(EnergyManager.isAwakeActive())
+        } finally {
+            handle.close()
+        }
+        assertFalse(handle.isActive)
+        assertFalse(EnergyManager.isAwakeActive())
+    }
+
+    @Test
+    fun `closing one of two handles leaves the request active`() {
+        assumeAvailable()
+        val first = EnergyManager.acquireAwake()
+        val second = EnergyManager.acquireAwake()
+        first.close()
+        assertTrue(EnergyManager.isAwakeActive())
+        assertFalse(first.isActive)
+        assertTrue(second.isActive)
+        second.close()
+        assertFalse(EnergyManager.isAwakeActive())
+    }
+
+    @Test
+    fun `releaseAwake does not drop a live acquireAwake handle`() {
+        assumeAvailable()
+        EnergyManager.keepAwake()
+        val handle = EnergyManager.acquireAwake()
+        assertTrue(EnergyManager.releaseAwake().success)
+        assertTrue(EnergyManager.isAwakeActive(), "handle must keep the OS request alive")
+        handle.close()
+        assertFalse(EnergyManager.isAwakeActive())
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        assumeAvailable()
+        val handle = EnergyManager.acquireAwake()
+        handle.close()
+        handle.close()
+        assertFalse(handle.isActive)
+        assertFalse(EnergyManager.isAwakeActive())
+    }
+
+    @Test
+    fun `windows display handle wins over a system-only keepAwake`() {
+        assumeWindows()
+        assumeAvailable()
+
+        EnergyManager.keepAwake(AwakeMode.SYSTEM_ONLY)
+        val handle = EnergyManager.acquireAwake(AwakeMode.SYSTEM_AND_DISPLAY)
+        val withDisplay = queryAwakeFlags()
+        handle.close()
+        val systemOnly = queryAwakeFlags()
+        EnergyManager.releaseAwake()
+
+        assertTrue(withDisplay and ES_SYSTEM_REQUIRED != 0)
+        assertTrue(withDisplay and ES_DISPLAY_REQUIRED != 0)
+        assertTrue(systemOnly and ES_SYSTEM_REQUIRED != 0)
+        assertEquals(0, systemOnly and ES_DISPLAY_REQUIRED)
+    }
+
+    private fun assumeAvailable() {
+        assumeTrue("Energy manager not available", EnergyManager.isAvailable())
+    }
+
+    private fun assumeWindows() {
+        assumeTrue(
+            "Test requires Windows",
+            System.getProperty("os.name").lowercase().contains("windows"),
+        )
+    }
+
+    private fun queryAwakeFlags(): Int =
+        WindowsEnergyManager.onAwakeThread { NativeWindowsEnergyBridge.nativeQueryAwakeFlags() }
+
+    private companion object {
+        const val ES_SYSTEM_REQUIRED = 0x00000001
+        const val ES_DISPLAY_REQUIRED = 0x00000002
+    }
+}

--- a/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
+++ b/energy-manager/src/test/kotlin/dev/nucleusframework/energymanager/EnergyManagerTest.kt
@@ -5,6 +5,7 @@ import dev.nucleusframework.energymanager.macos.NativeMacOsEnergyBridge
 import dev.nucleusframework.energymanager.windows.NativeWindowsEnergyBridge
 import dev.nucleusframework.energymanager.windows.WindowsEnergyManager
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Assume.assumeTrue
 import java.io.File
 import kotlin.test.Test
@@ -19,6 +20,11 @@ import kotlin.test.assertTrue
  * Tests are skipped on platforms that don't match.
  */
 class EnergyManagerTest {
+    @After
+    fun tearDownAwake() {
+        EnergyManager.resetAwakeForTests()
+    }
+
     private fun assumeLinux() {
         assumeTrue(
             "Test requires Linux",


### PR DESCRIPTION
## Summary

- Honor Compose `Modifier.keepScreenOn()` on the Tao backend. Desktop Compose leaves `PlatformContext.isKeepScreenOnEnabled` as a no-op; every Tao scene (window, popup, overlay) now forwards it to EnergyManager so the display stays awake for the lifetime of the modifier.
- Add `EnergyManager.acquireAwake()` / `AwakeHandle`. `keepAwake()` / `releaseAwake()` stay the explicit last-writer slot; handles coexist with that slot and the OS request uses the strongest live `AwakeMode`. Closing the last handle (and the explicit slot) releases the native request.
- A process-wide refcount in `TaoKeepScreenOn` turns per-scene 0/1 into one handle, so multiple windows do not release each other and do not drop an app-owned `keepAwake()`.

AWT/JBR remains a no-op: Compose Desktop's `DesktopPlatformContext` is private and does not implement the flag.

## Test plan

- [x] `:energy-manager:apiCheck`
- [x] `:energy-manager:test` (including `EnergyManagerAwakeHandleTest`: two handles, `releaseAwake` does not drop a live handle, display wins over system-only)
- [x] `:decorated-window-tao:test --tests TaoKeepScreenOnTest` (refcount, idempotent setter, does not drop `keepAwake`, `Modifier.keepScreenOn` attach/detach through a scene)
- [x] detekt + ktlint on `energy-manager` and `decorated-window-tao`