### PR TITLE
fix(tao): gate the PressAndHold heuristic while an IME composition is live

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoImeSession.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoImeSession.kt
@@ -84,7 +84,11 @@ internal class TaoImeSession(
      * `DesktopTextInputService2` / JDK-8074882). Falls back to a typed-key
      * sequence when no text-input session is up yet.
      */
-    fun replaceCommit(text: String) {
+    fun replaceCommit(rawText: String) {
+        // Apple corporate (function-key) characters must never reach the field:
+        // they render as tofu, and `deleteSurroundingTextInCodePoints` would
+        // still remove a real character before "inserting" them (#595).
+        val text = rawText.filterNot { it in '\uF700'..'\uF8FF' }
         if (text.isEmpty()) return
         val request = activeRequest
         if (request != null) {

--- a/decorated-window-tao/src/main/native/macos/main_thread_dispatch.m
+++ b/decorated-window-tao/src/main/native/macos/main_thread_dispatch.m
@@ -238,6 +238,24 @@ static void nucleus_insert_text(id self, SEL sel, id string, NSRange replacement
     BOOL isRepeat = nucleus_event_is_key_repeat(event);
     BOOL sameAsBase = (g_base_text != nil) && [incoming isEqualToString:g_base_text];
 
+    // Nucleus patch (nucleusframework#595 follow-up): a marked-text IME
+    // (Japanese, Chinese, ...) commits through insertText: while the view
+    // still holds the preedit. That is never PressAndHold: its picker only
+    // engages on a plain committed letter, outside any composition
+    // (JDK-8074882 flow). Without this gate a segment commit that lands
+    // while the next romaji key is down is registered as a "base letter",
+    // the IME's own selectedRange queries then look like the picker
+    // starting, and the *next* commit is hijacked into the replace-commit
+    // path — deleting a code point, skipping ImeCommit, and leaving the
+    // preedit stranded (visible as duplicated segments).
+    if ([(NSView<NSTextInputClient> *)self hasMarkedText]) {
+        nucleus_clear_press_and_hold();
+        if (g_orig_insert_text) {
+            ((void (*)(id, SEL, id, NSRange))g_orig_insert_text)(self, sel, string, replacement);
+        }
+        return;
+    }
+
     // First repeat / selectedRange query: PressAndHold re-inserts the base
     // letter. Swallow it or we consume the replace flag and the accent
     // arrives later as a second KEY_TYPED (eé).

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -190,6 +190,9 @@ public object TaoSceneTestBattery {
         run("TaoSceneImeTest: cancelled composition removes the preedit") {
             TaoSceneImeTest().`cancelled composition removes the preedit`()
         }
+        run("TaoSceneImeTest: empty IME commit while composing does not wipe the preedit") {
+            TaoSceneImeTest().`empty IME commit while composing does not wipe the preedit`()
+        }
         run("TaoSceneImeTest: typing after a commit works normally") {
             TaoSceneImeTest().`typing after a commit works normally`()
         }


### PR DESCRIPTION
Follow-up to #596 (on top of 3b9fdcb), for the remaining #595 symptoms. With the NSTextInputClient truthfulness fixes in place but **without** this gate, real ATOK prediction still produced duplicated segments (「二重**二重**に入力される不具合を再**再**現させて確認します**します**。」) plus U+F7xx tofu; with the gate, ATOK and Kotoeri type clean in our app.

## The remaining failure: the PressAndHold heuristic hijacks IME commits

Traced with instrumentation in `nucleus_insert_text` / `nucleus_note_press_and_hold_query`:

1. A marked-text IME segment commit (`insertText:("二重")`) often lands **while the next romaji key is physically down** — `nucleus_is_letter_key_event(NSApp.currentEvent)` is `YES`, so the committed segment is registered as a PressAndHold "base letter" (`g_did_insert_base`, `g_base_text = "二重"`).
2. The IME's own `selectedRange` queries (now frequent, since the view finally answers them) run `nucleus_note_press_and_hold_query()` → `g_press_and_hold_queried = YES`. The picker has been "detected" — but nothing was held down.
3. The **next** commit (`insertText:("します")`) matches `g_press_and_hold_queried && !sameAsBase` and is hijacked into `g_ime_replace_commit`: one code point gets deleted, `ImeCommit` is skipped, `in_ime_preedit` stays true, and the preedit is left stranded → duplicated segments on screen. When the hijacked payload is a function-key char, the tofu lands in the field through this path too (it had no corporate-character filter).

PressAndHold itself can never be active during a composition — its picker only engages on a plain committed letter outside any marked text (the JDK-8074882 flow this code documents). So the gate is simply: **while `hasMarkedText`, bypass all PressAndHold bookkeeping and forward `insertText:` straight to TaoView.**

## Changes

- `main_thread_dispatch.m`: gate `nucleus_insert_text` on `hasMarkedText` — clear stale picker state and delegate to the original implementation while a composition is live.
- `TaoImeSession.replaceCommit`: filter Apple corporate characters (defense in depth: a stray function-key payload must never delete a real character and insert tofu).
- `TaoSceneTestBattery`: register the new `empty IME commit while composing does not wipe the preedit` case — `TaoSceneTestBatteryDriftTest` is currently failing on this branch without it.

## Testing

- `:decorated-window-tao:test` (incl. the drift test) / `ktlintCheck` / `detekt` all green.
- Manual on real IMEs (macOS, Apple Silicon): ATOK predictive typing across multiple sentences, Kotoeri live conversion, arrow keys during/after conversion — no duplicated segments, no U+F7xx tofu, commits land once. Without the gate the duplication reproduces within a few sentences.

Happy to iterate — we can re-test any revision on ATOK + Kotoeri quickly.
