### PR TITLE
fix(updater): escape manifest-derived paths in the Windows update script

### DIFF
--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/WindowsUpdateScript.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/WindowsUpdateScript.kt
@@ -3,6 +3,17 @@ package dev.nucleusframework.updater.internal
 import java.io.File
 
 /**
+ * Escapes a value for safe interpolation inside a **single-quoted** PowerShell string.
+ *
+ * The artifact path is derived from the `url` field of the remote update manifest, so a
+ * hostile or compromised manifest could otherwise embed a `'` to break out of the quoting
+ * and inject PowerShell that runs at install time. In a single-quoted PowerShell string a
+ * literal quote is written as two quotes, so doubling every `'` closes the injection while
+ * leaving ordinary Windows paths unchanged.
+ */
+internal fun psSingleQuote(value: String): String = value.replace("'", "''")
+
+/**
  * PowerShell that waits for the current process, runs the downloaded installer,
  * optionally relaunches, then deletes the artifact and itself.
  *
@@ -25,25 +36,27 @@ internal fun buildWindowsUpdateScript(
     |$installerCommand
     |$relaunchCommand
     |# Clean up
-    |Remove-Item '$artifactPath' -Force -ErrorAction SilentlyContinue
-    |Remove-Item '$scriptPath' -Force -ErrorAction SilentlyContinue
+    |Remove-Item '${psSingleQuote(artifactPath)}' -Force -ErrorAction SilentlyContinue
+    |Remove-Item '${psSingleQuote(scriptPath)}' -Force -ErrorAction SilentlyContinue
     """.trimMargin()
 
 internal fun windowsInstallerCommand(
     file: File,
     extension: String,
-): String =
-    when (extension) {
-        "msi" -> "Start-Process msiexec -ArgumentList '/i', '\"${file.absolutePath}\"', '/passive' -Wait"
-        else -> "Start-Process '${file.absolutePath}' -ArgumentList '/S', '--updated' -Wait"
+): String {
+    val path = psSingleQuote(file.absolutePath)
+    return when (extension) {
+        "msi" -> "Start-Process msiexec -ArgumentList '/i', '\"$path\"', '/passive' -Wait"
+        else -> "Start-Process '$path' -ArgumentList '/S', '--updated' -Wait"
     }
+}
 
 internal fun windowsRelaunchCommand(
     restart: Boolean,
     launcher: String?,
 ): String =
     if (restart && launcher != null) {
-        "\n# Relaunch the application\nStart-Process '$launcher'"
+        "\n# Relaunch the application\nStart-Process '${psSingleQuote(launcher)}'"
     } else {
         ""
     }

--- a/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/internal/WindowsUpdateScriptTest.kt
+++ b/updater-runtime/src/test/kotlin/dev/nucleusframework/updater/internal/WindowsUpdateScriptTest.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.updater.internal
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -53,5 +54,23 @@ class WindowsUpdateScriptTest {
         assertTrue("artifact cleanup: $script", script.contains("Remove-Item '${artifact.absolutePath}'"))
         assertTrue("script cleanup: $script", script.contains("Remove-Item '${scriptFile.absolutePath}'"))
         assertFalse("unexpected msiexec: $script", script.contains("msiexec"))
+    }
+
+    @Test
+    fun `a single quote in the manifest-derived name cannot break out of the powershell string`() {
+        // The artifact name comes from the remote manifest's `url`; a hostile `'` must be neutralised.
+        val artifact = File("C:\\\\Temp\\\\ev'il; Start-Process calc.exe #.exe")
+        val script =
+            buildWindowsUpdateScript(
+                pid = 1L,
+                installerCommand = windowsInstallerCommand(artifact, "exe"),
+                relaunchCommand = "",
+                artifactPath = artifact.absolutePath,
+                scriptPath = "C:\\\\Temp\\\\nucleus-update.ps1",
+            )
+        // The lone quote is doubled (escaped); the raw break-out sequence never appears verbatim.
+        assertTrue("escaped: $script", script.contains("ev''il; Start-Process calc.exe #.exe"))
+        assertFalse("raw quote break-out: $script", script.contains("ev'il;"))
+        assertEquals("ev''il", psSingleQuote("ev'il"))
     }
 }


### PR DESCRIPTION
## Security fix — F-6 (audit 2026-08-19)

**Severity:** Medium · **Module:** `updater-runtime`

### Problem
The `url` field from the remote update manifest is used verbatim as the local artifact file name and then interpolated into **single-quoted** PowerShell strings with no escaping:

```kotlin
"Start-Process '${file.absolutePath}' -ArgumentList '/S', '--updated' -Wait"
"Remove-Item '$artifactPath' -Force -ErrorAction SilentlyContinue"
```

A hostile or compromised manifest can put a `'` in the name to break out of the quoting and inject PowerShell that runs at install time. The macOS and Linux script builders already escape via `quoteForShell()`; the Windows builder had no equivalent.

### Fix
A `psSingleQuote()` helper doubles every `'` — the PowerShell escape for a literal quote inside a single-quoted string — and every manifest-derived value (artifact path, script path, installer path, relaunch launcher) is passed through it. Ordinary Windows paths are unchanged; a `'` can no longer terminate the string and start a new command.

### Test
`WindowsUpdateScriptTest` gains a case feeding a name containing `ev'il; Start-Process calc.exe #` and asserting the quote is doubled in the generated script and the raw break-out sequence never appears.

**Note (out of scope here):** path traversal via a `../`-containing manifest name is a separate concern in the staging-path construction (`NucleusUpdater` / `FileSelector`) and is best fixed there with a filename charset allow-list; this PR closes the injection (RCE) vector only.

Verified locally: `:updater-runtime:ktlintCheck :updater-runtime:detekt :updater-runtime:test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)