### PR TITLE
fix(updater): reject non-https GenericProvider origins

### DIFF
--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/provider/GenericProvider.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/provider/GenericProvider.kt
@@ -1,11 +1,16 @@
 package dev.nucleusframework.updater.provider
 
 import dev.nucleusframework.core.runtime.Platform
+import java.net.URI
 
 public class GenericProvider(
     public val baseUrl: String,
 ) : UpdateProvider {
     private val normalizedBaseUrl = baseUrl.trimEnd('/')
+
+    init {
+        requireSecureBaseUrl(baseUrl)
+    }
 
     override fun getUpdateMetadataUrl(
         channel: String,
@@ -29,3 +34,27 @@ public class GenericProvider(
             Platform.Unknown -> ""
         }
 }
+
+/**
+ * Rejects a non-`https` update origin at construction time.
+ *
+ * The whole update is fetched from this base URL — manifest, checksums and the artifact.
+ * Over plain `http` an on-path attacker can rewrite all three together, so the SHA-512 in the
+ * manifest provides no protection (they control the manifest too). `http` is allowed only for
+ * loopback hosts so local integration tests can serve fixtures without TLS.
+ */
+private fun requireSecureBaseUrl(baseUrl: String) {
+    val uri =
+        runCatching { URI(baseUrl) }.getOrElse {
+            throw IllegalArgumentException("GenericProvider baseUrl is not a valid URL: $baseUrl", it)
+        }
+    val scheme = uri.scheme?.lowercase()
+    require(scheme == "https" || (scheme == "http" && isLoopbackHost(uri.host))) {
+        "GenericProvider requires an https:// baseUrl (got: $baseUrl). Plain http would let an on-path " +
+            "attacker tamper with the update manifest, checksums and artifact together. http is permitted " +
+            "only for loopback hosts (local testing)."
+    }
+}
+
+private fun isLoopbackHost(host: String?): Boolean =
+    host == "localhost" || host == "127.0.0.1" || host == "::1" || host?.startsWith("127.") == true

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/GenericProviderTest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/GenericProviderTest.kt
@@ -3,10 +3,32 @@ package dev.nucleusframework.updater
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.updater.provider.GenericProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GenericProviderTest {
+    @Test
+    fun `rejects a plain http base url on a public host`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GenericProvider("http://updates.example.com")
+        }
+    }
+
+    @Test
+    fun `rejects a non http scheme`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GenericProvider("ftp://updates.example.com")
+        }
+    }
+
+    @Test
+    fun `allows plain http only for loopback hosts`() {
+        // Local integration tests (e.g. the delta RangeHttpServer) serve fixtures over loopback http.
+        assertEquals("http://127.0.0.1:8080", GenericProvider("http://127.0.0.1:8080").baseUrl)
+        assertEquals("http://localhost:8080", GenericProvider("http://localhost:8080").baseUrl)
+    }
+
     @Test
     fun `trims a trailing slash from the base url`() {
         val provider = GenericProvider("https://updates.example.com/channel/")


### PR DESCRIPTION
## Security fix — F-5 (audit 2026-08-19)

**Severity:** Medium · **Module:** `updater-runtime`

### Problem
`GenericProvider(baseUrl)` performed **no scheme validation**:

```kotlin
public class GenericProvider(public val baseUrl: String) : UpdateProvider
```

So `GenericProvider("http://updates.example.com")` drives the entire update — metadata manifest, checksums, artifact and the detached `.asc` — over plaintext `http`. On that channel the SHA-512 recorded in `latest*.yml` offers **no protection**, because an on-path attacker who can rewrite the artifact can rewrite the manifest that vouches for it. `GitHubProvider` already hardcodes `https://`; this was the one origin an application could point anywhere.

### Fix
The base URL is validated at construction (`init`): `https` is required, and plain `http` is permitted **only for loopback hosts** (`localhost`, `127.0.0.0/8`, `::1`) so local integration tests — e.g. the delta `RangeHttpServer`, which serves fixtures over `http://127.0.0.1` — keep working without TLS. Any other `http`/`ftp`/… origin throws `IllegalArgumentException` immediately, rather than silently downgrading security at the first network call.

### Test
`GenericProviderTest` gains cases: public `http` rejected, non-http scheme rejected, loopback `http` allowed. Existing tests already use `https` only.

Verified locally: `:updater-runtime:ktlintCheck :updater-runtime:detekt :updater-runtime:test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)