### PR TITLE
fix(updater): write self-update scripts to a private 0700 dir, not /tmp

### DIFF
--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/PlatformInstaller.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/PlatformInstaller.kt
@@ -2,8 +2,23 @@ package dev.nucleusframework.updater.internal
 
 import dev.nucleusframework.core.runtime.Platform
 import java.io.File
+import java.nio.file.Files
 import java.util.logging.Logger
 import kotlin.system.exitProcess
+
+/**
+ * Creates a fresh, owner-only (POSIX `0700`) working directory for the detached update
+ * scripts and their log.
+ *
+ * A predictable path in the shared temp dir — e.g. `/tmp/nucleus-update.sh` on Linux — lets
+ * any other local user pre-create that path as a file they own or as a symlink, so this
+ * process ends up writing the script body into (and then executing) a file the attacker
+ * controls. Each update run therefore gets its own unguessable private directory, mirroring
+ * the owner-only download staging directory used one layer up in `NucleusUpdater`.
+ *
+ * Exposed for unit tests.
+ */
+internal fun createUpdateWorkDir(): File = Files.createTempDirectory("nucleus-update-").toFile()
 
 /**
  * Walks up from [launcher]'s directory looking for [PlatformInstaller.UPDATE_HELPER_NAME].
@@ -90,9 +105,9 @@ internal object PlatformInstaller {
         // previous inode open. Avoids racing the FUSE unmount that follows process exit.
         val replacedInPlace = replaceAppImageInPlace(newAppImage, destination)
 
-        val tmpDir = System.getProperty("java.io.tmpdir")
-        val script = File(tmpDir, "nucleus-update.sh")
-        val logFile = File(tmpDir, "nucleus-update.log")
+        val workDir = createUpdateWorkDir()
+        val script = File(workDir, "nucleus-update.sh")
+        val logFile = File(workDir, "nucleus-update.log")
         script.writeText(
             buildLinuxAppImageUpdateScript(
                 newFile = newAppImage.absolutePath,
@@ -106,7 +121,7 @@ internal object PlatformInstaller {
         script.setExecutable(true)
 
         // New session, started from $HOME so a FUSE-mount CWD cannot poison the relaunch.
-        val home = File(System.getProperty("user.home") ?: tmpDir)
+        val home = File(System.getProperty("user.home") ?: workDir.absolutePath)
         ProcessBuilder("setsid", "bash", script.absolutePath)
             .directory(home)
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
@@ -186,7 +201,7 @@ internal object PlatformInstaller {
                 ""
             }
 
-        val script = File(System.getProperty("java.io.tmpdir"), "nucleus-update.sh")
+        val script = File(createUpdateWorkDir(), "nucleus-update.sh")
         script.writeText(
             """
             |#!/usr/bin/env bash
@@ -278,16 +293,16 @@ internal object PlatformInstaller {
             resolveCurrentAppBundle()
                 ?: error("Cannot resolve current .app bundle from java.home")
         val installDir = appBundle.parentFile
-        val tmpDir = System.getProperty("java.io.tmpdir")
+        val workDir = createUpdateWorkDir()
 
-        val script = File(tmpDir, "nucleus-update.sh")
+        val script = File(workDir, "nucleus-update.sh")
         script.writeText(
             buildMacZipUpdateScript(
                 zipFile = zipFile.absolutePath,
                 appPath = appBundle.absolutePath,
                 installDir = installDir.absolutePath,
                 appPid = ProcessHandle.current().pid(),
-                logFile = File(tmpDir, "nucleus-update.log").absolutePath,
+                logFile = File(workDir, "nucleus-update.log").absolutePath,
                 restart = restart,
             ),
         )
@@ -319,7 +334,7 @@ internal object PlatformInstaller {
     ) {
         val pid = ProcessHandle.current().pid()
         val launcher = currentExecutablePath()
-        val script = File(System.getProperty("java.io.tmpdir"), "nucleus-update.ps1")
+        val script = File(createUpdateWorkDir(), "nucleus-update.ps1")
         script.writeText(
             buildWindowsUpdateScript(
                 pid = pid,

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/internal/PlatformInstallerHelpersTest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/internal/PlatformInstallerHelpersTest.kt
@@ -3,14 +3,44 @@ package dev.nucleusframework.updater.internal
 import dev.nucleusframework.core.runtime.Platform
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFileAttributeView
+import java.nio.file.attribute.PosixFilePermission
 
 class PlatformInstallerHelpersTest {
+    @Test
+    fun `update work dir is a fresh private directory not a predictable shared temp path`() {
+        val first = createUpdateWorkDir()
+        val second = createUpdateWorkDir()
+        try {
+            assertTrue("work dir must exist", first.isDirectory)
+            // A fixed name in the shared temp dir would collide across runs; each run is unique.
+            assertNotEquals("each update run gets its own directory", first.absolutePath, second.absolutePath)
+            // On POSIX the directory must be owner-only (rwx------), closing the symlink/pre-create hole.
+            val posix = Files.getFileAttributeView(first.toPath(), PosixFileAttributeView::class.java)
+            if (posix != null) {
+                assertEquals(
+                    setOf(
+                        PosixFilePermission.OWNER_READ,
+                        PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.OWNER_EXECUTE,
+                    ),
+                    posix.readAttributes().permissions(),
+                )
+            }
+        } finally {
+            first.delete()
+            second.delete()
+        }
+    }
+
     @get:Rule
     val tmp = TemporaryFolder()
 


### PR DESCRIPTION
## Security fix — F-3 (audit 2026-08-19)

**Severity:** High · **Module:** `updater-runtime`

### Problem
`PlatformInstaller` writes the detached self-update script (and its log) to a **fixed, predictable path** in the shared temp dir:

```kotlin
val script = File(System.getProperty("java.io.tmpdir"), "nucleus-update.sh")
```

On Linux `java.io.tmpdir` is `/tmp`. The sticky bit stops another user from *deleting* the file, but not from **pre-creating** it (as a mode-0666 file they own, or as a symlink). The victim process then writes the script body into a file the attacker fully controls and executes it with `bash`/`powershell` — **local code execution as the app's user**, from any other local account. The same applies to `nucleus-update.log`.

This directly contradicts the hardening already applied one layer up in `NucleusUpdater`, where the download staging directory is deliberately created private with the multi-user rationale spelled out in a comment.

### Fix
Each update run now gets a fresh, owner-only working directory:

```kotlin
internal fun createUpdateWorkDir(): File = Files.createTempDirectory("nucleus-update-").toFile()
```

`Files.createTempDirectory` creates the directory with POSIX `rwx------` (0700) and an unguessable name, defeating the pre-create/symlink hazard. All four script-writing sites (Linux AppImage, Linux deb/rpm, macOS zip, Windows) now write into it. macOS/Windows already used a per-user temp dir; this makes all three platforms uniform, private and unpredictable.

### Test
`PlatformInstallerHelpersTest` gains a guard asserting the work dir is unique per run and — on POSIX — owner-only (`rwx------`), so a revert to a fixed shared path fails the suite.

Verified locally: `:updater-runtime:ktlintCheck :updater-runtime:detekt :updater-runtime:test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)