### PR TITLE
fix(tao): match AWT wheel mapping on macOS popups

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDelta.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDelta.kt
@@ -1,0 +1,76 @@
+package dev.nucleusframework.window.tao.event
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.scene.ComposeScene
+import dev.nucleusframework.window.tao.TaoPointerScrollEvent
+
+/** Same factor [dev.nucleusframework.window.tao.TaoWindow] uses on `SCROLL_PIXEL`. */
+internal const val AWT_PIXEL_TO_ROTATION: Float = 10f
+
+/** macOS AWT `MouseWheelEvent.scrollAmount`. */
+internal const val MACOS_AWT_SCROLL_AMOUNT: Int = 1
+
+/**
+ * Maps raw AppKit `scrollingDelta*` onto AWT `preciseWheelRotation`.
+ *
+ * Matches [dev.nucleusframework.window.tao.TaoWindow] `SCROLL_LINE` /
+ * `SCROLL_PIXEL`: tao already flips X then Kotlin negates both axes, so
+ * the net sign from raw AppKit is `Offset(dx, -dy)`. Precise (trackpad)
+ * deltas are converted to physical pixels then divided by 10, same as
+ * AWT's NSEvent → `preciseWheelRotation` conversion.
+ *
+ * Popup NSPanel content views skip tao and must go through this before
+ * Compose.
+ */
+internal fun appKitWheelToAwtScrollDelta(
+    dx: Float,
+    dy: Float,
+    precise: Boolean,
+    scale: Float,
+): Offset {
+    val awtSign = Offset(dx, -dy)
+    return if (precise) awtSign * (scale / AWT_PIXEL_TO_ROTATION) else awtSign
+}
+
+internal fun appKitWheelToAwtScrollEvent(
+    dx: Float,
+    dy: Float,
+    precise: Boolean,
+    scale: Float,
+): TaoPointerScrollEvent {
+    val delta = appKitWheelToAwtScrollDelta(dx, dy, precise, scale)
+    return TaoPointerScrollEvent(
+        dxAwt = delta.x,
+        dyAwt = delta.y,
+        scrollAmount = MACOS_AWT_SCROLL_AMOUNT,
+    )
+}
+
+@OptIn(InternalComposeUiApi::class)
+internal fun ComposeScene.dispatchAppKitScroll(
+    x: Float,
+    y: Float,
+    dx: Float,
+    dy: Float,
+    precise: Boolean,
+    scale: Float,
+) {
+    val event = appKitWheelToAwtScrollEvent(dx, dy, precise, scale)
+    sendPointerEvent(
+        eventType = PointerEventType.Scroll,
+        position = Offset(x, y),
+        scrollDelta = Offset(event.dxAwt, event.dyAwt),
+        type = PointerType.Mouse,
+        nativeEvent =
+            TaoSyntheticMouseWheelEvent.create(
+                event = event,
+                x = x,
+                y = y,
+                keyboardModifiers = PointerKeyboardModifiers(),
+            ),
+    )
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/PopupNativeBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/PopupNativeBridge.kt
@@ -116,13 +116,20 @@ internal object PopupNativeBridge {
             modifiers: Int,
         )
 
-        /** AppKit `scrollingDelta*` units. */
+        /**
+         * Raw AppKit `scrollingDelta*` units. [precise] is
+         * `NSEvent.hasPreciseScrollingDeltas` (trackpad / Magic Mouse).
+         * Callers must map through
+         * [dev.nucleusframework.window.tao.event.dispatchAppKitScroll]
+         * before Compose.
+         */
         @Suppress("FunctionParameterNaming")
         fun onScroll(
             x: Float,
             y: Float,
             dx: Float,
             dy: Float,
+            precise: Boolean,
         )
 
         /** [type] = 1 down, 2 up. */

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import dev.nucleusframework.window.tao.TaoCursorIcon
+import dev.nucleusframework.window.tao.event.dispatchAppKitScroll
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
 import dev.nucleusframework.window.tao.event.toTaoCursorIconCode
 import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
@@ -264,13 +265,9 @@ internal class TaoPopupSceneLayer(
             y: Float,
             dx: Float,
             dy: Float,
+            precise: Boolean,
         ) {
-            innerScene.sendPointerEvent(
-                eventType = PointerEventType.Scroll,
-                position = Offset(x, y),
-                scrollDelta = Offset(dx, dy),
-                type = PointerType.Mouse,
-            )
+            innerScene.dispatchAppKitScroll(x, y, dx, dy, precise, scale)
         }
 
         override fun onKeyEvent(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
@@ -22,6 +22,7 @@ import dev.nucleusframework.window.tao.TaoScreenGeometry
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager
 import dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+import dev.nucleusframework.window.tao.event.dispatchAppKitScroll
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
 import dev.nucleusframework.window.tao.event.toTaoCursorIconCode
 import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
@@ -435,13 +436,9 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
             y: Float,
             dx: Float,
             dy: Float,
+            precise: Boolean,
         ) {
-            scene?.sendPointerEvent(
-                eventType = PointerEventType.Scroll,
-                position = Offset(x, y),
-                scrollDelta = Offset(dx, dy),
-                type = PointerType.Mouse,
-            )
+            scene?.dispatchAppKitScroll(x, y, dx, dy, precise, scale)
         }
 
         override fun onKeyEvent(

--- a/decorated-window-tao/src/main/native/macos/popup_panel.m
+++ b/decorated-window-tao/src/main/native/macos/popup_panel.m
@@ -49,7 +49,7 @@
 static JavaVM *sJVM = NULL;
 static jclass sCallbackClass = NULL;          // global ref to the Java callback interface
 static jmethodID sOnPointerMethod = NULL;     // (IFFII)V — type, x, y, button, modifiers
-static jmethodID sOnScrollMethod = NULL;      // (FFFF)V  — x, y, dx, dy
+static jmethodID sOnScrollMethod = NULL;      // (FFFFZ)V — x, y, dx, dy, precise
 static jmethodID sOnKeyMethod = NULL;         // (IIII)V  — type, vkCode, codePoint, modifiers
 static jclass sOutsideListenerClass = NULL;
 static jmethodID sOutsideOnClickMethod = NULL; // (II)V  — eventType, button
@@ -70,7 +70,7 @@ static void ensureCallbackCache(JNIEnv *env, jobject cbSample, jobject outsideSa
             sCallbackClass = (*env)->NewGlobalRef(env, local);
             (*env)->DeleteLocalRef(env, local);
             sOnPointerMethod = (*env)->GetMethodID(env, sCallbackClass, "onPointerEvent", "(IFFII)V");
-            sOnScrollMethod  = (*env)->GetMethodID(env, sCallbackClass, "onScroll",       "(FFFF)V");
+            sOnScrollMethod  = (*env)->GetMethodID(env, sCallbackClass, "onScroll",       "(FFFFZ)V");
             sOnKeyMethod     = (*env)->GetMethodID(env, sCallbackClass, "onKeyEvent",     "(IIII)V");
         }
     }
@@ -283,7 +283,8 @@ static const char kCursorKey         = 6; // NSCursor — set via nativeSetPanel
     jfloat x, y;
     [self pixelsForEvent:event outX:&x outY:&y];
     (*env)->CallVoidMethod(env, cb, sOnScrollMethod,
-        x, y, (jfloat)event.scrollingDeltaX, (jfloat)event.scrollingDeltaY);
+        x, y, (jfloat)event.scrollingDeltaX, (jfloat)event.scrollingDeltaY,
+        event.hasPreciseScrollingDeltas ? JNI_TRUE : JNI_FALSE);
     if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
 }
 

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -331,7 +331,7 @@
             "jniAccessible": true,
             "methods": [
                 { "name": "onPointerEvent", "parameterTypes": ["int","float","float","int","int"] },
-                { "name": "onScroll",       "parameterTypes": ["float","float","float","float"] },
+                { "name": "onScroll",       "parameterTypes": ["float","float","float","float","boolean"] },
                 { "name": "onKeyEvent",     "parameterTypes": ["int","int","int","int"] }
             ]
         },
@@ -367,7 +367,7 @@
             "jniAccessible": true,
             "methods": [
                 { "name": "onPointerEvent", "parameterTypes": ["int","float","float","int","int"] },
-                { "name": "onScroll",       "parameterTypes": ["float","float","float","float"] },
+                { "name": "onScroll",       "parameterTypes": ["float","float","float","float","boolean"] },
                 { "name": "onKeyEvent",     "parameterTypes": ["int","int","int","int"] }
             ]
         },

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -4,6 +4,7 @@ import dev.nucleusframework.window.TitleBarHitTestTest
 import dev.nucleusframework.window.tao.TaoWindowResizableTest
 import dev.nucleusframework.window.tao.TaoWindowScrollTest
 import dev.nucleusframework.window.tao.a11y.TaoA11yProjectionTest
+import dev.nucleusframework.window.tao.event.MacOsWheelDeltaTest
 import dev.nucleusframework.window.tao.event.TaoKeyMappingTest
 import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
 import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
@@ -110,6 +111,18 @@ public object TaoSceneTestBattery {
         }
         run("Win32WheelDeltaTest: horizontalWheelIsNegatedToAwtSign") {
             Win32WheelDeltaTest().horizontalWheelIsNegatedToAwtSign()
+        }
+        run("MacOsWheelDeltaTest: scrollUpMatchesTaoWindowAwtSign") {
+            MacOsWheelDeltaTest().scrollUpMatchesTaoWindowAwtSign()
+        }
+        run("MacOsWheelDeltaTest: horizontalDeltaKeepsAppKitX") {
+            MacOsWheelDeltaTest().horizontalDeltaKeepsAppKitX()
+        }
+        run("MacOsWheelDeltaTest: precisePixelDeltaMatchesTaoWindowScale") {
+            MacOsWheelDeltaTest().precisePixelDeltaMatchesTaoWindowScale()
+        }
+        run("MacOsWheelDeltaTest: precisePixelHorizontalMatchesTaoWindowScale") {
+            MacOsWheelDeltaTest().precisePixelHorizontalMatchesTaoWindowScale()
         }
         run("TaoWheelPinchZoomTest: fullWheelDeltaProducesModerateZoomStep") {
             TaoWheelPinchZoomTest().fullWheelDeltaProducesModerateZoomStep()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -4,6 +4,7 @@ import dev.nucleusframework.window.TitleBarHitTestTest
 import dev.nucleusframework.window.tao.a11y.TaoA11yProjectionTest
 import dev.nucleusframework.window.tao.dnd.TaoSyntheticDndTest
 import dev.nucleusframework.window.tao.dnd.TaoTransferableAccessGuardTest
+import dev.nucleusframework.window.tao.event.MacOsWheelDeltaTest
 import dev.nucleusframework.window.tao.event.TaoKeyMappingTest
 import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
 import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
@@ -45,6 +46,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoKeyboardModifiersDecodeTest::class.java,
             TaoSyntheticMouseWheelEventTest::class.java,
             Win32WheelDeltaTest::class.java,
+            MacOsWheelDeltaTest::class.java,
             TaoWheelPinchZoomTest::class.java,
             TaoWindowScrollTest::class.java,
             TaoWindowResizableTest::class.java,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDeltaTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDeltaTest.kt
@@ -1,0 +1,43 @@
+package dev.nucleusframework.window.tao.event
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MacOsWheelDeltaTest {
+    @Test
+    fun scrollUpMatchesTaoWindowAwtSign() {
+        // AppKit scrollingDeltaY > 0 is a scroll up. Popup NSPanels report
+        // that raw. TaoWindow SCROLL_LINE negates, so AWT/Compose get -1.
+        val delta =
+            appKitWheelToAwtScrollDelta(dx = 0f, dy = 1f, precise = false, scale = 2f)
+        assertEquals(0f, delta.x, absoluteTolerance = 0f)
+        assertEquals(-1f, delta.y, absoluteTolerance = 0f)
+    }
+
+    @Test
+    fun horizontalDeltaKeepsAppKitX() {
+        // tao flips X then TaoWindow negates, net identity vs raw AppKit X.
+        val delta =
+            appKitWheelToAwtScrollDelta(dx = 1f, dy = 0f, precise = false, scale = 2f)
+        assertEquals(1f, delta.x, absoluteTolerance = 0f)
+        assertEquals(0f, delta.y, absoluteTolerance = 0f)
+    }
+
+    @Test
+    fun precisePixelDeltaMatchesTaoWindowScale() {
+        // 10 AppKit points at 2x → physical 20 → AWT preciseWheelRotation -2
+        // after TaoWindow SCROLL_PIXEL's negate and /10.
+        val delta =
+            appKitWheelToAwtScrollDelta(dx = 0f, dy = 10f, precise = true, scale = 2f)
+        assertEquals(0f, delta.x, absoluteTolerance = 0f)
+        assertEquals(-2f, delta.y, absoluteTolerance = 0f)
+    }
+
+    @Test
+    fun precisePixelHorizontalMatchesTaoWindowScale() {
+        val delta =
+            appKitWheelToAwtScrollDelta(dx = 10f, dy = 0f, precise = true, scale = 2f)
+        assertEquals(2f, delta.x, absoluteTolerance = 0f)
+        assertEquals(0f, delta.y, absoluteTolerance = 0f)
+    }
+}


### PR DESCRIPTION
## Summary
- Popup NSPanels forwarded raw AppKit `scrollingDelta*` (positive Y = scroll up).
- `TaoWindow` already reshapes those to AWT `preciseWheelRotation`: negate Y, and for precise (trackpad) deltas convert to physical pixels then divide by 10.
- TrayApp (`TaoStandalonePopupHostMac`) and owned overlay popups (`TaoPopupSceneLayer`) skipped that path, so scroll was inverted and trackpad magnitude disagreed with the main window.
- Both hosts now go through `dispatchAppKitScroll` / `appKitWheelToAwtScrollDelta`, with `hasPreciseScrollingDeltas` plumbed from `popup_panel.m`. Compose gets the same synthetic `MouseWheelEvent` as the main-window path.

No public API change (`apiDump` is unchanged).

## Test plan
- [x] `MacOsWheelDeltaTest`: line scroll up maps to AWT −Y; horizontal keeps AppKit X; precise pixel deltas apply scale then `/10`
- [x] `:decorated-window-tao:ktlintCheck` and `:decorated-window-tao:detekt`
- [ ] Wheel a TrayApp / popup list on macOS: same direction and distance as a list in the main window (trackpad and mouse)