### PR TITLE
fix(tao): follow the caret with the Windows IME candidate window

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -524,9 +524,15 @@ internal object NativeTaoBridge {
     )
 
     /**
-     * Anchors macOS IME UI at the given window-local rect in *physical pixels*
-     * (top-left origin). Tao's stock `firstRectForCharacterRange:` returns
-     * 0×0; we override it so candidate windows can follow the caret.
+     * Anchors native IME UI at the given window-local rect in *physical pixels*
+     * (top-left origin).
+     *
+     * On macOS, Tao's stock `firstRectForCharacterRange:` returns 0×0; we
+     * override it so candidate windows can follow the caret. On Windows the
+     * rect is pushed to IMM32 as the composition point plus the candidate
+     * window's exclusion zone.
+     *
+     * Not implemented on Linux yet (#558).
      */
     @JvmStatic
     external fun nativeSetImeRect(
@@ -536,6 +542,14 @@ internal object NativeTaoBridge {
         width: Int,
         height: Int,
     )
+
+    /**
+     * Discards any in-flight IME composition — called when the focused field's
+     * input session ends so a pending candidate window does not linger, nor
+     * commit into whatever gains focus next. Windows only.
+     */
+    @JvmStatic
+    external fun nativeCancelImeComposition(handle: Long)
 
     /** Calls `[view.inputContext activate]` for TaoView's NSTextInputClient. */
     @JvmStatic

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
@@ -46,7 +47,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BackendRenderTarget
@@ -1824,6 +1827,57 @@ private class WindowsTaoPlatformContext(
         )
     }
 
+    /**
+     * Compose calls this when a `BasicTextField` gains focus. We track the
+     * caret rectangle and push it to IMM32 (#558) so the candidate window of
+     * MS-IME / Pinyin / Hangul sits on the caret instead of the client area's
+     * top-left corner. (The `Win+.` emoji panel is positioned through TSF, not
+     * IMM32, so it is unaffected by this.)
+     *
+     * Mirrors `DesktopTextInputService2.startInput` in compose-multiplatform-core,
+     * but feeds the rect through `ImmSetCandidateWindow` / `ImmSetCompositionWindow`
+     * rather than AWT's `InputMethodRequests.getTextLocation`.
+     *
+     * The rect is in scene-root physical pixels, which is exactly what IMM32
+     * wants: the scene covers the whole client area (the custom title bar is
+     * drawn inside it and reports no platform inset), so root (0, 0) is
+     * client (0, 0).
+     */
+    @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+    override suspend fun startInputMethod(
+        request: androidx.compose.ui.platform.PlatformTextInputMethodRequest,
+    ): Nothing {
+        try {
+            coroutineScope {
+                launch {
+                    androidx.compose.runtime
+                        .snapshotFlow {
+                            // The caret rect is unbounded: it goes negative — or past
+                            // the client area — once the field scrolls out of the
+                            // viewport, which would fling the candidate window off the
+                            // window. Clip it to the field's visible text region.
+                            request.focusedRectInRoot()?.clampedTo(request.textClippingRectInRoot())
+                        }.collect { rect ->
+                            if (rect != null) {
+                                NativeTaoBridge.nativeSetImeRect(
+                                    windowHandle,
+                                    rect.left.toInt(),
+                                    rect.top.toInt(),
+                                    rect.width.toInt().coerceAtLeast(1),
+                                    rect.height.toInt().coerceAtLeast(1),
+                                )
+                            }
+                        }
+                }
+                awaitCancellation()
+            }
+        } finally {
+            // Field blurred (or the session restarted): drop any composition so
+            // the candidate window goes away with it.
+            NativeTaoBridge.nativeCancelImeComposition(windowHandle)
+        }
+    }
+
     private fun mapPointerIcon(icon: androidx.compose.ui.input.pointer.PointerIcon): Int {
         when {
             icon === androidx.compose.ui.input.pointer.PointerIcon.Default ->
@@ -1855,4 +1909,21 @@ private class WindowsTaoPlatformContext(
             }
         }.getOrDefault(dev.nucleusframework.window.tao.TaoCursorIcon.DEFAULT)
     }
+}
+
+/**
+ * Confines this rect to [bounds], collapsing rather than inverting when it
+ * falls entirely outside. `Rect.intersect` is not usable here: the caret rect
+ * can legitimately be zero-width, which no overlap test accepts.
+ */
+private fun Rect.clampedTo(bounds: Rect?): Rect {
+    if (bounds == null || bounds.isEmpty) return this
+    val clampedLeft = left.coerceIn(bounds.left, bounds.right)
+    val clampedTop = top.coerceIn(bounds.top, bounds.bottom)
+    return Rect(
+        left = clampedLeft,
+        top = clampedTop,
+        right = right.coerceIn(clampedLeft, bounds.right),
+        bottom = bottom.coerceIn(clampedTop, bounds.bottom),
+    )
 }

--- a/decorated-window-tao/src/main/native/Cargo.toml
+++ b/decorated-window-tao/src/main/native/Cargo.toml
@@ -58,6 +58,8 @@ windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
+    # IMM32 for the IME caret rect (#558).
+    "Win32_UI_Input_Ime",
 ] }
 
 [build-dependencies]

--- a/decorated-window-tao/src/main/native/src/platform/windows/ime.rs
+++ b/decorated-window-tao/src/main/native/src/platform/windows/ime.rs
@@ -1,0 +1,120 @@
+// IMM32 caret-rect plumbing (#558) so the native IME candidate window follows
+// the caret instead of sitting at the client area's top-left corner.
+//
+// Tao's own `Window::set_ime_position` only pushes a `COMPOSITIONFORM`, which
+// positions the *inline composition* window; the candidate list of MS-IME /
+// Pinyin / Hangul is placed from the `CANDIDATEFORM`. We set both, mirroring
+// what winit's `ImeContext::set_ime_cursor_area` does: the caret rect becomes
+// an exclusion zone (`CFS_EXCLUDE`) so the candidate list never covers the
+// text being edited.
+
+use std::ffi::c_void;
+
+use jni::objects::JClass;
+use jni::sys::{jint, jlong};
+use jni::JNIEnv;
+
+use tao::platform::windows::WindowExtWindows;
+
+use windows::Win32::Foundation::{HWND, POINT, RECT};
+use windows::Win32::UI::Input::Ime::{
+    ImmGetContext, ImmNotifyIME, ImmReleaseContext, ImmSetCandidateWindow,
+    ImmSetCompositionWindow, CANDIDATEFORM, CFS_EXCLUDE, CFS_POINT, COMPOSITIONFORM, CPS_CANCEL,
+    NI_COMPOSITIONSTR,
+};
+use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_IMMENABLED};
+
+use crate::state::WINDOWS;
+
+/// Copies the HWND out of the window map so the IMM calls run without holding
+/// the global lock.
+fn hwnd_for(handle: jlong) -> Option<HWND> {
+    let guard = WINDOWS.lock().ok()?;
+    let map = guard.as_ref()?;
+    let window = map.get(&(handle as u64))?;
+    Some(HWND(window.hwnd() as *mut c_void))
+}
+
+fn ime_enabled() -> bool {
+    unsafe { GetSystemMetrics(SM_IMMENABLED) != 0 }
+}
+
+/// Anchors the IME UI at the given window-local rect in *physical pixels*
+/// (top-left origin). The Compose scene covers the whole client area on this
+/// backend — the custom title bar is drawn inside it and reports no platform
+/// inset — so root coordinates are already client coordinates.
+#[no_mangle]
+pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_nativeSetImeRect(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+    x_px: jint,
+    y_px: jint,
+    w_px: jint,
+    h_px: jint,
+) {
+    if !ime_enabled() {
+        return;
+    }
+    let Some(hwnd) = hwnd_for(handle) else { return };
+    let area = RECT {
+        left: x_px,
+        top: y_px,
+        right: x_px + w_px.max(1),
+        bottom: y_px + h_px.max(1),
+    };
+    // Top-left of the caret, for both forms — same anchor winit and Tao's own
+    // `set_ime_position_physical` use. `CFS_POINT` documents `ptCurrentPos` as
+    // the upper-left corner of the composition window, so the OS-drawn
+    // composition string stays on the caret's line; pushing the candidate list
+    // *below* the caret is the job of the `CFS_EXCLUDE` area, not of a
+    // bottom-anchored point.
+    let spot = POINT {
+        x: area.left,
+        y: area.top,
+    };
+    unsafe {
+        let himc = ImmGetContext(hwnd);
+        if himc.is_invalid() {
+            return;
+        }
+        let candidate = CANDIDATEFORM {
+            dwIndex: 0,
+            dwStyle: CFS_EXCLUDE,
+            ptCurrentPos: spot,
+            rcArea: area,
+        };
+        let _ = ImmSetCandidateWindow(himc, &candidate);
+        let composition = COMPOSITIONFORM {
+            dwStyle: CFS_POINT,
+            ptCurrentPos: spot,
+            rcArea: area,
+        };
+        let _ = ImmSetCompositionWindow(himc, &composition);
+        let _ = ImmReleaseContext(hwnd, himc);
+    }
+}
+
+/// Drops any in-flight composition when the focused field's input session ends.
+/// Without this the candidate window stays up over unfocused content, and the
+/// pending composition would commit into whatever gains focus next — same
+/// blur behaviour as Chromium's `ImeInput::CancelIME`.
+#[no_mangle]
+pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_nativeCancelImeComposition(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+) {
+    if !ime_enabled() {
+        return;
+    }
+    let Some(hwnd) = hwnd_for(handle) else { return };
+    unsafe {
+        let himc = ImmGetContext(hwnd);
+        if himc.is_invalid() {
+            return;
+        }
+        let _ = ImmNotifyIME(himc, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
+        let _ = ImmReleaseContext(hwnd, himc);
+    }
+}

--- a/decorated-window-tao/src/main/native/src/platform/windows/mod.rs
+++ b/decorated-window-tao/src/main/native/src/platform/windows/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod a11y;
 pub(crate) mod handles;
+pub(crate) mod ime;

--- a/examples/rect-stress-demo/api/rect-stress-demo.api
+++ b/examples/rect-stress-demo/api/rect-stress-demo.api
@@ -2,8 +2,8 @@ public final class com/example/rectstress/ComposableSingletons$MainKt {
 	public static final field INSTANCE Lcom/example/rectstress/ComposableSingletons$MainKt;
 	public fun <init> ()V
 	public final fun getLambda$-1782098224$Nucleus_examples_rect_stress_demo ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-535725003$Nucleus_examples_rect_stress_demo ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda$1066003079$Nucleus_examples_rect_stress_demo ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$2115872294$Nucleus_examples_rect_stress_demo ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$514144212$Nucleus_examples_rect_stress_demo ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class com/example/rectstress/MainKt {

--- a/examples/widget-demo/api/widget-demo.api
+++ b/examples/widget-demo/api/widget-demo.api
@@ -1,0 +1,14 @@
+public final class com/example/widget/ComposableSingletons$MainKt {
+	public static final field INSTANCE Lcom/example/widget/ComposableSingletons$MainKt;
+	public fun <init> ()V
+	public final fun getLambda$932567716$Nucleus_examples_widget_demo ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class com/example/widget/MainKt {
+	public static final fun main ([Ljava/lang/String;)V
+}
+
+public final class com/example/widget/NucleusAtomKt {
+	public static final fun NucleusAtom-rAjV9yQ (Landroidx/compose/ui/Modifier;FLandroidx/compose/runtime/Composer;II)V
+}
+


### PR DESCRIPTION
Windows half of #558. Linux is untouched — the issue stays open for the GTK / Wayland text-input side.

## Summary

- `WindowsTaoPlatformContext` now overrides `startInputMethod` the way the macOS host does: it keeps an input session for the focused `BasicTextField` and pushes `focusedRectInRoot()` to IMM32. Compose's default is `awaitCancellation()` with no IME spot, which is why the candidate list — and the OS-drawn composition string — sat at the client area's top-left instead of on the caret.
- New `platform/windows/ime.rs` exposes `nativeSetImeRect`, setting **both** IMM32 forms. Tao's own `set_ime_position` only sets a `COMPOSITIONFORM`, which positions the inline composition window; the candidate list is placed from the `CANDIDATEFORM`. The caret box is passed as a `CFS_EXCLUDE` area so the candidate list never covers the text being edited, and both forms anchor at the caret's top-left (same as winit and as Tao's `set_ime_position_physical`) so the composition string stays on the caret's line.
- `nativeCancelImeComposition` drops any in-flight composition when the input session ends, so a pending candidate window does not linger over unfocused content nor commit into whatever gains focus next.
- The caret rect is clamped to `textClippingRectInRoot()`. It is root-relative and goes negative once the field scrolls out of the viewport, which would fling the candidate window off the window. A clamp rather than `Rect.intersect` + `overlaps`, because a caret rect can legitimately be zero-width and no overlap test accepts a degenerate rect.
- Adds the `Win32_UI_Input_Ime` feature to the `windows` crate.

No coordinate conversion is needed: the scene covers the whole client area — the custom title bar is drawn inside it and reports no platform inset — so scene-root physical pixels are already client pixels. Both new externs are Java→native only, so no GraalVM reachability metadata is required.

Also refreshes two example API baselines that had drifted (Compose lambda name hashes in `rect-stress-demo`, plus a first dump for `widget-demo`). Unrelated to the fix, carried along from an `apiDump`.

## Test plan

- [x] `cargo build --release --target x86_64-pc-windows-msvc` clean, no new warnings
- [x] `build.bat` produces win32-x64 + win32-aarch64 DLLs; both JNI symbols exported
- [x] `compileKotlin`, `ktlintCheck`, `detekt`, `apiCheck` pass
- [x] tao-demo launches without an `UnsatisfiedLinkError`
- [ ] **Manual, with a CJK IME installed** (Microsoft Pinyin or Japanese IME): focus a `BasicTextField` in tao-demo, type `nihao` / `konnichiha` — the candidate window sits under the caret and follows it when the window moves or resizes
- [ ] Manual: the underlined composition string renders on the caret's line, not one line below it
- [ ] Manual: start a composition, click into another field — composition and candidate window disappear, and the pending text is not inserted into the new field
- [ ] Manual: scroll the focused field out of the viewport mid-composition — the candidate window stays clamped to the visible text region

Marked draft: the IMM32 behaviour above still needs a run on a machine with a CJK IME installed.