### PR TITLE
fix(tao): register inbound XDND on Linux standalone tray popups

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/PopupNativeBridgeLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/PopupNativeBridgeLinux.kt
@@ -6,8 +6,8 @@ import dev.nucleusframework.core.runtime.NativeLibraryLoader
 
 /**
  * JNI bridge to the Linux standalone popup panel helper
- * (`linux/nucleus_tao_linux_popup.c`, shipped as
- * `libnucleus_tao_linux_popup.so`).
+ * (`linux/nucleus_tao_linux_popup.c` + `nucleus_tao_linux_popup_xdnd.c`,
+ * shipped as `libnucleus_tao_linux_popup.so`).
  *
  * The Linux twin of [PopupNativeBridgeWindows] / [PopupNativeBridge]
  * (macOS), standalone panels only — there is no owner-based variant on
@@ -200,10 +200,86 @@ internal object PopupNativeBridgeLinux {
     external fun nativeUninstallOutsideClickMonitor(panel: Long)
 
     /**
+     * Receives XDND callbacks for this raw X11 panel. Same shape as
+     * [NativeTaoLinuxDndBridge.Callback] / the Windows IDropTarget bridge so
+     * [dev.nucleusframework.window.tao.dnd.TaoSceneDnD] can stay shared.
+     *
+     * Invoked on the panel's X event thread — hop to the Tao main thread
+     * before touching a Compose scene. [handle] is the panel pointer.
+     *
+     * Return values for `onDragEnter`/`onDragOver`/`onDrop`:
+     *   - [DROP_EFFECT_NONE] — reject the drag/drop
+     *   - [DROP_EFFECT_COPY] — accept as a copy
+     *
+     * Must be a named class, not a lambda or anonymous object: GraalVM's
+     * `GetMethodID` does not pick up inherited interface methods on anonymous
+     * classes.
+     */
+    interface DnDCallback {
+        @Suppress("FunctionParameterNaming")
+        fun onDragEnter(
+            handle: Long,
+            x: Int,
+            y: Int,
+            modState: Int,
+            hasFiles: Boolean,
+        ): Int
+
+        @Suppress("FunctionParameterNaming")
+        fun onDragOver(
+            handle: Long,
+            x: Int,
+            y: Int,
+            modState: Int,
+            hasFiles: Boolean,
+        ): Int
+
+        fun onDragLeave(handle: Long)
+
+        @Suppress("FunctionParameterNaming")
+        fun onDrop(
+            handle: Long,
+            x: Int,
+            y: Int,
+            modState: Int,
+            files: Array<String>?,
+        ): Int
+    }
+
+    /**
+     * Installs the inbound XDND callback. Pass `null` to remove. The panel
+     * advertises `XdndAware` at creation, so file managers can discover it
+     * even before a callback is set — without one, every Status is a reject.
+     */
+    @JvmStatic
+    external fun nativeSetDnDCallback(
+        panel: Long,
+        callback: DnDCallback?,
+    )
+
+    /**
+     * Test-only XDND source: acts as a second X client and drops [files]
+     * onto [panel] (`XdndEnter` → `XdndPosition` → `XdndDrop`, serving
+     * `text/uri-list` on `SelectionRequest`). Returns [DROP_EFFECT_COPY]
+     * after `XdndFinished`, or [DROP_EFFECT_NONE] on timeout / protocol
+     * failure. Production code must not call this.
+     */
+    @JvmStatic
+    external fun nativeSmokeXdndDrop(
+        panel: Long,
+        files: Array<String>,
+    ): Int
+
+    /**
      * Stops the event thread, destroys the X window and frees the panel.
      * The EGL attachment must have been detached first
      * (`NativeTaoEglBridge.nativeDetach`).
      */
     @JvmStatic
     external fun nativeRelease(panel: Long)
+
+    const val DROP_EFFECT_NONE: Int = 0
+    const val DROP_EFFECT_COPY: Int = 1
+    const val DROP_EFFECT_MOVE: Int = 2
+    const val DROP_EFFECT_LINK: Int = 4
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
@@ -11,13 +12,17 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.TaoCursorIcon
+import dev.nucleusframework.window.tao.TaoDnDDiagnostics
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+import dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager
+import dev.nucleusframework.window.tao.dnd.TaoSceneDnD
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
 import dev.nucleusframework.window.tao.event.toTaoCursorIconCode
 import dev.nucleusframework.window.tao.ffi.NativeTaoEglBridge
@@ -66,7 +71,7 @@ import kotlin.math.roundToInt
  * on the panel's X event thread and hop to the main thread before touching
  * the scene.
  */
-@OptIn(InternalComposeUiApi::class)
+@OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
 internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
     override val isValid: Boolean
 
@@ -183,21 +188,22 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
             panel = 0
             return false
         }
+        val dndManager =
+            TaoDragAndDropManager(
+                getRootNode = { scene!!.rootDragAndDropNode },
+            )
         sceneBundle =
             canvasLayersSceneBundle(
                 coroutineContext = flushingDispatcher,
                 density = Density(panelScale),
                 layoutDirection = GlobalLayoutDirection,
                 size = IntSize(1, 1),
-                platformContext = StandalonePopupPlatformContext(),
+                platformContext = StandalonePopupPlatformContext(dndManager),
                 requestFrame = { scheduleRender() },
             )
         PopupNativeBridgeLinux.nativeSetEventCallback(panel, PanelEventCallback())
         publishGlTextureHost()
-        // Inbound OS file drops are not registered here: NativeTaoLinuxDndBridge
-        // binds GTK widgets, and this panel is a raw X11 window. Tray popups
-        // that need DnD on Linux should use the DecoratedWindow fallback path
-        // (TrayAppImplWindow) until an XDND helper exists for this surface.
+        registerInboundDnD()
         logger.fine { "Standalone popup panel ready (panel=$panel, scale=$panelScale)" }
         return true
     }
@@ -308,6 +314,7 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
     override fun dispose() {
         if (!isValid || disposed) return
         disposed = true
+        revokeInboundDnD()
         PopupNativeBridgeLinux.nativeUninstallOutsideClickMonitor(panel)
         PopupNativeBridgeLinux.nativeSetEventCallback(panel, null)
         // Teardown binds this panel's context for the Skia frees below and then
@@ -475,9 +482,99 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
         }
     }
 
+    // ── Inbound drag-and-drop ─────────────────────────────────────────────
+    //
+    // The panel is a raw X11 window, not a GtkWindow, so NativeTaoLinuxDndBridge
+    // cannot hang gtk_drag_dest_set on it. Register an XDND helper on the
+    // panel XID instead — same TaoSceneDnD dispatch as the Windows/macOS
+    // standalone hosts (#605).
+
+    @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
+    private fun registerInboundDnD() {
+        if (!PopupNativeBridgeLinux.isLoaded) {
+            TaoDnDDiagnostics.log("linux standalone popup DnD lib not loaded — inbound disabled")
+            return
+        }
+        if (panel == 0L) {
+            TaoDnDDiagnostics.log("linux standalone popup has no panel — inbound disabled")
+            return
+        }
+        PopupNativeBridgeLinux.nativeSetDnDCallback(panel, InboundDnDCallback())
+        TaoDnDDiagnostics.log("linux standalone popup XDND callback installed")
+    }
+
+    private fun revokeInboundDnD() {
+        if (!PopupNativeBridgeLinux.isLoaded || panel == 0L) return
+        PopupNativeBridgeLinux.nativeSetDnDCallback(panel, null)
+    }
+
+    /**
+     * Named (non-anonymous) callback class so GraalVM JNI reachability metadata
+     * can register it explicitly — same constraint as the DecoratedWindow host.
+     *
+     * JNI arrives on the panel's X event thread. Hop async onto Tao main
+     * like pointer events — the dispatcher queue keeps enter/over/drop in
+     * order. [XdndStatus] uses an optimistic COPY when the source offers
+     * files: a tray popup is a drop zone, and blocking the event thread
+     * for Compose would deadlock dispose.
+     */
+    @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
+    private inner class InboundDnDCallback : PopupNativeBridgeLinux.DnDCallback {
+        private fun node() = scene?.rootDragAndDropNode
+
+        private fun onMain(block: () -> Unit) {
+            TaoMainDispatcher.dispatch(EmptyCoroutineContext) {
+                if (!disposed) block()
+            }
+        }
+
+        override fun onDragEnter(
+            handle: Long,
+            x: Int,
+            y: Int,
+            modState: Int,
+            hasFiles: Boolean,
+        ): Int {
+            TaoDnDDiagnostics.log("linux standalone popup onDragEnter x=$x y=$y hasFiles=$hasFiles")
+            if (!hasFiles) return PopupNativeBridgeLinux.DROP_EFFECT_NONE
+            onMain { TaoSceneDnD.onDragEnter(node(), x, y) }
+            return PopupNativeBridgeLinux.DROP_EFFECT_COPY
+        }
+
+        override fun onDragOver(
+            handle: Long,
+            x: Int,
+            y: Int,
+            modState: Int,
+            hasFiles: Boolean,
+        ): Int {
+            onMain { TaoSceneDnD.onDragOver(node(), x, y) }
+            return PopupNativeBridgeLinux.DROP_EFFECT_COPY
+        }
+
+        override fun onDragLeave(handle: Long) {
+            TaoDnDDiagnostics.log("linux standalone popup onDragLeave")
+            onMain { TaoSceneDnD.onDragLeave(node()) }
+        }
+
+        override fun onDrop(
+            handle: Long,
+            x: Int,
+            y: Int,
+            modState: Int,
+            files: Array<String>?,
+        ): Int {
+            TaoDnDDiagnostics.log("linux standalone popup onDrop x=$x y=$y files=${files?.size ?: 0}")
+            onMain { TaoSceneDnD.onDrop(node(), x, y, files) }
+            return PopupNativeBridgeLinux.DROP_EFFECT_COPY
+        }
+    }
+
     // ── Platform plumbing ─────────────────────────────────────────────────
 
-    private inner class StandalonePopupPlatformContext : TaoPlatformContextBase() {
+    private inner class StandalonePopupPlatformContext(
+        override val dragAndDropManager: PlatformDragAndDropManager,
+    ) : TaoPlatformContextBase() {
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostLinux.windowInfo
 
         // Standalone popup surfaces are always per-pixel transparent, so

--- a/decorated-window-tao/src/main/native/linux/build.sh
+++ b/decorated-window-tao/src/main/native/linux/build.sh
@@ -136,7 +136,8 @@ build_popup() {
     local OUT="$OUT_DIR/libnucleus_tao_linux_popup.so"
     "$CC" -shared -fPIC -O2 -fvisibility=hidden \
         -I"$JNI_INCLUDE" -I"$JNI_INCLUDE_LINUX" \
-        "$SCRIPT_DIR/nucleus_tao_linux_popup.c" -ldl -lpthread \
+        "$SCRIPT_DIR/nucleus_tao_linux_popup.c" \
+        "$SCRIPT_DIR/nucleus_tao_linux_popup_xdnd.c" -ldl -lpthread \
         -o "$OUT"
     strip --strip-unneeded "$OUT" || true
 }

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup.c
@@ -33,17 +33,32 @@
  *     `NativeTaoEglBridge.nativeAttachX11`, so EGL work stays on the
  *     same thread/connection.
  *   - Each panel owns an EVENT connection + thread: it opens its own
- *     `Display`, calls `XSelectInput` on the panel XID (event masks are
- *     per-client, so this works across connections) and blocks in a
- *     `poll()` loop on the X fd + a quit pipe. Input events are forwarded
- *     to Java through cached JNI method IDs (same pattern as
+ *     `Display`, **creates the X window** (so this client is the creator),
+ *     calls `XSelectInput` on the panel XID and blocks in a `poll()` loop
+ *     on the X fd + a quit pipe. Input events are forwarded to Java
+ *     through cached JNI method IDs (same pattern as
  *     `nucleus_tao_linux_widget.c`).
+ *
+ *     The window is created on the event connection on purpose: XDND
+ *     ClientMessages are sent with `event_mask = NoEventMask`, which the
+ *     X server delivers only to the *creating* client. The command
+ *     connection never pumps `XNextEvent`, so a command-created window
+ *     would queue every `XdndEnter`/`Position`/`Drop` forever. Creating
+ *     on the event thread makes that thread the creator and the XDND
+ *     destination. Move/map/cursor/destroy still go through the command
+ *     connection — those requests are XID-based and not creator-bound.
+ *     EGL attach keeps using the command `Display*` (`nativeDisplayPtr`);
+ *     `eglCreateWindowSurface` keys on the XID, which is server-global.
  *
  * Outside-click: XI2 raw ButtonPress on the root window — the X11 analog
  * of the Windows `WH_MOUSE_LL` hook (raw events are observe-only, don't
  * consume, and multiple clients may listen). Fully global on X11
  * sessions; under XWayland raw events only fire while X11 surfaces have
  * input focus — the tray-icon toggle covers the remaining cases.
+ *
+ * Inbound file DnD lives in `nucleus_tao_linux_popup_xdnd.c` — the event
+ * thread is the creating client, so it is the only place XDND
+ * ClientMessages (mask 0) arrive. This file just forwards them.
  *
  * Keyboard: clicking the panel while focusable calls
  * `XSetInputFocus(RevertToParent)` (the `takeKeyboardFocus()` equivalent).
@@ -63,30 +78,18 @@
  * union.
  */
 
-#include <jni.h>
+#include "nucleus_tao_linux_popup.h"
+
 #include <dlfcn.h>
+#include <errno.h>
 #include <poll.h>
-#include <pthread.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
-#include <X11/Xlib.h>
-#include <X11/Xutil.h>
-#include <X11/Xatom.h>
 #include <X11/XKBlib.h>
 #include <X11/cursorfont.h>
-#include <X11/extensions/XInput2.h>
-#include <X11/extensions/Xrandr.h>
-
-#define NUCLEUS_TAO_POPUP_DEBUG 0
-#if NUCLEUS_TAO_POPUP_DEBUG
-#define DBG(...) fprintf(stderr, "[nucleus_tao_linux_popup] " __VA_ARGS__)
-#else
-#define DBG(...) ((void)0)
-#endif
 
 /* ── Wire format (must stay in sync with TaoNativeWireFormat.kt) ────────── */
 
@@ -125,67 +128,7 @@
 
 typedef struct xkb_keysym_dummy xkb_keysym_dummy; /* unused, keeps clang-tidy calm */
 
-static struct {
-    int initialized;
-
-    /* libX11 */
-    Display *(*XOpenDisplay)(const char *);
-    int (*XCloseDisplay)(Display *);
-    Window (*XCreateWindow)(Display *, Window, int, int, unsigned, unsigned,
-                            unsigned, int, unsigned, Visual *, unsigned long,
-                            XSetWindowAttributes *);
-    int (*XDestroyWindow)(Display *, Window);
-    int (*XMapRaised)(Display *, Window);
-    int (*XUnmapWindow)(Display *, Window);
-    int (*XRaiseWindow)(Display *, Window);
-    int (*XMoveResizeWindow)(Display *, Window, int, int, unsigned, unsigned);
-    int (*XFlush)(Display *);
-    int (*XSync)(Display *, Bool);
-    int (*XSelectInput)(Display *, Window, long);
-    int (*XNextEvent)(Display *, XEvent *);
-    int (*XPending)(Display *);
-    Colormap (*XCreateColormap)(Display *, Window, Visual *, int);
-    int (*XFreeColormap)(Display *, Colormap);
-    XVisualInfo *(*XGetVisualInfo)(Display *, long, XVisualInfo *, int *);
-    int (*XFree)(void *);
-    int (*XSetInputFocus)(Display *, Window, int, Time);
-    Cursor (*XCreateFontCursor)(Display *, unsigned int);
-    int (*XDefineCursor)(Display *, Window, Cursor);
-    int (*XFreeCursor)(Display *, Cursor);
-    int (*XStoreName)(Display *, Window, const char *);
-    char *(*XResourceManagerString)(Display *);
-    int (*XLookupString)(XKeyEvent *, char *, int, KeySym *, XComposeStatus *);
-    KeySym (*XkbKeycodeToKeysym)(Display *, KeyCode, unsigned, unsigned);
-    Bool (*XQueryExtension)(Display *, const char *, int *, int *, int *);
-    Bool (*XGetEventData)(Display *, XGenericEventCookie *);
-    void (*XFreeEventData)(Display *, XGenericEventCookie *);
-    Bool (*XQueryPointer)(Display *, Window, Window *, Window *, int *, int *,
-                          int *, int *, unsigned *);
-
-    Atom (*XInternAtom)(Display *, const char *, Bool);
-    int (*XGetWindowProperty)(Display *, Window, Atom, long, long, Bool, Atom,
-                              Atom *, int *, unsigned long *, unsigned long *,
-                              unsigned char **);
-
-    /* libXi */
-    int (*XISelectEvents)(Display *, Window, XIEventMask *, int);
-    int (*XIQueryVersion)(Display *, int *, int *);
-
-    /* libXrandr (optional — full-screen fallback without it) */
-    XRRMonitorInfo *(*XRRGetMonitors)(Display *, Window, Bool, int *);
-    void (*XRRFreeMonitors)(XRRMonitorInfo *);
-
-    /* libxkbcommon (optional — Latin-1 fallback without it) */
-    uint32_t (*xkb_keysym_to_utf32)(uint32_t keysym);
-
-    /* libEGL (visual selection only) */
-    void *(*eglGetPlatformDisplay)(unsigned, void *, const intptr_t *);
-    void *(*eglGetDisplay)(void *);
-    int (*eglInitialize)(void *, int *, int *);
-    int (*eglBindAPI)(unsigned);
-    int (*eglChooseConfig)(void *, const int *, void **, int, int *);
-    int (*eglGetConfigAttrib)(void *, void *, int, int *);
-} fn;
+PopupX11 fn;
 
 static void *load_first(const char *const *names) {
     for (int i = 0; names[i] != NULL; i++) {
@@ -228,6 +171,9 @@ static int ensure_libs_loaded(void) {
     X11_SYM(XQueryExtension);    X11_SYM(XGetEventData);
     X11_SYM(XFreeEventData);     X11_SYM(XQueryPointer);
     X11_SYM(XInternAtom);        X11_SYM(XGetWindowProperty);
+    X11_SYM(XChangeProperty);    X11_SYM(XDeleteProperty);
+    X11_SYM(XSendEvent);         X11_SYM(XConvertSelection);
+    X11_SYM(XSetSelectionOwner);
 #undef X11_SYM
 
     if (libxi != NULL) {
@@ -261,7 +207,10 @@ static int ensure_libs_loaded(void) {
         !fn.XFree || !fn.XSetInputFocus || !fn.XCreateFontCursor ||
         !fn.XDefineCursor || !fn.XFreeCursor || !fn.XLookupString ||
         !fn.XkbKeycodeToKeysym || !fn.XQueryPointer ||
-        !fn.XInternAtom || !fn.XGetWindowProperty) {
+        !fn.XInternAtom || !fn.XGetWindowProperty ||
+        !fn.XChangeProperty || !fn.XDeleteProperty ||
+        !fn.XSendEvent || !fn.XConvertSelection ||
+        !fn.XSetSelectionOwner) {
         DBG("missing libX11 symbols\n");
         return 0;
     }
@@ -288,7 +237,7 @@ static Display *ensure_cmd_display(void) {
 
 /* ── JNI callback plumbing ──────────────────────────────────────────────── */
 
-static JavaVM *g_jvm = NULL;
+JavaVM *g_jvm = NULL;
 
 /* Cached once per interface, from the first registered instance (all
  * implementors are the same named classes — GraalVM metadata requirement). */
@@ -342,30 +291,6 @@ static void cache_outside_listener_id(JNIEnv *env, jobject listener) {
     if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
 }
 
-/* ── Panel state ────────────────────────────────────────────────────────── */
-
-typedef struct {
-    Window   win;
-    Colormap cmap;
-    Cursor   cursor;         /* current XCreateFontCursor, or None        */
-
-    /* Geometry mirror for the outside-click hit test (event thread reads,
-     * command thread writes). */
-    pthread_mutex_t lock;
-    int x, y, w, h;
-    int visible;
-    int focusable;
-
-    /* Event thread. */
-    pthread_t evt_thread;
-    int       evt_thread_started;
-    int       quit_pipe[2];
-
-    /* Java refs (guarded by [lock]; invoked from the event thread). */
-    jobject event_cb;    /* EventCallback global ref, or NULL   */
-    jobject outside_cb;  /* OutsideClickListener global ref     */
-} Panel;
-
 /* ── Keysym helpers ─────────────────────────────────────────────────────── */
 
 /* Active-layout keysym → Unicode code point. libxkbcommon handles every
@@ -411,6 +336,48 @@ static int wire_button(unsigned xbutton) {
         case Button3: return WIRE_BUTTON_SECONDARY;
         default:      return WIRE_BUTTON_NONE;
     }
+}
+
+static int create_panel_window(Display *dpy, Panel *p) {
+    Window root = DefaultRootWindow(dpy);
+    XVisualInfo tmpl;
+    memset(&tmpl, 0, sizeof(tmpl));
+    tmpl.visualid = p->visual_id;
+    int n = 0;
+    XVisualInfo *vi = fn.XGetVisualInfo(dpy, VisualIDMask, &tmpl, &n);
+    if (vi == NULL || n <= 0) {
+        if (vi != NULL) fn.XFree(vi);
+        DBG("event thread: visual 0x%lx not found\n", (unsigned long) p->visual_id);
+        return 0;
+    }
+    Visual *visual = vi[0].visual;
+    int depth = vi[0].depth;
+    fn.XFree(vi);
+
+    Colormap cmap = fn.XCreateColormap(dpy, root, visual, AllocNone);
+    XSetWindowAttributes swa;
+    memset(&swa, 0, sizeof(swa));
+    swa.colormap = cmap;
+    swa.border_pixel = 0;
+    swa.background_pixel = 0;
+    swa.override_redirect = True;
+    unsigned w = p->w > 0 ? (unsigned) p->w : 1;
+    unsigned h = p->h > 0 ? (unsigned) p->h : 1;
+    Window win = fn.XCreateWindow(
+        dpy, root, p->x, p->y, w, h, 0, depth, InputOutput, visual,
+        CWColormap | CWBorderPixel | CWBackPixel | CWOverrideRedirect, &swa);
+    if (win == 0) {
+        fn.XFreeColormap(dpy, cmap);
+        return 0;
+    }
+    if (fn.XStoreName != NULL) fn.XStoreName(dpy, win, "NucleusStandalonePopup");
+    p->win = win;
+    p->cmap = cmap;
+    popup_xdnd_intern_atoms(dpy, p);
+    popup_xdnd_set_aware(dpy, p);
+    fn.XSync(dpy, False);
+    DBG("event thread: window 0x%lx created (XdndAware)\n", (unsigned long) win);
+    return 1;
 }
 
 /* ── Event thread ───────────────────────────────────────────────────────── */
@@ -497,17 +464,34 @@ static void handle_key_event(JNIEnv *env, Display *dpy, Panel *p, XKeyEvent *ke,
     forward_key(env, p, wire_type, (int) vk, codepoint, wire_modifiers(ke->state));
 }
 
+static void signal_ready(Panel *p, int ready) {
+    pthread_mutex_lock(&p->lock);
+    p->ready = ready;
+    pthread_cond_signal(&p->ready_cond);
+    pthread_mutex_unlock(&p->lock);
+}
+
 static void *event_thread_main(void *arg) {
     Panel *p = (Panel *) arg;
 
     Display *dpy = fn.XOpenDisplay(NULL);
-    if (dpy == NULL) return NULL;
+    if (dpy == NULL) {
+        signal_ready(p, -1);
+        return NULL;
+    }
+    if (!create_panel_window(dpy, p)) {
+        fn.XCloseDisplay(dpy);
+        signal_ready(p, -1);
+        return NULL;
+    }
 
-    /* Per-client event mask on the shared XID — the command connection
-     * never selects anything, so ButtonPress ownership is uncontended. */
+    /* Per-client event mask. We are the creating client, so mask-0
+     * XDND ClientMessages land here too. SelectionNotify is always
+     * delivered to the converting client (also us). */
     fn.XSelectInput(dpy, p->win,
                     ButtonPressMask | ButtonReleaseMask | PointerMotionMask |
-                    KeyPressMask | KeyReleaseMask | StructureNotifyMask);
+                    KeyPressMask | KeyReleaseMask | StructureNotifyMask |
+                    PropertyChangeMask);
 
     /* XI2 raw buttons on the root for the outside-click monitor. Selected
      * unconditionally (cheap); forwarding is gated on the Java listener. */
@@ -537,6 +521,9 @@ static void *event_thread_main(void *arg) {
     fn.XFlush(dpy);
 
     JNIEnv *env = attach_jvm_thread();
+    /* Ready only after the window exists AND JNI is attached — callers
+     * (including the XDND smoke source) may send ClientMessages immediately. */
+    signal_ready(p, 1);
 
     struct pollfd fds[2] = {
         { .fd = ConnectionNumber(dpy), .events = POLLIN },
@@ -599,6 +586,12 @@ static void *event_thread_main(void *arg) {
                 case DestroyNotify:
                     if (ev.xdestroywindow.window == p->win) running = 0;
                     break;
+                case ClientMessage:
+                    popup_xdnd_on_client_message(dpy, env, p, &ev.xclient);
+                    break;
+                case SelectionNotify:
+                    popup_xdnd_on_selection_notify(dpy, env, p, &ev.xselection);
+                    break;
                 case GenericEvent: {
                     XGenericEventCookie *cookie = &ev.xcookie;
                     if (xi_opcode >= 0 && cookie->extension == xi_opcode &&
@@ -620,14 +613,25 @@ static void *event_thread_main(void *arg) {
         if (fds[1].revents & POLLIN) break; /* quit pipe */
     }
 
+    /* We created the window + colormap on this connection. Default
+     * close-down mode is DestroyAll, so XCloseDisplay would destroy them
+     * — and the command thread's nativeRelease used to XDestroyWindow
+     * afterwards, which is a fatal BadWindow. Destroy here, once. */
+    if (p->win != 0) {
+        fn.XDestroyWindow(dpy, p->win);
+        p->win = 0;
+    }
+    if (p->cmap != 0) {
+        fn.XFreeColormap(dpy, p->cmap);
+        p->cmap = 0;
+    }
+    fn.XFlush(dpy);
     fn.XCloseDisplay(dpy);
     detach_jvm_thread();
     return NULL;
 }
 
 /* ── JNI exports ────────────────────────────────────────────────────────── */
-
-#define EXPORT JNIEXPORT __attribute__((visibility("default")))
 
 EXPORT jboolean JNICALL
 Java_dev_nucleusframework_window_tao_ffi_PopupNativeBridgeLinux_nativeIsAvailable(
@@ -841,6 +845,19 @@ static Visual *choose_argb_visual(Display *dpy, int *out_depth) {
     return NULL;
 }
 
+static void panel_free(JNIEnv *env, Panel *p) {
+    if (p->quit_pipe[0] >= 0) close(p->quit_pipe[0]);
+    if (p->quit_pipe[1] >= 0) close(p->quit_pipe[1]);
+    if (env != NULL) {
+        if (p->event_cb != NULL) (*env)->DeleteGlobalRef(env, p->event_cb);
+        if (p->outside_cb != NULL) (*env)->DeleteGlobalRef(env, p->outside_cb);
+        if (p->dnd_cb != NULL) (*env)->DeleteGlobalRef(env, p->dnd_cb);
+    }
+    pthread_cond_destroy(&p->ready_cond);
+    pthread_mutex_destroy(&p->lock);
+    free(p);
+}
+
 EXPORT jlong JNICALL
 Java_dev_nucleusframework_window_tao_ffi_PopupNativeBridgeLinux_nativeCreatePanel(
     JNIEnv *env, jclass clazz, jint xPx, jint yPx, jint widthPx, jint heightPx)
@@ -857,53 +874,55 @@ Java_dev_nucleusframework_window_tao_ffi_PopupNativeBridgeLinux_nativeCreatePane
         return 0;
     }
 
-    Window root = DefaultRootWindow(dpy);
-    Colormap cmap = fn.XCreateColormap(dpy, root, visual, AllocNone);
-
-    XSetWindowAttributes swa;
-    memset(&swa, 0, sizeof(swa));
-    swa.colormap = cmap;
-    swa.border_pixel = 0;
-    swa.background_pixel = 0;
-    swa.override_redirect = True;
-    /* No event_mask here: input is selected per-client by the event
-     * thread's own connection. */
-    unsigned w = widthPx > 0 ? (unsigned) widthPx : 1;
-    unsigned h = heightPx > 0 ? (unsigned) heightPx : 1;
-    Window win = fn.XCreateWindow(
-        dpy, root, xPx, yPx, w, h, 0, depth, InputOutput, visual,
-        CWColormap | CWBorderPixel | CWBackPixel | CWOverrideRedirect, &swa);
-    if (win == 0) {
-        fn.XFreeColormap(dpy, cmap);
-        return 0;
-    }
-    if (fn.XStoreName != NULL) fn.XStoreName(dpy, win, "NucleusStandalonePopup");
-    fn.XSync(dpy, False);
-
     Panel *p = (Panel *) calloc(1, sizeof(Panel));
-    if (p == NULL) {
-        fn.XDestroyWindow(dpy, win);
-        fn.XFreeColormap(dpy, cmap);
-        return 0;
-    }
-    p->win = win;
-    p->cmap = cmap;
+    if (p == NULL) return 0;
+    p->visual_id = visual->visualid;
+    p->depth = depth;
     p->x = xPx;
     p->y = yPx;
-    p->w = (int) w;
-    p->h = (int) h;
+    p->w = widthPx > 0 ? widthPx : 1;
+    p->h = heightPx > 0 ? heightPx : 1;
+    p->quit_pipe[0] = p->quit_pipe[1] = -1;
     pthread_mutex_init(&p->lock, NULL);
+    pthread_cond_init(&p->ready_cond, NULL);
     if (pipe(p->quit_pipe) != 0) {
         p->quit_pipe[0] = p->quit_pipe[1] = -1;
     }
 
-    if (pthread_create(&p->evt_thread, NULL, event_thread_main, p) == 0) {
-        p->evt_thread_started = 1;
-    } else {
+    if (pthread_create(&p->evt_thread, NULL, event_thread_main, p) != 0) {
         DBG("event thread creation failed\n");
+        panel_free(env, p);
+        return 0;
+    }
+    p->evt_thread_started = 1;
+
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += 2;
+    pthread_mutex_lock(&p->lock);
+    while (p->ready == 0) {
+        int rc = pthread_cond_timedwait(&p->ready_cond, &p->lock, &deadline);
+        if (rc == ETIMEDOUT) break;
+    }
+    int ready = p->ready;
+    Window win = p->win;
+    pthread_mutex_unlock(&p->lock);
+
+    if (ready != 1 || win == 0) {
+        DBG("event thread failed to create window\n");
+        if (p->quit_pipe[1] >= 0) {
+            char one = 1;
+            ssize_t ignored = write(p->quit_pipe[1], &one, 1);
+            (void) ignored;
+        }
+        pthread_join(p->evt_thread, NULL);
+        p->evt_thread_started = 0;
+        panel_free(env, p);
+        return 0;
     }
 
-    DBG("panel created: win=0x%lx depth=%d\n", win, depth);
+    DBG("panel created: win=0x%lx depth=%d visual=0x%lx\n",
+        (unsigned long) win, depth, (unsigned long) p->visual_id);
     return (jlong) (uintptr_t) p;
 }
 
@@ -1072,18 +1091,22 @@ Java_dev_nucleusframework_window_tao_ffi_PopupNativeBridgeLinux_nativeRelease(
     pthread_mutex_lock(&p->lock);
     jobject event_cb = p->event_cb;
     jobject outside_cb = p->outside_cb;
+    jobject dnd_cb = p->dnd_cb;
     p->event_cb = NULL;
     p->outside_cb = NULL;
+    p->dnd_cb = NULL;
     pthread_mutex_unlock(&p->lock);
     if (event_cb != NULL) (*env)->DeleteGlobalRef(env, event_cb);
     if (outside_cb != NULL) (*env)->DeleteGlobalRef(env, outside_cb);
+    if (dnd_cb != NULL) (*env)->DeleteGlobalRef(env, dnd_cb);
 
     if (dpy != NULL) {
         if (p->cursor != None) fn.XFreeCursor(dpy, p->cursor);
-        fn.XDestroyWindow(dpy, p->win);
-        fn.XFreeColormap(dpy, p->cmap);
+        /* Window + colormap are destroyed by the event thread (creator)
+         * before it closes its Display. Touching them here is BadWindow. */
         fn.XFlush(dpy);
     }
+    pthread_cond_destroy(&p->ready_cond);
     pthread_mutex_destroy(&p->lock);
     free(p);
 }

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup.h
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup.h
@@ -1,0 +1,155 @@
+/**
+ * Shared types for the Linux standalone popup .so:
+ *   nucleus_tao_linux_popup.c      — window, event thread, input
+ *   nucleus_tao_linux_popup_xdnd.c — inbound XDND + test source
+ *
+ * XDND ClientMessages are delivered to the *creating* client (event_mask=0),
+ * so the protocol has to run on the event thread. The split keeps the panel
+ * file from owning the protocol.
+ */
+#ifndef NUCLEUS_TAO_LINUX_POPUP_H
+#define NUCLEUS_TAO_LINUX_POPUP_H
+
+#include <jni.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/Xatom.h>
+#include <X11/extensions/XInput2.h>
+#include <X11/extensions/Xrandr.h>
+
+#define NUCLEUS_TAO_POPUP_DEBUG 0
+#if NUCLEUS_TAO_POPUP_DEBUG
+#define DBG(...) fprintf(stderr, "[nucleus_tao_linux_popup] " __VA_ARGS__)
+#else
+#define DBG(...) ((void)0)
+#endif
+
+#define EXPORT JNIEXPORT __attribute__((visibility("default")))
+
+#define DROP_EFFECT_NONE 0
+#define DROP_EFFECT_COPY 1
+#define XDND_VERSION     5
+#define XDND_MAX_FILES   64
+
+typedef struct {
+    int initialized;
+
+    Display *(*XOpenDisplay)(const char *);
+    int (*XCloseDisplay)(Display *);
+    Window (*XCreateWindow)(Display *, Window, int, int, unsigned, unsigned,
+                            unsigned, int, unsigned, Visual *, unsigned long,
+                            XSetWindowAttributes *);
+    int (*XDestroyWindow)(Display *, Window);
+    int (*XMapRaised)(Display *, Window);
+    int (*XUnmapWindow)(Display *, Window);
+    int (*XRaiseWindow)(Display *, Window);
+    int (*XMoveResizeWindow)(Display *, Window, int, int, unsigned, unsigned);
+    int (*XFlush)(Display *);
+    int (*XSync)(Display *, Bool);
+    int (*XSelectInput)(Display *, Window, long);
+    int (*XNextEvent)(Display *, XEvent *);
+    int (*XPending)(Display *);
+    Colormap (*XCreateColormap)(Display *, Window, Visual *, int);
+    int (*XFreeColormap)(Display *, Colormap);
+    XVisualInfo *(*XGetVisualInfo)(Display *, long, XVisualInfo *, int *);
+    int (*XFree)(void *);
+    int (*XSetInputFocus)(Display *, Window, int, Time);
+    Cursor (*XCreateFontCursor)(Display *, unsigned int);
+    int (*XDefineCursor)(Display *, Window, Cursor);
+    int (*XFreeCursor)(Display *, Cursor);
+    int (*XStoreName)(Display *, Window, const char *);
+    char *(*XResourceManagerString)(Display *);
+    int (*XLookupString)(XKeyEvent *, char *, int, KeySym *, XComposeStatus *);
+    KeySym (*XkbKeycodeToKeysym)(Display *, KeyCode, unsigned, unsigned);
+    Bool (*XQueryExtension)(Display *, const char *, int *, int *, int *);
+    Bool (*XGetEventData)(Display *, XGenericEventCookie *);
+    void (*XFreeEventData)(Display *, XGenericEventCookie *);
+    Bool (*XQueryPointer)(Display *, Window, Window *, Window *, int *, int *,
+                          int *, int *, unsigned *);
+
+    Atom (*XInternAtom)(Display *, const char *, Bool);
+    int (*XGetWindowProperty)(Display *, Window, Atom, long, long, Bool, Atom,
+                              Atom *, int *, unsigned long *, unsigned long *,
+                              unsigned char **);
+    int (*XChangeProperty)(Display *, Window, Atom, Atom, int, int,
+                           const unsigned char *, int);
+    int (*XDeleteProperty)(Display *, Window, Atom);
+    Status (*XSendEvent)(Display *, Window, Bool, long, XEvent *);
+    int (*XConvertSelection)(Display *, Atom, Atom, Atom, Window, Time);
+    int (*XSetSelectionOwner)(Display *, Atom, Window, Time);
+
+    int (*XISelectEvents)(Display *, Window, XIEventMask *, int);
+    int (*XIQueryVersion)(Display *, int *, int *);
+
+    XRRMonitorInfo *(*XRRGetMonitors)(Display *, Window, Bool, int *);
+    void (*XRRFreeMonitors)(XRRMonitorInfo *);
+
+    uint32_t (*xkb_keysym_to_utf32)(uint32_t keysym);
+
+    void *(*eglGetPlatformDisplay)(unsigned, void *, const intptr_t *);
+    void *(*eglGetDisplay)(void *);
+    int (*eglInitialize)(void *, int *, int *);
+    int (*eglBindAPI)(unsigned);
+    int (*eglChooseConfig)(void *, const int *, void **, int, int *);
+    int (*eglGetConfigAttrib)(void *, void *, int, int *);
+} PopupX11;
+
+extern PopupX11 fn;
+extern JavaVM *g_jvm;
+
+typedef struct {
+    Window   win;
+    Colormap cmap;
+    Cursor   cursor;
+    VisualID visual_id;
+    int      depth;
+
+    pthread_mutex_t lock;
+    pthread_cond_t  ready_cond;
+    int x, y, w, h;
+    int visible;
+    int focusable;
+    int ready;
+
+    pthread_t evt_thread;
+    int       evt_thread_started;
+    int       quit_pipe[2];
+
+    jobject event_cb;
+    jobject outside_cb;
+    jobject dnd_cb;
+
+    Atom a_XdndAware;
+    Atom a_XdndEnter;
+    Atom a_XdndPosition;
+    Atom a_XdndStatus;
+    Atom a_XdndLeave;
+    Atom a_XdndDrop;
+    Atom a_XdndFinished;
+    Atom a_XdndSelection;
+    Atom a_XdndTypeList;
+    Atom a_XdndActionCopy;
+    Atom a_text_uri_list;
+
+    Window xdnd_source;
+    int    xdnd_version;
+    int    xdnd_entered;
+    int    xdnd_has_files;
+    int    xdnd_x;
+    int    xdnd_y;
+    int    xdnd_awaiting_sel;
+    Time   xdnd_time;
+} Panel;
+
+void popup_xdnd_intern_atoms(Display *dpy, Panel *p);
+void popup_xdnd_set_aware(Display *dpy, Panel *p);
+void popup_xdnd_on_client_message(Display *dpy, JNIEnv *env, Panel *p,
+                                  const XClientMessageEvent *cm);
+void popup_xdnd_on_selection_notify(Display *dpy, JNIEnv *env, Panel *p,
+                                    const XSelectionEvent *se);
+
+#endif /* NUCLEUS_TAO_LINUX_POPUP_H */

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup_xdnd.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup_xdnd.c
@@ -1,0 +1,585 @@
+/**
+ * Inbound XDND for the Linux standalone popup panel.
+ *
+ * Lives in its own translation unit so the panel file stays window/input/EGL.
+ * Runs on the panel's event thread: XDND ClientMessages are sent with
+ * `event_mask = NoEventMask`, which the X server delivers only to the
+ * creating client — that is this thread, which created the window.
+ *
+ * JNI shape matches the Windows IDropTarget / GTK bridges so TaoSceneDnD
+ * stays shared. `nativeSmokeXdndDrop` is a second-client XDND source used
+ * only by StandalonePanelLinuxNativeSmokeTest.
+ */
+
+#include "nucleus_tao_linux_popup.h"
+
+#include <poll.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static jmethodID g_on_drag_enter = NULL; /* (JIIIZ)I */
+static jmethodID g_on_drag_over  = NULL; /* (JIIIZ)I */
+static jmethodID g_on_drag_leave = NULL; /* (J)V     */
+static jmethodID g_on_drag_drop  = NULL; /* (JIII[Ljava/lang/String;)I */
+
+static void cache_dnd_callback_ids(JNIEnv *env, jobject callback) {
+    if (g_on_drag_enter != NULL) return;
+    jclass cls = (*env)->GetObjectClass(env, callback);
+    if (cls == NULL) return;
+    g_on_drag_enter = (*env)->GetMethodID(env, cls, "onDragEnter", "(JIIIZ)I");
+    g_on_drag_over  = (*env)->GetMethodID(env, cls, "onDragOver",  "(JIIIZ)I");
+    g_on_drag_leave = (*env)->GetMethodID(env, cls, "onDragLeave", "(J)V");
+    g_on_drag_drop  = (*env)->GetMethodID(env, cls, "onDrop",
+                                         "(JIII[Ljava/lang/String;)I");
+    (*env)->DeleteLocalRef(env, cls);
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+}
+
+void popup_xdnd_intern_atoms(Display *dpy, Panel *p) {
+    p->a_XdndAware      = fn.XInternAtom(dpy, "XdndAware", False);
+    p->a_XdndEnter      = fn.XInternAtom(dpy, "XdndEnter", False);
+    p->a_XdndPosition   = fn.XInternAtom(dpy, "XdndPosition", False);
+    p->a_XdndStatus     = fn.XInternAtom(dpy, "XdndStatus", False);
+    p->a_XdndLeave      = fn.XInternAtom(dpy, "XdndLeave", False);
+    p->a_XdndDrop       = fn.XInternAtom(dpy, "XdndDrop", False);
+    p->a_XdndFinished   = fn.XInternAtom(dpy, "XdndFinished", False);
+    p->a_XdndSelection  = fn.XInternAtom(dpy, "XdndSelection", False);
+    p->a_XdndTypeList   = fn.XInternAtom(dpy, "XdndTypeList", False);
+    p->a_XdndActionCopy = fn.XInternAtom(dpy, "XdndActionCopy", False);
+    p->a_text_uri_list  = fn.XInternAtom(dpy, "text/uri-list", False);
+}
+
+void popup_xdnd_set_aware(Display *dpy, Panel *p) {
+    unsigned long version = XDND_VERSION;
+    fn.XChangeProperty(dpy, p->win, p->a_XdndAware, XA_ATOM, 32,
+                       PropModeReplace, (unsigned char *) &version, 1);
+}
+
+static void send_xdnd_client(Display *dpy, Window dest, Atom type,
+                             long l0, long l1, long l2, long l3, long l4) {
+    XEvent ev;
+    memset(&ev, 0, sizeof(ev));
+    ev.xclient.type = ClientMessage;
+    ev.xclient.display = dpy;
+    ev.xclient.window = dest;
+    ev.xclient.message_type = type;
+    ev.xclient.format = 32;
+    ev.xclient.data.l[0] = l0;
+    ev.xclient.data.l[1] = l1;
+    ev.xclient.data.l[2] = l2;
+    ev.xclient.data.l[3] = l3;
+    ev.xclient.data.l[4] = l4;
+    fn.XSendEvent(dpy, dest, False, NoEventMask, &ev);
+    fn.XFlush(dpy);
+}
+
+static int xdnd_type_is_uri_list(Panel *p, Atom type) {
+    return type != None && type == p->a_text_uri_list;
+}
+
+static int xdnd_source_offers_files(Display *dpy, Panel *p, const XClientMessageEvent *cm) {
+    int more = cm->data.l[1] & 1;
+    if (!more) {
+        return xdnd_type_is_uri_list(p, (Atom) cm->data.l[2]) ||
+               xdnd_type_is_uri_list(p, (Atom) cm->data.l[3]) ||
+               xdnd_type_is_uri_list(p, (Atom) cm->data.l[4]);
+    }
+    Window source = (Window) cm->data.l[0];
+    Atom actual_type = None;
+    int actual_format = 0;
+    unsigned long nitems = 0, bytes_after = 0;
+    unsigned char *prop = NULL;
+    if (fn.XGetWindowProperty(dpy, source, p->a_XdndTypeList, 0, 64, False,
+                              XA_ATOM, &actual_type, &actual_format, &nitems,
+                              &bytes_after, &prop) != Success ||
+        prop == NULL) {
+        return 0;
+    }
+    int has = 0;
+    Atom *atoms = (Atom *) prop;
+    for (unsigned long i = 0; i < nitems; i++) {
+        if (xdnd_type_is_uri_list(p, atoms[i])) {
+            has = 1;
+            break;
+        }
+    }
+    fn.XFree(prop);
+    return has;
+}
+
+static int hex_nibble(int c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+static void percent_decode(const char *src, char *dst, size_t dst_cap) {
+    size_t o = 0;
+    for (size_t i = 0; src[i] != '\0' && o + 1 < dst_cap; i++) {
+        if (src[i] == '%' && src[i + 1] && src[i + 2]) {
+            int hi = hex_nibble((unsigned char) src[i + 1]);
+            int lo = hex_nibble((unsigned char) src[i + 2]);
+            if (hi >= 0 && lo >= 0) {
+                dst[o++] = (char) ((hi << 4) | lo);
+                i += 2;
+                continue;
+            }
+        }
+        dst[o++] = src[i];
+    }
+    dst[o] = '\0';
+}
+
+static void uri_to_path(const char *uri, char *out, size_t out_cap) {
+    const char *rest = uri;
+    if (strncmp(uri, "file://", 7) == 0) {
+        rest = uri + 7;
+        if (strncmp(rest, "localhost", 9) == 0 &&
+            (rest[9] == '/' || rest[9] == '\0')) {
+            rest += 9;
+        }
+    }
+    percent_decode(rest, out, out_cap);
+}
+
+static int parse_uri_list(const char *data, char paths[][4096], int max_paths) {
+    int n = 0;
+    const char *p = data;
+    while (*p && n < max_paths) {
+        while (*p == '\r' || *p == '\n') p++;
+        if (*p == '\0') break;
+        if (*p == '#') {
+            while (*p && *p != '\n') p++;
+            continue;
+        }
+        const char *start = p;
+        while (*p && *p != '\r' && *p != '\n') p++;
+        size_t len = (size_t) (p - start);
+        if (len == 0) continue;
+        char uri[4096];
+        if (len >= sizeof(uri)) len = sizeof(uri) - 1;
+        memcpy(uri, start, len);
+        uri[len] = '\0';
+        uri_to_path(uri, paths[n], 4096);
+        if (paths[n][0] != '\0') n++;
+    }
+    return n;
+}
+
+static jint call_dnd_motion(JNIEnv *env, Panel *p, jmethodID method, int x, int y, int has_files) {
+    pthread_mutex_lock(&p->lock);
+    jobject cb = p->dnd_cb;
+    pthread_mutex_unlock(&p->lock);
+    if (cb == NULL || method == NULL) return DROP_EFFECT_NONE;
+    jint effect = (*env)->CallIntMethod(env, cb, method, (jlong) (uintptr_t) p,
+                                        (jint) x, (jint) y, (jint) 0,
+                                        has_files ? JNI_TRUE : JNI_FALSE);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        return DROP_EFFECT_NONE;
+    }
+    return effect;
+}
+
+static void call_dnd_leave(JNIEnv *env, Panel *p) {
+    pthread_mutex_lock(&p->lock);
+    jobject cb = p->dnd_cb;
+    pthread_mutex_unlock(&p->lock);
+    if (cb == NULL || g_on_drag_leave == NULL) return;
+    (*env)->CallVoidMethod(env, cb, g_on_drag_leave, (jlong) (uintptr_t) p);
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+}
+
+static jint call_dnd_drop(JNIEnv *env, Panel *p, int x, int y,
+                          char paths[][4096], int npaths) {
+    pthread_mutex_lock(&p->lock);
+    jobject cb = p->dnd_cb;
+    pthread_mutex_unlock(&p->lock);
+    if (cb == NULL || g_on_drag_drop == NULL) return DROP_EFFECT_NONE;
+
+    jclass str_cls = (*env)->FindClass(env, "java/lang/String");
+    if (str_cls == NULL) {
+        if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+        return DROP_EFFECT_NONE;
+    }
+    jobjectArray arr = (*env)->NewObjectArray(env, npaths, str_cls, NULL);
+    (*env)->DeleteLocalRef(env, str_cls);
+    if (arr == NULL) {
+        if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+        return DROP_EFFECT_NONE;
+    }
+    for (int i = 0; i < npaths; i++) {
+        jstring s = (*env)->NewStringUTF(env, paths[i]);
+        if (s == NULL) {
+            if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+            continue;
+        }
+        (*env)->SetObjectArrayElement(env, arr, i, s);
+        (*env)->DeleteLocalRef(env, s);
+    }
+    jint effect = (*env)->CallIntMethod(env, cb, g_on_drag_drop,
+                                        (jlong) (uintptr_t) p,
+                                        (jint) x, (jint) y, (jint) 0, arr);
+    (*env)->DeleteLocalRef(env, arr);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        return DROP_EFFECT_NONE;
+    }
+    return effect;
+}
+
+static void xdnd_reset_session(Panel *p) {
+    p->xdnd_source = None;
+    p->xdnd_version = 0;
+    p->xdnd_entered = 0;
+    p->xdnd_has_files = 0;
+    p->xdnd_x = 0;
+    p->xdnd_y = 0;
+    p->xdnd_awaiting_sel = 0;
+    p->xdnd_time = CurrentTime;
+}
+
+static void xdnd_send_status(Display *dpy, Panel *p, int accept) {
+    if (p->xdnd_source == None) return;
+    long flags = accept ? 1 : 0;
+    flags |= 2;
+    send_xdnd_client(dpy, p->xdnd_source, p->a_XdndStatus,
+                     (long) p->win, flags, 0, 0,
+                     accept ? (long) p->a_XdndActionCopy : 0);
+}
+
+static void xdnd_send_finished(Display *dpy, Panel *p, int accept) {
+    if (p->xdnd_source == None) return;
+    long flags = 0;
+    long action = 0;
+    if (p->xdnd_version >= 5) {
+        flags = accept ? 1 : 0;
+        action = accept ? (long) p->a_XdndActionCopy : 0;
+    }
+    send_xdnd_client(dpy, p->xdnd_source, p->a_XdndFinished,
+                     (long) p->win, flags, action, 0, 0);
+}
+
+static void handle_xdnd_enter(Display *dpy, Panel *p, const XClientMessageEvent *cm) {
+    xdnd_reset_session(p);
+    p->xdnd_source = (Window) cm->data.l[0];
+    p->xdnd_version = (int) ((cm->data.l[1] >> 24) & 0xFF);
+    if (p->xdnd_version > XDND_VERSION) p->xdnd_version = XDND_VERSION;
+    p->xdnd_has_files = xdnd_source_offers_files(dpy, p, cm);
+}
+
+static void handle_xdnd_position(Display *dpy, JNIEnv *env, Panel *p,
+                                 const XClientMessageEvent *cm) {
+    Window source = (Window) cm->data.l[0];
+    if (p->xdnd_source == None) {
+        p->xdnd_source = source;
+        p->xdnd_version = XDND_VERSION;
+        p->xdnd_has_files = 1;
+    }
+    if (source != p->xdnd_source) return;
+
+    int root_x = (int) ((cm->data.l[2] >> 16) & 0xFFFF);
+    int root_y = (int) (cm->data.l[2] & 0xFFFF);
+    pthread_mutex_lock(&p->lock);
+    int local_x = root_x - p->x;
+    int local_y = root_y - p->y;
+    pthread_mutex_unlock(&p->lock);
+    p->xdnd_x = local_x;
+    p->xdnd_y = local_y;
+    if (cm->data.l[3]) p->xdnd_time = (Time) cm->data.l[3];
+
+    jint effect;
+    if (!p->xdnd_entered) {
+        p->xdnd_entered = 1;
+        effect = call_dnd_motion(env, p, g_on_drag_enter, local_x, local_y,
+                                 p->xdnd_has_files);
+    } else {
+        effect = call_dnd_motion(env, p, g_on_drag_over, local_x, local_y,
+                                 p->xdnd_has_files);
+    }
+    xdnd_send_status(dpy, p, effect != DROP_EFFECT_NONE);
+}
+
+static void handle_xdnd_leave(JNIEnv *env, Panel *p, const XClientMessageEvent *cm) {
+    if (p->xdnd_source != None && (Window) cm->data.l[0] != p->xdnd_source) return;
+    if (p->xdnd_entered) call_dnd_leave(env, p);
+    xdnd_reset_session(p);
+}
+
+static void handle_xdnd_drop(Display *dpy, JNIEnv *env, Panel *p,
+                             const XClientMessageEvent *cm) {
+    if (p->xdnd_source != None && (Window) cm->data.l[0] != p->xdnd_source) return;
+    Time time = cm->data.l[2] ? (Time) cm->data.l[2] : CurrentTime;
+    p->xdnd_time = time;
+    if (!p->xdnd_has_files) {
+        xdnd_send_finished(dpy, p, 0);
+        if (p->xdnd_entered) call_dnd_leave(env, p);
+        xdnd_reset_session(p);
+        return;
+    }
+    fn.XConvertSelection(dpy, p->a_XdndSelection, p->a_text_uri_list,
+                         p->a_XdndSelection, p->win, time);
+    p->xdnd_awaiting_sel = 1;
+}
+
+void popup_xdnd_on_client_message(Display *dpy, JNIEnv *env, Panel *p,
+                                  const XClientMessageEvent *cm) {
+    Atom mtype = cm->message_type;
+    if (mtype == p->a_XdndEnter) {
+        handle_xdnd_enter(dpy, p, cm);
+    } else if (mtype == p->a_XdndPosition) {
+        handle_xdnd_position(dpy, env, p, cm);
+    } else if (mtype == p->a_XdndLeave) {
+        handle_xdnd_leave(env, p, cm);
+    } else if (mtype == p->a_XdndDrop) {
+        handle_xdnd_drop(dpy, env, p, cm);
+    }
+}
+
+void popup_xdnd_on_selection_notify(Display *dpy, JNIEnv *env, Panel *p,
+                                    const XSelectionEvent *se) {
+    if (!p->xdnd_awaiting_sel) return;
+    p->xdnd_awaiting_sel = 0;
+    int accepted = 0;
+    if (se->property != None) {
+        Atom actual_type = None;
+        int actual_format = 0;
+        unsigned long nitems = 0, bytes_after = 0;
+        unsigned char *prop = NULL;
+        if (fn.XGetWindowProperty(dpy, p->win, se->property, 0, 65536, False,
+                                  AnyPropertyType, &actual_type, &actual_format,
+                                  &nitems, &bytes_after, &prop) == Success &&
+            prop != NULL && actual_format == 8 && nitems > 0) {
+            char *text = (char *) malloc(nitems + 1);
+            if (text != NULL) {
+                memcpy(text, prop, nitems);
+                text[nitems] = '\0';
+                char paths[XDND_MAX_FILES][4096];
+                int npaths = parse_uri_list(text, paths, XDND_MAX_FILES);
+                free(text);
+                if (npaths > 0) {
+                    jint effect = call_dnd_drop(env, p, p->xdnd_x, p->xdnd_y,
+                                                paths, npaths);
+                    accepted = effect != DROP_EFFECT_NONE;
+                }
+            }
+        }
+        if (prop != NULL) fn.XFree(prop);
+        fn.XDeleteProperty(dpy, p->win, se->property);
+    }
+    xdnd_send_finished(dpy, p, accepted);
+    xdnd_reset_session(p);
+}
+
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_PopupNativeBridgeLinux_nativeSetDnDCallback(
+    JNIEnv *env, jclass clazz, jlong panel, jobject callback)
+{
+    (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    if (p == NULL) return;
+    if (g_jvm == NULL) (*env)->GetJavaVM(env, &g_jvm);
+    jobject global = NULL;
+    if (callback != NULL) {
+        cache_dnd_callback_ids(env, callback);
+        global = (*env)->NewGlobalRef(env, callback);
+    }
+    pthread_mutex_lock(&p->lock);
+    jobject prev = p->dnd_cb;
+    p->dnd_cb = global;
+    pthread_mutex_unlock(&p->lock);
+    if (prev != NULL) (*env)->DeleteGlobalRef(env, prev);
+}
+
+static void percent_encode_append(char *buf, size_t cap, size_t *len, unsigned char b) {
+    int safe = (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') ||
+               (b >= '0' && b <= '9') || b == '-' || b == '_' ||
+               b == '.' || b == '~' || b == '/';
+    if (*len + 4 >= cap) return;
+    if (safe) {
+        buf[(*len)++] = (char) b;
+    } else {
+        static const char hex[] = "0123456789ABCDEF";
+        buf[(*len)++] = '%';
+        buf[(*len)++] = hex[b >> 4];
+        buf[(*len)++] = hex[b & 0xF];
+    }
+}
+
+static char *build_uri_list(JNIEnv *env, jobjectArray files) {
+    if (files == NULL) return NULL;
+    jsize n = (*env)->GetArrayLength(env, files);
+    if (n <= 0) return NULL;
+    char *buf = (char *) malloc(8192);
+    if (buf == NULL) return NULL;
+    size_t len = 0;
+    buf[0] = '\0';
+    for (jsize i = 0; i < n; i++) {
+        jstring js = (jstring) (*env)->GetObjectArrayElement(env, files, i);
+        if (js == NULL) continue;
+        const char *path = (*env)->GetStringUTFChars(env, js, NULL);
+        if (path != NULL) {
+            const char *prefix = "file://";
+            size_t plen = strlen(prefix);
+            if (len + plen + 4 < 8192) {
+                memcpy(buf + len, prefix, plen);
+                len += plen;
+            }
+            for (const unsigned char *c = (const unsigned char *) path; *c; c++) {
+                percent_encode_append(buf, 8192, &len, *c);
+            }
+            if (len + 3 < 8192) {
+                buf[len++] = '\r';
+                buf[len++] = '\n';
+            }
+            (*env)->ReleaseStringUTFChars(env, js, path);
+        }
+        (*env)->DeleteLocalRef(env, js);
+    }
+    buf[len] = '\0';
+    if (len == 0) {
+        free(buf);
+        return NULL;
+    }
+    return buf;
+}
+
+static int serve_selection_request(Display *dpy, const XSelectionRequestEvent *req,
+                                   const char *payload, Atom text_uri) {
+    Atom property = req->property;
+    if (property == None) property = req->target;
+    int ok = 0;
+    if (payload != NULL &&
+        (req->target == text_uri || req->target == XA_STRING)) {
+        fn.XChangeProperty(dpy, req->requestor, property, req->target, 8,
+                           PropModeReplace, (const unsigned char *) payload,
+                           (int) strlen(payload));
+        ok = 1;
+    }
+    XEvent notify;
+    memset(&notify, 0, sizeof(notify));
+    notify.xselection.type = SelectionNotify;
+    notify.xselection.display = dpy;
+    notify.xselection.requestor = req->requestor;
+    notify.xselection.selection = req->selection;
+    notify.xselection.target = req->target;
+    notify.xselection.property = ok ? property : None;
+    notify.xselection.time = req->time;
+    fn.XSendEvent(dpy, req->requestor, False, NoEventMask, &notify);
+    fn.XFlush(dpy);
+    return ok;
+}
+
+static int pump_xdnd_source(Display *dpy, Window src, Atom want, Atom text_uri,
+                            const char *payload, int timeout_ms, int *accepted) {
+    struct timespec start, now;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    struct pollfd fd = { .fd = ConnectionNumber(dpy), .events = POLLIN };
+    for (;;) {
+        while (fn.XPending(dpy) > 0) {
+            XEvent ev;
+            fn.XNextEvent(dpy, &ev);
+            if (ev.type == SelectionRequest) {
+                serve_selection_request(dpy, &ev.xselectionrequest, payload, text_uri);
+            } else if (ev.type == ClientMessage &&
+                       ev.xclient.window == src &&
+                       ev.xclient.message_type == want) {
+                if (accepted != NULL) {
+                    *accepted = (ev.xclient.data.l[1] & 1) ? 1 : 0;
+                }
+                return 1;
+            }
+        }
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        long elapsed_ms = (long) ((now.tv_sec - start.tv_sec) * 1000 +
+                                  (now.tv_nsec - start.tv_nsec) / 1000000);
+        if (elapsed_ms >= timeout_ms) return 0;
+        int wait = (int) (timeout_ms - elapsed_ms);
+        if (wait < 1) wait = 1;
+        poll(&fd, 1, wait);
+    }
+}
+
+EXPORT jint JNICALL
+Java_dev_nucleusframework_window_tao_ffi_PopupNativeBridgeLinux_nativeSmokeXdndDrop(
+    JNIEnv *env, jclass clazz, jlong panel, jobjectArray files)
+{
+    (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    if (p == NULL || p->win == 0) return DROP_EFFECT_NONE;
+    char *payload = build_uri_list(env, files);
+    if (payload == NULL) return DROP_EFFECT_NONE;
+
+    Display *dpy = fn.XOpenDisplay(NULL);
+    if (dpy == NULL) {
+        free(payload);
+        return DROP_EFFECT_NONE;
+    }
+
+    pthread_mutex_lock(&p->lock);
+    Window target = p->win;
+    int tx = p->x, ty = p->y, tw = p->w, th = p->h;
+    Atom text_uri = p->a_text_uri_list;
+    Atom a_enter = p->a_XdndEnter;
+    Atom a_pos = p->a_XdndPosition;
+    Atom a_drop = p->a_XdndDrop;
+    Atom a_status = p->a_XdndStatus;
+    Atom a_finished = p->a_XdndFinished;
+    Atom a_sel = p->a_XdndSelection;
+    Atom a_copy = p->a_XdndActionCopy;
+    pthread_mutex_unlock(&p->lock);
+
+    Window root = DefaultRootWindow(dpy);
+    XSetWindowAttributes swa;
+    memset(&swa, 0, sizeof(swa));
+    swa.override_redirect = True;
+    Window src = fn.XCreateWindow(dpy, root, 0, 0, 1, 1, 0, CopyFromParent,
+                                  InputOutput, CopyFromParent,
+                                  CWOverrideRedirect, &swa);
+    if (src == 0) {
+        fn.XCloseDisplay(dpy);
+        free(payload);
+        return DROP_EFFECT_NONE;
+    }
+    fn.XSelectInput(dpy, src, StructureNotifyMask);
+    fn.XSetSelectionOwner(dpy, a_sel, src, CurrentTime);
+    fn.XFlush(dpy);
+
+    int drop_x = tx + (tw > 20 ? 10 : tw / 2);
+    int drop_y = ty + (th > 20 ? 10 : th / 2);
+    if (drop_x < 0) drop_x = 0;
+    if (drop_y < 0) drop_y = 0;
+
+    send_xdnd_client(dpy, target, a_enter,
+                     (long) src, (long) (XDND_VERSION << 24),
+                     (long) text_uri, 0, 0);
+    send_xdnd_client(dpy, target, a_pos,
+                     (long) src, 0,
+                     ((long) drop_x << 16) | ((long) drop_y & 0xFFFF),
+                     (long) CurrentTime, (long) a_copy);
+
+    if (!pump_xdnd_source(dpy, src, a_status, text_uri, payload, 1500, NULL)) {
+        DBG("smoke XDND: no XdndStatus\n");
+        fn.XDestroyWindow(dpy, src);
+        fn.XCloseDisplay(dpy);
+        free(payload);
+        return DROP_EFFECT_NONE;
+    }
+
+    send_xdnd_client(dpy, target, a_drop, (long) src, 0, (long) CurrentTime, 0, 0);
+    int accepted = 0;
+    if (!pump_xdnd_source(dpy, src, a_finished, text_uri, payload, 2000, &accepted)) {
+        DBG("smoke XDND: no XdndFinished\n");
+        fn.XDestroyWindow(dpy, src);
+        fn.XCloseDisplay(dpy);
+        free(payload);
+        return DROP_EFFECT_NONE;
+    }
+
+    fn.XDestroyWindow(dpy, src);
+    fn.XCloseDisplay(dpy);
+    free(payload);
+    return accepted ? DROP_EFFECT_COPY : DROP_EFFECT_NONE;
+}

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -363,6 +363,26 @@
             ]
         },
         {
+            "type": "dev.nucleusframework.window.tao.ffi.PopupNativeBridgeLinux$DnDCallback",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onDragEnter", "parameterTypes": ["long","int","int","int","boolean"] },
+                { "name": "onDragOver",  "parameterTypes": ["long","int","int","int","boolean"] },
+                { "name": "onDragLeave", "parameterTypes": ["long"] },
+                { "name": "onDrop",      "parameterTypes": ["long","int","int","int","java.lang.String[]"] }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.popup.TaoStandalonePopupHostLinux$InboundDnDCallback",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onDragEnter", "parameterTypes": ["long","int","int","int","boolean"] },
+                { "name": "onDragOver",  "parameterTypes": ["long","int","int","int","boolean"] },
+                { "name": "onDragLeave", "parameterTypes": ["long"] },
+                { "name": "onDrop",      "parameterTypes": ["long","int","int","int","java.lang.String[]"] }
+            ]
+        },
+        {
             "type": "dev.nucleusframework.window.tao.popup.TaoPopupSceneLayer$PopupEventCallback",
             "jniAccessible": true,
             "methods": [

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelLinuxNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelLinuxNativeSmokeTest.kt
@@ -5,7 +5,13 @@ import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeLinux
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.GLAssembledInterface
 import org.jetbrains.skia.makeGLWithInterface
+import java.nio.file.Files
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -153,5 +159,112 @@ class StandalonePanelLinuxNativeSmokeTest {
             // quit pipe hangs here and trips the test timeout.
             PopupNativeBridgeLinux.nativeRelease(panel)
         }
+    }
+
+    /**
+     * End-to-end inbound file drop on the raw X11 panel (#605): a second X
+     * client runs the XDND protocol (`XdndEnter`/`Position`/`Drop` +
+     * `text/uri-list` selection) against the panel and the JNI callback
+     * must see the dropped path. Named callback class — same GraalVM
+     * `GetMethodID` constraint as production.
+     */
+    @Test
+    fun standalonePanelReceivesXdndFileDrop() {
+        if (!System.getProperty("os.name", "").lowercase().contains("linux")) return
+        assertTrue(PopupNativeBridgeLinux.isLoaded, "nucleus_tao_linux_popup failed to load")
+        if (!PopupNativeBridgeLinux.nativeIsAvailable()) {
+            println("SKIP: no X server reachable (DISPLAY unset?)")
+            return
+        }
+
+        val droppedFile = Files.createTempFile("nucleus xdnd", ".txt")
+        Files.writeString(droppedFile, "nucleus-xdnd-e2e")
+        val expectedPath = droppedFile.toAbsolutePath().toString()
+
+        val panel =
+            PopupNativeBridgeLinux.nativeCreatePanel(
+                xPx = 80,
+                yPx = 90,
+                widthPx = 200,
+                heightPx = 120,
+            )
+        assertNotEquals(0L, panel, "standalone panel creation failed")
+
+        val callback = RecordingXdndCallback()
+        try {
+            PopupNativeBridgeLinux.nativeSetDnDCallback(panel, callback)
+            PopupNativeBridgeLinux.nativeSetFrameOnScreen(panel, 80, 90, 200, 120)
+            PopupNativeBridgeLinux.nativeSetPanelVisible(panel, true)
+
+            val rc =
+                PopupNativeBridgeLinux.nativeSmokeXdndDrop(
+                    panel,
+                    arrayOf(expectedPath),
+                )
+            assertEquals(
+                PopupNativeBridgeLinux.DROP_EFFECT_COPY,
+                rc,
+                "XDND round-trip failed (no XdndStatus/Finished). rc=$rc " +
+                    "entered=${callback.entered.get()} dropped=${callback.dropped}",
+            )
+            assertTrue(
+                callback.dropLatch.await(3, TimeUnit.SECONDS),
+                "onDrop was not invoked. entered=${callback.entered.get()} dropped=${callback.dropped}",
+            )
+            assertTrue(callback.entered.get() >= 1, "onDragEnter was not invoked")
+            assertEquals(listOf(expectedPath), callback.dropped.toList())
+        } finally {
+            PopupNativeBridgeLinux.nativeSetDnDCallback(panel, null)
+            PopupNativeBridgeLinux.nativeRelease(panel)
+            Files.deleteIfExists(droppedFile)
+        }
+    }
+}
+
+/**
+ * Named class (not a lambda) so [PopupNativeBridgeLinux.nativeSetDnDCallback]'s
+ * `GetMethodID` lookup succeeds — same GraalVM JNI constraint as production
+ * inbound callbacks.
+ */
+private class RecordingXdndCallback : PopupNativeBridgeLinux.DnDCallback {
+    val entered = AtomicInteger(0)
+    val dropped = CopyOnWriteArrayList<String>()
+    val dropLatch = CountDownLatch(1)
+
+    override fun onDragEnter(
+        handle: Long,
+        x: Int,
+        y: Int,
+        modState: Int,
+        hasFiles: Boolean,
+    ): Int {
+        entered.incrementAndGet()
+        return if (hasFiles) {
+            PopupNativeBridgeLinux.DROP_EFFECT_COPY
+        } else {
+            PopupNativeBridgeLinux.DROP_EFFECT_NONE
+        }
+    }
+
+    override fun onDragOver(
+        handle: Long,
+        x: Int,
+        y: Int,
+        modState: Int,
+        hasFiles: Boolean,
+    ): Int = PopupNativeBridgeLinux.DROP_EFFECT_COPY
+
+    override fun onDragLeave(handle: Long) = Unit
+
+    override fun onDrop(
+        handle: Long,
+        x: Int,
+        y: Int,
+        modState: Int,
+        files: Array<String>?,
+    ): Int {
+        files?.let { dropped.addAll(it) }
+        dropLatch.countDown()
+        return PopupNativeBridgeLinux.DROP_EFFECT_COPY
     }
 }


### PR DESCRIPTION
## Summary

- Completes the Linux side of [#604](https://github.com/NucleusFramework/Nucleus/pull/604) / [#605](https://github.com/NucleusFramework/Nucleus/issues/605): `TaoStandalonePopup` on Linux is a raw override-redirect X11 window, so GTK `gtk_drag_dest_set` cannot attach.
- XDND ClientMessages are sent with `event_mask = 0`, so they only reach the **creating** client. The panel window is now created on the event thread (the command connection never pumps `XNextEvent`).
- Inbound `text/uri-list` drops dispatch through `TaoSceneDnD`, matching the Windows `IDropTarget` / macOS `NSDraggingDestination` hosts. JNI hops async onto the Tao main thread like pointer events.
- Protocol lives in `nucleus_tao_linux_popup_xdnd.c`; the panel file stays window/input/EGL. GraalVM JNI metadata for `InboundDnDCallback`.

## Test plan

- [x] `StandalonePanelLinuxNativeSmokeTest` — pipeline, lifecycle, and a real XDND source dropping a file (space in the name) onto the panel
- [x] `:decorated-window-tao:ktlintCheck` / `detekt`
- [ ] Drag a file from Nautilus/Files onto a `Modifier.dragAndDropTarget` inside Linux `TrayApp` / `TaoStandalonePopup` and confirm `onDrop` fires
- [x] Confirm DecoratedWindow (GTK) drop still works