### PR TITLE
fix(tao): skip GPU frames on hidden Windows standalone tray popup

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -352,6 +352,15 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
         val bundle = sceneBundle ?: return
         if (widthPx <= 0 || heightPx <= 0) return
 
+        // Keep the scene's coroutine work (recomposer steps, effects) moving
+        // even while hidden — only the GPU part is skipped below.
+        flushingDispatcher.drain()
+
+        // On-demand rendering: no frames while the panel is hidden. Pending
+        // frame-clock awaiters stay parked; setVisible(true) re-arms the
+        // paced loop.
+        if (!visible) return
+
         // Pace self-invalidating content (animations): DComp presents don't
         // block on vsync, so an unthrottled invalidate->render loop would
         // spin the Tao thread at 100%. Pacing runs on an ABSOLUTE deadline


### PR DESCRIPTION
## Summary
- Hidden Windows `TaoStandalonePopup` panels kept ticking the Compose frame clock, presenting DComp frames, and holding the GPU as if they were still on screen.
- Mac and Linux already drain the scene dispatcher then return before pacing/GPU work; Windows now does the same in `renderNow()`.
- `setVisible(true)` still re-arms the paced loop. Public API unchanged (`apiDump` is a no-op).

## Test plan
- [ ] Hide a Windows tray popup (`TrayApp` / `TaoStandalonePopup`) and confirm GPU/CPU drop instead of a ~60 fps present loop
- [ ] Show the popup again and confirm the first frame + enter animation still play
- [ ] Rapid hide/show does not leave the panel stuck blank
- [ ] `:decorated-window-tao:ktlintCheck`, `detekt`, and `apiDump` stay green