### PR TITLE
fix(build): pin javac/javadoc encoding to UTF-8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,6 +116,28 @@ subprojects {
         }
     }
 
+    // Sources are UTF-8, but `javac` and `javadoc` default to the *platform*
+    // encoding, which is only UTF-8 where the JVM's default charset happens to
+    // be. On a Windows machine with a non-Western system locale it is a legacy
+    // code page (windows-31j on Japanese, GBK on Simplified Chinese, ...), and
+    // any non-ASCII character in a Java source file — the em dash in
+    // `TaoTransferableAccess`, for instance — becomes
+    // "unmappable character for encoding", which is a hard error in `javadoc`.
+    // That makes `publishToMavenLocal` fail for those developers even though CI
+    // (Linux/macOS, UTF-8 by default) is green. Stating the encoding explicitly
+    // makes the build reproducible regardless of the host locale.
+    tasks.withType<JavaCompile>().configureEach {
+        options.encoding = "UTF-8"
+    }
+
+    tasks.withType<Javadoc>().configureEach {
+        options.encoding = "UTF-8"
+        (options as StandardJavadocDocletOptions).apply {
+            docEncoding = "UTF-8"
+            charSet = "UTF-8"
+        }
+    }
+
     ktlint {
         debug.set(false)
         verbose.set(true)


### PR DESCRIPTION
## Problem

`javac` and `javadoc` read sources in the **platform default** encoding, not UTF-8. On Windows with a non-Western system locale that is a legacy code page — `windows-31j` on Japanese, `GBK` on Simplified Chinese, and so on — so a non-ASCII character in a Java source file cannot be decoded.

`decorated-window-tao` has exactly one: the em dash in the KDoc of `TaoTransferableAccess`.

`javac` reports it as a warning, but `javadoc` treats it as an **error**, so `:decorated-window-tao:javadoc` fails and takes `publishToMavenLocal` down with it:

```
TaoTransferableAccess.java:8: error: unmappable character (0x94) for encoding windows-31j
 * and therefore unreachable from another Kotlin module ? but Java does not
                                                         ^
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':decorated-window-tao:javadoc'.
> Javadoc generation failed.
```

CI never sees this because Linux and macOS default to UTF-8. But it means a contributor on a Japanese/Chinese/Korean Windows machine cannot run `publishToMavenLocal` at all, which is the documented way to test a local build of the framework.

## Why not `-Dfile.encoding=UTF-8`

Setting `org.gradle.jvmargs=-Dfile.encoding=UTF-8` in `gradle.properties` does **not** fix it — `javadoc` runs in its own process, not in the Gradle daemon. The encoding has to be stated on the tasks themselves.

## Change

One block in the root `subprojects { }`, applying to every module:

```kotlin
tasks.withType<JavaCompile>().configureEach {
    options.encoding = "UTF-8"
}

tasks.withType<Javadoc>().configureEach {
    options.encoding = "UTF-8"
    (options as StandardJavadocDocletOptions).apply {
        docEncoding = "UTF-8"
        charSet = "UTF-8"
    }
}
```

`options.encoding` fixes reading the sources; `docEncoding` / `charSet` make the generated HTML declare UTF-8 as well, so the doc output is identical no matter which host produced it.

No behaviour change on Linux/macOS — it makes explicit what those platforms already default to.

## Verification

On Windows 11 (Japanese locale, JDK 17, `chcp` 932):

- before: `:decorated-window-tao:javadoc` FAILED, `publishToMavenLocal` never completes
- after: `BUILD SUCCESSFUL`, and `nucleus.decorated-window-tao-dev.jar` / `-sources.jar` / `-javadoc.jar` / `.pom` are published to `~/.m2`

Found while setting up a Windows environment to work on the Windows side of the Tao IME support (#558).
