### PR TITLE
fix(tao): stop TitleBar+content tremble when animating WindowState.size

### DIFF
--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -154,6 +154,9 @@ val taoHeadfulTest by tasks.registering(JavaExec::class) {
     System.getProperty("nucleus.tao.headful.filter")?.let {
         systemProperty("nucleus.tao.headful.filter", it)
     }
+    System.getProperty("nucleus.issue576.samples")?.let {
+        systemProperty("nucleus.issue576.samples", it)
+    }
     // Honor a caller-forced Linux renderer (x11 / wayland) so portal parenting
     // e2es can be launched against XWayland from a native Wayland session.
     providers.environmentVariable("NUCLEUS_TAO_LINUX_RENDERER").orNull?.let {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -31,6 +31,7 @@ import dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDecoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
 import dev.nucleusframework.window.tao.ffi.toRgbaIcon
 import kotlinx.coroutines.delay
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
@@ -215,6 +216,8 @@ public fun ApplicationScope.DecoratedWindow(
                 var placement: WindowPlacement? = null
                 var isMinimized: Boolean? = null
                 var wrapSettled: Boolean = !wrapWidth && !wrapHeight
+                /** Physical px of the last programmatic [TaoWindow.setInnerSize]; null = user/OS resize. */
+                var pendingProgrammaticPx: IntSize? = null
             }
         }
 
@@ -304,14 +307,30 @@ public fun ApplicationScope.DecoratedWindow(
                 if (wPx <= 0 || hPx <= 0) return@onResized
                 val scale = (NativeTaoBridge.nativeScaleFactor(w.handle).coerceAtLeast(1)) / 1000f
                 val newSize = DpSize((wPx / scale).dp, (hPx / scale).dp)
-                if (newSize != applied.size) {
-                    applied.size = newSize
-                    // Keep Unspecified in WindowState until wrap-content
-                    // measurement writes the real size; otherwise the first
-                    // native configure (creation fallback) would freeze the
-                    // requested wrap axis at 600dp.
-                    if (applied.wrapSettled) {
-                        latestState.size = newSize
+                val pending = applied.pendingProgrammaticPx
+                val programmaticEcho =
+                    pending != null &&
+                        abs(wPx - pending.width) <= PROGRAMMATIC_SIZE_ECHO_PX &&
+                        abs(hPx - pending.height) <= PROGRAMMATIC_SIZE_ECHO_PX
+                // In-flight programmatic resize: a stale WM_SIZE from the
+                // previous request must not write WindowState.size backwards
+                // and fight animateDpAsState (#576).
+                if (pending == null || programmaticEcho) {
+                    if (programmaticEcho) {
+                        applied.pendingProgrammaticPx = null
+                    }
+                    if (newSize != applied.size) {
+                        applied.size = newSize
+                        // Keep Unspecified in WindowState until wrap-content
+                        // measurement writes the real size; otherwise the first
+                        // native configure (creation fallback) would freeze the
+                        // requested wrap axis at 600dp.
+                        // Programmatic echoes must not overwrite the size the
+                        // animation/composition just wrote — dp↔px rounding
+                        // would otherwise ping-pong setInnerSize.
+                        if (applied.wrapSettled && !programmaticEcho) {
+                            latestState.size = newSize
+                        }
                     }
                 }
                 // Tao doesn't emit a dedicated "placement changed" event, but
@@ -326,6 +345,9 @@ public fun ApplicationScope.DecoratedWindow(
                         else -> WindowPlacement.Floating
                     }
                 if (placementNow != applied.placement) {
+                    if (placementNow != WindowPlacement.Floating) {
+                        applied.pendingProgrammaticPx = null
+                    }
                     applied.placement = placementNow
                     latestState.placement = placementNow
                 }
@@ -378,6 +400,11 @@ public fun ApplicationScope.DecoratedWindow(
                 measured = measured,
                 scale = scale,
             ) ?: return@LaunchedEffect
+        applied.pendingProgrammaticPx =
+            IntSize(
+                (resolved.width.value * scale).roundToInt(),
+                (resolved.height.value * scale).roundToInt(),
+            )
         window.setInnerSize(
             resolved.width.value.toDouble(),
             resolved.height.value.toDouble(),
@@ -395,6 +422,12 @@ public fun ApplicationScope.DecoratedWindow(
         if (state.placement != WindowPlacement.Floating) return@LaunchedEffect
         if (!state.size.width.isSpecified || !state.size.height.isSpecified) return@LaunchedEffect
         if (state.size != applied.size) {
+            val scale = (NativeTaoBridge.nativeScaleFactor(window.handle).coerceAtLeast(1)) / 1000f
+            applied.pendingProgrammaticPx =
+                IntSize(
+                    (state.size.width.value * scale).roundToInt(),
+                    (state.size.height.value * scale).roundToInt(),
+                )
             window.setInnerSize(
                 state.size.width.value
                     .toDouble(),
@@ -569,6 +602,9 @@ private fun WindowState.applyMacOsInitialMaximizedSize() {
  */
 private const val ALIGNED_POSITION_RETRIES = 10
 private const val ALIGNED_POSITION_RETRY_MS = 16L
+
+/** Native px slop when matching a programmatic setInnerSize echo (#576). */
+private const val PROGRAMMATIC_SIZE_ECHO_PX = 1
 
 /**
  * Resolves a [WindowPosition.Aligned] against the primary monitor's work area

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -216,6 +216,7 @@ public fun ApplicationScope.DecoratedWindow(
                 var placement: WindowPlacement? = null
                 var isMinimized: Boolean? = null
                 var wrapSettled: Boolean = !wrapWidth && !wrapHeight
+
                 /** Physical px of the last programmatic [TaoWindow.setInnerSize]; null = user/OS resize. */
                 var pendingProgrammaticPx: IntSize? = null
             }

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -655,12 +655,34 @@ pub(crate) fn run_event_loop_blocking() {
                     width,
                     height,
                 } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
+                    let inner = {
+                        let guard = WINDOWS.lock().unwrap();
+                        guard.as_ref().and_then(|map| {
+                            let w = map.get(&handle)?;
                             w.set_inner_size(LogicalSize::new(width, height));
-                        }
+                            Some(w.inner_size())
+                        })
+                    };
+                    // Win32 `SetWindowPos(SWP_ASYNCWINDOWPOS)` and a GCD-async
+                    // `setContentSize:` both update the live window rect before
+                    // the matching `Resized` event is delivered. Push
+                    // EVENT_RESIZED from the size we just applied so the
+                    // Compose scene/present tracks the HWND/NSWindow in this
+                    // turn — otherwise TitleBar + content tremble against the
+                    // already-resized chrome (#576). GTK queues Size through
+                    // the request channel; `inner_size()` is still the previous
+                    // configure there, so the real `Resized` follows later.
+                    #[cfg(any(target_os = "windows", target_os = "macos"))]
+                    if let Some(size) = inner {
+                        dispatch(
+                            handle,
+                            EVENT_RESIZED,
+                            size.width as jint,
+                            size.height as jint,
+                        );
                     }
+                    #[cfg(target_os = "linux")]
+                    let _ = inner;
                 }
                 UserEvent::SetOuterPosition { handle, x, y } => {
                     let guard = WINDOWS.lock().unwrap();

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/macos/util/async.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/macos/util/async.rs
@@ -85,6 +85,14 @@ pub unsafe fn set_style_mask_sync(ns_window: &NSWindow, ns_view: &NSView, mask: 
 // `setContentSize:` isn't thread-safe either, though it doesn't log any errors
 // and just fails silently. Anyway, GCD to the rescue!
 pub unsafe fn set_content_size_async(ns_window: &NSWindow, size: LogicalSize<f64>) {
+  // PATCH(nucleus): apply immediately on the main thread so a programmatic
+  // WindowState.size animation (#576) doesn't leave the NSWindow a frame
+  // behind the Compose scene. GCD async is only needed off-thread
+  // (`setContentSize:` is not thread-safe). Mirrors `set_frame_top_left_point_async`.
+  if is_main_thread() {
+    ns_window.setContentSize(NSSize::new(size.width as CGFloat, size.height as CGFloat));
+    return;
+  }
   let ns_window = MainThreadSafe(ns_window.retain());
   DispatchQueue::main().exec_async(move || {
     ns_window.setContentSize(NSSize::new(size.width as CGFloat, size.height as CGFloat));

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/util.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/util.rs
@@ -104,6 +104,12 @@ pub(crate) fn set_inner_size_physical(window: HWND, x: i32, y: i32, is_decorated
 
     let outer_x = (rect.right - rect.left).abs();
     let outer_y = (rect.top - rect.bottom).abs();
+    // PATCH(nucleus): do not use SWP_ASYNCWINDOWPOS. That flag updates the
+    // outer HWND (GetWindowRect) before WM_SIZE / GetClientRect catch up, so
+    // a programmatic WindowState.size animation (#576) leaves the Compose
+    // scene a frame behind the chrome — TitleBar + content tremble. Tao
+    // buffers nested WM_SIZE while a UserEvent is in flight, so a
+    // synchronous SetWindowPos does not re-enter the event handler.
     let _ = SetWindowPos(
       window,
       None,
@@ -111,7 +117,7 @@ pub(crate) fn set_inner_size_physical(window: HWND, x: i32, y: i32, is_decorated
       0,
       outer_x,
       outer_y,
-      SWP_ASYNCWINDOWPOS | SWP_NOZORDER | SWP_NOREPOSITION | SWP_NOMOVE | SWP_NOACTIVATE,
+      SWP_NOZORDER | SWP_NOREPOSITION | SWP_NOMOVE | SWP_NOACTIVATE,
     );
     let _ = InvalidateRgn(window, None, false);
   }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AnimatedWindowSizeHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AnimatedWindowSizeHeadfulCases.kt
@@ -161,9 +161,7 @@ internal object AnimatedWindowSizeHeadfulCases {
                         .fillMaxWidth()
                         .weight(1f)
                         .background(Color(CONTENT_ARGB))
-                        .drawBehind {
-                            drawRect(Color.Black.copy(alpha = (frameTick % 2f) * 0.01f))
-                        }
+                        .drawBehind { drawRect(Color.Black.copy(alpha = (frameTick % 2f) * 0.01f)) }
                         .onGloballyPositioned { coords ->
                             val p = coords.positionInWindow()
                             content.set(

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AnimatedWindowSizeHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AnimatedWindowSizeHeadfulCases.kt
@@ -1,0 +1,378 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
+import dev.nucleusframework.window.TitleBar
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * #576 — programmatic animated [WindowState.size] height must not make
+ * TitleBar + body content tremble against the native window.
+ *
+ * Reproduces the issue's `animateDpAsState` → `WindowState.size` path on a
+ * real Tao `DecoratedWindow` with TitleBar + content, samples native bounds
+ * vs Compose layout/scene each frame, and gates the tremble metric.
+ */
+internal object AnimatedWindowSizeHeadfulCases {
+    fun all(): List<TaoWindowTestCase> = listOf(animatedHeightDoesNotTremble())
+
+    private data class LayoutPx(
+        var x: Int = 0,
+        var y: Int = 0,
+        var w: Int = 0,
+        var h: Int = 0,
+    )
+
+    private data class Sample(
+        val nanos: Long,
+        val requestedH: Int,
+        val stateH: Int,
+        val outerX: Int,
+        val outerY: Int,
+        val outerW: Int,
+        val outerH: Int,
+        val innerW: Int,
+        val innerH: Int,
+        val sceneW: Int,
+        val sceneH: Int,
+        val titleX: Int,
+        val titleY: Int,
+        val titleW: Int,
+        val titleH: Int,
+        val contentX: Int,
+        val contentY: Int,
+        val contentW: Int,
+        val contentH: Int,
+    )
+
+    private fun animatedHeightDoesNotTremble(): TaoWindowTestCase {
+        val windowState =
+            WindowState(
+                position = WindowPosition.Aligned(Alignment.Center),
+                size = DpSize(WINDOW_WIDTH_DP.dp, START_HEIGHT_DP.dp),
+            )
+        val targetHeight = mutableStateOf(START_HEIGHT_DP.dp)
+        val samples = CopyOnWriteArrayList<Sample>()
+        val recording = AtomicBoolean(false)
+        val innerW = AtomicInteger(0)
+        val innerH = AtomicInteger(0)
+        val titleBar = AtomicReference(LayoutPx())
+        val content = AtomicReference(LayoutPx())
+        val latestRequestedH = AtomicInteger(0)
+
+        return TaoWindowTestCase(
+            name = "#576 animated WindowState.size height does not tremble TitleBar + content",
+            timeoutMillis = CASE_TIMEOUT_MILLIS,
+            paintDefaultBackground = false,
+            windowState = windowState,
+            size = DpSize(WINDOW_WIDTH_DP.dp, START_HEIGHT_DP.dp),
+            content = {
+                val density = LocalDensity.current.density
+                val scene = LocalWindowInfo.current.containerSize
+                val animatedHeight by animateDpAsState(
+                    targetValue = targetHeight.value,
+                    animationSpec = tween(durationMillis = ANIM_MILLIS, easing = LinearEasing),
+                    label = "issue576-window-height",
+                )
+                windowState.size = DpSize(WINDOW_WIDTH_DP.dp, animatedHeight)
+                latestRequestedH.set((animatedHeight.value * density).roundToInt())
+
+                fun snapshot() {
+                    if (!recording.get()) return
+                    val outer = window.outerBoundsPx() ?: return
+                    val tb = titleBar.get()
+                    val body = content.get()
+                    if (tb.w <= 0 || body.w <= 0) return
+                    // SideEffect runs before layout. If containerSize already
+                    // moved, wait for onGloballyPositioned of this frame.
+                    if (abs(tb.h + body.h - scene.height) > PX_TOLERANCE) return
+                    samples +=
+                        Sample(
+                            nanos = System.nanoTime(),
+                            requestedH = latestRequestedH.get(),
+                            stateH = (windowState.size.height.value * density).roundToInt(),
+                            outerX = outer[0].toInt(),
+                            outerY = outer[1].toInt(),
+                            outerW = outer[2].toInt(),
+                            outerH = outer[3].toInt(),
+                            innerW = innerW.get(),
+                            innerH = innerH.get(),
+                            sceneW = scene.width,
+                            sceneH = scene.height,
+                            titleX = tb.x,
+                            titleY = tb.y,
+                            titleW = tb.w,
+                            titleH = tb.h,
+                            contentX = body.x,
+                            contentY = body.y,
+                            contentW = body.w,
+                            contentH = body.h,
+                        )
+                }
+
+                val phase = remember { mutableFloatStateOf(0f) }
+                // Read in composition so every frame clock tick recomposes
+                // and snapshot() runs during baseline, not only on layout changes.
+                val frameTick = phase.floatValue
+                TitleBar(
+                    Modifier.onGloballyPositioned { coords ->
+                        val p = coords.positionInWindow()
+                        titleBar.set(
+                            LayoutPx(
+                                p.x.roundToInt(),
+                                p.y.roundToInt(),
+                                coords.size.width,
+                                coords.size.height,
+                            ),
+                        )
+                    },
+                )
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .background(Color(CONTENT_ARGB))
+                        .drawBehind {
+                            drawRect(Color.Black.copy(alpha = (frameTick % 2f) * 0.01f))
+                        }
+                        .onGloballyPositioned { coords ->
+                            val p = coords.positionInWindow()
+                            content.set(
+                                LayoutPx(
+                                    p.x.roundToInt(),
+                                    p.y.roundToInt(),
+                                    coords.size.width,
+                                    coords.size.height,
+                                ),
+                            )
+                            snapshot()
+                        },
+                )
+
+                SideEffect { snapshot() }
+
+                LaunchedEffect(window) {
+                    window.onResized { w, h ->
+                        innerW.set(w)
+                        innerH.set(h)
+                    }
+                    while (true) {
+                        withFrameNanos { phase.floatValue += 1f }
+                    }
+                }
+            },
+            driver = {
+                awaitUntil("window mapped") { bounds() != null }
+                settle()
+                window.onResized { w, h ->
+                    innerW.set(w)
+                    innerH.set(h)
+                }
+                recording.set(true)
+                settle(BASELINE_MILLIS)
+                check(samples.isNotEmpty()) { "no baseline samples before the height animation" }
+
+                targetHeight.value = END_HEIGHT_DP.dp
+                settle(ANIM_MILLIS + SETTLE_AFTER_ANIM_MILLIS)
+                recording.set(false)
+
+                val dump = writeSamples(samples)
+                System.err.println("[#576] wrote ${samples.size} samples to $dump")
+                assertNoTremble(samples)
+            },
+        )
+    }
+
+    private fun writeSamples(samples: List<Sample>): File {
+        val path =
+            System.getProperty("nucleus.issue576.samples")
+                ?: File(System.getProperty("java.io.tmpdir"), "576-samples.csv").absolutePath
+        val file = File(path)
+        file.parentFile?.mkdirs()
+        file.writeText(
+            buildString {
+                appendLine(
+                    "nanos,requestedH,stateH,outerX,outerY,outerW,outerH,innerW,innerH," +
+                        "sceneW,sceneH,titleX,titleY,titleW,titleH,contentX,contentY,contentW,contentH," +
+                        "sceneVsInnerH,layoutVsSceneH,titleY,contentGap,outerY",
+                )
+                for (s in samples) {
+                    val sceneVsInner = if (s.innerH > 0) abs(s.sceneH - s.innerH) else -1
+                    val layoutVsScene = abs(s.titleH + s.contentH - s.sceneH)
+                    val contentGap = abs(s.contentY - s.titleH)
+                    appendLine(
+                        listOf(
+                            s.nanos,
+                            s.requestedH,
+                            s.stateH,
+                            s.outerX,
+                            s.outerY,
+                            s.outerW,
+                            s.outerH,
+                            s.innerW,
+                            s.innerH,
+                            s.sceneW,
+                            s.sceneH,
+                            s.titleX,
+                            s.titleY,
+                            s.titleW,
+                            s.titleH,
+                            s.contentX,
+                            s.contentY,
+                            s.contentW,
+                            s.contentH,
+                            sceneVsInner,
+                            layoutVsScene,
+                            s.titleY,
+                            contentGap,
+                            s.outerY,
+                        ).joinToString(","),
+                    )
+                }
+            },
+        )
+        return file
+    }
+
+    private fun assertNoTremble(samples: List<Sample>) {
+        check(samples.size >= MIN_SAMPLES) {
+            "need at least $MIN_SAMPLES frames, got ${samples.size}"
+        }
+        val startH = samples.first().requestedH
+        val animated =
+            samples.filter { abs(it.requestedH - startH) > 0 }
+        check(animated.size >= MIN_ANIM_SAMPLES) {
+            "height animation never moved on the sampled frames " +
+                "(start=$startH, samples=${samples.size}, animated=${animated.size})"
+        }
+
+        val baseline = samples.takeWhile { abs(it.requestedH - startH) <= 0 }
+        val chrome =
+            baseline
+                .map { it.outerH - it.sceneH }
+                .groupingBy { it }
+                .eachCount()
+                .maxByOrNull { it.value }
+                ?.key
+                ?: (samples.first().outerH - samples.first().sceneH)
+
+        var maxTitleY = 0
+        var maxContentGap = 0
+        var maxSceneVsInner = 0
+        var maxLayoutVsScene = 0
+        var maxSceneVsOuter = 0
+        var maxOriginOscillation = 0
+        var nativeHeightReversals = 0
+        var prevInnerH = animated.first().innerH.takeIf { it > 0 } ?: animated.first().sceneH
+        var prevOuterY = animated.first().outerY
+        var haveOuterYDir = false
+        var outerYRising = false
+
+        for (s in animated) {
+            maxTitleY = maxOf(maxTitleY, abs(s.titleY))
+            maxContentGap = maxOf(maxContentGap, abs(s.contentY - s.titleH))
+            maxLayoutVsScene = maxOf(maxLayoutVsScene, abs(s.titleH + s.contentH - s.sceneH))
+            // `innerH` is the last onResized callback — it can race ahead of
+            // this composition. Live inner size is outer minus chrome.
+            val liveInner = s.outerH - chrome
+            if (s.innerH > 0 && abs(s.innerH - liveInner) <= PX_TOLERANCE) {
+                maxSceneVsInner = maxOf(maxSceneVsInner, abs(s.sceneH - s.innerH))
+            }
+            maxSceneVsInner = maxOf(maxSceneVsInner, abs(s.sceneH - liveInner))
+            maxSceneVsOuter = maxOf(maxSceneVsOuter, abs(s.outerH - s.sceneH - chrome))
+            maxOriginOscillation = maxOf(maxOriginOscillation, abs(s.titleX), abs(s.contentX))
+
+            val nativeH = if (s.innerH > 0) s.innerH else s.sceneH
+            if (nativeH + PX_TOLERANCE < prevInnerH) {
+                nativeHeightReversals++
+            }
+            prevInnerH = nativeH
+
+            val dy = s.outerY - prevOuterY
+            if (dy != 0) {
+                val nowRising = dy > 0
+                if (haveOuterYDir && nowRising != outerYRising && abs(dy) > PX_TOLERANCE) {
+                    maxOriginOscillation = maxOf(maxOriginOscillation, abs(dy))
+                }
+                outerYRising = nowRising
+                haveOuterYDir = true
+            }
+            prevOuterY = s.outerY
+        }
+
+        System.err.println(
+            "[#576] metric maxTitleY=$maxTitleY maxContentGap=$maxContentGap " +
+                "maxSceneVsInner=$maxSceneVsInner maxLayoutVsScene=$maxLayoutVsScene " +
+                "maxSceneVsOuter=$maxSceneVsOuter (chrome=$chrome) " +
+                "heightReversals=$nativeHeightReversals originOsc=$maxOriginOscillation " +
+                "animatedFrames=${animated.size}",
+        )
+
+        val failures = mutableListOf<String>()
+        if (maxTitleY > PX_TOLERANCE) {
+            failures += "TitleBar origin Y jumped ${maxTitleY}px (window-top pin)"
+        }
+        if (maxContentGap > PX_TOLERANCE) {
+            failures += "content did not stay immediately under TitleBar (gap ${maxContentGap}px)"
+        }
+        if (maxLayoutVsScene > PX_TOLERANCE) {
+            failures += "TitleBar+content height drifted from scene by ${maxLayoutVsScene}px"
+        }
+        if (maxSceneVsInner > PX_TOLERANCE) {
+            failures += "Compose scene height drifted from native inner size by ${maxSceneVsInner}px"
+        }
+        if (maxSceneVsOuter > PX_TOLERANCE) {
+            failures += "Compose scene height drifted from native outer size by ${maxSceneVsOuter}px (chrome $chrome)"
+        }
+        if (nativeHeightReversals > 0) {
+            failures += "native height reversed $nativeHeightReversals time(s) while the animation only grew"
+        }
+        if (maxOriginOscillation > PX_TOLERANCE) {
+            failures += "window/content origin oscillated by ${maxOriginOscillation}px"
+        }
+        check(failures.isEmpty()) {
+            failures.joinToString("; ")
+        }
+    }
+
+    private const val WINDOW_WIDTH_DP = 420
+    private const val START_HEIGHT_DP = 360
+    private const val END_HEIGHT_DP = 560
+    private const val ANIM_MILLIS = 500
+    private const val BASELINE_MILLIS = 200L
+    private const val SETTLE_AFTER_ANIM_MILLIS = 250L
+    private const val CASE_TIMEOUT_MILLIS = 20_000L
+    private const val MIN_SAMPLES = 20
+    private const val MIN_ANIM_SAMPLES = 8
+    private const val PX_TOLERANCE = 1
+    private const val CONTENT_ARGB = 0xFF203040.toInt()
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -364,7 +364,8 @@ public object TaoHeadfulTestSuiteMain {
             FramePacingHeadfulCases.all() +
             MacWindowChromeStateHeadfulCases.all() +
             PopupScaleHeadfulCases.all() +
-            ClipboardHeadfulCases.all()
+            ClipboardHeadfulCases.all() +
+            AnimatedWindowSizeHeadfulCases.all()
 
     private val cases: List<TaoWindowTestCase> =
         allCases.filter { nameFilter == null || it.name.contains(nameFilter, ignoreCase = true) }
@@ -415,12 +416,13 @@ public object TaoHeadfulTestSuiteMain {
 
             if (skipReason == null) {
                 androidx.compose.runtime.key(current) {
+                    val fallbackState =
+                        rememberWindowState(
+                            size = case.size ?: DpSize(800.dp, 600.dp),
+                        )
                     DecoratedWindow(
                         onCloseRequest = { /* cases drive their own lifecycle */ },
-                        state =
-                            rememberWindowState(
-                                size = case.size ?: DpSize(800.dp, 600.dp),
-                            ),
+                        state = case.windowState ?: fallbackState,
                         title = "tao-headful: ${case.name}",
                         transparent = case.transparent,
                         nativePopupLayers = case.nativePopupLayers,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoWindowTestHarness.kt
@@ -2,6 +2,7 @@ package dev.nucleusframework.window.tao.headful
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.window.WindowState
 import dev.nucleusframework.window.tao.TaoDecoratedDialogScope
 import dev.nucleusframework.window.tao.TaoDecoratedWindowScope
 import dev.nucleusframework.window.tao.TaoWindow
@@ -52,6 +53,13 @@ internal class TaoWindowTestCase(
      * exercise wrap-content sizing (#532).
      */
     val size: DpSize? = null,
+    /**
+     * When non-null, the suite uses this [WindowState] instead of a fresh
+     * [androidx.compose.ui.window.rememberWindowState]. Lets a case animate
+     * or otherwise mutate size the same way an app drives
+     * `DecoratedWindow(state)` (#576).
+     */
+    val windowState: WindowState? = null,
     /**
      * When non-null, the suite also composes a [dev.nucleusframework.window.tao.DecoratedDialog]
      * at application scope (parented to this case's window). [dialogSize]


### PR DESCRIPTION
## Summary
- Programmatic `WindowState.size` height animation (`animateDpAsState`) left the HWND/NSWindow a frame ahead of the Compose scene, so TitleBar + content trembled against the already-resized chrome (#576).
- Swallow in-flight programmatic resize echoes so they cannot write `WindowState.size` backwards and fight the animation.
- After `set_inner_size`, dispatch `EVENT_RESIZED` immediately on Windows/macOS so the scene present tracks the live window in the same turn.
- Apply `setContentSize:` synchronously on the AppKit main thread; drop `SWP_ASYNCWINDOWPOS` so client and outer size update together.
- Add a filterable `taoHeadfulTest` case that animates height with TitleBar + body and asserts TitleBar stays pinned, content stays under it, and scene size tracks live native bounds within 1px.

## Test plan
- [ ] `./gradlew :decorated-window-tao:taoHeadfulTest -Dnucleus.tao.headful.filter=576` (Windows, this machine: failed at 23px scene-vs-outer before the fix, passed twice after)
- [ ] Same filter on macOS if a display is available (`setContentSize:` path)
- [ ] Spot-check a window that animates height between two screens with TitleBar + content