### PR TITLE
fix(media-control): never hang on invalid MPRIS D-Bus name (Linux)

### DIFF
--- a/media-control/src/main/kotlin/dev/nucleusframework/media/control/MediaControlService.kt
+++ b/media-control/src/main/kotlin/dev/nucleusframework/media/control/MediaControlService.kt
@@ -43,12 +43,17 @@ public object MediaControlService {
      * On Linux, registers the MPRIS D-Bus name (format `org.mpris.MediaPlayer2.<name>`).
      * On macOS, this is a no-op — identity is derived from the host app bundle.
      *
-     * @param dbusName The D-Bus bus name (Linux only). Defaults to `org.mpris.MediaPlayer2.${NucleusApp.appId}`.
+     * @param dbusName The D-Bus bus name (Linux only). Defaults to
+     *                 `org.mpris.MediaPlayer2.<suffix>` where the suffix is [NucleusApp.appId]
+     *                 sanitized into a legal D-Bus name (characters outside `[A-Za-z0-9_-]`
+     *                 replaced, digit-leading elements prefixed). An explicit value is used as-is;
+     *                 if it is not a valid D-Bus name, MPRIS registration is skipped and
+     *                 [attach] returns without blocking.
      * @param displayName The human-readable name shown in the system media center.
      *                    Defaults to [NucleusApp.appName] or `"Nucleus App"`.
      */
     public fun configure(
-        dbusName: String = "org.mpris.MediaPlayer2.${NucleusApp.appId}",
+        dbusName: String = "org.mpris.MediaPlayer2.${sanitizeMprisSuffix(NucleusApp.appId)}",
         displayName: String = NucleusApp.appName ?: "Nucleus App",
     ) {
         backend.configure(dbusName, displayName)
@@ -145,6 +150,26 @@ public object MediaControlService {
     }
 
     private const val MICROS_PER_MS = 1000L
+
+    // "org.mpris.MediaPlayer2." + suffix must stay under the 255-char D-Bus name limit.
+    private const val MAX_MPRIS_SUFFIX_LENGTH = 200
+    private val dbusIllegalChars = Regex("[^A-Za-z0-9_-]")
+
+    /**
+     * Builds a legal D-Bus name suffix from an arbitrary application id: within each
+     * dot-separated element, illegal characters (e.g. spaces) become `_` and elements
+     * starting with a digit get a `_` prefix; empty elements are dropped.
+     */
+    internal fun sanitizeMprisSuffix(appId: String): String =
+        appId
+            .split('.')
+            .filter { it.isNotEmpty() }
+            .joinToString(".") { element ->
+                val cleaned = element.replace(dbusIllegalChars, "_")
+                if (cleaned.first().isDigit()) "_$cleaned" else cleaned
+            }.take(MAX_MPRIS_SUFFIX_LENGTH)
+            .trimEnd('.')
+            .ifEmpty { "NucleusApp" }
 
     // ---- Backend abstraction ------------------------------------------------
 

--- a/media-control/src/main/kotlin/dev/nucleusframework/media/control/linux/NativeLinuxBridge.kt
+++ b/media-control/src/main/kotlin/dev/nucleusframework/media/control/linux/NativeLinuxBridge.kt
@@ -1,10 +1,12 @@
 package dev.nucleusframework.media.control.linux
 
 import dev.nucleusframework.core.runtime.NativeLibraryLoader
+import java.util.logging.Logger
 
 private const val LIBRARY_NAME = "nucleus_media_control_linux"
 
 internal object NativeLinuxBridge {
+    private val logger = Logger.getLogger(NativeLinuxBridge::class.java.name)
     private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeLinuxBridge::class.java)
     val isLoaded: Boolean get() = loaded
 
@@ -14,7 +16,13 @@ internal object NativeLinuxBridge {
     fun attach(callback: (String) -> Unit): Boolean {
         userCallback = callback
         if (!isLoaded) return false
-        return nativeStartListening()
+        val started = nativeStartListening()
+        if (!started) {
+            logger.warning(
+                "MPRIS registration failed (invalid or unavailable D-Bus name) — OS media controls disabled",
+            )
+        }
+        return started
     }
 
     fun detach() {

--- a/media-control/src/main/native/linux/nucleus_media_control_linux.c
+++ b/media-control/src/main/native/linux/nucleus_media_control_linux.c
@@ -18,6 +18,8 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <inttypes.h>
+#include <errno.h>
+#include <time.h>
 
 /* ---- Constants -------------------------------------------------------- */
 
@@ -29,6 +31,8 @@
 #define STATUS_STOPPED 0
 #define STATUS_PAUSED  1
 #define STATUS_PLAYING 2
+
+#define NAME_ACQUISITION_TIMEOUT_SECONDS 10
 
 /* ---- Introspection XML ------------------------------------------------ */
 
@@ -625,6 +629,22 @@ static void *service_thread_func(void *arg) {
         NULL, NULL);
     g_free(bus_name);
 
+    if (g_own_id == 0) {
+        /* g_bus_own_name() rejected the name without invoking any callback
+           (e.g. failed g_dbus_is_name assertion): fail open so waiters in
+           nativeStartListening() are released instead of blocking forever. */
+        pthread_mutex_lock(&g_state_mutex);
+        g_ready = -1;
+        pthread_cond_broadcast(&g_ready_cond);
+        g_ctx = NULL;
+        g_running = 0;
+        pthread_mutex_unlock(&g_state_mutex);
+        pthread_detach(pthread_self());
+        g_main_context_pop_thread_default(ctx);
+        g_main_context_unref(ctx);
+        return NULL;
+    }
+
     GMainLoop *loop = g_main_loop_new(ctx, FALSE);
 
     pthread_mutex_lock(&g_state_mutex);
@@ -760,6 +780,12 @@ Java_dev_nucleusframework_media_control_linux_NativeLinuxBridge_nativeStartListe
         pthread_mutex_unlock(&g_state_mutex);
         return JNI_FALSE;
     }
+    if (!g_dbus_is_name(g_bus_name) || g_dbus_is_unique_name(g_bus_name)) {
+        g_warning("nucleus-media-control: '%s' is not a valid D-Bus well-known name; "
+                  "MPRIS registration skipped", g_bus_name);
+        pthread_mutex_unlock(&g_state_mutex);
+        return JNI_FALSE;
+    }
     g_running = 1;
     g_ready   = 0;
     if (pthread_create(&g_thread, NULL, service_thread_func, NULL) != 0) {
@@ -767,9 +793,17 @@ Java_dev_nucleusframework_media_control_linux_NativeLinuxBridge_nativeStartListe
         pthread_mutex_unlock(&g_state_mutex);
         return JNI_FALSE;
     }
-    /* Wait until the bus name is acquired (or definitively lost) */
+    /* Wait until the bus name is acquired (or definitively lost). Bounded so a
+       stalled bus can never block the caller — often the UI thread — forever;
+       on timeout we fail open and the service thread keeps trying in the
+       background (controls simply appear if the name is acquired later). */
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += NAME_ACQUISITION_TIMEOUT_SECONDS;
     while (g_ready == 0 && g_running) {
-        pthread_cond_wait(&g_ready_cond, &g_state_mutex);
+        if (pthread_cond_timedwait(&g_ready_cond, &g_state_mutex, &deadline) == ETIMEDOUT) {
+            break;
+        }
     }
     jboolean ok = (g_ready == 1) ? JNI_TRUE : JNI_FALSE;
     pthread_mutex_unlock(&g_state_mutex);

--- a/media-control/src/test/kotlin/dev/nucleusframework/media/control/MediaControlTest.kt
+++ b/media-control/src/test/kotlin/dev/nucleusframework/media/control/MediaControlTest.kt
@@ -71,6 +71,43 @@ class MediaControlTest {
     }
 
     @Test
+    fun `mpris suffix sanitization produces legal dbus names`() {
+        assertEquals("Music_Radio", MediaControlService.sanitizeMprisSuffix("Music Radio"))
+        assertEquals("dev.kdroid.musicradio", MediaControlService.sanitizeMprisSuffix("dev.kdroid.musicradio"))
+        assertEquals("_1password", MediaControlService.sanitizeMprisSuffix("1password"))
+        assertEquals("my-app", MediaControlService.sanitizeMprisSuffix("my-app"))
+        assertEquals("caf__app", MediaControlService.sanitizeMprisSuffix("café app"))
+        assertEquals("a.b", MediaControlService.sanitizeMprisSuffix(".a..b."))
+        assertEquals("NucleusApp", MediaControlService.sanitizeMprisSuffix(""))
+        assertEquals("NucleusApp", MediaControlService.sanitizeMprisSuffix("..."))
+        assertEquals(200, MediaControlService.sanitizeMprisSuffix("a".repeat(300)).length)
+    }
+
+    @Test
+    fun `attach with an invalid dbus name fails open without blocking`() {
+        if (Platform.Current != Platform.Linux || !MediaControlService.isAvailable()) return
+
+        val done = CountDownLatch(1)
+        Thread {
+            MediaControlService.configure(
+                dbusName = "org.mpris.MediaPlayer2.Music Radio",
+                displayName = "Test Player",
+            )
+            MediaControlService.attach { }
+            done.countDown()
+        }.apply {
+            isDaemon = true
+            start()
+        }
+        try {
+            assertTrue(done.await(15, TimeUnit.SECONDS), "attach blocked forever on an invalid D-Bus name")
+        } finally {
+            MediaControlService.detach()
+            MediaControlService.configure(dbusName = "org.mpris.MediaPlayer2.test", displayName = "Test Player")
+        }
+    }
+
+    @Test
     fun `native event json is parsed into typed events when a backend is attached`() {
         if (!MediaControlService.isAvailable()) {
             MediaControlService.attach { }


### PR DESCRIPTION
Fixes #548

## Summary

An `app.id` containing characters illegal in a D-Bus name (e.g. `Music Radio`) produced an invalid default MPRIS bus name. `g_bus_own_name()` rejected it without invoking `on_name_acquired`/`on_name_lost`, so `nativeStartListening()` waited on the ready condition forever — blocking the caller (often the Tao UI thread during first composition), leaving the app windowless while it still owned the single-instance lock.

- `MediaControlService`: the default `dbusName` now sanitizes `NucleusApp.appId` into a legal D-Bus name (illegal chars → `_`, digit-leading elements prefixed with `_`, empty elements dropped, 255-char name limit respected) — `Music Radio` → `org.mpris.MediaPlayer2.Music_Radio`
- native: validate the name with `g_dbus_is_name()` before spawning the service thread; skip MPRIS with a warning instead of blocking
- native: fail open (`g_ready = -1` + broadcast) if `g_bus_own_name()` returns 0 without invoking any callback
- native: bound the ready wait with a 10 s `pthread_cond_timedwait` backstop so a stalled session bus can never block the UI thread indefinitely (if the name is acquired later, controls simply start working)
- `NativeLinuxBridge`: JUL warning when MPRIS registration fails, so the skip is visible

No public ABI change (default-parameter expression + internal helper only); `apiCheck` passes.

## Test plan

- [x] New unit test: `sanitizeMprisSuffix` cases (spaces, digit-leading, hyphens, empty/dot-only ids, length cap)
- [x] New regression test: `attach()` with the exact invalid name from the issue (`org.mpris.MediaPlayer2.Music Radio`) returns instead of hanging (bounded latch)
- [x] `:media-control:test` (Linux `.so` rebuilt from the patched C source) — 8 tests green
- [x] `:media-control:detekt`, `:media-control:ktlintCheck`, `:media-control:apiCheck`