### PR TITLE
chore(plugin): include jdk.unsupported in default runtime modules

### DIFF
--- a/examples/jewel-demo/build.gradle.kts
+++ b/examples/jewel-demo/build.gradle.kts
@@ -97,16 +97,6 @@ tasks.withType<Test>().configureEach {
 
 nucleus.application {
     mainClass = "jewelsample.MainKt"
-    jvmArgs +=
-        listOf(
-            "--add-opens",
-            "java.desktop/sun.awt=ALL-UNNAMED",
-            "--add-opens",
-            "java.desktop/sun.lwawt=ALL-UNNAMED",
-            "--add-opens",
-            "java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
-        )
-
     buildTypes {
         release {
             proguard {

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplicationDistributions.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplicationDistributions.kt
@@ -18,6 +18,8 @@ internal val DEFAULT_RUNTIME_MODULES =
         "java.net.http",
         "jdk.accessibility",
         "jdk.crypto.ec",
+        // sun.misc.Unsafe — required by JNA, Jewel and many common libraries
+        "jdk.unsupported",
     )
 
 abstract class JvmApplicationDistributions : AbstractDistributions() {


### PR DESCRIPTION
## Summary
- Add `jdk.unsupported` to `DEFAULT_RUNTIME_MODULES` — `sun.misc.Unsafe` is required by JNA, Jewel and many other common libraries, and packaged (jlink) distributions crash at runtime without it.
- Drop the `--add-opens java.desktop/sun.awt` / `sun.lwawt` / `sun.lwawt.macosx` workaround from `jewel-demo`, no longer needed.

## Test plan
- [x] `jewel-demo` runs without the `--add-opens` flags