### PR TITLE
fix(tao): register inbound DnD on standalone tray popups

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
@@ -11,17 +12,22 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.TaoCursorIcon
+import dev.nucleusframework.window.tao.TaoDnDDiagnostics
 import dev.nucleusframework.window.tao.TaoScreenGeometry
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+import dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager
+import dev.nucleusframework.window.tao.dnd.TaoSceneDnD
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
 import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollDelta
 import dev.nucleusframework.window.tao.ffi.NativeTaoGlBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeWindows
 import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.releaseWindowsTextureImports
@@ -150,17 +156,25 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
                             null
                         }
                     if (directContext != null) {
+                        // Same lazy getRootNode as the DecoratedWindow host: the
+                        // scene is built with this manager in PlatformContext,
+                        // then rootDragAndDropNode exists after construction.
+                        val dndManager =
+                            TaoDragAndDropManager(
+                                getRootNode = { scene!!.rootDragAndDropNode },
+                            )
                         sceneBundle =
                             canvasLayersSceneBundle(
                                 coroutineContext = flushingDispatcher,
                                 density = Density(scale),
                                 layoutDirection = GlobalLayoutDirection,
                                 size = IntSize(1, 1),
-                                platformContext = StandalonePopupPlatformContext(),
+                                platformContext = StandalonePopupPlatformContext(dndManager),
                                 requestFrame = { scheduleRender() },
                             )
                         PopupNativeBridgeWindows.nativeSetEventCallback(panel, PanelEventCallback())
                         publishTextureHost()
+                        registerInboundDnD()
                         // See TaoComposeSceneHostWindows: all contexts sharing the
                         // process EGL context must resetGLAll when siblings exist.
                         TaoComposeSceneHostWindows.attachedHostCount.incrementAndGet()
@@ -309,6 +323,7 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
             PopupNativeBridgeWindows.nativeSetHighResTimer(false)
         }
         TaoComposeSceneHostWindows.attachedHostCount.decrementAndGet()
+        revokeInboundDnD()
         PopupNativeBridgeWindows.nativeUninstallOutsideClickMonitor(panel)
         PopupNativeBridgeWindows.nativeSetEventCallback(panel, null)
         // Teardown binds this panel's own surface for the Skia frees below, and
@@ -474,9 +489,99 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
         }
     }
 
+    // ── Inbound drag-and-drop ─────────────────────────────────────────────
+    //
+    // Tray popups are ownerless WS_POPUP HWNDs, not Tao windows, so they never
+    // get Tao's RegisterDragDrop — and unlike DecoratedWindow they also skipped
+    // Nucleus's IDropTarget. Modifier.dragAndDropTarget in a TrayApp (e.g. a
+    // file converter) therefore never saw OS drops. Mirror the window host:
+    // register on the panel HWND, dispatch through TaoSceneDnD.
+
+    @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
+    private fun registerInboundDnD() {
+        if (!NativeTaoWindowsDndBridge.isLoaded) {
+            TaoDnDDiagnostics.log("windows standalone popup DnD lib not loaded — inbound disabled")
+            return
+        }
+        val hwnd = PopupNativeBridgeWindows.nativeContentHwnd(panel)
+        if (hwnd == 0L) {
+            TaoDnDDiagnostics.log("windows standalone popup has no HWND — inbound disabled")
+            return
+        }
+        val rc = NativeTaoWindowsDndBridge.nativeRegister(hwnd, InboundDnDCallback())
+        TaoDnDDiagnostics.log("standalone popup RegisterDragDrop rc=$rc")
+    }
+
+    private fun revokeInboundDnD() {
+        if (!NativeTaoWindowsDndBridge.isLoaded) return
+        val hwnd = PopupNativeBridgeWindows.nativeContentHwnd(panel)
+        if (hwnd == 0L) return
+        NativeTaoWindowsDndBridge.nativeRevoke(hwnd)
+    }
+
+    /**
+     * Named (non-anonymous) callback class so GraalVM JNI reachability metadata
+     * can register it explicitly — same constraint as the DecoratedWindow host.
+     */
+    @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
+    private inner class InboundDnDCallback : NativeTaoWindowsDndBridge.Callback {
+        private fun node() = scene?.rootDragAndDropNode
+
+        override fun onDragEnter(
+            hwnd: Long,
+            x: Int,
+            y: Int,
+            keyState: Int,
+            hasFiles: Boolean,
+        ): Int {
+            TaoDnDDiagnostics.log("standalone popup onDragEnter x=$x y=$y hasFiles=$hasFiles")
+            if (!hasFiles) return NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
+            return if (TaoSceneDnD.onDragEnter(node(), x, y)) {
+                NativeTaoWindowsDndBridge.DROP_EFFECT_COPY
+            } else {
+                NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
+            }
+        }
+
+        override fun onDragOver(
+            hwnd: Long,
+            x: Int,
+            y: Int,
+            keyState: Int,
+            hasFiles: Boolean,
+        ): Int =
+            if (TaoSceneDnD.onDragOver(node(), x, y)) {
+                NativeTaoWindowsDndBridge.DROP_EFFECT_COPY
+            } else {
+                NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
+            }
+
+        override fun onDragLeave(hwnd: Long) {
+            TaoDnDDiagnostics.log("standalone popup onDragLeave")
+            TaoSceneDnD.onDragLeave(node())
+        }
+
+        override fun onDrop(
+            hwnd: Long,
+            x: Int,
+            y: Int,
+            keyState: Int,
+            files: Array<String>?,
+        ): Int {
+            TaoDnDDiagnostics.log("standalone popup onDrop x=$x y=$y files=${files?.size ?: 0}")
+            return if (TaoSceneDnD.onDrop(node(), x, y, files)) {
+                NativeTaoWindowsDndBridge.DROP_EFFECT_COPY
+            } else {
+                NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
+            }
+        }
+    }
+
     // ── Platform plumbing ─────────────────────────────────────────────────
 
-    private inner class StandalonePopupPlatformContext : TaoPlatformContextBase() {
+    private inner class StandalonePopupPlatformContext(
+        override val dragAndDropManager: PlatformDragAndDropManager,
+    ) : TaoPlatformContextBase() {
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHost.windowInfo
 
         // Standalone popup surfaces are always per-pixel transparent, so

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
@@ -194,6 +194,10 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
             )
         PopupNativeBridgeLinux.nativeSetEventCallback(panel, PanelEventCallback())
         publishGlTextureHost()
+        // Inbound OS file drops are not registered here: NativeTaoLinuxDndBridge
+        // binds GTK widgets, and this panel is a raw X11 window. Tray popups
+        // that need DnD on Linux should use the DecoratedWindow fallback path
+        // (TrayAppImplWindow) until an XDND helper exists for this surface.
         logger.fine { "Standalone popup panel ready (panel=$panel, scale=$panelScale)" }
         return true
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
@@ -2,6 +2,7 @@ package dev.nucleusframework.window.tao.popup
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
@@ -9,17 +10,22 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.TaoCursorIcon
+import dev.nucleusframework.window.tao.TaoDnDDiagnostics
 import dev.nucleusframework.window.tao.TaoScreenGeometry
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+import dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager
+import dev.nucleusframework.window.tao.dnd.TaoSceneDnD
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
 import dev.nucleusframework.window.tao.event.toTaoCursorIconCode
 import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridge
 import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.scene.LocalTaoMetalTextureHost
@@ -137,16 +143,21 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
                     val queuePtr = NativeMetalBridge.nativeQueuePtr(attachmentHandle)
                     directContext =
                         runOnRenderThread { DirectContext.makeMetal(devicePtr, queuePtr) }
+                    val dndManager =
+                        TaoDragAndDropManager(
+                            getRootNode = { scene!!.rootDragAndDropNode },
+                        )
                     sceneBundle =
                         canvasLayersSceneBundle(
                             coroutineContext = flushingDispatcher,
                             density = Density(scale),
                             layoutDirection = GlobalLayoutDirection,
                             size = IntSize(1, 1),
-                            platformContext = StandalonePopupPlatformContext(),
+                            platformContext = StandalonePopupPlatformContext(dndManager),
                             requestFrame = { scheduleRender() },
                         )
                     PopupNativeBridge.nativeSetEventCallback(panel, PanelEventCallback())
+                    registerInboundDnD()
                     PopupNativeBridge.nativeOrderOut(panel) // hidden until first setVisible(true)
                     valid = true
                     logger.fine { "Standalone popup panel ready (panel=$panel, scale=$scale)" }
@@ -271,6 +282,7 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
     override fun dispose() {
         if (!isValid || disposed) return
         disposed = true
+        revokeInboundDnD()
         PopupNativeBridge.nativeUninstallOutsideClickMonitor(panel)
         PopupNativeBridge.nativeSetEventCallback(panel, null)
         sceneBundle?.close()
@@ -449,9 +461,97 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
         }
     }
 
+    // ── Inbound drag-and-drop ─────────────────────────────────────────────
+    //
+    // Ownerless NSPanel content views never go through DecoratedWindow's
+    // NSDraggingDestination install. Register here so Modifier.dragAndDropTarget
+    // inside a TrayApp (e.g. a file converter) receives OS drops.
+
+    @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
+    private fun registerInboundDnD() {
+        if (!NativeTaoMacOsDndBridge.isLoaded) {
+            TaoDnDDiagnostics.log("macOS standalone popup DnD lib not loaded — inbound disabled")
+            return
+        }
+        val nsView = PopupNativeBridge.nativeContentNsView(panel)
+        if (nsView == 0L) {
+            TaoDnDDiagnostics.log("macOS standalone popup has no NSView — inbound disabled")
+            return
+        }
+        val rc = NativeTaoMacOsDndBridge.nativeRegister(nsView = nsView, callback = InboundDnDCallback())
+        TaoDnDDiagnostics.log("standalone popup nativeRegister rc=$rc")
+    }
+
+    private fun revokeInboundDnD() {
+        if (!NativeTaoMacOsDndBridge.isLoaded) return
+        val nsView = PopupNativeBridge.nativeContentNsView(panel)
+        if (nsView == 0L) return
+        NativeTaoMacOsDndBridge.nativeRevoke(nsView)
+    }
+
+    /**
+     * Named (non-anonymous) callback class so GraalVM JNI reachability metadata
+     * can register it explicitly — same constraint as the DecoratedWindow host.
+     */
+    @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
+    private inner class InboundDnDCallback : NativeTaoMacOsDndBridge.Callback {
+        private fun node() = scene?.rootDragAndDropNode
+
+        override fun onDragEnter(
+            nsView: Long,
+            x: Int,
+            y: Int,
+            modState: Int,
+            hasFiles: Boolean,
+        ): Int {
+            TaoDnDDiagnostics.log("standalone popup onDragEnter x=$x y=$y hasFiles=$hasFiles")
+            if (!hasFiles) return NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
+            return if (TaoSceneDnD.onDragEnter(node(), x, y)) {
+                NativeTaoMacOsDndBridge.DROP_EFFECT_COPY
+            } else {
+                NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
+            }
+        }
+
+        override fun onDragOver(
+            nsView: Long,
+            x: Int,
+            y: Int,
+            modState: Int,
+            hasFiles: Boolean,
+        ): Int =
+            if (TaoSceneDnD.onDragOver(node(), x, y)) {
+                NativeTaoMacOsDndBridge.DROP_EFFECT_COPY
+            } else {
+                NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
+            }
+
+        override fun onDragLeave(nsView: Long) {
+            TaoDnDDiagnostics.log("standalone popup onDragLeave")
+            TaoSceneDnD.onDragLeave(node())
+        }
+
+        override fun onDrop(
+            nsView: Long,
+            x: Int,
+            y: Int,
+            modState: Int,
+            files: Array<String>?,
+        ): Int {
+            TaoDnDDiagnostics.log("standalone popup onDrop x=$x y=$y files=${files?.size ?: 0}")
+            return if (TaoSceneDnD.onDrop(node(), x, y, files)) {
+                NativeTaoMacOsDndBridge.DROP_EFFECT_COPY
+            } else {
+                NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
+            }
+        }
+    }
+
     // ── Platform plumbing ─────────────────────────────────────────────────
 
-    private inner class StandalonePopupPlatformContext : TaoPlatformContextBase() {
+    private inner class StandalonePopupPlatformContext(
+        override val dragAndDropManager: PlatformDragAndDropManager,
+    ) : TaoPlatformContextBase() {
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostMac.windowInfo
 
         // Standalone popup surfaces are always per-pixel transparent, so

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -449,6 +449,16 @@
             ]
         },
         {
+            "type": "dev.nucleusframework.window.tao.popup.TaoStandalonePopupHost$InboundDnDCallback",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onDragEnter", "parameterTypes": ["long","int","int","int","boolean"] },
+                { "name": "onDragOver",  "parameterTypes": ["long","int","int","int","boolean"] },
+                { "name": "onDragLeave", "parameterTypes": ["long"] },
+                { "name": "onDrop",      "parameterTypes": ["long","int","int","int","java.lang.String[]"] }
+            ]
+        },
+        {
             "type": "dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge$DragPump",
             "jniAccessible": true,
             "methods": [
@@ -478,6 +488,16 @@
         },
         {
             "type": "dev.nucleusframework.window.tao.scene.TaoComposeSceneHost$InboundDnDCallback",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onDragEnter", "parameterTypes": ["long","int","int","int","boolean"] },
+                { "name": "onDragOver",  "parameterTypes": ["long","int","int","int","boolean"] },
+                { "name": "onDragLeave", "parameterTypes": ["long"] },
+                { "name": "onDrop",      "parameterTypes": ["long","int","int","int","java.lang.String[]"] }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.popup.TaoStandalonePopupHostMac$InboundDnDCallback",
             "jniAccessible": true,
             "methods": [
                 { "name": "onDragEnter", "parameterTypes": ["long","int","int","int","boolean"] },

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelNativeSmokeTest.kt
@@ -1,11 +1,13 @@
 package dev.nucleusframework.window.tao
 
 import dev.nucleusframework.window.tao.ffi.NativeTaoGlBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeWindows
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.GLAssembledInterface
 import org.jetbrains.skia.makeGLWithInterface
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
@@ -51,8 +53,51 @@ class StandalonePanelNativeSmokeTest {
                 )
             val ctx = DirectContext.makeGLWithInterface(intf)
             ctx.close()
+
+            // Ownerless tray panels must accept RegisterDragDrop: TrayApp hosts
+            // Compose in this HWND, not a DecoratedWindow, so inbound file drops
+            // never reached Modifier.dragAndDropTarget without this path.
+            assertTrue(NativeTaoWindowsDndBridge.isLoaded, "nucleus_tao_dnd failed to load")
+            val hwnd = PopupNativeBridgeWindows.nativeContentHwnd(panel)
+            assertNotEquals(0L, hwnd, "standalone panel HWND is 0")
+            val rc = NativeTaoWindowsDndBridge.nativeRegister(hwnd, NoOpInboundDnDCallback())
+            assertEquals(0, rc, "RegisterDragDrop on standalone panel failed (rc=$rc)")
+            NativeTaoWindowsDndBridge.nativeRevoke(hwnd)
         } finally {
             PopupNativeBridgeWindows.nativeRelease(panel)
         }
     }
+}
+
+/**
+ * Named class (not a lambda) so [NativeTaoWindowsDndBridge.nativeRegister]'s
+ * `GetMethodID` lookup succeeds — same GraalVM JNI constraint as production
+ * inbound callbacks.
+ */
+private class NoOpInboundDnDCallback : NativeTaoWindowsDndBridge.Callback {
+    override fun onDragEnter(
+        hwnd: Long,
+        x: Int,
+        y: Int,
+        keyState: Int,
+        hasFiles: Boolean,
+    ): Int = NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
+
+    override fun onDragOver(
+        hwnd: Long,
+        x: Int,
+        y: Int,
+        keyState: Int,
+        hasFiles: Boolean,
+    ): Int = NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
+
+    override fun onDragLeave(hwnd: Long) = Unit
+
+    override fun onDrop(
+        hwnd: Long,
+        x: Int,
+        y: Int,
+        keyState: Int,
+        files: Array<String>?,
+    ): Int = NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
 }

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/macos-reachability-metadata.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/macos-reachability-metadata.json
@@ -2213,6 +2213,48 @@
       ]
     },
     {
+      "type": "dev.nucleusframework.window.tao.popup.TaoStandalonePopupHostMac$InboundDnDCallback",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "onDragEnter",
+          "parameterTypes": [
+            "long",
+            "int",
+            "int",
+            "int",
+            "boolean"
+          ]
+        },
+        {
+          "name": "onDragLeave",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "onDragOver",
+          "parameterTypes": [
+            "long",
+            "int",
+            "int",
+            "int",
+            "boolean"
+          ]
+        },
+        {
+          "name": "onDrop",
+          "parameterTypes": [
+            "long",
+            "int",
+            "int",
+            "int",
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
       "type": "java.io.OutputStream",
       "jniAccessible": true,
       "methods": [

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/windows-reachability-metadata.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/windows-reachability-metadata.json
@@ -2701,6 +2701,48 @@
         },
         {
             "type": "sun.java2d.d3d.D3DSurfaceData$D3DWindowSurfaceData"
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.popup.TaoStandalonePopupHost$InboundDnDCallback",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "onDragEnter",
+                    "parameterTypes": [
+                        "long",
+                        "int",
+                        "int",
+                        "int",
+                        "boolean"
+                    ]
+                },
+                {
+                    "name": "onDragOver",
+                    "parameterTypes": [
+                        "long",
+                        "int",
+                        "int",
+                        "int",
+                        "boolean"
+                    ]
+                },
+                {
+                    "name": "onDragLeave",
+                    "parameterTypes": [
+                        "long"
+                    ]
+                },
+                {
+                    "name": "onDrop",
+                    "parameterTypes": [
+                        "long",
+                        "int",
+                        "int",
+                        "int",
+                        "java.lang.String[]"
+                    ]
+                }
+            ]
         }
     ],
     "resources": [


### PR DESCRIPTION
## Summary

- TrayApp hosts UI in `TaoStandalonePopup` (ownerless `WS_POPUP` / `NSPanel`), not `DecoratedWindow`.
- Inbound OS file drops were only registered on DecoratedWindow hosts, so `Modifier.dragAndDropTarget` in a tray popup never received drops (e.g. AeroDL converter).
- Register Nucleus `IDropTarget` / `NSDraggingDestination` on the standalone panel HWND / content NSView and dispatch through `TaoSceneDnD`, matching tao-demo.
- Linux standalone panels stay on raw X11; GTK DnD does not apply (TrayApp `DecoratedWindow` fallback still works).
- GraalVM JNI metadata for the new inbound callbacks; smoke test asserts `RegisterDragDrop` succeeds on the ownerless Windows panel HWND.

## Test plan

- [x] `:decorated-window-tao:ktlintCheck` / `detekt` / `apiDump`
- [x] `StandalonePanelNativeSmokeTest` — `RegisterDragDrop` on standalone panel HWND returns 0
- [ ] Drag a file from Explorer onto a `Modifier.dragAndDropTarget` inside `TrayApp` / `TaoStandalonePopup` and confirm `onDrop` fires
- [ ] Confirm DecoratedWindow (tao-demo) drop still works