### PR TITLE
fix(tao): report isWindowTransparent to Compose scenes

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayController.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayController.kt
@@ -101,6 +101,7 @@ internal class NativeViewOverlayController(
             override val sceneCoroutineContext: CoroutineContext get() = popupHost.sceneCoroutineContext
             override val coordinateOffset: IntOffset
                 get() = IntOffset(overlayOffsetX, overlayOffsetY)
+            override val isOwnerWindowTransparent: Boolean get() = popupHost.isOwnerWindowTransparent
 
             override fun requestRedraw() = popupHost.requestRedraw()
 
@@ -393,6 +394,11 @@ internal class NativeViewOverlayController(
         val ourPlatformContext =
             object : TaoPlatformContextBase() {
                 override val windowInfo: WindowInfo get() = overlayWindowInfo
+
+                // The overlay composites into the owner window's surface, so
+                // dialog scrims must blend the same way as the owner's (#559).
+                override val isWindowTransparent: Boolean
+                    get() = popupHost.isOwnerWindowTransparent
 
                 override fun setPointerIcon(pointerIcon: PointerIcon) {
                     popupHost.setCursor(pointerIcon.toTaoCursorIconCode())

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayControllerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/NativeViewOverlayControllerWindows.kt
@@ -121,6 +121,7 @@ internal class NativeViewOverlayControllerWindows(
             override val hostDirectContext: DirectContext get() = popupHost.hostDirectContext
             override val coordinateOffset: IntOffset
                 get() = IntOffset(overlayOffsetX, overlayOffsetY)
+            override val isOwnerWindowTransparent: Boolean get() = popupHost.isOwnerWindowTransparent
 
             override fun requestRedraw() = popupHost.requestRedraw()
 
@@ -438,6 +439,11 @@ internal class NativeViewOverlayControllerWindows(
             val ourPlatformContext =
                 object : TaoPlatformContextBase() {
                     override val windowInfo: WindowInfo get() = overlayWindowInfo
+
+                    // The overlay composites into the owner window's surface, so
+                    // dialog scrims must blend the same way as the owner's (#559).
+                    override val isWindowTransparent: Boolean
+                        get() = popupHost.isOwnerWindowTransparent
 
                     override fun setPointerIcon(pointerIcon: PointerIcon) {
                         // While a manual cursor override is active (consumeOverlayPointerEvents

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHost.kt
@@ -61,6 +61,15 @@ internal interface TaoPopupHost {
      */
     val coordinateOffset: IntOffset get() = IntOffset.Zero
 
+    /**
+     * Whether the owner window was created per-pixel transparent
+     * (`DecoratedWindow(transparent = true)`, #416). Overlay scenes render
+     * inside the owner's surface, so they forward this as
+     * `PlatformContext.isWindowTransparent` — the hint Compose uses to pick
+     * the alpha-aware dialog-scrim blend mode (#559).
+     */
+    val isOwnerWindowTransparent: Boolean get() = false
+
     fun requestRedraw()
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostWindows.kt
@@ -51,6 +51,15 @@ internal interface TaoPopupHostWindows {
     val coordinateOffset: IntOffset get() = IntOffset.Zero
 
     /**
+     * Whether the owner window was created per-pixel transparent
+     * (`DecoratedWindow(transparent = true)`, #416). Overlay scenes render
+     * inside the owner's surface, so they forward this as
+     * `PlatformContext.isWindowTransparent` — the hint Compose uses to pick
+     * the alpha-aware dialog-scrim blend mode (#559).
+     */
+    val isOwnerWindowTransparent: Boolean get() = false
+
+    /**
      * The HOST scene's Skia DirectContext — shared with every
      * overlay/popup on Windows. Single-context architecture: every
      * overlay/popup renders through the host's EGLContext bound to its

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
@@ -208,6 +208,11 @@ internal class TaoPopupSceneLayer(
                     override val windowInfo: androidx.compose.ui.platform.WindowInfo
                         get() = popupWindowInfo
 
+                    // The panel's surface is per-pixel transparent, so dialog
+                    // scrims must use the alpha-aware blend — same contract as
+                    // Compose Desktop's `WindowComposeSceneLayer` (#559).
+                    override val isWindowTransparent: Boolean get() = true
+
                     override fun setPointerIcon(pointerIcon: PointerIcon) {
                         host.setCursor(pointerIcon.toTaoCursorIconCode())
                     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
@@ -183,6 +183,12 @@ internal class TaoPopupSceneLayerLinux(
                     override val windowInfo: androidx.compose.ui.platform.WindowInfo
                         get() = popupWindowInfo
 
+                    // The popup window's surface is per-pixel transparent, so
+                    // dialog scrims must use the alpha-aware blend — same
+                    // contract as Compose Desktop's `WindowComposeSceneLayer`
+                    // (#559).
+                    override val isWindowTransparent: Boolean get() = true
+
                     override fun setPointerIcon(pointerIcon: PointerIcon) {
                         if (released) return
                         NativeTaoBridge.nativeSetCursorIcon(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -172,6 +172,12 @@ internal class TaoPopupSceneLayerWindows(
                 object : TaoPlatformContextBase() {
                     override val windowInfo: androidx.compose.ui.platform.WindowInfo
                         get() = popupWindowInfo
+
+                    // The popup HWND's surface is per-pixel transparent, so
+                    // dialog scrims must use the alpha-aware blend — same
+                    // contract as Compose Desktop's `WindowComposeSceneLayer`
+                    // (#559).
+                    override val isWindowTransparent: Boolean get() = true
                 },
             requestFrame = { host.requestRedraw() },
         )

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -469,6 +469,10 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     private inner class StandalonePopupPlatformContext : TaoPlatformContextBase() {
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHost.windowInfo
 
+        // Standalone popup surfaces are always per-pixel transparent, so
+        // dialog scrims must use the alpha-aware blend (#559).
+        override val isWindowTransparent: Boolean get() = true
+
         override fun setPointerIcon(pointerIcon: PointerIcon) {
             if (!isValid) return
             PopupNativeBridgeWindows.nativeSetPanelCursor(panel, mapPointerIcon(pointerIcon))

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
@@ -476,6 +476,10 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
     private inner class StandalonePopupPlatformContext : TaoPlatformContextBase() {
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostLinux.windowInfo
 
+        // Standalone popup surfaces are always per-pixel transparent, so
+        // dialog scrims must use the alpha-aware blend (#559).
+        override val isWindowTransparent: Boolean get() = true
+
         override fun setPointerIcon(pointerIcon: PointerIcon) {
             if (!isValid || disposed) return
             PopupNativeBridgeLinux.nativeSetPanelCursor(panel, pointerIcon.toTaoCursorIconCode())

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
@@ -454,6 +454,10 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
     private inner class StandalonePopupPlatformContext : TaoPlatformContextBase() {
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostMac.windowInfo
 
+        // Standalone popup surfaces are always per-pixel transparent, so
+        // dialog scrims must use the alpha-aware blend (#559).
+        override val isWindowTransparent: Boolean get() = true
+
         override fun setPointerIcon(pointerIcon: PointerIcon) {
             if (!isValid || disposed) return
             PopupNativeBridge.nativeSetPanelCursor(panel, pointerIcon.toTaoCursorIconCode())

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -368,6 +368,7 @@ internal class TaoComposeSceneHost(
                 dragAndDropManager = dndManager,
                 textToolbar = textToolbar,
                 onInputSession = { activeInputRequest = it },
+                isWindowTransparent = fullyTransparent,
             )
 
         val hostPopupHost = if (nativePopupLayers) popupHost() else null
@@ -778,6 +779,7 @@ internal class TaoComposeSceneHost(
         return object : TaoPopupHost {
             override val parentNsView: Long get() = outer.nsViewHandle
             override val scale: Float get() = outer.scale
+            override val isOwnerWindowTransparent: Boolean get() = outer.fullyTransparent
             override val parentWindowSize: IntSize get() = IntSize(outer.widthPx, outer.heightPx)
             override val workAreaSize: IntSize get() {
                 val packed = NativeMetalBridge.nativeOwnerWorkAreaSize(outer.nsViewHandle)
@@ -1528,6 +1530,11 @@ private class TaoPlatformContext(
     override val dragAndDropManager: androidx.compose.ui.platform.PlatformDragAndDropManager,
     override val textToolbar: androidx.compose.ui.platform.TextToolbar,
     private val onInputSession: (androidx.compose.ui.platform.PlatformTextInputMethodRequest?) -> Unit,
+    // #559: forwarded to Compose so `CanvasLayersComposeScene` picks the
+    // alpha-aware dialog-scrim blend mode (`BlendMode.SrcAtop`) on windows
+    // created with `transparent = true` — same as Compose Desktop's
+    // `DesktopPlatformContext` forwarding `windowContext.isWindowTransparent`.
+    override val isWindowTransparent: Boolean = false,
 ) : TaoPlatformContextBase() {
     // Compose's Popup framework reads `LocalPlatformWindowInsets.current.systemBars`
     // when `usePlatformInsets = true` (the default). The popup positioning logic

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -455,6 +455,7 @@ internal class TaoComposeSceneHostLinux(
                 semanticsOwnerListener = semanticsOwnerListener,
                 dragAndDropManager = dndManager,
                 textToolbar = textToolbar,
+                isWindowTransparent = fullyTransparent,
             )
         sceneBundle =
             if (nativePopupLayers) {
@@ -2442,6 +2443,11 @@ private class LinuxTaoPlatformContext(
     override val semanticsOwnerListener: androidx.compose.ui.platform.PlatformContext.SemanticsOwnerListener?,
     override val dragAndDropManager: androidx.compose.ui.platform.PlatformDragAndDropManager,
     override val textToolbar: androidx.compose.ui.platform.TextToolbar,
+    // #559: forwarded to Compose so `CanvasLayersComposeScene` picks the
+    // alpha-aware dialog-scrim blend mode (`BlendMode.SrcAtop`) on windows
+    // created with `transparent = true` — same as Compose Desktop's
+    // `DesktopPlatformContext` forwarding `windowContext.isWindowTransparent`.
+    override val isWindowTransparent: Boolean,
 ) : TaoPlatformContextBase() {
     override val windowInsets: androidx.compose.ui.platform.PlatformWindowInsets =
         object : androidx.compose.ui.platform.PlatformWindowInsets {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -360,6 +360,7 @@ internal class TaoComposeSceneHostWindows(
                 semanticsOwnerListener = semanticsOwnerListener,
                 dragAndDropManager = dndManager,
                 textToolbar = textToolbar,
+                isWindowTransparent = fullyTransparent,
             )
         sceneBundle =
             if (nativePopupLayers) {
@@ -1454,6 +1455,7 @@ internal class TaoComposeSceneHostWindows(
         return object : TaoPopupHostWindows {
             override val parentHwnd: Long get() = outer.hwnd
             override val scale: Float get() = outer.scale
+            override val isOwnerWindowTransparent: Boolean get() = outer.fullyTransparent
             override val parentWindowSize: IntSize get() = IntSize(outer.widthPx, outer.heightPx)
             override val workAreaSize: IntSize get() {
                 if (!NativeTaoWindowsDecoBridge.isLoaded) return parentWindowSize
@@ -1798,6 +1800,11 @@ private class WindowsTaoPlatformContext(
     override val semanticsOwnerListener: androidx.compose.ui.platform.PlatformContext.SemanticsOwnerListener? = null,
     override val dragAndDropManager: androidx.compose.ui.platform.PlatformDragAndDropManager,
     override val textToolbar: androidx.compose.ui.platform.TextToolbar,
+    // #559: forwarded to Compose so `CanvasLayersComposeScene` picks the
+    // alpha-aware dialog-scrim blend mode (`BlendMode.SrcAtop`) on windows
+    // created with `transparent = true` — same as Compose Desktop's
+    // `DesktopPlatformContext` forwarding `windowContext.isWindowTransparent`.
+    override val isWindowTransparent: Boolean = false,
 ) : TaoPlatformContextBase() {
     override val windowInsets: androidx.compose.ui.platform.PlatformWindowInsets =
         object : androidx.compose.ui.platform.PlatformWindowInsets {

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -76,6 +76,8 @@ class TaoSceneTestBatteryDriftTest {
             TaoSceneRectManagerRaceTest::class.java to
                 "races the real AWT EDT against wall-clock frames; the no-AWT image never initialises AWT",
             TaoTransferableAccessGuardTest::class.java to "Compose interop ABI guard, not a scene behaviour",
+            dev.nucleusframework.window.tao.scene.TaoKeepScreenOnTest::class.java to
+                "acquires real EnergyManager awake handles against the host OS",
             TaoSceneTestBatteryDriftTest::class.java to "meta-test for the battery itself",
         )
 


### PR DESCRIPTION
Fixes #559

## Summary
- Compose picks the dialog-scrim blend mode from `PlatformContext.isWindowTransparent` (`SrcAtop` on alpha-channel windows, `SrcOver` otherwise). The Tao contexts never overrode it, so scrims on `DecoratedWindow(transparent = true)` blended as if the window were opaque.
- Main window platform contexts (macOS/Windows/Linux) now forward the host's existing `fullyTransparent` flag (#416) — same forwarding Compose Desktop's `DesktopPlatformContext` does with `windowContext.isWindowTransparent`.
- Native popup layers (`TaoPopupSceneLayer` mac/win/linux) and standalone popup hosts report `true`: their surfaces are always per-pixel transparent, same contract as Compose Desktop's `WindowComposeSceneLayer`.
- `NativeView` overlay scenes composite into the owner window's surface, so they inherit the owner's value via the new `TaoPopupHost(Windows).isOwnerWindowTransparent` (default `false`, forwarded by the overlay delegating adapters).
- The hint is creation-time only, matching the native side: `transparent = true` is applied at window creation (`with_transparent` / DWM blur-behind) and cannot change afterwards.
- Also registers `TaoKeepScreenOnTest` (from #556) as JVM-only in the battery drift guard — it was missing there and failed `:decorated-window-tao:test` on the base commit.

## Test plan
- [x] `:decorated-window-tao:test` (117 tests, green — including the previously failing battery drift guard)
- [x] `:decorated-window-tao:ktlintCheck` and `:decorated-window-tao:detekt`
