### PR TITLE
fix(tao): match AWT wheel sign on Windows popups

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/Win32WheelDelta.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/Win32WheelDelta.kt
@@ -1,0 +1,18 @@
+package dev.nucleusframework.window.tao.event
+
+import androidx.compose.ui.geometry.Offset
+
+/**
+ * Maps a raw Win32 wheel delta (`GET_WHEEL_DELTA_WPARAM / WHEEL_DELTA`) onto
+ * AWT `preciseWheelRotation` / [dev.nucleusframework.window.tao.TaoPointerScrollEvent]
+ * sign.
+ *
+ * Win32 positive is away from the user; AWT positive is towards the user.
+ * [dev.nucleusframework.window.tao.TaoWindow] applies the same negate on
+ * `SCROLL_LINE` / `SCROLL_PIXEL`. Popup and overlay WndProcs emit the raw
+ * Win32 units and must go through this before Compose.
+ */
+internal fun win32WheelToAwtScrollDelta(
+    dx: Float,
+    dy: Float,
+): Offset = Offset(-dx, -dy)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
+import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollDelta
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeWindows
 import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
@@ -225,7 +226,7 @@ internal class TaoPopupSceneLayerWindows(
             innerScene.sendPointerEvent(
                 eventType = PointerEventType.Scroll,
                 position = scenePosition(x, y),
-                scrollDelta = Offset(dx, dy),
+                scrollDelta = win32WheelToAwtScrollDelta(dx, dy),
                 type = PointerType.Mouse,
             )
         }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -20,6 +20,7 @@ import dev.nucleusframework.window.tao.TaoCursorIcon
 import dev.nucleusframework.window.tao.TaoScreenGeometry
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
+import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollDelta
 import dev.nucleusframework.window.tao.ffi.NativeTaoGlBridge
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeWindows
 import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
@@ -442,7 +443,7 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
             scene?.sendPointerEvent(
                 eventType = PointerEventType.Scroll,
                 position = Offset(x, y),
-                scrollDelta = Offset(dx, dy),
+                scrollDelta = win32WheelToAwtScrollDelta(dx, dy),
                 type = PointerType.Mouse,
             )
         }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -36,6 +36,7 @@ import dev.nucleusframework.window.tao.event.TaoWheelPinchZoom
 import dev.nucleusframework.window.tao.event.taoKeyEvent
 import dev.nucleusframework.window.tao.event.taoKeyboardModifiers
 import dev.nucleusframework.window.tao.event.taoTypedKeyEvent
+import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollDelta
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoGlBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
@@ -1795,7 +1796,7 @@ internal class TaoComposeSceneHostWindows(
             scene?.sendPointerEvent(
                 eventType = PointerEventType.Scroll,
                 position = Offset(x, y),
-                scrollDelta = Offset(-dx, -dy),
+                scrollDelta = win32WheelToAwtScrollDelta(dx, dy),
                 type = PointerType.Mouse,
                 keyboardModifiers = currentKeyboardModifiers,
             )

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -8,6 +8,7 @@ import dev.nucleusframework.window.tao.event.TaoKeyMappingTest
 import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
 import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
+import dev.nucleusframework.window.tao.event.Win32WheelDeltaTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
@@ -103,6 +104,12 @@ public object TaoSceneTestBattery {
         }
         run("TaoSyntheticMouseWheelEventTest: syntheticEventCarriesAwtScrollMetadata") {
             TaoSyntheticMouseWheelEventTest().syntheticEventCarriesAwtScrollMetadata()
+        }
+        run("Win32WheelDeltaTest: wheelTowardsUserMatchesTaoWindowAwtSign") {
+            Win32WheelDeltaTest().wheelTowardsUserMatchesTaoWindowAwtSign()
+        }
+        run("Win32WheelDeltaTest: horizontalWheelIsNegatedToAwtSign") {
+            Win32WheelDeltaTest().horizontalWheelIsNegatedToAwtSign()
         }
         run("TaoWheelPinchZoomTest: fullWheelDeltaProducesModerateZoomStep") {
             TaoWheelPinchZoomTest().fullWheelDeltaProducesModerateZoomStep()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -8,6 +8,7 @@ import dev.nucleusframework.window.tao.event.TaoKeyMappingTest
 import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
 import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
+import dev.nucleusframework.window.tao.event.Win32WheelDeltaTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
@@ -43,6 +44,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoKeyMappingTest::class.java,
             TaoKeyboardModifiersDecodeTest::class.java,
             TaoSyntheticMouseWheelEventTest::class.java,
+            Win32WheelDeltaTest::class.java,
             TaoWheelPinchZoomTest::class.java,
             TaoWindowScrollTest::class.java,
             TaoWindowResizableTest::class.java,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/Win32WheelDeltaTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/Win32WheelDeltaTest.kt
@@ -1,0 +1,23 @@
+package dev.nucleusframework.window.tao.event
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Win32WheelDeltaTest {
+    @Test
+    fun wheelTowardsUserMatchesTaoWindowAwtSign() {
+        // WM_MOUSEWHEEL towards the user is a negative GET_WHEEL_DELTA_WPARAM.
+        // Popup/overlay WndProcs report that as dy = -1 (one notch).
+        // TaoWindow negates SCROLL_LINE so AWT/Compose get +1 (towards the user).
+        val delta = win32WheelToAwtScrollDelta(dx = 0f, dy = -1f)
+        assertEquals(0f, delta.x, absoluteTolerance = 0f)
+        assertEquals(1f, delta.y, absoluteTolerance = 0f)
+    }
+
+    @Test
+    fun horizontalWheelIsNegatedToAwtSign() {
+        val delta = win32WheelToAwtScrollDelta(dx = 1f, dy = 0f)
+        assertEquals(-1f, delta.x, absoluteTolerance = 0f)
+        assertEquals(0f, delta.y, absoluteTolerance = 0f)
+    }
+}


### PR DESCRIPTION
## Summary
- Windows popup and overlay WndProcs report raw Win32 wheel units (positive = away from the user).
- `TaoWindow` already negates those to AWT `preciseWheelRotation` (positive = towards the user).
- Standalone popup (TrayApp) and owned popup layers forwarded the raw sign, so mouse-wheel scrolling was inverted.
- Route those paths through `win32WheelToAwtScrollDelta`, the same negate already used by the overlay blending host.

No public API change (`apiDump` is unchanged).

## Test plan
- [x] `Win32WheelDeltaTest`: wheel towards the user maps to AWT +Y; horizontal is negated
- [x] `:decorated-window-tao:ktlintCheck` and `:decorated-window-tao:detekt`
- [ ] Wheel a TrayApp / popup list on Windows: rolling towards the user scrolls content down