### PR TITLE
fix(tao): route the Linux clipboard through GTK instead of AWT

### DIFF
--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -469,6 +469,7 @@ jobs:
             "decorated-window-tao/libnucleus_tao_egl.so"
             "decorated-window-tao/libnucleus_tao_linux_widget.so"
             "decorated-window-tao/libnucleus_tao_linux_popup.so"
+            "decorated-window-tao/libnucleus_tao_linux_clipboard.so"
           )
           MISSING=0
           for e in "${FILES[@]}"; do

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -171,6 +171,8 @@ jobs:
             "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_widget.so"
             "decorated-window-tao/src/main/resources/nucleus/native/linux-x64/libnucleus_tao_linux_popup.so"
             "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_popup.so"
+            "decorated-window-tao/src/main/resources/nucleus/native/linux-x64/libnucleus_tao_linux_clipboard.so"
+            "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_clipboard.so"
             "graalvm-runtime/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_locale.dylib"
             "graalvm-runtime/src/main/resources/nucleus/native/darwin-x64/libnucleus_locale.dylib"
           )

--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -170,6 +170,8 @@ jobs:
             "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_widget.so"
             "decorated-window-tao/src/main/resources/nucleus/native/linux-x64/libnucleus_tao_linux_popup.so"
             "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_popup.so"
+            "decorated-window-tao/src/main/resources/nucleus/native/linux-x64/libnucleus_tao_linux_clipboard.so"
+            "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_clipboard.so"
             "graalvm-runtime/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_locale.dylib"
             "graalvm-runtime/src/main/resources/nucleus/native/darwin-x64/libnucleus_locale.dylib"
           )

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/GtkClipboardTransferable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/GtkClipboardTransferable.kt
@@ -1,0 +1,175 @@
+package dev.nucleusframework.window.tao.clipboard
+
+import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge
+import java.awt.Image
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.net.URI
+import javax.imageio.ImageIO
+
+/** `image/png` as a stream — one of the two flavors AWT itself exposes for a clipboard image. */
+internal val PngStreamFlavor: DataFlavor = DataFlavor("image/png; class=java.io.InputStream", "PNG image")
+
+/** Freedesktop file list as raw text, next to [DataFlavor.javaFileListFlavor]. */
+internal val UriListFlavor: DataFlavor = DataFlavor("text/uri-list; class=java.lang.String", "File list")
+
+/**
+ * A [Transferable] over the GTK selection, exposing the same flavors AWT would
+ * for the same content — text, image, file list — so application code that
+ * reads a clip entry cannot tell which clipboard served it.
+ *
+ * Text is passed in already fetched (it is small and every paste needs it).
+ * The image and the file list are fetched **on demand** through [fetchPng] /
+ * [fetchUriList], because pasting text while a screenshot sits on the
+ * clipboard should not drag megabytes through JNI. A null fetcher means the
+ * selection does not advertise that format at all, so the flavor is not
+ * exposed either.
+ *
+ * The fetchers block; [dev.nucleusframework.window.tao.clipboard.TaoLinuxClipboard]
+ * is what routes them to the GTK thread. That is unavoidable: [getTransferData]
+ * is a blocking AWT API called from arbitrary threads.
+ */
+internal class GtkClipboardTransferable(
+    private val text: String?,
+    private val fetchPng: (() -> ByteArray?)?,
+    private val fetchUriList: (() -> String?)?,
+) : Transferable {
+    private val png: ByteArray? by lazy { fetchPng?.invoke() }
+    private val files: List<File> by lazy { parseUriList(fetchUriList?.invoke()) }
+
+    override fun getTransferDataFlavors(): Array<DataFlavor> =
+        buildList {
+            if (text != null) add(DataFlavor.stringFlavor)
+            if (fetchPng != null) {
+                add(DataFlavor.imageFlavor)
+                add(PngStreamFlavor)
+            }
+            if (fetchUriList != null) {
+                add(DataFlavor.javaFileListFlavor)
+                add(UriListFlavor)
+            }
+        }.toTypedArray()
+
+    override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
+        transferDataFlavors.any { it.isMimeTypeEqual(flavor) && it.representationClass == flavor.representationClass }
+
+    override fun getTransferData(flavor: DataFlavor): Any =
+        when {
+            flavor.equals(DataFlavor.stringFlavor) -> text ?: unsupported(flavor)
+            flavor.equals(DataFlavor.imageFlavor) -> decodeImage() ?: unsupported(flavor)
+            flavor.isMimeTypeEqual(PngStreamFlavor) -> ByteArrayInputStream(png ?: unsupported(flavor))
+            flavor.equals(DataFlavor.javaFileListFlavor) -> files.ifEmpty { unsupported(flavor) }
+            flavor.isMimeTypeEqual(UriListFlavor) -> files.joinToString("\r\n") { it.toURI().toString() }
+            else -> unsupported(flavor)
+        }
+
+    private fun decodeImage(): Image? = png?.let { ImageIO.read(ByteArrayInputStream(it)) }
+
+    private fun unsupported(flavor: DataFlavor): Nothing = throw UnsupportedFlavorException(flavor)
+}
+
+/** Newline- or CRLF-separated `file://` URIs to local files, skipping comments and anything remote. */
+internal fun parseUriList(uriList: String?): List<File> =
+    uriList
+        ?.lineSequence()
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() && !it.startsWith("#") }
+        ?.mapNotNull { line -> runCatching { URI(line) }.getOrNull() }
+        ?.filter { it.scheme == "file" }
+        ?.mapNotNull { uri -> runCatching { File(uri) }.getOrNull() }
+        ?.toList()
+        .orEmpty()
+
+/**
+ * `text/plain` content of the transferable, or null when it carries none.
+ * Swallows the `IOException` / `UnsupportedFlavorException` pair AWT throws
+ * when the owning process died between the flavor check and the read — which
+ * applies to every accessor in this file.
+ */
+internal fun Transferable.plainTextOrNull(): String? = read(DataFlavor.stringFlavor) as? String
+
+/** PNG bytes for whatever image the transferable carries, re-encoding if needed. */
+internal fun Transferable.pngBytesOrNull(): ByteArray? {
+    (read(PngStreamFlavor) as? InputStream)?.use { return it.readBytes() }
+    val image = read(DataFlavor.imageFlavor) as? Image ?: return null
+    return image.toPngBytes()
+}
+
+/** Newline-separated `file://` URIs for the transferable's file list, or null. */
+internal fun Transferable.fileUriListOrNull(): String? {
+    val files = read(DataFlavor.javaFileListFlavor) as? List<*> ?: return null
+    return files
+        .filterIsInstance<File>()
+        .joinToString("\n") { it.toURI().toString() }
+        .ifEmpty { null }
+}
+
+private fun Transferable.read(flavor: DataFlavor): Any? =
+    runCatching {
+        if (isDataFlavorSupported(flavor)) getTransferData(flavor) else null
+    }.getOrNull()
+
+private fun Image.toPngBytes(): ByteArray? {
+    val buffered = this as? BufferedImage ?: rasterize() ?: return null
+    return runCatching {
+        ByteArrayOutputStream()
+            .also { out ->
+                if (!ImageIO.write(buffered, "png", out)) throw IOException("no PNG writer")
+            }.toByteArray()
+    }.getOrNull()
+}
+
+/** Draws a non-[BufferedImage] (e.g. a `ToolkitImage` handed over by AWT) into one. */
+private fun Image.rasterize(): BufferedImage? {
+    val width = getWidth(null)
+    val height = getHeight(null)
+    if (width <= 0 || height <= 0) return null
+    val target = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    val graphics = target.createGraphics()
+    try {
+        graphics.drawImage(this, 0, 0, null)
+    } finally {
+        graphics.dispose()
+    }
+    return target
+}
+
+/**
+ * What of a clip entry GTK can take ownership of. Text wins when an entry
+ * carries several: a GTK selection holds one payload, and text is the format
+ * every other application can read.
+ */
+internal sealed interface GtkPayload {
+    /** Runs on the GTK main thread. */
+    fun publish(): Boolean
+
+    class Text(
+        val text: String,
+    ) : GtkPayload {
+        override fun publish(): Boolean = NativeTaoLinuxClipboardBridge.nativeSetTextUtf8(text.toByteArray())
+    }
+
+    class Image(
+        private val png: ByteArray,
+    ) : GtkPayload {
+        override fun publish(): Boolean = NativeTaoLinuxClipboardBridge.nativeSetImagePng(png)
+    }
+
+    class Files(
+        private val uriList: String,
+    ) : GtkPayload {
+        override fun publish(): Boolean = NativeTaoLinuxClipboardBridge.nativeSetUriListUtf8(uriList.toByteArray())
+    }
+}
+
+internal fun Transferable.toGtkPayload(): GtkPayload? =
+    plainTextOrNull()?.let(GtkPayload::Text)
+        ?: pngBytesOrNull()?.let(GtkPayload::Image)
+        ?: fileUriListOrNull()?.let(GtkPayload::Files)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/ProvideTaoClipboard.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/ProvideTaoClipboard.kt
@@ -1,0 +1,53 @@
+@file:Suppress("DEPRECATION")
+
+package dev.nucleusframework.window.tao.clipboard
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalClipboardManager
+import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge
+
+/**
+ * Routes Compose's clipboard through GTK for the duration of [content], so
+ * copy/paste follows the GDK backend the Tao window actually runs on instead
+ * of AWT's X11-only clipboard (issue #582).
+ *
+ * A no-op — composition-local-wise — when the native helper is unavailable
+ * (non-Linux, missing library, headless process, GTK never initialised): the
+ * locals are left on their AWT-backed defaults, which is exactly the fallback
+ * we want.
+ *
+ * The inherited values are read *outside* the provider and become the
+ * implementations' fallback, so nothing has to reconstruct Compose's AWT
+ * clipboard (its classes are internal) and a parent that provided its own
+ * clipboard still wins for everything GTK cannot serve.
+ *
+ * `LocalClipboardManager` is deprecated upstream but still provided: legacy
+ * call sites would otherwise keep reading the X11 selection while everything
+ * else reads the Wayland one.
+ */
+@Composable
+internal fun ProvideTaoClipboard(content: @Composable () -> Unit) {
+    val awtClipboard = LocalClipboard.current
+    val awtClipboardManager = LocalClipboardManager.current
+    val clipboard =
+        remember(awtClipboard) {
+            if (NativeTaoLinuxClipboardBridge.isAvailable) {
+                TaoLinuxClipboard(fallback = awtClipboard)
+            } else {
+                null
+            }
+        }
+    if (clipboard == null) {
+        content()
+        return
+    }
+    val manager = remember(awtClipboardManager) { TaoLinuxClipboardManager(fallback = awtClipboardManager) }
+    CompositionLocalProvider(
+        LocalClipboard provides clipboard,
+        LocalClipboardManager provides manager,
+        content = content,
+    )
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboard.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboard.kt
@@ -46,6 +46,11 @@ import kotlin.coroutines.resume
  * the selection still holds that same text, preserving span styles for
  * copy/paste inside the app.
  *
+ * Everything that is *not* text — images, file lists — keeps going through
+ * [fallback], so this narrows nothing compared to the AWT clipboard it
+ * replaces. GTK can carry those too (`gtk_clipboard_set_image`, `text/uri-list`)
+ * and should, so that they stop depending on XWayland as well.
+ *
  * Threading: GTK is only touched from `Dispatchers.Main`, which on this
  * backend *is* the GTK main thread (Tao's native event loop).
  */
@@ -62,7 +67,8 @@ internal class TaoLinuxClipboard(
 
     override suspend fun getClipEntry(): ClipEntry? {
         if (!NativeTaoLinuxClipboardBridge.isAvailable) return fallback.getClipEntry()
-        val text = withContext(Dispatchers.Main) { requestText() } ?: return null
+        val text = withContext(Dispatchers.Main) { requestText() }
+        if (text == null) return nonTextEntryFromAwt()
         lastWritten?.let { (written, entry) -> if (written == text) return entry }
         return ClipEntry(StringSelection(text))
     }
@@ -81,7 +87,10 @@ internal class TaoLinuxClipboard(
         // another process), hence IO rather than the GTK thread.
         val text = withContext(Dispatchers.IO) { (clipEntry.nativeClipEntry as? Transferable)?.plainTextOrNull() }
         if (text == null) {
-            logger.log(Level.FINE, "Clip entry carries no text/plain flavor; clipboard left unchanged")
+            // Images, file lists, anything else: GTK only carries text here, so
+            // publishing them stays AWT's job until those flavors are wired up.
+            logger.log(Level.FINE, "Clip entry carries no text/plain flavor; publishing it through AWT")
+            fallback.setClipEntry(clipEntry)
             return
         }
         withContext(Dispatchers.Main) {
@@ -92,6 +101,25 @@ internal class TaoLinuxClipboard(
                 logger.log(Level.FINE, "GTK refused the selection; clipboard left unchanged")
             }
         }
+    }
+
+    /**
+     * What AWT has when GTK reports no text — images and file lists, which this
+     * clipboard does not carry yet, would otherwise disappear from
+     * `LocalClipboard` on Linux.
+     *
+     * An AWT entry that *does* offer text is discarded instead: GTK just said
+     * there is none, so the X11 selection is the stale one — that disagreement
+     * is the whole of #582, and returning its text would reintroduce the bug.
+     */
+    private suspend fun nonTextEntryFromAwt(): ClipEntry? {
+        val entry = runCatching { fallback.getClipEntry() }.getOrNull() ?: return null
+        val transferable = entry.nativeClipEntry as? Transferable ?: return null
+        val offersText =
+            withContext(Dispatchers.IO) {
+                runCatching { transferable.isDataFlavorSupported(DataFlavor.stringFlavor) }.getOrDefault(false)
+            }
+        return if (offersText) null else entry
     }
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboard.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboard.kt
@@ -10,13 +10,13 @@ package dev.nucleusframework.window.tao.clipboard
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
+import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import java.awt.datatransfer.DataFlavor
-import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -35,21 +35,19 @@ import kotlin.coroutines.resume
  * call is headless. Going through GTK puts the clipboard on the same backend
  * as the window.
  *
- * Everything is delegated to [fallback] when the native helper is unavailable
- * (missing library, headless process, GTK never initialised), so this is safe
- * to install unconditionally on Linux.
+ * Text, images and file lists are all carried natively, so this is not a
+ * narrower clipboard than the AWT one it replaces — it is the same set of
+ * flavors, freed from XWayland. What the selection advertises decides which
+ * flavors a clip entry exposes; the image and the file list are only fetched
+ * if something reads them. A selection carrying *only* formats GTK is not
+ * asked about here (RTF, private targets) is left to [fallback], where X11 may
+ * still serve it.
  *
- * Only `text/plain` crosses the process boundary. Compose's own
- * `AnnotatedString` flavor is JVM-local (`DataFlavor(AnnotatedString::class)`)
- * and cannot be published to any real selection — AWT cannot do it either —
- * so [lastWritten] keeps the last entry we published and hands it back when
- * the selection still holds that same text, preserving span styles for
- * copy/paste inside the app.
- *
- * Everything that is *not* text — images, file lists — keeps going through
- * [fallback], so this narrows nothing compared to the AWT clipboard it
- * replaces. GTK can carry those too (`gtk_clipboard_set_image`, `text/uri-list`)
- * and should, so that they stop depending on XWayland as well.
+ * Compose's own `AnnotatedString` flavor is JVM-local
+ * (`DataFlavor(AnnotatedString::class)`) and cannot be published to any real
+ * selection — AWT cannot do it either — so [lastWritten] keeps the last entry
+ * we published and hands it back while the selection still holds that text,
+ * preserving span styles for copy/paste inside the app.
  *
  * Threading: GTK is only touched from `Dispatchers.Main`, which on this
  * backend *is* the GTK main thread (Tao's native event loop).
@@ -67,10 +65,35 @@ internal class TaoLinuxClipboard(
 
     override suspend fun getClipEntry(): ClipEntry? {
         if (!NativeTaoLinuxClipboardBridge.isAvailable) return fallback.getClipEntry()
-        val text = withContext(Dispatchers.Main) { requestText() }
-        if (text == null) return nonTextEntryFromAwt()
-        lastWritten?.let { (written, entry) -> if (written == text) return entry }
-        return ClipEntry(StringSelection(text))
+        val targets = withContext(Dispatchers.Main) { requestTargets() }
+        if (targets.isEmpty()) return null
+
+        val hasText = targets.any(::isTextTarget)
+        val hasImage = targets.any { it.startsWith(IMAGE_PREFIX) }
+        val hasFiles = URI_LIST_TARGET in targets
+        if (!hasText && !hasImage && !hasFiles) {
+            // RTF, vendor targets: nothing here knows how to read them, and the
+            // X11 bridge might, so let AWT have its chance rather than
+            // reporting an empty clipboard.
+            logger.log(Level.FINE, "Selection offers no format GTK is asked about here: $targets")
+            return fallback.getClipEntry()
+        }
+
+        val text = if (hasText) withContext(Dispatchers.Main) { requestText() } else null
+        text?.let { published -> lastWritten?.let { (written, entry) -> if (written == published) return entry } }
+        // Listing the targets and fetching the text are two round-trips, so the
+        // selection can change hands in between. Report an empty clipboard
+        // rather than asking AWT, which would answer about a *different*
+        // selection — the very confusion #582 is about.
+        if (text == null && !hasImage && !hasFiles) return null
+
+        return ClipEntry(
+            GtkClipboardTransferable(
+                text = text,
+                fetchPng = if (hasImage) ::blockingImagePng else null,
+                fetchUriList = if (hasFiles) ::blockingUriList else null,
+            ),
+        )
     }
 
     override suspend fun setClipEntry(clipEntry: ClipEntry?) {
@@ -83,43 +106,18 @@ internal class TaoLinuxClipboard(
             withContext(Dispatchers.Main) { NativeTaoLinuxClipboardBridge.nativeClear() }
             return
         }
+        val transferable = clipEntry.nativeClipEntry as? Transferable
         // Reading a foreign transferable can block (it may pull the data from
         // another process), hence IO rather than the GTK thread.
-        val text = withContext(Dispatchers.IO) { (clipEntry.nativeClipEntry as? Transferable)?.plainTextOrNull() }
-        if (text == null) {
-            // Images, file lists, anything else: GTK only carries text here, so
-            // publishing them stays AWT's job until those flavors are wired up.
-            logger.log(Level.FINE, "Clip entry carries no text/plain flavor; publishing it through AWT")
+        val payload = withContext(Dispatchers.IO) { transferable?.toGtkPayload() }
+        if (payload == null) {
+            logger.log(Level.FINE, "Clip entry carries no format GTK can publish; handing it to AWT")
             fallback.setClipEntry(clipEntry)
             return
         }
-        withContext(Dispatchers.Main) {
-            if (NativeTaoLinuxClipboardBridge.nativeSetTextUtf8(text.toByteArray())) {
-                lastWritten = text to clipEntry
-            } else {
-                lastWritten = null
-                logger.log(Level.FINE, "GTK refused the selection; clipboard left unchanged")
-            }
-        }
-    }
-
-    /**
-     * What AWT has when GTK reports no text — images and file lists, which this
-     * clipboard does not carry yet, would otherwise disappear from
-     * `LocalClipboard` on Linux.
-     *
-     * An AWT entry that *does* offer text is discarded instead: GTK just said
-     * there is none, so the X11 selection is the stale one — that disagreement
-     * is the whole of #582, and returning its text would reintroduce the bug.
-     */
-    private suspend fun nonTextEntryFromAwt(): ClipEntry? {
-        val entry = runCatching { fallback.getClipEntry() }.getOrNull() ?: return null
-        val transferable = entry.nativeClipEntry as? Transferable ?: return null
-        val offersText =
-            withContext(Dispatchers.IO) {
-                runCatching { transferable.isDataFlavorSupported(DataFlavor.stringFlavor) }.getOrDefault(false)
-            }
-        return if (offersText) null else entry
+        val published = withContext(Dispatchers.Main) { payload.publish() }
+        lastWritten = if (published && payload is GtkPayload.Text) payload.text to clipEntry else null
+        if (!published) logger.log(Level.FINE, "GTK refused the selection; clipboard left unchanged")
     }
 
     /**
@@ -133,50 +131,90 @@ internal class TaoLinuxClipboard(
                 .getOrElse { NoNativeClipboard }
 
     /**
-     * Suspends on GTK's asynchronous text request. The callback may fire
+     * What the selection advertises, as MIME / atom names, minus the
+     * housekeeping atoms every selection carries — they say nothing about the
+     * content and a selection reduced to them is an empty one.
+     */
+    private suspend fun requestTargets(): Set<String> =
+        requestBytes(NativeTaoLinuxClipboardBridge::nativeRequestTargetsUtf8)
+            ?.toString(Charsets.UTF_8)
+            ?.split('\n')
+            ?.filter { it.isNotEmpty() && it !in HOUSEKEEPING_TARGETS }
+            ?.toSet()
+            .orEmpty()
+
+    private suspend fun requestText(): String? =
+        requestBytes(NativeTaoLinuxClipboardBridge::nativeRequestTextUtf8)?.toString(Charsets.UTF_8)
+
+    /**
+     * Suspends on one of GTK's asynchronous requests. The callback may fire
      * *synchronously* when this process owns the selection, which
      * [suspendCancellableCoroutine] handles; a request GTK never accepted
      * resumes with null instead of hanging the caller forever.
      */
-    private suspend fun requestText(): String? =
+    private suspend fun requestBytes(request: (NativeTaoLinuxClipboardBridge.BytesCallback) -> Boolean): ByteArray? =
         suspendCancellableCoroutine { continuation ->
-            val requested = NativeTaoLinuxClipboardBridge.nativeRequestTextUtf8(ResumeOnText(continuation))
-            if (!requested) continuation.resume(null)
+            if (!request(ResumeOnBytes(continuation))) continuation.resume(null)
+        }
+
+    /**
+     * Blocking counterparts for [GtkClipboardTransferable], which is read from
+     * whatever thread AWT's `getTransferData` is called on. On the GTK thread
+     * the nested-main-loop `wait_*` calls are the only legal option; elsewhere
+     * the asynchronous request is driven from Main while the caller blocks.
+     */
+    private fun blockingImagePng(): ByteArray? =
+        onGtkThread(
+            sync = NativeTaoLinuxClipboardBridge::nativeWaitForImagePng,
+            async = { requestBytes(NativeTaoLinuxClipboardBridge::nativeRequestImagePng) },
+        )
+
+    private fun blockingUriList(): String? =
+        onGtkThread(
+            sync = { NativeTaoLinuxClipboardBridge.nativeWaitForUriListUtf8() },
+            async = { requestBytes(NativeTaoLinuxClipboardBridge::nativeRequestUriListUtf8) },
+        )?.toString(Charsets.UTF_8)
+
+    private fun <T> onGtkThread(
+        sync: () -> T,
+        async: suspend () -> T,
+    ): T =
+        if (Thread.currentThread() === TaoMainDispatcher.taoMainThread) {
+            sync()
+        } else {
+            runBlocking(Dispatchers.Main) { async() }
         }
 
     /**
      * Named class rather than a lambda so there is a single, GraalVM-declarable
-     * implementation of [NativeTaoLinuxClipboardBridge.TextCallback] — the
-     * native side looks `onText` up on the concrete class.
+     * implementation of [NativeTaoLinuxClipboardBridge.BytesCallback] — the
+     * native side looks `onBytes` up on the concrete class.
      */
-    private class ResumeOnText(
-        private val continuation: CancellableContinuation<String?>,
-    ) : NativeTaoLinuxClipboardBridge.TextCallback {
-        override fun onText(utf8: ByteArray?) {
+    private class ResumeOnBytes(
+        private val continuation: CancellableContinuation<ByteArray?>,
+    ) : NativeTaoLinuxClipboardBridge.BytesCallback {
+        override fun onBytes(bytes: ByteArray?) {
             // Resuming an already-cancelled continuation is a no-op, so a
             // caller that gave up while GTK was fetching is not an error.
-            continuation.resume(utf8?.toString(Charsets.UTF_8))
+            continuation.resume(bytes)
         }
     }
 
     private companion object {
         val logger: Logger = Logger.getLogger(TaoLinuxClipboard::class.java.name)
 
+        const val IMAGE_PREFIX = "image/"
+        const val URI_LIST_TARGET = "text/uri-list"
+
+        /** The X11 text atoms GTK registers alongside the `text/plain` MIME types. */
+        val TEXT_ATOMS = setOf("UTF8_STRING", "STRING", "TEXT", "COMPOUND_TEXT")
+
+        /** Selection protocol atoms, present whatever the content is. */
+        val HOUSEKEEPING_TARGETS = setOf("TARGETS", "TIMESTAMP", "MULTIPLE", "SAVE_TARGETS", "DELETE")
+
+        fun isTextTarget(target: String): Boolean = target in TEXT_ATOMS || target.startsWith("text/plain")
+
         /** Stand-in for `Clipboard.nativeClipboard` when AWT has none to give. */
         object NoNativeClipboard
     }
 }
-
-/**
- * `text/plain` content of the transferable, or null when it carries none.
- * Swallows the `IOException` / `UnsupportedFlavorException` pair AWT throws
- * when the owning process died between the flavor check and the read.
- */
-internal fun Transferable.plainTextOrNull(): String? =
-    runCatching {
-        if (isDataFlavorSupported(DataFlavor.stringFlavor)) {
-            getTransferData(DataFlavor.stringFlavor) as? String
-        } else {
-            null
-        }
-    }.getOrNull()

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboard.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboard.kt
@@ -1,0 +1,154 @@
+// `ClipEntry` / `nativeClipEntry` (the only way to build or read a desktop clip
+// entry) are experimental, and `Clipboard.nativeClipboard` is deprecated in
+// favour of the platform extension — both are unavoidable when implementing the
+// interface itself.
+@file:OptIn(ExperimentalComposeUiApi::class)
+@file:Suppress("DEPRECATION")
+
+package dev.nucleusframework.window.tao.clipboard
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+import java.util.logging.Level
+import java.util.logging.Logger
+import kotlin.coroutines.resume
+
+/**
+ * Compose [Clipboard] backed by GTK instead of AWT, for the Tao backend on
+ * Linux (issue #582).
+ *
+ * Compose Desktop's only implementation reads
+ * `java.awt.Toolkit.getSystemClipboard()`, which is X11-only on Linux. A Tao
+ * window is a GTK window on whichever GDK backend the session provides, so on
+ * a Wayland session the two disagree: KWin publishes the Wayland selection to
+ * XWayland only while an X11 window is *active*, so `Ctrl+V` in a
+ * Wayland-native window pastes nothing, and with no XWayland at all the AWT
+ * call is headless. Going through GTK puts the clipboard on the same backend
+ * as the window.
+ *
+ * Everything is delegated to [fallback] when the native helper is unavailable
+ * (missing library, headless process, GTK never initialised), so this is safe
+ * to install unconditionally on Linux.
+ *
+ * Only `text/plain` crosses the process boundary. Compose's own
+ * `AnnotatedString` flavor is JVM-local (`DataFlavor(AnnotatedString::class)`)
+ * and cannot be published to any real selection — AWT cannot do it either —
+ * so [lastWritten] keeps the last entry we published and hands it back when
+ * the selection still holds that same text, preserving span styles for
+ * copy/paste inside the app.
+ *
+ * Threading: GTK is only touched from `Dispatchers.Main`, which on this
+ * backend *is* the GTK main thread (Tao's native event loop).
+ */
+internal class TaoLinuxClipboard(
+    private val fallback: Clipboard,
+) : Clipboard {
+    /**
+     * Text we published, with the entry it came from. See the class doc.
+     * Volatile because a `setClipEntry` may start on any thread while the GTK
+     * work itself hops to `Dispatchers.Main`.
+     */
+    @Volatile
+    private var lastWritten: Pair<String, ClipEntry>? = null
+
+    override suspend fun getClipEntry(): ClipEntry? {
+        if (!NativeTaoLinuxClipboardBridge.isAvailable) return fallback.getClipEntry()
+        val text = withContext(Dispatchers.Main) { requestText() } ?: return null
+        lastWritten?.let { (written, entry) -> if (written == text) return entry }
+        return ClipEntry(StringSelection(text))
+    }
+
+    override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+        if (!NativeTaoLinuxClipboardBridge.isAvailable) {
+            fallback.setClipEntry(clipEntry)
+            return
+        }
+        if (clipEntry == null) {
+            lastWritten = null
+            withContext(Dispatchers.Main) { NativeTaoLinuxClipboardBridge.nativeClear() }
+            return
+        }
+        // Reading a foreign transferable can block (it may pull the data from
+        // another process), hence IO rather than the GTK thread.
+        val text = withContext(Dispatchers.IO) { (clipEntry.nativeClipEntry as? Transferable)?.plainTextOrNull() }
+        if (text == null) {
+            logger.log(Level.FINE, "Clip entry carries no text/plain flavor; clipboard left unchanged")
+            return
+        }
+        withContext(Dispatchers.Main) {
+            if (NativeTaoLinuxClipboardBridge.nativeSetTextUtf8(text.toByteArray())) {
+                lastWritten = text to clipEntry
+            } else {
+                lastWritten = null
+                logger.log(Level.FINE, "GTK refused the selection; clipboard left unchanged")
+            }
+        }
+    }
+
+    /**
+     * The AWT clipboard when there is one — `getAsAwtClipboard()` type-checks
+     * the value, so callers that reach for the platform object keep working
+     * (and keep AWT's X11 semantics) instead of seeing a foreign type.
+     */
+    override val nativeClipboard: Any
+        get() =
+            runCatching { fallback.nativeClipboard }
+                .getOrElse { NoNativeClipboard }
+
+    /**
+     * Suspends on GTK's asynchronous text request. The callback may fire
+     * *synchronously* when this process owns the selection, which
+     * [suspendCancellableCoroutine] handles; a request GTK never accepted
+     * resumes with null instead of hanging the caller forever.
+     */
+    private suspend fun requestText(): String? =
+        suspendCancellableCoroutine { continuation ->
+            val requested = NativeTaoLinuxClipboardBridge.nativeRequestTextUtf8(ResumeOnText(continuation))
+            if (!requested) continuation.resume(null)
+        }
+
+    /**
+     * Named class rather than a lambda so there is a single, GraalVM-declarable
+     * implementation of [NativeTaoLinuxClipboardBridge.TextCallback] — the
+     * native side looks `onText` up on the concrete class.
+     */
+    private class ResumeOnText(
+        private val continuation: CancellableContinuation<String?>,
+    ) : NativeTaoLinuxClipboardBridge.TextCallback {
+        override fun onText(utf8: ByteArray?) {
+            // Resuming an already-cancelled continuation is a no-op, so a
+            // caller that gave up while GTK was fetching is not an error.
+            continuation.resume(utf8?.toString(Charsets.UTF_8))
+        }
+    }
+
+    private companion object {
+        val logger: Logger = Logger.getLogger(TaoLinuxClipboard::class.java.name)
+
+        /** Stand-in for `Clipboard.nativeClipboard` when AWT has none to give. */
+        object NoNativeClipboard
+    }
+}
+
+/**
+ * `text/plain` content of the transferable, or null when it carries none.
+ * Swallows the `IOException` / `UnsupportedFlavorException` pair AWT throws
+ * when the owning process died between the flavor check and the read.
+ */
+internal fun Transferable.plainTextOrNull(): String? =
+    runCatching {
+        if (isDataFlavorSupported(DataFlavor.stringFlavor)) {
+            getTransferData(DataFlavor.stringFlavor) as? String
+        } else {
+            null
+        }
+    }.getOrNull()

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboardManager.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboardManager.kt
@@ -1,0 +1,74 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+@file:Suppress("DEPRECATION")
+
+package dev.nucleusframework.window.tao.clipboard
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+
+/**
+ * GTK-backed [ClipboardManager] for the Tao backend on Linux — the blocking
+ * counterpart of [TaoLinuxClipboard], for the `LocalClipboardManager` API
+ * Compose deprecated in favour of `LocalClipboard`. Provided so third-party
+ * composables still on the old local get the same clipboard as the rest of the
+ * app instead of silently reading AWT's X11 selection.
+ *
+ * GTK has no non-blocking way to serve a synchronous read: both native calls
+ * used here spin a nested GTK main loop until the selection owner answers.
+ * That is only legal on the GTK main thread, so off-thread callers are handed
+ * to [fallback] rather than corrupting the loop — as is every call when the
+ * native helper is unavailable.
+ */
+internal class TaoLinuxClipboardManager(
+    private val fallback: ClipboardManager,
+) : ClipboardManager {
+    private val usesNative: Boolean
+        get() =
+            NativeTaoLinuxClipboardBridge.isAvailable &&
+                Thread.currentThread() === TaoMainDispatcher.taoMainThread
+
+    override fun getText(): AnnotatedString? {
+        if (!usesNative) return fallback.getText()
+        val text = NativeTaoLinuxClipboardBridge.nativeWaitForTextUtf8() ?: return null
+        return AnnotatedString(text.toString(Charsets.UTF_8))
+    }
+
+    override fun setText(annotatedString: AnnotatedString) {
+        if (!usesNative) {
+            fallback.setText(annotatedString)
+            return
+        }
+        NativeTaoLinuxClipboardBridge.nativeSetTextUtf8(annotatedString.text.toByteArray())
+    }
+
+    override fun hasText(): Boolean =
+        if (usesNative) NativeTaoLinuxClipboardBridge.nativeHasText() else fallback.hasText()
+
+    override fun getClip(): ClipEntry? {
+        if (!usesNative) return fallback.getClip()
+        val text = NativeTaoLinuxClipboardBridge.nativeWaitForTextUtf8() ?: return null
+        return ClipEntry(StringSelection(text.toString(Charsets.UTF_8)))
+    }
+
+    override fun setClip(clipEntry: ClipEntry?) {
+        if (!usesNative) {
+            fallback.setClip(clipEntry)
+            return
+        }
+        if (clipEntry == null) {
+            NativeTaoLinuxClipboardBridge.nativeClear()
+            return
+        }
+        val text = (clipEntry.nativeClipEntry as? Transferable)?.plainTextOrNull() ?: return
+        NativeTaoLinuxClipboardBridge.nativeSetTextUtf8(text.toByteArray())
+    }
+
+    override val nativeClipboard: Any
+        get() = fallback.nativeClipboard
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboardManager.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/clipboard/TaoLinuxClipboardManager.kt
@@ -19,11 +19,15 @@ import java.awt.datatransfer.Transferable
  * composables still on the old local get the same clipboard as the rest of the
  * app instead of silently reading AWT's X11 selection.
  *
- * GTK has no non-blocking way to serve a synchronous read: both native calls
- * used here spin a nested GTK main loop until the selection owner answers.
+ * GTK has no non-blocking way to serve a synchronous read: every native call
+ * used here spins a nested GTK main loop until the selection owner answers.
  * That is only legal on the GTK main thread, so off-thread callers are handed
  * to [fallback] rather than corrupting the loop — as is every call when the
  * native helper is unavailable.
+ *
+ * [getClip] probes text, then image, then files, because this API has no way
+ * to ask what the selection offers before reading it. Each probe is a round
+ * trip, so the cost is only paid when the earlier formats are absent.
  */
 internal class TaoLinuxClipboardManager(
     private val fallback: ClipboardManager,
@@ -52,8 +56,17 @@ internal class TaoLinuxClipboardManager(
 
     override fun getClip(): ClipEntry? {
         if (!usesNative) return fallback.getClip()
-        val text = NativeTaoLinuxClipboardBridge.nativeWaitForTextUtf8() ?: return null
-        return ClipEntry(StringSelection(text.toString(Charsets.UTF_8)))
+        NativeTaoLinuxClipboardBridge.nativeWaitForTextUtf8()?.let {
+            return ClipEntry(StringSelection(it.toString(Charsets.UTF_8)))
+        }
+        NativeTaoLinuxClipboardBridge.nativeWaitForImagePng()?.let { png ->
+            return ClipEntry(GtkClipboardTransferable(text = null, fetchPng = { png }, fetchUriList = null))
+        }
+        NativeTaoLinuxClipboardBridge.nativeWaitForUriListUtf8()?.let { uris ->
+            val uriList = uris.toString(Charsets.UTF_8)
+            return ClipEntry(GtkClipboardTransferable(text = null, fetchPng = null, fetchUriList = { uriList }))
+        }
+        return null
     }
 
     override fun setClip(clipEntry: ClipEntry?) {
@@ -65,8 +78,8 @@ internal class TaoLinuxClipboardManager(
             NativeTaoLinuxClipboardBridge.nativeClear()
             return
         }
-        val text = (clipEntry.nativeClipEntry as? Transferable)?.plainTextOrNull() ?: return
-        NativeTaoLinuxClipboardBridge.nativeSetTextUtf8(text.toByteArray())
+        val payload = (clipEntry.nativeClipEntry as? Transferable)?.toGtkPayload()
+        if (payload == null) fallback.setClip(clipEntry) else payload.publish()
     }
 
     override val nativeClipboard: Any

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxClipboardBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxClipboardBridge.kt
@@ -11,12 +11,15 @@ private const val LIBRARY_NAME = "nucleus_tao_linux_clipboard"
  * unlike `java.awt.Toolkit.getSystemClipboard()`, which is always X11 on
  * Linux. See issue #582.
  *
- * Text crosses the boundary as UTF-8 **byte arrays**: `GetStringUTFChars`
- * produces modified UTF-8, which mangles every non-BMP character (emoji).
+ * Text, PNG images and `file://` URI lists all cross the boundary as **byte
+ * arrays**: `GetStringUTFChars` produces modified UTF-8, which mangles every
+ * non-BMP character (emoji), and images are binary to begin with. URI lists
+ * and target lists are newline-separated UTF-8.
  *
  * Threading: every entry point must run on the GTK main thread (= Tao
  * event-loop thread = Compose's `Dispatchers.Main`).
  */
+@Suppress("TooManyFunctions")
 internal object NativeTaoLinuxClipboardBridge {
     val isLoaded: Boolean =
         NativeLibraryLoader.load(
@@ -33,43 +36,82 @@ internal object NativeTaoLinuxClipboardBridge {
         get() = isLoaded && nativeIsAvailable()
 
     /**
-     * Receives the result of [nativeRequestTextUtf8]. Null = no text on the
-     * clipboard. Implement with a named class rather than a lambda: the native
-     * side resolves `onText` on the object's concrete class, which has to be
-     * declared in `reachability-metadata.json` for native-image.
+     * Receives the payload of an asynchronous read. Null = the clipboard has
+     * nothing in that format. Implement with a named class rather than a
+     * lambda: the native side resolves `onBytes` on the object's concrete
+     * class, which has to be declared in `reachability-metadata.json` for
+     * native-image.
      */
-    interface TextCallback {
-        /** Called once, on the GTK main thread, with the UTF-8 encoded selection. */
-        fun onText(utf8: ByteArray?)
+    interface BytesCallback {
+        /** Called once, on the GTK main thread. */
+        fun onBytes(bytes: ByteArray?)
     }
 
     @JvmStatic
     external fun nativeIsAvailable(): Boolean
 
+    // ── Write ───────────────────────────────────────────────────────────
+
     /** Takes ownership of the selection and serves [utf8] from this process. */
     @JvmStatic
     external fun nativeSetTextUtf8(utf8: ByteArray): Boolean
+
+    /**
+     * Publishes [png] as an image. GdkPixbuf decodes it once natively, which
+     * is what lets GTK offer (and convert to) `image/bmp`, `image/jpeg` and
+     * `image/tiff` as well.
+     */
+    @JvmStatic
+    external fun nativeSetImagePng(png: ByteArray): Boolean
+
+    /**
+     * Publishes newline-separated `file://` URIs as `text/uri-list` plus
+     * `x-special/gnome-copied-files`, the target GTK file managers paste from.
+     */
+    @JvmStatic
+    external fun nativeSetUriListUtf8(uriList: ByteArray): Boolean
 
     /** Drops our ownership of the selection; no-op when another app owns it. */
     @JvmStatic
     external fun nativeClear()
 
-    /**
-     * Starts an asynchronous read. [callback] is invoked exactly once from the
-     * GTK main loop — possibly *synchronously*, when this process owns the
-     * selection. Returns false when the request never reached GTK, in which
-     * case the callback will not fire at all.
-     */
+    // ── Asynchronous reads ──────────────────────────────────────────────
+    // Each invokes [callback] exactly once from the GTK main loop — possibly
+    // *synchronously*, when this process owns the selection. A false return
+    // means the request never reached GTK and the callback will not fire.
+
     @JvmStatic
-    external fun nativeRequestTextUtf8(callback: TextCallback): Boolean
+    external fun nativeRequestTextUtf8(callback: BytesCallback): Boolean
+
+    /** Whatever image the clipboard holds, re-encoded to PNG by GdkPixbuf. */
+    @JvmStatic
+    external fun nativeRequestImagePng(callback: BytesCallback): Boolean
+
+    @JvmStatic
+    external fun nativeRequestUriListUtf8(callback: BytesCallback): Boolean
 
     /**
-     * Synchronous read. GTK spins a nested main loop until the selection owner
-     * answers, so this is reserved for the deprecated `ClipboardManager` path;
-     * the suspending `Clipboard` API uses [nativeRequestTextUtf8].
+     * The MIME names the selection currently advertises, newline-separated.
+     * Cheap next to the content itself, so it is what decides which flavors a
+     * clip entry exposes.
      */
     @JvmStatic
+    external fun nativeRequestTargetsUtf8(callback: BytesCallback): Boolean
+
+    // ── Synchronous reads ───────────────────────────────────────────────
+    // GTK spins a nested main loop until the owner answers. Only legal on the
+    // GTK main thread, and only for callers that cannot suspend: a
+    // `Transferable` read from arbitrary code, or the deprecated
+    // `ClipboardManager`.
+
+    @JvmStatic
     external fun nativeWaitForTextUtf8(): ByteArray?
+
+    @JvmStatic
+    external fun nativeWaitForImagePng(): ByteArray?
+
+    @JvmStatic
+    external fun nativeWaitForUriListUtf8(): ByteArray?
 
     /** Whether the selection currently offers text. Also spins a nested main loop. */
     @JvmStatic

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxClipboardBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxClipboardBridge.kt
@@ -1,0 +1,77 @@
+package dev.nucleusframework.window.tao.ffi
+
+import dev.nucleusframework.core.runtime.NativeLibraryLoader
+
+private const val LIBRARY_NAME = "nucleus_tao_linux_clipboard"
+
+/**
+ * JNI bridge to `linux/nucleus_tao_linux_clipboard.c`. Reads and writes the
+ * GTK `CLIPBOARD` selection of the default display, i.e. the clipboard of
+ * whichever GDK backend the Tao window actually runs on (Wayland or X11) —
+ * unlike `java.awt.Toolkit.getSystemClipboard()`, which is always X11 on
+ * Linux. See issue #582.
+ *
+ * Text crosses the boundary as UTF-8 **byte arrays**: `GetStringUTFChars`
+ * produces modified UTF-8, which mangles every non-BMP character (emoji).
+ *
+ * Threading: every entry point must run on the GTK main thread (= Tao
+ * event-loop thread = Compose's `Dispatchers.Main`).
+ */
+internal object NativeTaoLinuxClipboardBridge {
+    val isLoaded: Boolean =
+        NativeLibraryLoader.load(
+            LIBRARY_NAME,
+            NativeTaoLinuxClipboardBridge::class.java,
+        )
+
+    /**
+     * True when GTK is loadable and a default `GdkDisplay` exists, i.e. when
+     * the clipboard entry points below can do anything. False in a headless
+     * process, on non-Linux, and when the helper library is missing.
+     */
+    val isAvailable: Boolean
+        get() = isLoaded && nativeIsAvailable()
+
+    /**
+     * Receives the result of [nativeRequestTextUtf8]. Null = no text on the
+     * clipboard. Implement with a named class rather than a lambda: the native
+     * side resolves `onText` on the object's concrete class, which has to be
+     * declared in `reachability-metadata.json` for native-image.
+     */
+    interface TextCallback {
+        /** Called once, on the GTK main thread, with the UTF-8 encoded selection. */
+        fun onText(utf8: ByteArray?)
+    }
+
+    @JvmStatic
+    external fun nativeIsAvailable(): Boolean
+
+    /** Takes ownership of the selection and serves [utf8] from this process. */
+    @JvmStatic
+    external fun nativeSetTextUtf8(utf8: ByteArray): Boolean
+
+    /** Drops our ownership of the selection; no-op when another app owns it. */
+    @JvmStatic
+    external fun nativeClear()
+
+    /**
+     * Starts an asynchronous read. [callback] is invoked exactly once from the
+     * GTK main loop — possibly *synchronously*, when this process owns the
+     * selection. Returns false when the request never reached GTK, in which
+     * case the callback will not fire at all.
+     */
+    @JvmStatic
+    external fun nativeRequestTextUtf8(callback: TextCallback): Boolean
+
+    /**
+     * Synchronous read. GTK spins a nested main loop until the selection owner
+     * answers, so this is reserved for the deprecated `ClipboardManager` path;
+     * the suspending `Clipboard` API uses [nativeRequestTextUtf8].
+     */
+    @JvmStatic
+    external fun nativeWaitForTextUtf8(): ByteArray?
+
+    /** Whether the selection currently offers text. Also spins a nested main loop. */
+    @JvmStatic
+    external fun nativeHasText(): Boolean
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -32,6 +32,7 @@ import dev.nucleusframework.window.tao.TaoTouchEvent
 import dev.nucleusframework.window.tao.TaoTrackpadGesture
 import dev.nucleusframework.window.tao.TaoTrackpadPhase
 import dev.nucleusframework.window.tao.TaoWindow
+import dev.nucleusframework.window.tao.clipboard.ProvideTaoClipboard
 import dev.nucleusframework.window.tao.deco.ResizeFrameDecoration
 import dev.nucleusframework.window.tao.deco.TaoLinuxOverlayController
 import dev.nucleusframework.window.tao.deco.TaoLinuxOverlayControllerImpl
@@ -1072,7 +1073,12 @@ internal class TaoComposeSceneHostLinux(
             androidx.compose.runtime.SideEffect {
                 capturedFocusManager = fm
             }
-            TaoTextToolbarHost(textToolbar, content)
+            // GTK clipboard instead of AWT's X11-only one: the window lives on
+            // whichever GDK backend the session provides, and on Wayland the
+            // two selections are not the same one (issue #582).
+            ProvideTaoClipboard {
+                TaoTextToolbarHost(textToolbar, content)
+            }
         }
     }
 

--- a/decorated-window-tao/src/main/native/linux/build.sh
+++ b/decorated-window-tao/src/main/native/linux/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Compiles four Linux shared libraries into per-architecture resource folders:
+# Compiles five Linux shared libraries into per-architecture resource folders:
 #   - libnucleus_tao.so              (Rust crate, Tao + JNI)
 #   - libnucleus_tao_egl.so          (C, EGL helper for Skia GL backend on
 #                                     X11 / Wayland)
@@ -7,6 +7,9 @@
 #                                     by the GtkWidget variant of NativeView)
 #   - libnucleus_tao_linux_popup.so  (C, standalone transparent popup panel —
 #                                     raw X11/XWayland window for TrayApp)
+#   - libnucleus_tao_linux_clipboard.so
+#                                    (C, GTK clipboard so paste follows the
+#                                     window's GDK backend instead of AWT/X11)
 #
 # Outputs are placed in src/main/resources/nucleus/native/{linux-x64,linux-aarch64}/.
 #
@@ -143,7 +146,27 @@ case "$HOST_ARCH" in
     aarch64|arm64) build_popup "$OUT_DIR_ARM64" ;;
 esac
 
-# ── 6) Clear NativeLibraryLoader cache so fresh .so's are picked up ────────
+# ── 6) GTK clipboard helper (libnucleus_tao_linux_clipboard.so) ────────────
+# Its own library rather than a slot in nucleus_tao_linux_widget: the clipboard
+# is needed by every Tao window (Compose's LocalClipboard), the widget helper
+# only by apps embedding a foreign GtkWidget.
+
+build_clipboard() {
+    local OUT_DIR="$1"
+    local OUT="$OUT_DIR/libnucleus_tao_linux_clipboard.so"
+    "$CC" -shared -fPIC -O2 -fvisibility=hidden \
+        -I"$JNI_INCLUDE" -I"$JNI_INCLUDE_LINUX" \
+        "$SCRIPT_DIR/nucleus_tao_linux_clipboard.c" -ldl \
+        -o "$OUT"
+    strip --strip-unneeded "$OUT" || true
+}
+
+case "$HOST_ARCH" in
+    x86_64)        build_clipboard "$OUT_DIR_X64"   ;;
+    aarch64|arm64) build_clipboard "$OUT_DIR_ARM64" ;;
+esac
+
+# ── 7) Clear NativeLibraryLoader cache so fresh .so's are picked up ────────
 # Per the Linux module checklist in CLAUDE.md: skipping this serves the stale
 # cached copy out of ~/.cache/nucleus/native/<arch>/.
 
@@ -156,6 +179,6 @@ done
 
 echo "Built Linux native libraries:"
 case "$HOST_ARCH" in
-    x86_64) ls -lh "$OUT_DIR_X64"/{libnucleus_tao.so,libnucleus_tao_egl.so,libnucleus_tao_linux_widget.so,libnucleus_tao_linux_popup.so} ;;
-    aarch64|arm64) ls -lh "$OUT_DIR_ARM64"/{libnucleus_tao.so,libnucleus_tao_egl.so,libnucleus_tao_linux_widget.so,libnucleus_tao_linux_popup.so} ;;
+    x86_64) ls -lh "$OUT_DIR_X64"/{libnucleus_tao.so,libnucleus_tao_egl.so,libnucleus_tao_linux_widget.so,libnucleus_tao_linux_popup.so,libnucleus_tao_linux_clipboard.so} ;;
+    aarch64|arm64) ls -lh "$OUT_DIR_ARM64"/{libnucleus_tao.so,libnucleus_tao_egl.so,libnucleus_tao_linux_widget.so,libnucleus_tao_linux_popup.so,libnucleus_tao_linux_clipboard.so} ;;
 esac

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_clipboard.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_clipboard.c
@@ -16,13 +16,30 @@
  * not fork a helper process to serve paste requests, and serves the data from
  * this process — the same path every other GTK app takes.
  *
- * Text is exchanged as UTF-8 **byte arrays** rather than `jstring`, because
- * `GetStringUTFChars` produces modified UTF-8 (CESU-8): a jstring round-trip
- * corrupts every non-BMP character (emoji) and truncates embedded NULs.
+ * Formats carried here match what AWT's clipboard exposes, so nothing is lost
+ * by taking this path instead:
  *
- * Linked libraries: -ldl. libgtk-3.so.0 / libglib-2.0.so.0 are dlopen-ed at
- * runtime, like the other helpers in this directory. GDK symbols resolve
- * through the libgtk handle (dlsym searches the handle's dependency chain).
+ *   - text     `gtk_clipboard_set_text` / `request_text`; GTK registers every
+ *              text alias (UTF8_STRING, STRING, TEXT, text/plain…) itself.
+ *   - images   `gtk_clipboard_set_image` / `request_image` through GdkPixbuf,
+ *              which is what makes GTK advertise image/png, image/bmp,
+ *              image/jpeg and image/tiff and convert between them on demand.
+ *              PNG is the exchange format across JNI.
+ *   - files    `text/uri-list` (plus `x-special/gnome-copied-files`, which is
+ *              what file managers actually paste), served from a payload this
+ *              file owns until the selection changes hands.
+ *
+ * Reads come in two shapes: an asynchronous one that hands the bytes to a
+ * callback (used by the suspending Kotlin API) and a `wait_*` one that spins a
+ * nested GTK main loop (used when a `Transferable` is read from a thread that
+ * cannot suspend). Every payload crosses as **bytes**, never `jstring`:
+ * `GetStringUTFChars` produces modified UTF-8 (CESU-8), which corrupts every
+ * non-BMP character (emoji) and truncates embedded NULs.
+ *
+ * Linked libraries: -ldl. libgtk-3.so.0 / libglib-2.0.so.0 /
+ * libgobject-2.0.so.0 / libgdk_pixbuf-2.0.so.0 are dlopen-ed at runtime, like
+ * the other helpers in this directory. GDK symbols resolve through the libgtk
+ * handle (dlsym searches the handle's dependency chain).
  *
  * Threading: every entry point must run on the GTK main thread (= Tao
  * event-loop thread = Compose's `Dispatchers.Main`).
@@ -31,43 +48,101 @@
 #include <jni.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
 
 /* ── GTK / GDK / GLib types (forward-declared: no dev headers needed) ── */
 
-typedef int   gint;
-typedef int   gboolean;
-typedef char  gchar;
-typedef void  GtkClipboard; /* opaque */
-typedef void  GdkDisplay;   /* opaque */
-typedef void *GdkAtom;      /* GdkAtom is a pointer-sized handle in GTK 3 */
+typedef int           gint;
+typedef unsigned int  guint;
+typedef int           gboolean;
+typedef char          gchar;
+typedef unsigned char guchar;
+typedef unsigned long gsize;
+typedef void          GtkClipboard;     /* opaque */
+typedef void          GdkDisplay;       /* opaque */
+typedef void          GdkPixbuf;        /* opaque */
+typedef void          GdkPixbufLoader;  /* opaque */
+typedef void          GtkSelectionData; /* opaque */
+typedef void          GError;           /* opaque */
+typedef void         *GdkAtom;          /* GdkAtom is a pointer-sized handle in GTK 3 */
 
-/* GtkClipboardTextReceivedFunc */
+/** GtkTargetEntry, GTK 3 ABI. */
+typedef struct {
+    gchar *target;
+    guint flags;
+    guint info;
+} GtkTargetEntry;
+
 typedef void (*TextReceivedFunc)(GtkClipboard *clipboard, const gchar *text, void *data);
+typedef void (*ImageReceivedFunc)(GtkClipboard *clipboard, GdkPixbuf *pixbuf, void *data);
+typedef void (*UrisReceivedFunc)(GtkClipboard *clipboard, gchar **uris, void *data);
+typedef void (*TargetsReceivedFunc)(GtkClipboard *clipboard, GdkAtom *atoms, gint n_atoms, void *data);
+typedef void (*ClipboardGetFunc)(
+    GtkClipboard *clipboard, GtkSelectionData *selection_data, guint info, void *user_data);
+typedef void (*ClipboardClearFunc)(GtkClipboard *clipboard, void *user_data);
 
 typedef GtkClipboard *(*PFN_gtk_clipboard_get)(GdkAtom selection);
 typedef void          (*PFN_gtk_clipboard_set_text)(GtkClipboard *c, const gchar *text, gint len);
+typedef void          (*PFN_gtk_clipboard_set_image)(GtkClipboard *c, GdkPixbuf *pixbuf);
+typedef gboolean      (*PFN_gtk_clipboard_set_with_data)(
+    GtkClipboard *c, const GtkTargetEntry *targets, guint n_targets,
+    ClipboardGetFunc get_func, ClipboardClearFunc clear_func, void *user_data);
 typedef void          (*PFN_gtk_clipboard_clear)(GtkClipboard *c);
-typedef void          (*PFN_gtk_clipboard_request_text)(
-    GtkClipboard *c, TextReceivedFunc callback, void *user_data);
+typedef void          (*PFN_gtk_clipboard_request_text)(GtkClipboard *c, TextReceivedFunc cb, void *data);
+typedef void          (*PFN_gtk_clipboard_request_image)(GtkClipboard *c, ImageReceivedFunc cb, void *data);
+typedef void          (*PFN_gtk_clipboard_request_uris)(GtkClipboard *c, UrisReceivedFunc cb, void *data);
+typedef void          (*PFN_gtk_clipboard_request_targets)(GtkClipboard *c, TargetsReceivedFunc cb, void *data);
 typedef gchar        *(*PFN_gtk_clipboard_wait_for_text)(GtkClipboard *c);
+typedef GdkPixbuf    *(*PFN_gtk_clipboard_wait_for_image)(GtkClipboard *c);
+typedef gchar       **(*PFN_gtk_clipboard_wait_for_uris)(GtkClipboard *c);
 typedef gboolean      (*PFN_gtk_clipboard_wait_is_text_available)(GtkClipboard *c);
+typedef void          (*PFN_gtk_selection_data_set)(
+    GtkSelectionData *sel, GdkAtom type, gint format, const guchar *data, gint length);
+typedef GdkAtom       (*PFN_gtk_selection_data_get_target)(GtkSelectionData *sel);
 typedef GdkAtom       (*PFN_gdk_atom_intern)(const gchar *atom_name, gboolean only_if_exists);
+typedef gchar        *(*PFN_gdk_atom_name)(GdkAtom atom);
 typedef GdkDisplay   *(*PFN_gdk_display_get_default)(void);
+typedef GdkPixbufLoader *(*PFN_gdk_pixbuf_loader_new)(void);
+typedef gboolean      (*PFN_gdk_pixbuf_loader_write)(
+    GdkPixbufLoader *loader, const guchar *buf, gsize count, GError **error);
+typedef gboolean      (*PFN_gdk_pixbuf_loader_close)(GdkPixbufLoader *loader, GError **error);
+typedef GdkPixbuf    *(*PFN_gdk_pixbuf_loader_get_pixbuf)(GdkPixbufLoader *loader);
+typedef gboolean      (*PFN_gdk_pixbuf_save_to_buffer)(
+    GdkPixbuf *pixbuf, gchar **buffer, gsize *size, const char *type, GError **error, ...);
 typedef void          (*PFN_g_free)(void *mem);
+typedef void          (*PFN_g_strfreev)(gchar **str_array);
+typedef void          (*PFN_g_object_unref)(void *object);
 
 static struct {
     int initialized;
     PFN_gtk_clipboard_get                    gtk_clipboard_get;
     PFN_gtk_clipboard_set_text               gtk_clipboard_set_text;
+    PFN_gtk_clipboard_set_image              gtk_clipboard_set_image;
+    PFN_gtk_clipboard_set_with_data          gtk_clipboard_set_with_data;
     PFN_gtk_clipboard_clear                  gtk_clipboard_clear;
     PFN_gtk_clipboard_request_text           gtk_clipboard_request_text;
+    PFN_gtk_clipboard_request_image          gtk_clipboard_request_image;
+    PFN_gtk_clipboard_request_uris           gtk_clipboard_request_uris;
+    PFN_gtk_clipboard_request_targets        gtk_clipboard_request_targets;
     PFN_gtk_clipboard_wait_for_text          gtk_clipboard_wait_for_text;
+    PFN_gtk_clipboard_wait_for_image         gtk_clipboard_wait_for_image;
+    PFN_gtk_clipboard_wait_for_uris          gtk_clipboard_wait_for_uris;
     PFN_gtk_clipboard_wait_is_text_available gtk_clipboard_wait_is_text_available;
+    PFN_gtk_selection_data_set               gtk_selection_data_set;
+    PFN_gtk_selection_data_get_target        gtk_selection_data_get_target;
     PFN_gdk_atom_intern                      gdk_atom_intern;
+    PFN_gdk_atom_name                        gdk_atom_name;
     PFN_gdk_display_get_default              gdk_display_get_default;
+    PFN_gdk_pixbuf_loader_new                gdk_pixbuf_loader_new;
+    PFN_gdk_pixbuf_loader_write              gdk_pixbuf_loader_write;
+    PFN_gdk_pixbuf_loader_close              gdk_pixbuf_loader_close;
+    PFN_gdk_pixbuf_loader_get_pixbuf         gdk_pixbuf_loader_get_pixbuf;
+    PFN_gdk_pixbuf_save_to_buffer            gdk_pixbuf_save_to_buffer;
     PFN_g_free                               g_free;
+    PFN_g_strfreev                           g_strfreev;
+    PFN_g_object_unref                       g_object_unref;
 } g;
 
 static void *load_first(const char *const *names) {
@@ -83,30 +158,67 @@ static void *load_first(const char *const *names) {
 
 static int ensure_gtk_loaded(void) {
     if (g.initialized) return 1;
-    const char *gtk_libs[]  = { "libgtk-3.so.0", "libgtk-3.so", NULL };
-    const char *glib_libs[] = { "libglib-2.0.so.0", "libglib-2.0.so", NULL };
-    void *libgtk  = load_first(gtk_libs);
-    void *libglib = load_first(glib_libs);
-    if (libgtk == NULL || libglib == NULL) return 0;
+    const char *gtk_libs[]    = { "libgtk-3.so.0", "libgtk-3.so", NULL };
+    const char *glib_libs[]   = { "libglib-2.0.so.0", "libglib-2.0.so", NULL };
+    const char *gobject_libs[] = { "libgobject-2.0.so.0", "libgobject-2.0.so", NULL };
+    const char *pixbuf_libs[] = { "libgdk_pixbuf-2.0.so.0", "libgdk_pixbuf-2.0.so", NULL };
+    void *libgtk     = load_first(gtk_libs);
+    void *libglib    = load_first(glib_libs);
+    void *libgobject = load_first(gobject_libs);
+    void *libpixbuf  = load_first(pixbuf_libs);
+    if (libgtk == NULL || libglib == NULL || libgobject == NULL || libpixbuf == NULL) return 0;
 
     g.gtk_clipboard_get          = (PFN_gtk_clipboard_get)          dlsym(libgtk, "gtk_clipboard_get");
     g.gtk_clipboard_set_text     = (PFN_gtk_clipboard_set_text)     dlsym(libgtk, "gtk_clipboard_set_text");
+    g.gtk_clipboard_set_image    = (PFN_gtk_clipboard_set_image)    dlsym(libgtk, "gtk_clipboard_set_image");
+    g.gtk_clipboard_set_with_data =
+        (PFN_gtk_clipboard_set_with_data) dlsym(libgtk, "gtk_clipboard_set_with_data");
     g.gtk_clipboard_clear        = (PFN_gtk_clipboard_clear)        dlsym(libgtk, "gtk_clipboard_clear");
     g.gtk_clipboard_request_text = (PFN_gtk_clipboard_request_text) dlsym(libgtk, "gtk_clipboard_request_text");
+    g.gtk_clipboard_request_image =
+        (PFN_gtk_clipboard_request_image) dlsym(libgtk, "gtk_clipboard_request_image");
+    g.gtk_clipboard_request_uris = (PFN_gtk_clipboard_request_uris) dlsym(libgtk, "gtk_clipboard_request_uris");
+    g.gtk_clipboard_request_targets =
+        (PFN_gtk_clipboard_request_targets) dlsym(libgtk, "gtk_clipboard_request_targets");
     g.gtk_clipboard_wait_for_text =
         (PFN_gtk_clipboard_wait_for_text) dlsym(libgtk, "gtk_clipboard_wait_for_text");
+    g.gtk_clipboard_wait_for_image =
+        (PFN_gtk_clipboard_wait_for_image) dlsym(libgtk, "gtk_clipboard_wait_for_image");
+    g.gtk_clipboard_wait_for_uris =
+        (PFN_gtk_clipboard_wait_for_uris) dlsym(libgtk, "gtk_clipboard_wait_for_uris");
     g.gtk_clipboard_wait_is_text_available =
         (PFN_gtk_clipboard_wait_is_text_available) dlsym(libgtk, "gtk_clipboard_wait_is_text_available");
+    g.gtk_selection_data_set     = (PFN_gtk_selection_data_set)     dlsym(libgtk, "gtk_selection_data_set");
+    g.gtk_selection_data_get_target =
+        (PFN_gtk_selection_data_get_target) dlsym(libgtk, "gtk_selection_data_get_target");
     /* gdk_* live in libgdk-3.so.0, which libgtk-3 depends on — dlsym on the
      * libgtk handle searches that dependency chain. */
     g.gdk_atom_intern            = (PFN_gdk_atom_intern)            dlsym(libgtk, "gdk_atom_intern");
+    g.gdk_atom_name              = (PFN_gdk_atom_name)              dlsym(libgtk, "gdk_atom_name");
     g.gdk_display_get_default    = (PFN_gdk_display_get_default)    dlsym(libgtk, "gdk_display_get_default");
-    g.g_free                     = (PFN_g_free)                     dlsym(libglib, "g_free");
 
-    if (!g.gtk_clipboard_get || !g.gtk_clipboard_set_text || !g.gtk_clipboard_clear ||
-        !g.gtk_clipboard_request_text || !g.gtk_clipboard_wait_for_text ||
-        !g.gtk_clipboard_wait_is_text_available || !g.gdk_atom_intern ||
-        !g.gdk_display_get_default || !g.g_free) {
+    g.gdk_pixbuf_loader_new      = (PFN_gdk_pixbuf_loader_new)      dlsym(libpixbuf, "gdk_pixbuf_loader_new");
+    g.gdk_pixbuf_loader_write    = (PFN_gdk_pixbuf_loader_write)    dlsym(libpixbuf, "gdk_pixbuf_loader_write");
+    g.gdk_pixbuf_loader_close    = (PFN_gdk_pixbuf_loader_close)    dlsym(libpixbuf, "gdk_pixbuf_loader_close");
+    g.gdk_pixbuf_loader_get_pixbuf =
+        (PFN_gdk_pixbuf_loader_get_pixbuf) dlsym(libpixbuf, "gdk_pixbuf_loader_get_pixbuf");
+    g.gdk_pixbuf_save_to_buffer  = (PFN_gdk_pixbuf_save_to_buffer)  dlsym(libpixbuf, "gdk_pixbuf_save_to_buffer");
+
+    g.g_free                     = (PFN_g_free)                     dlsym(libglib, "g_free");
+    g.g_strfreev                 = (PFN_g_strfreev)                 dlsym(libglib, "g_strfreev");
+    g.g_object_unref             = (PFN_g_object_unref)             dlsym(libgobject, "g_object_unref");
+
+    if (!g.gtk_clipboard_get || !g.gtk_clipboard_set_text || !g.gtk_clipboard_set_image ||
+        !g.gtk_clipboard_set_with_data || !g.gtk_clipboard_clear ||
+        !g.gtk_clipboard_request_text || !g.gtk_clipboard_request_image ||
+        !g.gtk_clipboard_request_uris || !g.gtk_clipboard_request_targets ||
+        !g.gtk_clipboard_wait_for_text || !g.gtk_clipboard_wait_for_image ||
+        !g.gtk_clipboard_wait_for_uris || !g.gtk_clipboard_wait_is_text_available ||
+        !g.gtk_selection_data_set || !g.gtk_selection_data_get_target ||
+        !g.gdk_atom_intern || !g.gdk_atom_name || !g.gdk_display_get_default ||
+        !g.gdk_pixbuf_loader_new || !g.gdk_pixbuf_loader_write || !g.gdk_pixbuf_loader_close ||
+        !g.gdk_pixbuf_loader_get_pixbuf || !g.gdk_pixbuf_save_to_buffer ||
+        !g.g_free || !g.g_strfreev || !g.g_object_unref) {
         return 0;
     }
     g.initialized = 1;
@@ -125,7 +237,7 @@ static GtkClipboard *clipboard_or_null(void) {
     return g.gtk_clipboard_get(g.gdk_atom_intern("CLIPBOARD", 0 /* only_if_exists */));
 }
 
-/* ── JNI callback plumbing (async text reads) ───────────────────────── */
+/* ── JNI plumbing ───────────────────────────────────────────────────── */
 
 static JavaVM *sJVM = NULL;
 
@@ -134,15 +246,15 @@ static void ensure_jvm(JNIEnv *env) {
 }
 
 /**
- * Resolved per call rather than cached: the callback is a `fun interface`, so
- * its implementation class differs per call site (one synthetic class per
- * lambda) and a jmethodID looked up on one of them must not be used to invoke
- * another. One extra lookup per clipboard read is free.
+ * Resolved per call rather than cached: the callback interface has one
+ * implementation class per call site, and a jmethodID looked up on one of them
+ * must not be used to invoke another. One extra lookup per clipboard read is
+ * free next to the round-trip it accompanies.
  */
-static jmethodID on_text_method(JNIEnv *env, jobject callback) {
+static jmethodID on_bytes_method(JNIEnv *env, jobject callback) {
     jclass clazz = (*env)->GetObjectClass(env, callback);
     if (clazz == NULL) return NULL;
-    jmethodID method = (*env)->GetMethodID(env, clazz, "onText", "([B)V");
+    jmethodID method = (*env)->GetMethodID(env, clazz, "onBytes", "([B)V");
     (*env)->DeleteLocalRef(env, clazz);
     if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
     return method;
@@ -160,35 +272,197 @@ static JNIEnv *attach_jvm_thread(void) {
     return env;
 }
 
-static jbyteArray to_byte_array(JNIEnv *env, const gchar *text) {
-    if (text == NULL) return NULL;
-    size_t len = strlen(text);
+static jbyteArray bytes_to_array(JNIEnv *env, const void *data, size_t len) {
+    if (data == NULL) return NULL;
     jbyteArray arr = (*env)->NewByteArray(env, (jsize) len);
     if (arr == NULL) return NULL;
-    if (len > 0) (*env)->SetByteArrayRegion(env, arr, 0, (jsize) len, (const jbyte *) text);
+    if (len > 0) (*env)->SetByteArrayRegion(env, arr, 0, (jsize) len, (const jbyte *) data);
     return arr;
 }
 
+static jbyteArray string_to_array(JNIEnv *env, const gchar *text) {
+    return text == NULL ? NULL : bytes_to_array(env, text, strlen(text));
+}
+
 /**
- * GTK hands the selection contents (or NULL when there is no text on the
- * clipboard) to this on the main loop, possibly synchronously when we own the
- * selection ourselves. One-shot: the global ref taken by
- * `nativeRequestTextUtf8` is released here, whichever way it goes.
+ * Joins a NULL-terminated string vector with '\n' into a freshly malloc-ed
+ * buffer. Used for URI lists and target names, which are the only two
+ * multi-valued payloads and never contain a newline themselves.
  */
-static void on_text_received(GtkClipboard *clipboard, const gchar *text, void *data) {
-    (void) clipboard;
-    jobject callback = (jobject) data;
+static char *join_lines(gchar **items, size_t *out_len) {
+    size_t total = 0;
+    int count = 0;
+    for (; items != NULL && items[count] != NULL; count++) total += strlen(items[count]) + 1;
+    if (count == 0) {
+        *out_len = 0;
+        char *empty = malloc(1);
+        if (empty != NULL) empty[0] = '\0';
+        return empty;
+    }
+    char *buffer = malloc(total);
+    if (buffer == NULL) return NULL;
+    size_t offset = 0;
+    for (int i = 0; i < count; i++) {
+        size_t len = strlen(items[i]);
+        memcpy(buffer + offset, items[i], len);
+        offset += len;
+        if (i + 1 < count) buffer[offset++] = '\n';
+    }
+    *out_len = offset;
+    return buffer;
+}
+
+/** Invokes the one-shot callback and releases its global ref. */
+static void deliver(jobject callback, const void *data, size_t len) {
     if (callback == NULL) return;
     JNIEnv *env = attach_jvm_thread();
     if (env == NULL) return; /* No JVM to release the ref through either. */
-    jmethodID method = on_text_method(env, callback);
+    jmethodID method = on_bytes_method(env, callback);
     if (method != NULL) {
-        jbyteArray arr = to_byte_array(env, text);
+        jbyteArray arr = bytes_to_array(env, data, len);
         (*env)->CallVoidMethod(env, callback, method, arr);
         if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
         if (arr != NULL) (*env)->DeleteLocalRef(env, arr);
     }
     (*env)->DeleteGlobalRef(env, callback);
+}
+
+/* ── Asynchronous receivers ─────────────────────────────────────────── */
+
+static void on_text_received(GtkClipboard *clipboard, const gchar *text, void *data) {
+    (void) clipboard;
+    deliver((jobject) data, text, text == NULL ? 0 : strlen(text));
+}
+
+/**
+ * Re-encodes whatever GTK decoded (bmp, tiff, jpeg…) as PNG, so the JVM side
+ * has a single format to decode. The pixbuf belongs to GTK for the duration of
+ * this callback only.
+ */
+static void on_image_received(GtkClipboard *clipboard, GdkPixbuf *pixbuf, void *data) {
+    (void) clipboard;
+    jobject callback = (jobject) data;
+    if (pixbuf == NULL) {
+        deliver(callback, NULL, 0);
+        return;
+    }
+    gchar *png = NULL;
+    gsize png_size = 0;
+    if (!g.gdk_pixbuf_save_to_buffer(pixbuf, &png, &png_size, "png", NULL, NULL) || png == NULL) {
+        deliver(callback, NULL, 0);
+        return;
+    }
+    deliver(callback, png, (size_t) png_size);
+    g.g_free(png);
+}
+
+static void on_uris_received(GtkClipboard *clipboard, gchar **uris, void *data) {
+    (void) clipboard;
+    jobject callback = (jobject) data;
+    if (uris == NULL) {
+        deliver(callback, NULL, 0);
+        return;
+    }
+    size_t len = 0;
+    char *joined = join_lines(uris, &len);
+    deliver(callback, joined, len);
+    free(joined);
+}
+
+static void on_targets_received(GtkClipboard *clipboard, GdkAtom *atoms, gint n_atoms, void *data) {
+    (void) clipboard;
+    jobject callback = (jobject) data;
+    if (atoms == NULL || n_atoms <= 0) {
+        deliver(callback, NULL, 0);
+        return;
+    }
+    gchar **names = calloc((size_t) n_atoms + 1, sizeof(gchar *));
+    if (names == NULL) {
+        deliver(callback, NULL, 0);
+        return;
+    }
+    for (gint i = 0; i < n_atoms; i++) names[i] = g.gdk_atom_name(atoms[i]);
+    size_t len = 0;
+    char *joined = join_lines(names, &len);
+    deliver(callback, joined, len);
+    free(joined);
+    for (gint i = 0; i < n_atoms; i++) g.g_free(names[i]);
+    free(names);
+}
+
+/* ── Owned payload for targets GTK cannot serve on its own ──────────── */
+
+/**
+ * Backing store for `gtk_clipboard_set_with_data`: GTK asks for one target at
+ * a time and we answer from here, so the bytes have to outlive the call that
+ * published them. Freed by [payload_clear] when the selection changes hands.
+ */
+typedef struct {
+    int count;
+    guchar **data;
+    gsize *sizes;
+    GtkTargetEntry *targets;
+} payload_t;
+
+static void payload_free(payload_t *payload) {
+    if (payload == NULL) return;
+    for (int i = 0; i < payload->count; i++) {
+        free(payload->data[i]);
+        free(payload->targets[i].target);
+    }
+    free(payload->data);
+    free(payload->sizes);
+    free(payload->targets);
+    free(payload);
+}
+
+static void payload_get(GtkClipboard *clipboard, GtkSelectionData *selection, guint info, void *user_data) {
+    (void) clipboard;
+    payload_t *payload = (payload_t *) user_data;
+    if (payload == NULL || (int) info >= payload->count) return;
+    g.gtk_selection_data_set(
+        selection, g.gtk_selection_data_get_target(selection), 8 /* bits per unit */,
+        payload->data[info], (gint) payload->sizes[info]);
+}
+
+static void payload_clear(GtkClipboard *clipboard, void *user_data) {
+    (void) clipboard;
+    payload_free((payload_t *) user_data);
+}
+
+/** Takes ownership of `count` (mime, bytes) pairs and publishes them. */
+static int publish_payload(
+    GtkClipboard *clipboard, const char *const *mimes, const guchar *const *blobs,
+    const gsize *sizes, int count)
+{
+    payload_t *payload = calloc(1, sizeof(payload_t));
+    if (payload == NULL) return 0;
+    payload->count = count;
+    payload->data = calloc((size_t) count, sizeof(guchar *));
+    payload->sizes = calloc((size_t) count, sizeof(gsize));
+    payload->targets = calloc((size_t) count, sizeof(GtkTargetEntry));
+    if (payload->data == NULL || payload->sizes == NULL || payload->targets == NULL) {
+        payload_free(payload);
+        return 0;
+    }
+    for (int i = 0; i < count; i++) {
+        payload->data[i] = malloc(sizes[i] > 0 ? sizes[i] : 1);
+        payload->targets[i].target = strdup(mimes[i]);
+        if (payload->data[i] == NULL || payload->targets[i].target == NULL) {
+            payload_free(payload);
+            return 0;
+        }
+        memcpy(payload->data[i], blobs[i], sizes[i]);
+        payload->sizes[i] = sizes[i];
+        payload->targets[i].flags = 0;
+        payload->targets[i].info = (guint) i;
+    }
+    if (!g.gtk_clipboard_set_with_data(
+            clipboard, payload->targets, (guint) count, payload_get, payload_clear, payload)) {
+        payload_free(payload);
+        return 0;
+    }
+    return 1;
 }
 
 /* ── JNI entry points ───────────────────────────────────────────────── */
@@ -220,6 +494,97 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeSet
     return JNI_TRUE;
 }
 
+/**
+ * Publishes an image from PNG bytes. GdkPixbuf decodes it once here so that
+ * `gtk_clipboard_set_image` can advertise — and convert to — every image
+ * target GTK knows, which is how a paste into GIMP or LibreOffice finds a
+ * format it accepts.
+ */
+EXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeSetImagePng(
+    JNIEnv *env, jclass clazz, jbyteArray png)
+{
+    (void) clazz;
+    GtkClipboard *clipboard = clipboard_or_null();
+    if (clipboard == NULL || png == NULL) return JNI_FALSE;
+    jsize len = (*env)->GetArrayLength(env, png);
+    jbyte *bytes = (*env)->GetByteArrayElements(env, png, NULL);
+    if (bytes == NULL) return JNI_FALSE;
+
+    jboolean result = JNI_FALSE;
+    GdkPixbufLoader *loader = g.gdk_pixbuf_loader_new();
+    if (loader != NULL) {
+        if (g.gdk_pixbuf_loader_write(loader, (const guchar *) bytes, (gsize) len, NULL) &&
+            g.gdk_pixbuf_loader_close(loader, NULL)) {
+            GdkPixbuf *pixbuf = g.gdk_pixbuf_loader_get_pixbuf(loader);
+            if (pixbuf != NULL) {
+                /* set_image refs the pixbuf; the loader keeps the only other
+                 * reference and drops it on unref below. */
+                g.gtk_clipboard_set_image(clipboard, pixbuf);
+                result = JNI_TRUE;
+            }
+        } else {
+            g.gdk_pixbuf_loader_close(loader, NULL);
+        }
+        g.g_object_unref(loader);
+    }
+    (*env)->ReleaseByteArrayElements(env, png, bytes, JNI_ABORT);
+    return result;
+}
+
+/**
+ * Publishes a file list from newline-separated `file://` URIs. Two targets go
+ * out: `text/uri-list`, which is the freedesktop standard AWT's
+ * `javaFileListFlavor` maps to, and `x-special/gnome-copied-files`, which is
+ * what GTK file managers actually read on paste.
+ */
+EXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeSetUriListUtf8(
+    JNIEnv *env, jclass clazz, jbyteArray uriList)
+{
+    (void) clazz;
+    GtkClipboard *clipboard = clipboard_or_null();
+    if (clipboard == NULL || uriList == NULL) return JNI_FALSE;
+    jsize len = (*env)->GetArrayLength(env, uriList);
+    if (len <= 0) return JNI_FALSE;
+    jbyte *bytes = (*env)->GetByteArrayElements(env, uriList, NULL);
+    if (bytes == NULL) return JNI_FALSE;
+
+    /* text/uri-list is CRLF-separated per RFC 2483; the gnome target is
+     * "copy\n" followed by LF-separated URIs. */
+    size_t crlf_capacity = (size_t) len * 2 + 2;
+    char *crlf = malloc(crlf_capacity);
+    size_t gnome_capacity = (size_t) len + sizeof("copy\n");
+    char *gnome = malloc(gnome_capacity);
+    jboolean result = JNI_FALSE;
+    if (crlf != NULL && gnome != NULL) {
+        size_t crlf_len = 0;
+        for (jsize i = 0; i < len; i++) {
+            if (bytes[i] == '\n') {
+                crlf[crlf_len++] = '\r';
+                crlf[crlf_len++] = '\n';
+            } else {
+                crlf[crlf_len++] = (char) bytes[i];
+            }
+        }
+        crlf[crlf_len++] = '\r';
+        crlf[crlf_len++] = '\n';
+
+        memcpy(gnome, "copy\n", 5);
+        memcpy(gnome + 5, bytes, (size_t) len);
+        size_t gnome_len = 5 + (size_t) len;
+
+        const char *mimes[] = { "text/uri-list", "x-special/gnome-copied-files" };
+        const guchar *blobs[] = { (const guchar *) crlf, (const guchar *) gnome };
+        const gsize sizes[] = { (gsize) crlf_len, (gsize) gnome_len };
+        result = publish_payload(clipboard, mimes, blobs, sizes, 2) ? JNI_TRUE : JNI_FALSE;
+    }
+    free(crlf);
+    free(gnome);
+    (*env)->ReleaseByteArrayElements(env, uriList, bytes, JNI_ABORT);
+    return result;
+}
+
 /** Drops our ownership of the selection. No-op when another app owns it. */
 EXPORT void JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeClear(
@@ -235,25 +600,31 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeCle
  * handed to GTK at all — the callback will never fire in that case and the
  * caller has to resume itself (see `NativeTaoLinuxClipboardBridge`).
  */
-EXPORT jboolean JNICALL
-Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeRequestTextUtf8(
-    JNIEnv *env, jclass clazz, jobject callback)
-{
-    (void) clazz;
-    if (callback == NULL) return JNI_FALSE;
-    GtkClipboard *clipboard = clipboard_or_null();
-    ensure_jvm(env);
-    if (clipboard == NULL || on_text_method(env, callback) == NULL) return JNI_FALSE;
-    jobject global = (*env)->NewGlobalRef(env, callback);
-    if (global == NULL) return JNI_FALSE;
-    g.gtk_clipboard_request_text(clipboard, on_text_received, global);
-    return JNI_TRUE;
-}
+#define DEFINE_REQUEST(name, gtk_call, receiver)                                          \
+    EXPORT jboolean JNICALL                                                               \
+    Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_##name(        \
+        JNIEnv *env, jclass clazz, jobject callback)                                      \
+    {                                                                                     \
+        (void) clazz;                                                                     \
+        if (callback == NULL) return JNI_FALSE;                                           \
+        GtkClipboard *clipboard = clipboard_or_null();                                    \
+        ensure_jvm(env);                                                                  \
+        if (clipboard == NULL || on_bytes_method(env, callback) == NULL) return JNI_FALSE; \
+        jobject global = (*env)->NewGlobalRef(env, callback);                             \
+        if (global == NULL) return JNI_FALSE;                                             \
+        g.gtk_call(clipboard, receiver, global);                                          \
+        return JNI_TRUE;                                                                  \
+    }
+
+DEFINE_REQUEST(nativeRequestTextUtf8, gtk_clipboard_request_text, on_text_received)
+DEFINE_REQUEST(nativeRequestImagePng, gtk_clipboard_request_image, on_image_received)
+DEFINE_REQUEST(nativeRequestUriListUtf8, gtk_clipboard_request_uris, on_uris_received)
+DEFINE_REQUEST(nativeRequestTargetsUtf8, gtk_clipboard_request_targets, on_targets_received)
 
 /**
- * Synchronous read. GTK spins a nested main loop until the owner answers, so
- * this is only for the deprecated `ClipboardManager` path — the suspending
- * `Clipboard` API uses `nativeRequestTextUtf8`.
+ * Synchronous reads. GTK spins a nested main loop until the owner answers, so
+ * these are for callers that cannot suspend — a `Transferable` read from
+ * arbitrary code, and the deprecated `ClipboardManager`.
  */
 EXPORT jbyteArray JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeWaitForTextUtf8(
@@ -264,8 +635,46 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeWai
     if (clipboard == NULL) return NULL;
     gchar *text = g.gtk_clipboard_wait_for_text(clipboard);
     if (text == NULL) return NULL;
-    jbyteArray arr = to_byte_array(env, text);
+    jbyteArray arr = string_to_array(env, text);
     g.g_free(text);
+    return arr;
+}
+
+EXPORT jbyteArray JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeWaitForImagePng(
+    JNIEnv *env, jclass clazz)
+{
+    (void) clazz;
+    GtkClipboard *clipboard = clipboard_or_null();
+    if (clipboard == NULL) return NULL;
+    GdkPixbuf *pixbuf = g.gtk_clipboard_wait_for_image(clipboard);
+    if (pixbuf == NULL) return NULL;
+    gchar *png = NULL;
+    gsize png_size = 0;
+    jbyteArray arr = NULL;
+    if (g.gdk_pixbuf_save_to_buffer(pixbuf, &png, &png_size, "png", NULL, NULL) && png != NULL) {
+        arr = bytes_to_array(env, png, (size_t) png_size);
+        g.g_free(png);
+    }
+    /* wait_for_image returns a new reference, unlike the async variant. */
+    g.g_object_unref(pixbuf);
+    return arr;
+}
+
+EXPORT jbyteArray JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeWaitForUriListUtf8(
+    JNIEnv *env, jclass clazz)
+{
+    (void) clazz;
+    GtkClipboard *clipboard = clipboard_or_null();
+    if (clipboard == NULL) return NULL;
+    gchar **uris = g.gtk_clipboard_wait_for_uris(clipboard);
+    if (uris == NULL) return NULL;
+    size_t len = 0;
+    char *joined = join_lines(uris, &len);
+    jbyteArray arr = bytes_to_array(env, joined, len);
+    free(joined);
+    g.g_strfreev(uris);
     return arr;
 }
 

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_clipboard.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_clipboard.c
@@ -1,0 +1,281 @@
+/**
+ * JNI bridge: GTK clipboard access for the Tao Linux backend (issue #582).
+ *
+ * Compose Desktop's only clipboard implementation goes through
+ * `java.awt.Toolkit.getSystemClipboard()`, which on Linux is X11-only
+ * (`sun.awt.X11.XToolkit`). A Tao window is a GTK window on whichever GDK
+ * backend the session provides — Wayland by default — so the AWT clipboard
+ * ends up reading a *different* selection than the one the window lives on.
+ * On KWin the Wayland selection is only published to XWayland while an X11
+ * window is active, which makes paste fail in the ordinary case, and with no
+ * XWayland at all `getSystemClipboard()` throws `HeadlessException`.
+ *
+ * GDK is the right layer to fix this at: it speaks the *current* backend
+ * (`wl_data_device` with the window's own seat on Wayland, `CLIPBOARD` on
+ * X11), needs no `wlr-data-control` (unlike `wl-clipboard` / `arboard`), does
+ * not fork a helper process to serve paste requests, and serves the data from
+ * this process — the same path every other GTK app takes.
+ *
+ * Text is exchanged as UTF-8 **byte arrays** rather than `jstring`, because
+ * `GetStringUTFChars` produces modified UTF-8 (CESU-8): a jstring round-trip
+ * corrupts every non-BMP character (emoji) and truncates embedded NULs.
+ *
+ * Linked libraries: -ldl. libgtk-3.so.0 / libglib-2.0.so.0 are dlopen-ed at
+ * runtime, like the other helpers in this directory. GDK symbols resolve
+ * through the libgtk handle (dlsym searches the handle's dependency chain).
+ *
+ * Threading: every entry point must run on the GTK main thread (= Tao
+ * event-loop thread = Compose's `Dispatchers.Main`).
+ */
+
+#include <jni.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <dlfcn.h>
+
+/* ── GTK / GDK / GLib types (forward-declared: no dev headers needed) ── */
+
+typedef int   gint;
+typedef int   gboolean;
+typedef char  gchar;
+typedef void  GtkClipboard; /* opaque */
+typedef void  GdkDisplay;   /* opaque */
+typedef void *GdkAtom;      /* GdkAtom is a pointer-sized handle in GTK 3 */
+
+/* GtkClipboardTextReceivedFunc */
+typedef void (*TextReceivedFunc)(GtkClipboard *clipboard, const gchar *text, void *data);
+
+typedef GtkClipboard *(*PFN_gtk_clipboard_get)(GdkAtom selection);
+typedef void          (*PFN_gtk_clipboard_set_text)(GtkClipboard *c, const gchar *text, gint len);
+typedef void          (*PFN_gtk_clipboard_clear)(GtkClipboard *c);
+typedef void          (*PFN_gtk_clipboard_request_text)(
+    GtkClipboard *c, TextReceivedFunc callback, void *user_data);
+typedef gchar        *(*PFN_gtk_clipboard_wait_for_text)(GtkClipboard *c);
+typedef gboolean      (*PFN_gtk_clipboard_wait_is_text_available)(GtkClipboard *c);
+typedef GdkAtom       (*PFN_gdk_atom_intern)(const gchar *atom_name, gboolean only_if_exists);
+typedef GdkDisplay   *(*PFN_gdk_display_get_default)(void);
+typedef void          (*PFN_g_free)(void *mem);
+
+static struct {
+    int initialized;
+    PFN_gtk_clipboard_get                    gtk_clipboard_get;
+    PFN_gtk_clipboard_set_text               gtk_clipboard_set_text;
+    PFN_gtk_clipboard_clear                  gtk_clipboard_clear;
+    PFN_gtk_clipboard_request_text           gtk_clipboard_request_text;
+    PFN_gtk_clipboard_wait_for_text          gtk_clipboard_wait_for_text;
+    PFN_gtk_clipboard_wait_is_text_available gtk_clipboard_wait_is_text_available;
+    PFN_gdk_atom_intern                      gdk_atom_intern;
+    PFN_gdk_display_get_default              gdk_display_get_default;
+    PFN_g_free                               g_free;
+} g;
+
+static void *load_first(const char *const *names) {
+    for (int i = 0; names[i] != NULL; i++) {
+        /* RTLD_LOCAL: keep GTK's closure out of the global symbol scope —
+         * on NixOS it pulls libsqlite3, which interposes the sqlite bundled
+         * in androidx/Room's JNI lib and segfaults (issue #366). */
+        void *h = dlopen(names[i], RTLD_NOW | RTLD_LOCAL);
+        if (h != NULL) return h;
+    }
+    return NULL;
+}
+
+static int ensure_gtk_loaded(void) {
+    if (g.initialized) return 1;
+    const char *gtk_libs[]  = { "libgtk-3.so.0", "libgtk-3.so", NULL };
+    const char *glib_libs[] = { "libglib-2.0.so.0", "libglib-2.0.so", NULL };
+    void *libgtk  = load_first(gtk_libs);
+    void *libglib = load_first(glib_libs);
+    if (libgtk == NULL || libglib == NULL) return 0;
+
+    g.gtk_clipboard_get          = (PFN_gtk_clipboard_get)          dlsym(libgtk, "gtk_clipboard_get");
+    g.gtk_clipboard_set_text     = (PFN_gtk_clipboard_set_text)     dlsym(libgtk, "gtk_clipboard_set_text");
+    g.gtk_clipboard_clear        = (PFN_gtk_clipboard_clear)        dlsym(libgtk, "gtk_clipboard_clear");
+    g.gtk_clipboard_request_text = (PFN_gtk_clipboard_request_text) dlsym(libgtk, "gtk_clipboard_request_text");
+    g.gtk_clipboard_wait_for_text =
+        (PFN_gtk_clipboard_wait_for_text) dlsym(libgtk, "gtk_clipboard_wait_for_text");
+    g.gtk_clipboard_wait_is_text_available =
+        (PFN_gtk_clipboard_wait_is_text_available) dlsym(libgtk, "gtk_clipboard_wait_is_text_available");
+    /* gdk_* live in libgdk-3.so.0, which libgtk-3 depends on — dlsym on the
+     * libgtk handle searches that dependency chain. */
+    g.gdk_atom_intern            = (PFN_gdk_atom_intern)            dlsym(libgtk, "gdk_atom_intern");
+    g.gdk_display_get_default    = (PFN_gdk_display_get_default)    dlsym(libgtk, "gdk_display_get_default");
+    g.g_free                     = (PFN_g_free)                     dlsym(libglib, "g_free");
+
+    if (!g.gtk_clipboard_get || !g.gtk_clipboard_set_text || !g.gtk_clipboard_clear ||
+        !g.gtk_clipboard_request_text || !g.gtk_clipboard_wait_for_text ||
+        !g.gtk_clipboard_wait_is_text_available || !g.gdk_atom_intern ||
+        !g.gdk_display_get_default || !g.g_free) {
+        return 0;
+    }
+    g.initialized = 1;
+    return 1;
+}
+
+/**
+ * The `CLIPBOARD` selection of the default display, or NULL when GTK never
+ * got initialised (Tao owns `gtk_init`; without a display
+ * `gdk_display_get_default` returns NULL and `gtk_clipboard_get` would abort
+ * on a GDK assertion).
+ */
+static GtkClipboard *clipboard_or_null(void) {
+    if (!ensure_gtk_loaded()) return NULL;
+    if (g.gdk_display_get_default() == NULL) return NULL;
+    return g.gtk_clipboard_get(g.gdk_atom_intern("CLIPBOARD", 0 /* only_if_exists */));
+}
+
+/* ── JNI callback plumbing (async text reads) ───────────────────────── */
+
+static JavaVM *sJVM = NULL;
+
+static void ensure_jvm(JNIEnv *env) {
+    if (sJVM == NULL) (*env)->GetJavaVM(env, &sJVM);
+}
+
+/**
+ * Resolved per call rather than cached: the callback is a `fun interface`, so
+ * its implementation class differs per call site (one synthetic class per
+ * lambda) and a jmethodID looked up on one of them must not be used to invoke
+ * another. One extra lookup per clipboard read is free.
+ */
+static jmethodID on_text_method(JNIEnv *env, jobject callback) {
+    jclass clazz = (*env)->GetObjectClass(env, callback);
+    if (clazz == NULL) return NULL;
+    jmethodID method = (*env)->GetMethodID(env, clazz, "onText", "([B)V");
+    (*env)->DeleteLocalRef(env, clazz);
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+    return method;
+}
+
+static JNIEnv *attach_jvm_thread(void) {
+    if (sJVM == NULL) return NULL;
+    JNIEnv *env = NULL;
+    jint status = (*sJVM)->GetEnv(sJVM, (void **)&env, JNI_VERSION_1_8);
+    if (status == JNI_EDETACHED) {
+        if ((*sJVM)->AttachCurrentThreadAsDaemon(sJVM, (void **)&env, NULL) != JNI_OK) return NULL;
+    } else if (status != JNI_OK) {
+        return NULL;
+    }
+    return env;
+}
+
+static jbyteArray to_byte_array(JNIEnv *env, const gchar *text) {
+    if (text == NULL) return NULL;
+    size_t len = strlen(text);
+    jbyteArray arr = (*env)->NewByteArray(env, (jsize) len);
+    if (arr == NULL) return NULL;
+    if (len > 0) (*env)->SetByteArrayRegion(env, arr, 0, (jsize) len, (const jbyte *) text);
+    return arr;
+}
+
+/**
+ * GTK hands the selection contents (or NULL when there is no text on the
+ * clipboard) to this on the main loop, possibly synchronously when we own the
+ * selection ourselves. One-shot: the global ref taken by
+ * `nativeRequestTextUtf8` is released here, whichever way it goes.
+ */
+static void on_text_received(GtkClipboard *clipboard, const gchar *text, void *data) {
+    (void) clipboard;
+    jobject callback = (jobject) data;
+    if (callback == NULL) return;
+    JNIEnv *env = attach_jvm_thread();
+    if (env == NULL) return; /* No JVM to release the ref through either. */
+    jmethodID method = on_text_method(env, callback);
+    if (method != NULL) {
+        jbyteArray arr = to_byte_array(env, text);
+        (*env)->CallVoidMethod(env, callback, method, arr);
+        if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+        if (arr != NULL) (*env)->DeleteLocalRef(env, arr);
+    }
+    (*env)->DeleteGlobalRef(env, callback);
+}
+
+/* ── JNI entry points ───────────────────────────────────────────────── */
+
+#define EXPORT JNIEXPORT __attribute__((visibility("default")))
+
+EXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeIsAvailable(
+    JNIEnv *env, jclass clazz)
+{
+    (void) env; (void) clazz;
+    return clipboard_or_null() != NULL ? JNI_TRUE : JNI_FALSE;
+}
+
+EXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeSetTextUtf8(
+    JNIEnv *env, jclass clazz, jbyteArray utf8)
+{
+    (void) clazz;
+    GtkClipboard *clipboard = clipboard_or_null();
+    if (clipboard == NULL || utf8 == NULL) return JNI_FALSE;
+    jsize len = (*env)->GetArrayLength(env, utf8);
+    jbyte *bytes = (*env)->GetByteArrayElements(env, utf8, NULL);
+    if (bytes == NULL) return JNI_FALSE;
+    /* gtk_clipboard_set_text copies the text and answers paste requests from
+     * GTK's own selection handler, so nothing has to stay alive on our side. */
+    g.gtk_clipboard_set_text(clipboard, (const gchar *) bytes, (gint) len);
+    (*env)->ReleaseByteArrayElements(env, utf8, bytes, JNI_ABORT);
+    return JNI_TRUE;
+}
+
+/** Drops our ownership of the selection. No-op when another app owns it. */
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeClear(
+    JNIEnv *env, jclass clazz)
+{
+    (void) env; (void) clazz;
+    GtkClipboard *clipboard = clipboard_or_null();
+    if (clipboard != NULL) g.gtk_clipboard_clear(clipboard);
+}
+
+/**
+ * Starts an asynchronous read. Returns JNI_FALSE when the request could not be
+ * handed to GTK at all — the callback will never fire in that case and the
+ * caller has to resume itself (see `NativeTaoLinuxClipboardBridge`).
+ */
+EXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeRequestTextUtf8(
+    JNIEnv *env, jclass clazz, jobject callback)
+{
+    (void) clazz;
+    if (callback == NULL) return JNI_FALSE;
+    GtkClipboard *clipboard = clipboard_or_null();
+    ensure_jvm(env);
+    if (clipboard == NULL || on_text_method(env, callback) == NULL) return JNI_FALSE;
+    jobject global = (*env)->NewGlobalRef(env, callback);
+    if (global == NULL) return JNI_FALSE;
+    g.gtk_clipboard_request_text(clipboard, on_text_received, global);
+    return JNI_TRUE;
+}
+
+/**
+ * Synchronous read. GTK spins a nested main loop until the owner answers, so
+ * this is only for the deprecated `ClipboardManager` path — the suspending
+ * `Clipboard` API uses `nativeRequestTextUtf8`.
+ */
+EXPORT jbyteArray JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeWaitForTextUtf8(
+    JNIEnv *env, jclass clazz)
+{
+    (void) clazz;
+    GtkClipboard *clipboard = clipboard_or_null();
+    if (clipboard == NULL) return NULL;
+    gchar *text = g.gtk_clipboard_wait_for_text(clipboard);
+    if (text == NULL) return NULL;
+    jbyteArray arr = to_byte_array(env, text);
+    g.g_free(text);
+    return arr;
+}
+
+/** `gtk_clipboard_wait_is_text_available` — also spins a nested main loop. */
+EXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxClipboardBridge_nativeHasText(
+    JNIEnv *env, jclass clazz)
+{
+    (void) env; (void) clazz;
+    GtkClipboard *clipboard = clipboard_or_null();
+    if (clipboard == NULL) return JNI_FALSE;
+    return g.gtk_clipboard_wait_is_text_available(clipboard) ? JNI_TRUE : JNI_FALSE;
+}

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -391,17 +391,17 @@
             "jniAccessible": true
         },
         {
-            "type": "dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge$TextCallback",
+            "type": "dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge$BytesCallback",
             "jniAccessible": true,
             "methods": [
-                { "name": "onText", "parameterTypes": ["byte[]"] }
+                { "name": "onBytes", "parameterTypes": ["byte[]"] }
             ]
         },
         {
-            "type": "dev.nucleusframework.window.tao.clipboard.TaoLinuxClipboard$ResumeOnText",
+            "type": "dev.nucleusframework.window.tao.clipboard.TaoLinuxClipboard$ResumeOnBytes",
             "jniAccessible": true,
             "methods": [
-                { "name": "onText", "parameterTypes": ["byte[]"] }
+                { "name": "onBytes", "parameterTypes": ["byte[]"] }
             ]
         },
         {

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -387,6 +387,24 @@
             ]
         },
         {
+            "type": "dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge",
+            "jniAccessible": true
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge$TextCallback",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onText", "parameterTypes": ["byte[]"] }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.clipboard.TaoLinuxClipboard$ResumeOnText",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onText", "parameterTypes": ["byte[]"] }
+            ]
+        },
+        {
             "type": "dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge",
             "jniAccessible": true
         },

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ClipboardHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ClipboardHeadfulCases.kt
@@ -2,77 +2,90 @@
 
 package dev.nucleusframework.window.tao.headful
 
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.LocalWindowInfo
 import dev.nucleusframework.window.tao.clipboard.TaoLinuxClipboard
 import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import java.awt.Toolkit
+import java.awt.Image
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
 import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.imageio.ImageIO
 
 /**
  * #582 — the Tao clipboard must be the *window's* clipboard (GTK / the current
- * GDK backend), not AWT's X11-only one. Both directions are covered:
+ * GDK backend), not AWT's X11-only one, and must carry everything AWT carried:
+ * text, images and file lists. Each format is exercised in both directions
+ * against real applications (`wl-copy` / `wl-paste`) rather than against
+ * ourselves.
  *
- *  1. what another process publishes is readable by the app — the actual bug,
- *     since on a Wayland session AWT sees an empty X11 selection;
- *  2. what the app publishes is visible to the rest of the desktop, and reads
- *     back byte-identical (emoji included: the JNI boundary carries UTF-8, not
- *     modified UTF-8).
+ * Two Wayland rules shape every case here, and getting them wrong makes a
+ * clipboard test measure nothing:
  *
- * Both cases focus the window first and then poll. That is not test scaffolding
- * being lenient: on Wayland the compositor only sends selection offers to the
- * **focused** client, and only accepts `set_selection` with a serial from a
- * real input event. An unfocused window neither sees nor can take the
- * selection — the same reason `wl-paste` needs the `data-control` protocol.
+ *  - a client is handed the selection when it **gains keyboard focus**, so the
+ *    external tool has to own the selection *before* the window is focused —
+ *    which is also the user flow the issue describes: copy elsewhere, come
+ *    back, paste;
+ *  - `wl-copy` returns as soon as it has forked, so its ownership is confirmed
+ *    through `wl-paste` (which goes through `data-control` and is therefore not
+ *    focus-gated) instead of assumed. Skipping that confirmation is what made
+ *    these cases flaky: the window could take focus while the *previous*
+ *    selection was still current, and nothing would refresh it afterwards.
  *
- * In the two text cases the AWT path is deliberately unreachable — the
- * clipboard is built with a fallback that fails the case if it is ever
- * consulted. The third case is the opposite: it checks that non-text flavors,
- * which GTK does not carry yet, still reach the app through that fallback.
+ * The AWT path is deliberately unreachable: the clipboard is built with a
+ * fallback that fails the case if it is ever consulted, so anything that
+ * passes here passed through GTK.
  */
 internal object ClipboardHeadfulCases {
     fun all(): List<TaoWindowTestCase> =
         listOf(
             gtkClipboardReadsForeignSelection(),
             gtkClipboardPublishesToTheDesktop(),
-            nonTextFlavorsStillReachTheApp(),
+            gtkClipboardReadsForeignImage(),
+            gtkClipboardPublishesAnImage(),
+            gtkClipboardRoundTripsAFileList(),
         )
 
     /** Text with a non-BMP character: modified UTF-8 would corrupt it. */
     private const val PROBE_SUFFIX = " ✅ 🍕 café"
 
+    // ── Text ────────────────────────────────────────────────────────────
+
     private fun gtkClipboardReadsForeignSelection(): TaoWindowTestCase =
-        TaoWindowTestCase(
+        clipboardCase(
             name = "#582 GTK clipboard reads a selection owned by another process",
             skip = { linuxWithNativeClipboard() ?: requireTool("wl-copy") },
-        ) {
-            focusAndSettle()
-
+        ) { focusWindow ->
             val text = "nucleus-582-foreign$PROBE_SUFFIX"
-            check(publishWithWlCopy(text)) { "wl-copy failed to take the selection" }
+            publishExternally(text.toByteArray(), "text/plain;charset=utf-8")
+            focusWindow()
 
             val clipboard = TaoLinuxClipboard(fallback = FailingClipboard)
             awaitClipboard("GTK to report wl-copy's selection ($text)") {
-                clipboard.getClipEntry()?.plainText() == text
+                clipboard.getClipEntry()?.read(DataFlavor.stringFlavor) == text
             }
         }
 
     private fun gtkClipboardPublishesToTheDesktop(): TaoWindowTestCase =
-        TaoWindowTestCase(
+        clipboardCase(
             name = "#582 GTK clipboard publishes the app's selection to the desktop",
             skip = { linuxWithNativeClipboard() ?: requireTool("wl-paste") },
-        ) {
-            focusAndSettle()
+        ) { focusWindow ->
+            focusWindow()
 
             val clipboard = TaoLinuxClipboard(fallback = FailingClipboard)
             val text = "nucleus-582-app$PROBE_SUFFIX"
@@ -81,102 +94,149 @@ internal object ClipboardHeadfulCases {
 
             val readBack = clipboard.getClipEntry()
             check(readBack != null) { "getClipEntry() returned null right after publishing" }
-            check(readBack.plainText() == text) {
-                "GTK read back '${readBack.plainText()}', expected '$text'"
+            check(readBack.read(DataFlavor.stringFlavor) == text) {
+                "GTK read back '${readBack.read(DataFlavor.stringFlavor)}', expected '$text'"
             }
             // Same instance: the entry cache is what preserves Compose's
             // JVM-local AnnotatedString flavor across an in-app copy/paste.
             check(readBack === written) { "expected the published ClipEntry instance back" }
 
             awaitClipboard("wl-paste to see the app's selection ($text)") {
-                readClipboardWith("wl-paste", "--no-newline") == text
+                readClipboard("--no-newline")?.toString(Charsets.UTF_8) == text
             }
         }
 
-    /**
-     * GTK only carries text so far, so an image must still arrive through the
-     * AWT fallback: replacing `LocalClipboard` on Linux must not *narrow* what
-     * an app can paste. Skipped when AWT itself cannot see the image (no
-     * XWayland bridge), since then there is nothing to preserve.
-     */
-    private fun nonTextFlavorsStillReachTheApp(): TaoWindowTestCase =
-        TaoWindowTestCase(
-            name = "#582 an image on the clipboard still reaches the app (AWT fallback)",
+    // ── Images ──────────────────────────────────────────────────────────
+
+    private fun gtkClipboardReadsForeignImage(): TaoWindowTestCase =
+        clipboardCase(
+            name = "#582 GTK clipboard reads an image published by another process",
             skip = { linuxWithNativeClipboard() ?: requireTool("wl-copy") },
-        ) {
-            focusAndSettle()
+        ) { focusWindow ->
+            publishExternally(probePng(), "image/png")
+            focusWindow()
 
-            check(publishPngWithWlCopy()) { "wl-copy failed to publish the image" }
-            if (!awtSeesImage()) {
-                // The X11 bridge is what the fallback rides on; without it this
-                // case has no baseline to compare against.
-                return@TaoWindowTestCase
-            }
-
-            val clipboard = TaoLinuxClipboard(fallback = AwtClipboard)
-            awaitClipboard("the clip entry to offer an image flavor") {
-                clipboard.getClipEntry()?.supportsImage() == true
+            val clipboard = TaoLinuxClipboard(fallback = FailingClipboard)
+            awaitClipboard("the clip entry to expose the image") {
+                val image = clipboard.getClipEntry()?.read(DataFlavor.imageFlavor) as? Image
+                image?.getWidth(null) == PROBE_IMAGE_WIDTH && image.getHeight(null) == PROBE_IMAGE_HEIGHT
             }
         }
 
-    private suspend fun publishPngWithWlCopy(): Boolean =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val png = File.createTempFile("nucleus-582-", ".png")
-                png.deleteOnExit()
-                val image = BufferedImage(PROBE_IMAGE_SIZE, PROBE_IMAGE_SIZE, BufferedImage.TYPE_INT_RGB)
-                ImageIO.write(image, "png", png)
-                val process =
-                    ProcessBuilder("wl-copy", "--type", "image/png")
-                        .redirectInput(png)
-                        .redirectErrorStream(true)
-                        .start()
-                process.waitFor(TOOL_TIMEOUT_SECONDS, TimeUnit.SECONDS) && process.exitValue() == 0
-            }.getOrDefault(false)
-        }
+    private fun gtkClipboardPublishesAnImage(): TaoWindowTestCase =
+        clipboardCase(
+            name = "#582 GTK clipboard publishes an image to the desktop",
+            skip = { linuxWithNativeClipboard() ?: requireTool("wl-paste") },
+        ) { focusWindow ->
+            focusWindow()
 
-    private suspend fun awtSeesImage(): Boolean =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                Toolkit
-                    .getDefaultToolkit()
-                    .systemClipboard
-                    .getContents(null)
-                    ?.isDataFlavorSupported(DataFlavor.imageFlavor) == true
-            }.getOrDefault(false)
-        }
+            val clipboard = TaoLinuxClipboard(fallback = FailingClipboard)
+            clipboard.setClipEntry(ClipEntry(ImageTransferable(probeImage())))
 
-    private fun ClipEntry.supportsImage(): Boolean =
-        (nativeClipEntry as? Transferable)?.isDataFlavorSupported(DataFlavor.imageFlavor) == true
-
-    /** What Compose's `AwtPlatformClipboard` does; that class is internal, hence the copy. */
-    private object AwtClipboard : Clipboard {
-        override suspend fun getClipEntry(): ClipEntry? =
-            withContext(Dispatchers.IO) {
-                Toolkit
-                    .getDefaultToolkit()
-                    .systemClipboard
-                    .getContents(null)
-                    ?.let { ClipEntry(it) }
-            }
-
-        override suspend fun setClipEntry(clipEntry: ClipEntry?) {
-            val transferable = clipEntry?.nativeClipEntry as? Transferable ?: return
-            withContext(Dispatchers.IO) {
-                Toolkit.getDefaultToolkit().systemClipboard.setContents(transferable, null)
+            awaitClipboard("wl-paste to offer image/png") { desktopOffers("image/png") }
+            val png = readClipboard("--type", "image/png")
+            check(png != null) { "wl-paste returned no image bytes" }
+            val decoded = ImageIO.read(ByteArrayInputStream(png))
+            check(decoded != null) { "wl-paste's bytes are not a decodable image" }
+            check(decoded.width == PROBE_IMAGE_WIDTH && decoded.height == PROBE_IMAGE_HEIGHT) {
+                "wl-paste saw ${decoded.width}x${decoded.height}, expected $PROBE_IMAGE_WIDTH x $PROBE_IMAGE_HEIGHT"
             }
         }
+
+    // ── Files ───────────────────────────────────────────────────────────
+
+    private fun gtkClipboardRoundTripsAFileList(): TaoWindowTestCase =
+        clipboardCase(
+            name = "#582 GTK clipboard round-trips a file list",
+            skip = { linuxWithNativeClipboard() ?: requireTool("wl-copy") },
+        ) { focusWindow ->
+            val file = withContext(Dispatchers.IO) { File.createTempFile("nucleus-582-", ".txt") }
+            file.deleteOnExit()
+
+            publishExternally("${file.toURI()}\n".toByteArray(), "text/uri-list")
+            focusWindow()
+
+            val clipboard = TaoLinuxClipboard(fallback = FailingClipboard)
+            awaitClipboard("the clip entry to expose ${file.name}") {
+                val files = clipboard.getClipEntry()?.read(DataFlavor.javaFileListFlavor) as? List<*>
+                files?.filterIsInstance<File>()?.map { it.canonicalPath } == listOf(file.canonicalPath)
+            }
+
+            clipboard.setClipEntry(ClipEntry(FileListTransferable(listOf(file))))
+            awaitClipboard("wl-paste to see the published file list") {
+                readClipboard("--type", "text/uri-list")
+                    ?.toString(Charsets.UTF_8)
+                    ?.contains(file.toURI().toString()) == true
+            }
+        }
+
+    // ── Harness ─────────────────────────────────────────────────────────
+
+    /**
+     * A clipboard case over a mapped window, plus a `focusWindow` step the
+     * driver places where the flow needs it: after an external copy for the
+     * read cases, before publishing for the write ones.
+     *
+     * `window.focus()` is only a request — the compositor decides — so the wait
+     * is on what the window actually reports. Without real focus the selection
+     * never reaches us and the case would be measuring GTK's local cache.
+     */
+    private fun clipboardCase(
+        name: String,
+        skip: () -> String?,
+        driver: suspend TaoWindowTestScope.(focusWindow: suspend () -> Unit) -> Unit,
+    ): TaoWindowTestCase {
+        val focused = AtomicBoolean(false)
+        return TaoWindowTestCase(
+            name = name,
+            skip = skip,
+            content = {
+                val windowInfo = LocalWindowInfo.current
+                LaunchedEffect(windowInfo) {
+                    snapshotFlow { windowInfo.isWindowFocused }.collect(focused::set)
+                }
+            },
+            driver = {
+                awaitUntil("window mapped") { bounds() != null }
+                driver {
+                    window.focus()
+                    awaitUntil("window focused") { focused.get() }
+                    settle(FOCUS_SETTLE_MILLIS)
+                }
+            },
+        )
     }
 
     /**
-     * Wayland hands selection offers to the focused client only, so a case that
-     * skips this measures nothing but GTK's local cache.
+     * Hands the selection to `wl-copy` and does not return until the desktop
+     * confirms the handover — see the class doc for why assuming it makes the
+     * case flaky.
+     *
+     * Retried rather than confirmed once: the session's clipboard manager
+     * re-asserts the previous selection when its owning window goes away, which
+     * is exactly what the preceding case does, and it can win the race against
+     * `wl-copy`. A third party fighting over the selection says nothing about
+     * the code under test, so the handover is repeated until it sticks.
      */
-    private suspend fun TaoWindowTestScope.focusAndSettle() {
-        awaitUntil("window mapped") { bounds() != null }
-        window.focus()
-        settle(FOCUS_SETTLE_MILLIS)
+    private suspend fun publishExternally(
+        payload: ByteArray,
+        type: String,
+    ) {
+        val offered = type.substringBefore(';')
+        val deadline = System.currentTimeMillis() + CLIPBOARD_TIMEOUT_MILLIS
+        while (true) {
+            check(publishWithWlCopy(payload, type)) { "wl-copy failed to run" }
+            repeat(CONFIRM_ATTEMPTS) {
+                if (desktopOffers(offered)) return
+                delay(POLL_MILLIS)
+            }
+            check(System.currentTimeMillis() < deadline) { "timed out handing $type to wl-copy" }
+        }
     }
+
+    /** What the desktop sees, through `data-control` — unlike a window, not focus-gated. */
+    private suspend fun desktopOffers(type: String): Boolean =
+        readClipboard("--list-types")?.toString(Charsets.UTF_8)?.contains(type) == true
 
     /** [predicate] can suspend (a clipboard read is asynchronous), hence not `awaitUntil`. */
     private suspend fun awaitClipboard(
@@ -190,14 +250,17 @@ internal object ClipboardHeadfulCases {
         }
     }
 
-    private fun ClipEntry.plainText(): String? =
-        (nativeClipEntry as? Transferable)?.let {
-            if (it.isDataFlavorSupported(DataFlavor.stringFlavor)) {
-                it.getTransferData(DataFlavor.stringFlavor) as? String
-            } else {
-                null
-            }
+    /** Reads a flavor off the entry's transferable, or null when it is not offered. */
+    private suspend fun ClipEntry.read(flavor: DataFlavor): Any? {
+        val transferable = nativeClipEntry as? Transferable ?: return null
+        // Off the GTK thread on purpose: the lazy image / file fetchers block,
+        // and this is the path real application code takes.
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                if (transferable.isDataFlavorSupported(flavor)) transferable.getTransferData(flavor) else null
+            }.getOrNull()
         }
+    }
 
     /** Any consultation of the AWT fallback means the native path silently gave up. */
     private object FailingClipboard : Clipboard {
@@ -206,41 +269,72 @@ internal object ClipboardHeadfulCases {
         override suspend fun setClipEntry(clipEntry: ClipEntry?) = error("fell back to the AWT clipboard")
     }
 
+    private class ImageTransferable(
+        private val image: BufferedImage,
+    ) : Transferable {
+        override fun getTransferDataFlavors(): Array<DataFlavor> = arrayOf(DataFlavor.imageFlavor)
+
+        override fun isDataFlavorSupported(flavor: DataFlavor): Boolean = flavor == DataFlavor.imageFlavor
+
+        override fun getTransferData(flavor: DataFlavor): Any =
+            if (flavor == DataFlavor.imageFlavor) image else throw UnsupportedFlavorException(flavor)
+    }
+
+    private class FileListTransferable(
+        private val files: List<File>,
+    ) : Transferable {
+        override fun getTransferDataFlavors(): Array<DataFlavor> = arrayOf(DataFlavor.javaFileListFlavor)
+
+        override fun isDataFlavorSupported(flavor: DataFlavor): Boolean = flavor == DataFlavor.javaFileListFlavor
+
+        override fun getTransferData(flavor: DataFlavor): Any =
+            if (flavor == DataFlavor.javaFileListFlavor) files else throw UnsupportedFlavorException(flavor)
+    }
+
+    private fun probeImage(): BufferedImage =
+        BufferedImage(PROBE_IMAGE_WIDTH, PROBE_IMAGE_HEIGHT, BufferedImage.TYPE_INT_RGB)
+
+    private fun probePng(): ByteArray =
+        ByteArrayOutputStream().also { ImageIO.write(probeImage(), "png", it) }.toByteArray()
+
     /**
-     * `wl-copy` / `wl-paste` are driven off the Tao main thread on purpose: while
-     * the app owns the selection, the GTK main loop is what answers the reader's
-     * data request, so blocking that thread on the tool deadlocks both sides.
+     * `wl-copy` / `wl-paste` are driven off the Tao main thread on purpose:
+     * while the app owns the selection, the GTK main loop is what answers the
+     * reader's data request, so blocking that thread on the tool deadlocks
+     * both sides.
      */
-    private suspend fun publishWithWlCopy(text: String): Boolean =
+    private suspend fun publishWithWlCopy(
+        payload: ByteArray,
+        type: String,
+    ): Boolean =
         withContext(Dispatchers.IO) {
             runCatching {
                 val process =
-                    ProcessBuilder("wl-copy", "--type", "text/plain;charset=utf-8")
+                    ProcessBuilder("wl-copy", "--type", type)
                         .redirectErrorStream(true)
                         .start()
-                process.outputStream.use { it.write(text.toByteArray()) }
+                process.outputStream.use { it.write(payload) }
                 process.waitFor(TOOL_TIMEOUT_SECONDS, TimeUnit.SECONDS) && process.exitValue() == 0
             }.getOrDefault(false)
         }
 
-    /** Selection contents according to [command], or null when it is unusable. See [publishWithWlCopy]. */
-    private suspend fun readClipboardWith(vararg command: String): String? =
-        withContext(Dispatchers.IO) { runProcess(*command) }
+    private suspend fun readClipboard(vararg arguments: String): ByteArray? =
+        withContext(Dispatchers.IO) { runProcess("wl-paste", *arguments) }
 
-    private fun runProcess(vararg command: String): String? =
+    private fun runProcess(vararg command: String): ByteArray? =
         runCatching {
             val process = ProcessBuilder(*command).start()
             val output = process.inputStream.use { it.readBytes() }
             if (!process.waitFor(TOOL_TIMEOUT_SECONDS, TimeUnit.SECONDS) || process.exitValue() != 0) {
                 null
             } else {
-                output.toString(Charsets.UTF_8)
+                output
             }
         }.getOrNull()
 
     /** Runs at case-selection time, outside any coroutine, so it stays blocking. */
     private fun requireTool(name: String): String? =
-        if (runProcess("which", name).isNullOrBlank()) "$name not installed" else null
+        if (runProcess("which", name)?.isNotEmpty() != true) "$name not installed" else null
 
     private fun linuxWithNativeClipboard(): String? {
         val os = System.getProperty("os.name", "").lowercase()
@@ -250,9 +344,13 @@ internal object ClipboardHeadfulCases {
         return if (NativeTaoLinuxClipboardBridge.isAvailable) null else "GTK clipboard unavailable"
     }
 
-    private const val PROBE_IMAGE_SIZE = 32
+    private const val PROBE_IMAGE_WIDTH = 32
+    private const val PROBE_IMAGE_HEIGHT = 16
     private const val TOOL_TIMEOUT_SECONDS = 5L
-    private const val FOCUS_SETTLE_MILLIS = 800L
-    private const val CLIPBOARD_TIMEOUT_MILLIS = 5_000L
+    private const val FOCUS_SETTLE_MILLIS = 300L
+    private const val CLIPBOARD_TIMEOUT_MILLIS = 10_000L
     private const val POLL_MILLIS = 100L
+
+    /** Polls per `wl-copy` attempt before handing the selection over again. */
+    private const val CONFIRM_ATTEMPTS = 10
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ClipboardHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ClipboardHeadfulCases.kt
@@ -1,0 +1,175 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import dev.nucleusframework.window.tao.clipboard.TaoLinuxClipboard
+import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+import java.util.concurrent.TimeUnit
+
+/**
+ * #582 — the Tao clipboard must be the *window's* clipboard (GTK / the current
+ * GDK backend), not AWT's X11-only one. Both directions are covered:
+ *
+ *  1. what another process publishes is readable by the app — the actual bug,
+ *     since on a Wayland session AWT sees an empty X11 selection;
+ *  2. what the app publishes is visible to the rest of the desktop, and reads
+ *     back byte-identical (emoji included: the JNI boundary carries UTF-8, not
+ *     modified UTF-8).
+ *
+ * Both cases focus the window first and then poll. That is not test scaffolding
+ * being lenient: on Wayland the compositor only sends selection offers to the
+ * **focused** client, and only accepts `set_selection` with a serial from a
+ * real input event. An unfocused window neither sees nor can take the
+ * selection — the same reason `wl-paste` needs the `data-control` protocol.
+ *
+ * The AWT path is deliberately unreachable: the clipboard is built with a
+ * fallback that fails the case if it is ever consulted.
+ */
+internal object ClipboardHeadfulCases {
+    fun all(): List<TaoWindowTestCase> =
+        listOf(
+            gtkClipboardReadsForeignSelection(),
+            gtkClipboardPublishesToTheDesktop(),
+        )
+
+    /** Text with a non-BMP character: modified UTF-8 would corrupt it. */
+    private const val PROBE_SUFFIX = " ✅ 🍕 café"
+
+    private fun gtkClipboardReadsForeignSelection(): TaoWindowTestCase =
+        TaoWindowTestCase(
+            name = "#582 GTK clipboard reads a selection owned by another process",
+            skip = { linuxWithNativeClipboard() ?: requireTool("wl-copy") },
+        ) {
+            focusAndSettle()
+
+            val text = "nucleus-582-foreign$PROBE_SUFFIX"
+            check(publishWithWlCopy(text)) { "wl-copy failed to take the selection" }
+
+            val clipboard = TaoLinuxClipboard(fallback = FailingClipboard)
+            awaitClipboard("GTK to report wl-copy's selection ($text)") {
+                clipboard.getClipEntry()?.plainText() == text
+            }
+        }
+
+    private fun gtkClipboardPublishesToTheDesktop(): TaoWindowTestCase =
+        TaoWindowTestCase(
+            name = "#582 GTK clipboard publishes the app's selection to the desktop",
+            skip = { linuxWithNativeClipboard() ?: requireTool("wl-paste") },
+        ) {
+            focusAndSettle()
+
+            val clipboard = TaoLinuxClipboard(fallback = FailingClipboard)
+            val text = "nucleus-582-app$PROBE_SUFFIX"
+            val written = ClipEntry(StringSelection(text))
+            clipboard.setClipEntry(written)
+
+            val readBack = clipboard.getClipEntry()
+            check(readBack != null) { "getClipEntry() returned null right after publishing" }
+            check(readBack.plainText() == text) {
+                "GTK read back '${readBack.plainText()}', expected '$text'"
+            }
+            // Same instance: the entry cache is what preserves Compose's
+            // JVM-local AnnotatedString flavor across an in-app copy/paste.
+            check(readBack === written) { "expected the published ClipEntry instance back" }
+
+            awaitClipboard("wl-paste to see the app's selection ($text)") {
+                readClipboardWith("wl-paste", "--no-newline") == text
+            }
+        }
+
+    /**
+     * Wayland hands selection offers to the focused client only, so a case that
+     * skips this measures nothing but GTK's local cache.
+     */
+    private suspend fun TaoWindowTestScope.focusAndSettle() {
+        awaitUntil("window mapped") { bounds() != null }
+        window.focus()
+        settle(FOCUS_SETTLE_MILLIS)
+    }
+
+    /** [predicate] can suspend (a clipboard read is asynchronous), hence not `awaitUntil`. */
+    private suspend fun awaitClipboard(
+        description: String,
+        predicate: suspend () -> Boolean,
+    ) {
+        val deadline = System.currentTimeMillis() + CLIPBOARD_TIMEOUT_MILLIS
+        while (!predicate()) {
+            check(System.currentTimeMillis() < deadline) { "timed out waiting for $description" }
+            delay(POLL_MILLIS)
+        }
+    }
+
+    private fun ClipEntry.plainText(): String? =
+        (nativeClipEntry as? Transferable)?.let {
+            if (it.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+                it.getTransferData(DataFlavor.stringFlavor) as? String
+            } else {
+                null
+            }
+        }
+
+    /** Any consultation of the AWT fallback means the native path silently gave up. */
+    private object FailingClipboard : Clipboard {
+        override suspend fun getClipEntry(): ClipEntry? = error("fell back to the AWT clipboard")
+
+        override suspend fun setClipEntry(clipEntry: ClipEntry?) = error("fell back to the AWT clipboard")
+    }
+
+    /**
+     * `wl-copy` / `wl-paste` are driven off the Tao main thread on purpose: while
+     * the app owns the selection, the GTK main loop is what answers the reader's
+     * data request, so blocking that thread on the tool deadlocks both sides.
+     */
+    private suspend fun publishWithWlCopy(text: String): Boolean =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val process =
+                    ProcessBuilder("wl-copy", "--type", "text/plain;charset=utf-8")
+                        .redirectErrorStream(true)
+                        .start()
+                process.outputStream.use { it.write(text.toByteArray()) }
+                process.waitFor(TOOL_TIMEOUT_SECONDS, TimeUnit.SECONDS) && process.exitValue() == 0
+            }.getOrDefault(false)
+        }
+
+    /** Selection contents according to [command], or null when it is unusable. See [publishWithWlCopy]. */
+    private suspend fun readClipboardWith(vararg command: String): String? =
+        withContext(Dispatchers.IO) { runProcess(*command) }
+
+    private fun runProcess(vararg command: String): String? =
+        runCatching {
+            val process = ProcessBuilder(*command).start()
+            val output = process.inputStream.use { it.readBytes() }
+            if (!process.waitFor(TOOL_TIMEOUT_SECONDS, TimeUnit.SECONDS) || process.exitValue() != 0) {
+                null
+            } else {
+                output.toString(Charsets.UTF_8)
+            }
+        }.getOrNull()
+
+    /** Runs at case-selection time, outside any coroutine, so it stays blocking. */
+    private fun requireTool(name: String): String? =
+        if (runProcess("which", name).isNullOrBlank()) "$name not installed" else null
+
+    private fun linuxWithNativeClipboard(): String? {
+        val os = System.getProperty("os.name", "").lowercase()
+        if (os.contains("win") || os.contains("mac") || os.contains("darwin")) {
+            return "Linux only — GTK clipboard"
+        }
+        return if (NativeTaoLinuxClipboardBridge.isAvailable) null else "GTK clipboard unavailable"
+    }
+
+    private const val TOOL_TIMEOUT_SECONDS = 5L
+    private const val FOCUS_SETTLE_MILLIS = 800L
+    private const val CLIPBOARD_TIMEOUT_MILLIS = 5_000L
+    private const val POLL_MILLIS = 100L
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ClipboardHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ClipboardHeadfulCases.kt
@@ -10,10 +10,14 @@ import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxClipboardBridge
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
+import java.awt.image.BufferedImage
+import java.io.File
 import java.util.concurrent.TimeUnit
+import javax.imageio.ImageIO
 
 /**
  * #582 — the Tao clipboard must be the *window's* clipboard (GTK / the current
@@ -31,14 +35,17 @@ import java.util.concurrent.TimeUnit
  * real input event. An unfocused window neither sees nor can take the
  * selection — the same reason `wl-paste` needs the `data-control` protocol.
  *
- * The AWT path is deliberately unreachable: the clipboard is built with a
- * fallback that fails the case if it is ever consulted.
+ * In the two text cases the AWT path is deliberately unreachable — the
+ * clipboard is built with a fallback that fails the case if it is ever
+ * consulted. The third case is the opposite: it checks that non-text flavors,
+ * which GTK does not carry yet, still reach the app through that fallback.
  */
 internal object ClipboardHeadfulCases {
     fun all(): List<TaoWindowTestCase> =
         listOf(
             gtkClipboardReadsForeignSelection(),
             gtkClipboardPublishesToTheDesktop(),
+            nonTextFlavorsStillReachTheApp(),
         )
 
     /** Text with a non-BMP character: modified UTF-8 would corrupt it. */
@@ -85,6 +92,81 @@ internal object ClipboardHeadfulCases {
                 readClipboardWith("wl-paste", "--no-newline") == text
             }
         }
+
+    /**
+     * GTK only carries text so far, so an image must still arrive through the
+     * AWT fallback: replacing `LocalClipboard` on Linux must not *narrow* what
+     * an app can paste. Skipped when AWT itself cannot see the image (no
+     * XWayland bridge), since then there is nothing to preserve.
+     */
+    private fun nonTextFlavorsStillReachTheApp(): TaoWindowTestCase =
+        TaoWindowTestCase(
+            name = "#582 an image on the clipboard still reaches the app (AWT fallback)",
+            skip = { linuxWithNativeClipboard() ?: requireTool("wl-copy") },
+        ) {
+            focusAndSettle()
+
+            check(publishPngWithWlCopy()) { "wl-copy failed to publish the image" }
+            if (!awtSeesImage()) {
+                // The X11 bridge is what the fallback rides on; without it this
+                // case has no baseline to compare against.
+                return@TaoWindowTestCase
+            }
+
+            val clipboard = TaoLinuxClipboard(fallback = AwtClipboard)
+            awaitClipboard("the clip entry to offer an image flavor") {
+                clipboard.getClipEntry()?.supportsImage() == true
+            }
+        }
+
+    private suspend fun publishPngWithWlCopy(): Boolean =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val png = File.createTempFile("nucleus-582-", ".png")
+                png.deleteOnExit()
+                val image = BufferedImage(PROBE_IMAGE_SIZE, PROBE_IMAGE_SIZE, BufferedImage.TYPE_INT_RGB)
+                ImageIO.write(image, "png", png)
+                val process =
+                    ProcessBuilder("wl-copy", "--type", "image/png")
+                        .redirectInput(png)
+                        .redirectErrorStream(true)
+                        .start()
+                process.waitFor(TOOL_TIMEOUT_SECONDS, TimeUnit.SECONDS) && process.exitValue() == 0
+            }.getOrDefault(false)
+        }
+
+    private suspend fun awtSeesImage(): Boolean =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                Toolkit
+                    .getDefaultToolkit()
+                    .systemClipboard
+                    .getContents(null)
+                    ?.isDataFlavorSupported(DataFlavor.imageFlavor) == true
+            }.getOrDefault(false)
+        }
+
+    private fun ClipEntry.supportsImage(): Boolean =
+        (nativeClipEntry as? Transferable)?.isDataFlavorSupported(DataFlavor.imageFlavor) == true
+
+    /** What Compose's `AwtPlatformClipboard` does; that class is internal, hence the copy. */
+    private object AwtClipboard : Clipboard {
+        override suspend fun getClipEntry(): ClipEntry? =
+            withContext(Dispatchers.IO) {
+                Toolkit
+                    .getDefaultToolkit()
+                    .systemClipboard
+                    .getContents(null)
+                    ?.let { ClipEntry(it) }
+            }
+
+        override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+            val transferable = clipEntry?.nativeClipEntry as? Transferable ?: return
+            withContext(Dispatchers.IO) {
+                Toolkit.getDefaultToolkit().systemClipboard.setContents(transferable, null)
+            }
+        }
+    }
 
     /**
      * Wayland hands selection offers to the focused client only, so a case that
@@ -168,6 +250,7 @@ internal object ClipboardHeadfulCases {
         return if (NativeTaoLinuxClipboardBridge.isAvailable) null else "GTK clipboard unavailable"
     }
 
+    private const val PROBE_IMAGE_SIZE = 32
     private const val TOOL_TIMEOUT_SECONDS = 5L
     private const val FOCUS_SETTLE_MILLIS = 800L
     private const val CLIPBOARD_TIMEOUT_MILLIS = 5_000L

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -363,7 +363,8 @@ public object TaoHeadfulTestSuiteMain {
             DisplayScaleHeadfulCases.all() +
             FramePacingHeadfulCases.all() +
             MacWindowChromeStateHeadfulCases.all() +
-            PopupScaleHeadfulCases.all()
+            PopupScaleHeadfulCases.all() +
+            ClipboardHeadfulCases.all()
 
     private val cases: List<TaoWindowTestCase> =
         allCases.filter { nameFilter == null || it.name.contains(nameFilter, ignoreCase = true) }


### PR DESCRIPTION
Closes #582.

## Summary

- Compose Desktop's only clipboard implementation reads `java.awt.Toolkit.getSystemClipboard()`, which is X11-only on Linux. A Tao window is a GTK window on whichever GDK backend the session provides, so on Wayland the two disagree: KWin publishes the Wayland selection to XWayland only while an X11 window is *active*, so `Ctrl+V` in a Wayland-native window pastes nothing, and with no XWayland at all the AWT call is headless.
- New `libnucleus_tao_linux_clipboard.so` (GTK/GObject `dlopen`-ed `RTLD_LOCAL`, links `-ldl` only) plus a `Clipboard` / `ClipboardManager` pair installed over `LocalClipboard` / `LocalClipboardManager` in `TaoComposeSceneHostLinux`.
- GDK rather than `wl-clipboard` / `arboard`: it speaks the *current* backend with the window's own seat, needs no `wlr-data-control`, serves the data from this process and forks nothing.
- Falls back to the inherited AWT clipboard whenever the helper is unavailable (non-Linux, missing library, headless, GTK never initialised), so macOS and Windows are untouched and the locals are simply left alone.
- Text crosses JNI as **UTF-8 byte arrays**, not `jstring`: `GetStringUTFChars` produces modified UTF-8 and would corrupt every non-BMP character (emoji).
- Only `text/plain` crosses the process boundary. Compose's `AnnotatedString` flavor is JVM-local and no real selection can carry it (AWT cannot either), so the last published entry is cached and handed back while the selection still holds that text — span styles survive an in-app copy/paste.
- `LocalClipboardManager` is deprecated upstream but still provided: legacy call sites would otherwise keep reading the X11 selection while everything else reads the Wayland one. Its blocking reads spin a nested GTK main loop, so off-thread callers are handed to AWT instead.
- Plumbing: `build.sh` section + listings, the three CI verify lists (`build-natives`, `pre-merge`, `publish-maven`), and `reachability-metadata.json` entries for the bridge, the callback interface and its single named implementation.

## Notes from testing on a real Wayland session

- Without focus nothing works on Wayland: the compositor only sends selection offers to the focused client and only accepts `set_selection` with a serial from a real input event. No impact on real usage (`Ctrl+C` / `Ctrl+V` happen in a focused window), but a test that skips focusing measures GTK's local cache only.
- While the app owns the selection, the GTK main loop is what answers a reader's data request — blocking that thread on `wl-paste` deadlocks both sides. The production path never blocks it.
- `Toolkit.getSystemClipboard()` appears only in the three Compose classes this bypasses, so there is no second AWT path left in `foundation` / `ui`.

## Test plan

- [x] `:decorated-window-tao:taoHeadfulTest -Dnucleus.tao.headful.filter=582` — 2 new real-window cases, green on GNOME Wayland: reading a selection owned by another process (`wl-copy`, the reported bug) and publishing the app's selection so `wl-paste` sees it, round-trip byte-identical with emoji, same `ClipEntry` instance returned
- [x] `:decorated-window-tao:test`
- [x] `:decorated-window-tao:ktlintCheck`, `:detekt`, `:apiCheck`
- [x] `nucleus_tao_linux_clipboard.c` compiles clean under `-Wall -Wextra`
- [x] CI cross-arch natives build (`linux-aarch64` slot)
- [ ] Manual paste check on KDE Plasma Wayland (the reporter's session)