### PR TITLE
fix(tao): align standalone tray popup wheel scroll with DecoratedWindow

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/LinuxWheelDelta.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/LinuxWheelDelta.kt
@@ -1,0 +1,22 @@
+package dev.nucleusframework.window.tao.event
+
+import dev.nucleusframework.window.tao.TaoPointerScrollEvent
+
+/**
+ * Mirrors AWT's common three-lines-per-notch default, which
+ * [dev.nucleusframework.window.tao.TaoWindow] reports as `scrollAmount` on
+ * Linux `SCROLL_LINE`. The X11 standalone panel emits discrete Button4–7
+ * clicks already in Compose's sign convention (no extra negate).
+ */
+internal const val LINUX_AWT_SCROLL_AMOUNT_DEFAULT: Int = 3
+
+/** Discrete X11 Button4–7 click already in Compose's sign convention. */
+internal fun linuxWheelToAwtScrollEvent(
+    dx: Float,
+    dy: Float,
+): TaoPointerScrollEvent =
+    TaoPointerScrollEvent(
+        dxAwt = dx,
+        dyAwt = dy,
+        scrollAmount = LINUX_AWT_SCROLL_AMOUNT_DEFAULT,
+    )

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/LinuxWheelDelta.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/LinuxWheelDelta.kt
@@ -7,6 +7,11 @@ import dev.nucleusframework.window.tao.TaoPointerScrollEvent
  * [dev.nucleusframework.window.tao.TaoWindow] reports as `scrollAmount` on
  * Linux `SCROLL_LINE`. The X11 standalone panel emits discrete Button4–7
  * clicks already in Compose's sign convention (no extra negate).
+ *
+ * Do not "harmonize" this to 1 to match Windows: Compose's `LinuxGtkConfig`
+ * multiplies by `MouseWheelEvent.scrollAmount`, while Windows uses
+ * [TaoWindowsScrollConfig] which applies the ×3 itself and expects
+ * `scrollAmount = 1`.
  */
 internal const val LINUX_AWT_SCROLL_AMOUNT_DEFAULT: Int = 3
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDelta.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDelta.kt
@@ -41,6 +41,9 @@ internal fun appKitWheelToAwtScrollEvent(
     return TaoPointerScrollEvent(
         dxAwt = delta.x,
         dyAwt = delta.y,
+        // 1, like TaoWindow / Windows: MacOSCocoaConfig does not read a
+        // lines-per-notch multiplier out of scrollAmount the way LinuxGtkConfig
+        // does. Do not copy LINUX_AWT_SCROLL_AMOUNT_DEFAULT here.
         scrollAmount = MACOS_AWT_SCROLL_AMOUNT,
     )
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDelta.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDelta.kt
@@ -1,11 +1,6 @@
 package dev.nucleusframework.window.tao.event
 
-import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
-import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.scene.ComposeScene
 import dev.nucleusframework.window.tao.TaoPointerScrollEvent
 
 /** Same factor [dev.nucleusframework.window.tao.TaoWindow] uses on `SCROLL_PIXEL`. */
@@ -47,30 +42,5 @@ internal fun appKitWheelToAwtScrollEvent(
         dxAwt = delta.x,
         dyAwt = delta.y,
         scrollAmount = MACOS_AWT_SCROLL_AMOUNT,
-    )
-}
-
-@OptIn(InternalComposeUiApi::class)
-internal fun ComposeScene.dispatchAppKitScroll(
-    x: Float,
-    y: Float,
-    dx: Float,
-    dy: Float,
-    precise: Boolean,
-    scale: Float,
-) {
-    val event = appKitWheelToAwtScrollEvent(dx, dy, precise, scale)
-    sendPointerEvent(
-        eventType = PointerEventType.Scroll,
-        position = Offset(x, y),
-        scrollDelta = Offset(event.dxAwt, event.dyAwt),
-        type = PointerType.Mouse,
-        nativeEvent =
-            TaoSyntheticMouseWheelEvent.create(
-                event = event,
-                x = x,
-                y = y,
-                keyboardModifiers = PointerKeyboardModifiers(),
-            ),
     )
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/TaoSyntheticMouseWheelEvent.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/TaoSyntheticMouseWheelEvent.kt
@@ -1,10 +1,15 @@
 package dev.nucleusframework.window.tao.event
 
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.isAltPressed
 import androidx.compose.ui.input.pointer.isCtrlPressed
 import androidx.compose.ui.input.pointer.isMetaPressed
 import androidx.compose.ui.input.pointer.isShiftPressed
+import androidx.compose.ui.scene.ComposeScene
 import dev.nucleusframework.window.tao.TaoPointerScrollEvent
 import java.awt.Component
 import java.awt.event.InputEvent
@@ -51,4 +56,37 @@ internal object TaoSyntheticMouseWheelEvent {
             (if (isCtrlPressed) InputEvent.CTRL_DOWN_MASK else 0) or
             (if (isAltPressed) InputEvent.ALT_DOWN_MASK else 0) or
             (if (isMetaPressed) InputEvent.META_DOWN_MASK else 0)
+}
+
+/**
+ * Feeds an already AWT-shaped [TaoPointerScrollEvent] into the scene, including
+ * the synthetic `MouseWheelEvent` Compose Desktop's scroll config reads for
+ * `scrollAmount` / `preciseWheelRotation`.
+ *
+ * Single Compose entry for wheel input: [dev.nucleusframework.window.tao.TaoWindow]
+ * produces the event; popup WndProcs / NSPanel / X11 Button4–7 skip tao and
+ * must map first ([win32WheelToAwtScrollEvent], [appKitWheelToAwtScrollEvent],
+ * [linuxWheelToAwtScrollEvent]).
+ */
+@OptIn(InternalComposeUiApi::class)
+internal fun ComposeScene.dispatchAwtShapedScroll(
+    x: Float,
+    y: Float,
+    event: TaoPointerScrollEvent,
+    keyboardModifiers: PointerKeyboardModifiers = PointerKeyboardModifiers(),
+) {
+    sendPointerEvent(
+        eventType = PointerEventType.Scroll,
+        position = Offset(x, y),
+        scrollDelta = Offset(event.dxAwt, event.dyAwt),
+        type = PointerType.Mouse,
+        keyboardModifiers = keyboardModifiers,
+        nativeEvent =
+            TaoSyntheticMouseWheelEvent.create(
+                event = event,
+                x = x,
+                y = y,
+                keyboardModifiers = keyboardModifiers,
+            ),
+    )
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/Win32WheelDelta.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/event/Win32WheelDelta.kt
@@ -1,6 +1,7 @@
 package dev.nucleusframework.window.tao.event
 
 import androidx.compose.ui.geometry.Offset
+import dev.nucleusframework.window.tao.TaoPointerScrollEvent
 
 /**
  * Maps a raw Win32 wheel delta (`GET_WHEEL_DELTA_WPARAM / WHEEL_DELTA`) onto
@@ -16,3 +17,20 @@ internal fun win32WheelToAwtScrollDelta(
     dx: Float,
     dy: Float,
 ): Offset = Offset(-dx, -dy)
+
+/**
+ * Raw Win32 units → AWT-shaped event. `scrollAmount = 1` matches
+ * [dev.nucleusframework.window.tao.TaoWindow] on Windows; the three-lines-per-notch
+ * policy lives in [TaoWindowsScrollConfig].
+ */
+internal fun win32WheelToAwtScrollEvent(
+    dx: Float,
+    dy: Float,
+): TaoPointerScrollEvent {
+    val delta = win32WheelToAwtScrollDelta(dx, dy)
+    return TaoPointerScrollEvent(
+        dxAwt = delta.x,
+        dyAwt = delta.y,
+        scrollAmount = 1,
+    )
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/PopupNativeBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/PopupNativeBridge.kt
@@ -120,7 +120,8 @@ internal object PopupNativeBridge {
          * Raw AppKit `scrollingDelta*` units. [precise] is
          * `NSEvent.hasPreciseScrollingDeltas` (trackpad / Magic Mouse).
          * Callers must map through
-         * [dev.nucleusframework.window.tao.event.dispatchAppKitScroll]
+         * [dev.nucleusframework.window.tao.event.appKitWheelToAwtScrollEvent]
+         * then [dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll]
          * before Compose.
          */
         @Suppress("FunctionParameterNaming")

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePump.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePump.kt
@@ -18,7 +18,14 @@ internal class StandaloneFramePump(
     private val render: () -> Unit,
 ) {
     private val pending = AtomicBoolean(false)
+
+    // Main-thread only. [schedule] reads this only after proving
+    // `Thread.currentThread() === taoMainThread`, so a nested [schedule]
+    // from inside [render] is posted and drained later on that same thread
+    // (production: `pump()` on MainEventsCleared). Never touch off-main.
     private var rendering = false
+
+    @Volatile
     var disposed: Boolean = false
 
     fun schedule() {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePump.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePump.kt
@@ -1,0 +1,45 @@
+package dev.nucleusframework.window.tao.popup
+
+import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Coalesced on-demand frames for a standalone popup. Every scene
+ * `requestFrame` (scroll, pointer, animation) goes through [schedule] —
+ * there is no separate wheel paint path.
+ *
+ * Runs [render] immediately when already on the Tao main thread and not
+ * already inside a frame. A WndProc / NSEvent flood otherwise starves
+ * `MainEventsCleared` and a queued frame never paints. Nested [schedule]
+ * calls from inside [render] are posted, not re-entered.
+ */
+internal class StandaloneFramePump(
+    private val render: () -> Unit,
+) {
+    private val pending = AtomicBoolean(false)
+    private var rendering = false
+    var disposed: Boolean = false
+
+    fun schedule() {
+        if (disposed) return
+        if (!pending.compareAndSet(false, true)) return
+        val onMain = Thread.currentThread() === TaoMainDispatcher.taoMainThread
+        if (onMain && !rendering) {
+            runRender()
+        } else {
+            TaoMainDispatcher.dispatch(EmptyCoroutineContext) { runRender() }
+        }
+    }
+
+    private fun runRender() {
+        pending.set(false)
+        if (disposed) return
+        rendering = true
+        try {
+            render()
+        } finally {
+            rendering = false
+        }
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePump.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePump.kt
@@ -15,14 +15,19 @@ import kotlin.coroutines.EmptyCoroutineContext
  * calls from inside [render] are posted, not re-entered.
  */
 internal class StandaloneFramePump(
+    private val isOnMain: () -> Boolean = {
+        Thread.currentThread() === TaoMainDispatcher.taoMainThread
+    },
+    private val post: (Runnable) -> Unit = { block ->
+        TaoMainDispatcher.dispatch(EmptyCoroutineContext, block)
+    },
     private val render: () -> Unit,
 ) {
     private val pending = AtomicBoolean(false)
 
-    // Main-thread only. [schedule] reads this only after proving
-    // `Thread.currentThread() === taoMainThread`, so a nested [schedule]
-    // from inside [render] is posted and drained later on that same thread
-    // (production: `pump()` on MainEventsCleared). Never touch off-main.
+    // Only the thread [isOnMain] accepted for an inline render, and the
+    // thread [post] delivers to (production: both are Tao main). Tests
+    // inject both so they never touch [TaoMainDispatcher.taoMainThread].
     private var rendering = false
 
     @Volatile
@@ -31,11 +36,10 @@ internal class StandaloneFramePump(
     fun schedule() {
         if (disposed) return
         if (!pending.compareAndSet(false, true)) return
-        val onMain = Thread.currentThread() === TaoMainDispatcher.taoMainThread
-        if (onMain && !rendering) {
+        if (isOnMain() && !rendering) {
             runRender()
         } else {
-            TaoMainDispatcher.dispatch(EmptyCoroutineContext) { runRender() }
+            post(Runnable { runRender() })
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
@@ -20,7 +20,8 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import dev.nucleusframework.window.tao.TaoCursorIcon
-import dev.nucleusframework.window.tao.event.dispatchAppKitScroll
+import dev.nucleusframework.window.tao.event.appKitWheelToAwtScrollEvent
+import dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
 import dev.nucleusframework.window.tao.event.toTaoCursorIconCode
 import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
@@ -267,7 +268,11 @@ internal class TaoPopupSceneLayer(
             dy: Float,
             precise: Boolean,
         ) {
-            innerScene.dispatchAppKitScroll(x, y, dx, dy, precise, scale)
+            innerScene.dispatchAwtShapedScroll(
+                x,
+                y,
+                appKitWheelToAwtScrollEvent(dx, dy, precise, scale),
+            )
         }
 
         override fun onKeyEvent(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import dev.nucleusframework.window.tao.TaoApplication
 import dev.nucleusframework.window.tao.TaoMouseButton
 import dev.nucleusframework.window.tao.TaoWindow
-import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEvent
+import dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll
 import dev.nucleusframework.window.tao.event.taoKeyboardModifiers
 import dev.nucleusframework.window.tao.event.toTaoCursorIconCode
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
@@ -505,20 +505,12 @@ internal class TaoPopupSceneLayerLinux(
         }
         popupWindow.onPointerScroll { event ->
             if (released) return@onPointerScroll
-            val modifiers = taoKeyboardModifiers(host.parentWindow.modifierState)
-            innerScene.sendPointerEvent(
-                eventType = PointerEventType.Scroll,
-                position = scenePosition(lastX, lastY),
-                scrollDelta = Offset(event.dxAwt, event.dyAwt),
-                type = PointerType.Mouse,
-                keyboardModifiers = modifiers,
-                nativeEvent =
-                    TaoSyntheticMouseWheelEvent.create(
-                        event = event,
-                        x = lastX,
-                        y = lastY,
-                        keyboardModifiers = modifiers,
-                    ),
+            val pos = scenePosition(lastX, lastY)
+            innerScene.dispatchAwtShapedScroll(
+                x = pos.x,
+                y = pos.y,
+                event = event,
+                keyboardModifiers = taoKeyboardModifiers(host.parentWindow.modifierState),
             )
         }
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -22,8 +22,9 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
-import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollDelta
+import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollEvent
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeWindows
 import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
@@ -223,12 +224,8 @@ internal class TaoPopupSceneLayerWindows(
             dx: Float,
             dy: Float,
         ) {
-            innerScene.sendPointerEvent(
-                eventType = PointerEventType.Scroll,
-                position = scenePosition(x, y),
-                scrollDelta = win32WheelToAwtScrollDelta(dx, dy),
-                type = PointerType.Mouse,
-            )
+            val pos = scenePosition(x, y)
+            innerScene.dispatchAwtShapedScroll(pos.x, pos.y, win32WheelToAwtScrollEvent(dx, dy))
         }
 
         override fun onKeyEvent(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -24,8 +24,10 @@ import dev.nucleusframework.window.tao.TaoScreenGeometry
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager
 import dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+import dev.nucleusframework.window.tao.event.ProvideTaoWindowsScrollConfig
+import dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
-import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollDelta
+import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollEvent
 import dev.nucleusframework.window.tao.ffi.NativeTaoGlBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeWindows
@@ -45,9 +47,7 @@ import org.jetbrains.skia.makeGLWithInterface
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.roundToInt
 
 /**
@@ -93,7 +93,7 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     private val flushingDispatcher = FlushingDispatcher()
     private val windowInfo = StandalonePopupWindowInfo()
 
-    private val renderPending = AtomicBoolean(false)
+    private val framePump = StandaloneFramePump { renderNow() }
     private var nextFrameNs = 0L
     private var visible = false
 
@@ -199,8 +199,13 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     /** This panel owns its Skia context, so `TextureView`s inside it must import onto that one. */
     @Composable
     override fun ProvidePanelLocals(content: @Composable () -> Unit) {
-        CompositionLocalProvider(LocalTaoWindowsTextureHost provides textureHostState.value) {
-            content()
+        // Innermost, so a TrayApp composed next to a DecoratedWindow still
+        // gets the window-host wheel policy instead of Compose's default
+        // (which reads scrollAmount=1 and under-scrolls 3×).
+        ProvideTaoWindowsScrollConfig {
+            CompositionLocalProvider(LocalTaoWindowsTextureHost provides textureHostState.value) {
+                content()
+            }
         }
     }
 
@@ -318,6 +323,7 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     override fun dispose() {
         if (!isValid || disposed) return
         disposed = true
+        framePump.disposed = true
         if (visible) {
             visible = false
             PopupNativeBridgeWindows.nativeSetHighResTimer(false)
@@ -356,13 +362,10 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     // ── Rendering ─────────────────────────────────────────────────────────
 
     private fun scheduleRender() {
-        if (disposed) return
-        if (!renderPending.compareAndSet(false, true)) return
-        TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() }
+        framePump.schedule()
     }
 
     private fun renderNow() {
-        renderPending.set(false)
         if (disposed) return
         val ctx = directContext ?: return
         val bundle = sceneBundle ?: return
@@ -386,13 +389,11 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
         // are what makes an animation look smooth.
         val now = System.nanoTime()
         if (now < nextFrameNs) {
-            if (renderPending.compareAndSet(false, true)) {
-                pacer.schedule(
-                    { TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() } },
-                    nextFrameNs - now,
-                    TimeUnit.NANOSECONDS,
-                )
-            }
+            pacer.schedule(
+                { scheduleRender() },
+                nextFrameNs - now,
+                TimeUnit.NANOSECONDS,
+            )
             return
         }
         // Resynchronize after an idle gap; otherwise stay on the fixed grid.
@@ -464,12 +465,7 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
             dx: Float,
             dy: Float,
         ) {
-            scene?.sendPointerEvent(
-                eventType = PointerEventType.Scroll,
-                position = Offset(x, y),
-                scrollDelta = win32WheelToAwtScrollDelta(dx, dy),
-                type = PointerType.Mouse,
-            )
+            scene?.dispatchAwtShapedScroll(x, y, win32WheelToAwtScrollEvent(dx, dy))
         }
 
         override fun onKeyEvent(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
@@ -23,7 +23,9 @@ import dev.nucleusframework.window.tao.TaoDnDDiagnostics
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager
 import dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+import dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
+import dev.nucleusframework.window.tao.event.linuxWheelToAwtScrollEvent
 import dev.nucleusframework.window.tao.event.toTaoCursorIconCode
 import dev.nucleusframework.window.tao.ffi.NativeTaoEglBridge
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeLinux
@@ -43,7 +45,6 @@ import org.jetbrains.skia.makeGLWithInterface
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.roundToInt
@@ -98,7 +99,7 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
     private val flushingDispatcher = FlushingDispatcher()
     private val windowInfo = StandalonePopupWindowInfo()
 
-    private val renderPending = AtomicBoolean(false)
+    private val framePump = StandaloneFramePump { renderNow() }
     private var nextFrameNs = 0L
     private var visible = false
 
@@ -314,6 +315,7 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
     override fun dispose() {
         if (!isValid || disposed) return
         disposed = true
+        framePump.disposed = true
         revokeInboundDnD()
         PopupNativeBridgeLinux.nativeUninstallOutsideClickMonitor(panel)
         PopupNativeBridgeLinux.nativeSetEventCallback(panel, null)
@@ -345,13 +347,10 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
     // ── Rendering ─────────────────────────────────────────────────────────
 
     private fun scheduleRender() {
-        if (disposed) return
-        if (!renderPending.compareAndSet(false, true)) return
-        TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() }
+        framePump.schedule()
     }
 
     private fun renderNow() {
-        renderPending.set(false)
         if (disposed) return
         val ctx = directContext ?: return
         val bundle = sceneBundle ?: return
@@ -369,13 +368,11 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
         // clock is fed evenly spaced timestamps.
         val now = System.nanoTime()
         if (now < nextFrameNs) {
-            if (renderPending.compareAndSet(false, true)) {
-                pacer.schedule(
-                    { TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() } },
-                    nextFrameNs - now,
-                    TimeUnit.NANOSECONDS,
-                )
-            }
+            pacer.schedule(
+                { scheduleRender() },
+                nextFrameNs - now,
+                TimeUnit.NANOSECONDS,
+            )
             return
         }
         // Resynchronize after an idle gap; otherwise stay on the fixed grid.
@@ -453,12 +450,7 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
         ) {
             TaoMainDispatcher.dispatch(EmptyCoroutineContext) {
                 if (disposed) return@dispatch
-                scene?.sendPointerEvent(
-                    eventType = PointerEventType.Scroll,
-                    position = Offset(x, y),
-                    scrollDelta = Offset(dx, dy),
-                    type = PointerType.Mouse,
-                )
+                scene?.dispatchAwtShapedScroll(x, y, linuxWheelToAwtScrollEvent(dx, dy))
             }
         }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
@@ -22,7 +22,8 @@ import dev.nucleusframework.window.tao.TaoScreenGeometry
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.dnd.TaoDragAndDropManager
 import dev.nucleusframework.window.tao.dnd.TaoSceneDnD
-import dev.nucleusframework.window.tao.event.dispatchAppKitScroll
+import dev.nucleusframework.window.tao.event.appKitWheelToAwtScrollEvent
+import dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll
 import dev.nucleusframework.window.tao.event.dispatchNativeKeyEvent
 import dev.nucleusframework.window.tao.event.toTaoCursorIconCode
 import dev.nucleusframework.window.tao.ffi.NativeMetalBridge
@@ -46,7 +47,6 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.roundToInt
 
 /**
@@ -97,7 +97,7 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
     private val flushingDispatcher = FlushingDispatcher()
     private val windowInfo = StandalonePopupWindowInfo()
 
-    private val renderPending = AtomicBoolean(false)
+    private val framePump = StandaloneFramePump { renderNow() }
     private val replayInFlight = AtomicBoolean(false)
     private var nextFrameNs = 0L
     private var visible = false
@@ -283,6 +283,7 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
     override fun dispose() {
         if (!isValid || disposed) return
         disposed = true
+        framePump.disposed = true
         revokeInboundDnD()
         PopupNativeBridge.nativeUninstallOutsideClickMonitor(panel)
         PopupNativeBridge.nativeSetEventCallback(panel, null)
@@ -303,13 +304,10 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
     // ── Rendering ─────────────────────────────────────────────────────────
 
     private fun scheduleRender() {
-        if (disposed) return
-        if (!renderPending.compareAndSet(false, true)) return
-        TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() }
+        framePump.schedule()
     }
 
     private fun renderNow() {
-        renderPending.set(false)
         if (disposed) return
         val bundle = sceneBundle ?: return
         val ctx = directContext ?: return
@@ -340,13 +338,7 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
                 if (now < nextFrameNs) nextFrameNs - now else 0L
             }
         if (retryNs > 0L) {
-            if (renderPending.compareAndSet(false, true)) {
-                pacer.schedule(
-                    { TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() } },
-                    retryNs,
-                    TimeUnit.NANOSECONDS,
-                )
-            }
+            pacer.schedule({ scheduleRender() }, retryNs, TimeUnit.NANOSECONDS)
             return
         }
         val now = System.nanoTime()
@@ -438,7 +430,11 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
             dy: Float,
             precise: Boolean,
         ) {
-            scene?.dispatchAppKitScroll(x, y, dx, dy, precise, scale)
+            scene?.dispatchAwtShapedScroll(
+                x,
+                y,
+                appKitWheelToAwtScrollEvent(dx, dy, precise, scale),
+            )
         }
 
         override fun onKeyEvent(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -33,7 +33,7 @@ import dev.nucleusframework.window.tao.TaoTrackpadGesture
 import dev.nucleusframework.window.tao.TaoTrackpadPhase
 import dev.nucleusframework.window.tao.TaoWindow
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
-import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEvent
+import dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll
 import dev.nucleusframework.window.tao.event.taoKeyEvent
 import dev.nucleusframework.window.tao.event.taoKeyboardModifiers
 import dev.nucleusframework.window.tao.event.taoTypedKeyEvent
@@ -1032,19 +1032,11 @@ internal class TaoComposeSceneHost(
     fun onPointerScroll(event: TaoPointerScrollEvent) {
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
-        scene?.sendPointerEvent(
-            eventType = PointerEventType.Scroll,
-            position = Offset(lastPointerX, lastPointerY),
-            scrollDelta = Offset(event.dxAwt, event.dyAwt),
-            type = PointerType.Mouse,
+        scene?.dispatchAwtShapedScroll(
+            x = lastPointerX,
+            y = lastPointerY,
+            event = event,
             keyboardModifiers = currentKeyboardModifiers,
-            nativeEvent =
-                TaoSyntheticMouseWheelEvent.create(
-                    event = event,
-                    x = lastPointerX,
-                    y = lastPointerY,
-                    keyboardModifiers = currentKeyboardModifiers,
-                ),
         )
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -36,8 +36,8 @@ import dev.nucleusframework.window.tao.clipboard.ProvideTaoClipboard
 import dev.nucleusframework.window.tao.deco.ResizeFrameDecoration
 import dev.nucleusframework.window.tao.deco.TaoLinuxOverlayController
 import dev.nucleusframework.window.tao.deco.TaoLinuxOverlayControllerImpl
-import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEvent
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoom
+import dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll
 import dev.nucleusframework.window.tao.event.taoKeyEvent
 import dev.nucleusframework.window.tao.event.taoKeyboardModifiers
 import dev.nucleusframework.window.tao.event.taoTypedKeyEvent
@@ -1863,19 +1863,11 @@ internal class TaoComposeSceneHostLinux(
             return
         }
 
-        scene?.sendPointerEvent(
-            eventType = PointerEventType.Scroll,
-            position = Offset(lastPointerX, lastPointerY),
-            scrollDelta = Offset(event.dxAwt, event.dyAwt),
-            type = PointerType.Mouse,
+        scene?.dispatchAwtShapedScroll(
+            x = lastPointerX,
+            y = lastPointerY,
+            event = event,
             keyboardModifiers = currentKeyboardModifiers,
-            nativeEvent =
-                TaoSyntheticMouseWheelEvent.create(
-                    event = event,
-                    x = lastPointerX,
-                    y = lastPointerY,
-                    keyboardModifiers = currentKeyboardModifiers,
-                ),
         )
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -31,12 +31,12 @@ import dev.nucleusframework.window.tao.TaoPointerScrollEvent
 import dev.nucleusframework.window.tao.TaoTouchEvent
 import dev.nucleusframework.window.tao.TaoWindow
 import dev.nucleusframework.window.tao.event.ProvideTaoWindowsScrollConfig
-import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEvent
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoom
+import dev.nucleusframework.window.tao.event.dispatchAwtShapedScroll
 import dev.nucleusframework.window.tao.event.taoKeyEvent
 import dev.nucleusframework.window.tao.event.taoKeyboardModifiers
 import dev.nucleusframework.window.tao.event.taoTypedKeyEvent
-import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollDelta
+import dev.nucleusframework.window.tao.event.win32WheelToAwtScrollEvent
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoGlBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
@@ -1392,19 +1392,11 @@ internal class TaoComposeSceneHostWindows(
     private fun sendScrollToScene(event: TaoPointerScrollEvent) {
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
-        scene?.sendPointerEvent(
-            eventType = PointerEventType.Scroll,
-            position = Offset(lastPointerX, lastPointerY),
-            scrollDelta = Offset(event.dxAwt, event.dyAwt),
-            type = PointerType.Mouse,
+        scene?.dispatchAwtShapedScroll(
+            x = lastPointerX,
+            y = lastPointerY,
+            event = event,
             keyboardModifiers = currentKeyboardModifiers,
-            nativeEvent =
-                TaoSyntheticMouseWheelEvent.create(
-                    event = event,
-                    x = lastPointerX,
-                    y = lastPointerY,
-                    keyboardModifiers = currentKeyboardModifiers,
-                ),
         )
     }
 
@@ -1803,15 +1795,12 @@ internal class TaoComposeSceneHostWindows(
         ) {
             lastPointerX = x
             lastPointerY = y
-            // Overlay WndProc reports raw Win32 wheel units. TaoWindow
-            // negates before Compose; match that so TaoWindowsScrollConfig
-            // (which multiplies by -lines-per-notch) agrees with the rest
-            // of the window. Native redispatch replays the original MSG.
-            scene?.sendPointerEvent(
-                eventType = PointerEventType.Scroll,
-                position = Offset(x, y),
-                scrollDelta = win32WheelToAwtScrollDelta(dx, dy),
-                type = PointerType.Mouse,
+            // Overlay WndProc reports raw Win32 units; map like TaoWindow
+            // then go through the same AWT-shaped dispatch as the window.
+            scene?.dispatchAwtShapedScroll(
+                x = x,
+                y = y,
+                event = win32WheelToAwtScrollEvent(dx, dy),
                 keyboardModifiers = currentKeyboardModifiers,
             )
         }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -4,6 +4,7 @@ import dev.nucleusframework.window.TitleBarHitTestTest
 import dev.nucleusframework.window.tao.TaoWindowResizableTest
 import dev.nucleusframework.window.tao.TaoWindowScrollTest
 import dev.nucleusframework.window.tao.a11y.TaoA11yProjectionTest
+import dev.nucleusframework.window.tao.event.LinuxWheelDeltaTest
 import dev.nucleusframework.window.tao.event.MacOsWheelDeltaTest
 import dev.nucleusframework.window.tao.event.TaoKeyMappingTest
 import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
@@ -111,6 +112,12 @@ public object TaoSceneTestBattery {
         }
         run("Win32WheelDeltaTest: horizontalWheelIsNegatedToAwtSign") {
             Win32WheelDeltaTest().horizontalWheelIsNegatedToAwtSign()
+        }
+        run("Win32WheelDeltaTest: popupWndProcNotchCarriesWindowScrollAmount") {
+            Win32WheelDeltaTest().popupWndProcNotchCarriesWindowScrollAmount()
+        }
+        run("LinuxWheelDeltaTest: popupButton5CarriesThreeLinesPerNotch") {
+            LinuxWheelDeltaTest().popupButton5CarriesThreeLinesPerNotch()
         }
         run("MacOsWheelDeltaTest: scrollUpMatchesTaoWindowAwtSign") {
             MacOsWheelDeltaTest().scrollUpMatchesTaoWindowAwtSign()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -11,6 +11,7 @@ import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
 import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.event.Win32WheelDeltaTest
+import dev.nucleusframework.window.tao.popup.StandaloneFramePumpTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
@@ -130,6 +131,24 @@ public object TaoSceneTestBattery {
         }
         run("MacOsWheelDeltaTest: precisePixelHorizontalMatchesTaoWindowScale") {
             MacOsWheelDeltaTest().precisePixelHorizontalMatchesTaoWindowScale()
+        }
+        run("MacOsWheelDeltaTest: lineDeltaCarriesMacOsScrollAmount") {
+            MacOsWheelDeltaTest().lineDeltaCarriesMacOsScrollAmount()
+        }
+        run("MacOsWheelDeltaTest: preciseDeltaCarriesMacOsScrollAmount") {
+            MacOsWheelDeltaTest().preciseDeltaCarriesMacOsScrollAmount()
+        }
+        run("StandaloneFramePumpTest: scheduleOnMainRunsInline") {
+            StandaloneFramePumpTest().scheduleOnMainRunsInline()
+        }
+        run("StandaloneFramePumpTest: nestedScheduleFromRenderDoesNotReenter") {
+            StandaloneFramePumpTest().nestedScheduleFromRenderDoesNotReenter()
+        }
+        run("StandaloneFramePumpTest: extraSchedulesWhileRenderingCoalesce") {
+            StandaloneFramePumpTest().extraSchedulesWhileRenderingCoalesce()
+        }
+        run("StandaloneFramePumpTest: scheduleAfterDisposeIsNoOp") {
+            StandaloneFramePumpTest().scheduleAfterDisposeIsNoOp()
         }
         run("TaoWheelPinchZoomTest: fullWheelDeltaProducesModerateZoomStep") {
             TaoWheelPinchZoomTest().fullWheelDeltaProducesModerateZoomStep()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -150,6 +150,9 @@ public object TaoSceneTestBattery {
         run("StandaloneFramePumpTest: scheduleAfterDisposeIsNoOp") {
             StandaloneFramePumpTest().scheduleAfterDisposeIsNoOp()
         }
+        run("StandaloneFramePumpTest: disposedPostedFrameIsDropped") {
+            StandaloneFramePumpTest().disposedPostedFrameIsDropped()
+        }
         run("TaoWheelPinchZoomTest: fullWheelDeltaProducesModerateZoomStep") {
             TaoWheelPinchZoomTest().fullWheelDeltaProducesModerateZoomStep()
         }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -11,6 +11,7 @@ import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
 import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.event.Win32WheelDeltaTest
+import dev.nucleusframework.window.tao.popup.StandaloneFramePumpTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
@@ -49,6 +50,7 @@ class TaoSceneTestBatteryDriftTest {
             Win32WheelDeltaTest::class.java,
             LinuxWheelDeltaTest::class.java,
             MacOsWheelDeltaTest::class.java,
+            StandaloneFramePumpTest::class.java,
             TaoWheelPinchZoomTest::class.java,
             TaoWindowScrollTest::class.java,
             TaoWindowResizableTest::class.java,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -4,6 +4,7 @@ import dev.nucleusframework.window.TitleBarHitTestTest
 import dev.nucleusframework.window.tao.a11y.TaoA11yProjectionTest
 import dev.nucleusframework.window.tao.dnd.TaoSyntheticDndTest
 import dev.nucleusframework.window.tao.dnd.TaoTransferableAccessGuardTest
+import dev.nucleusframework.window.tao.event.LinuxWheelDeltaTest
 import dev.nucleusframework.window.tao.event.MacOsWheelDeltaTest
 import dev.nucleusframework.window.tao.event.TaoKeyMappingTest
 import dev.nucleusframework.window.tao.event.TaoKeyboardModifiersDecodeTest
@@ -46,6 +47,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoKeyboardModifiersDecodeTest::class.java,
             TaoSyntheticMouseWheelEventTest::class.java,
             Win32WheelDeltaTest::class.java,
+            LinuxWheelDeltaTest::class.java,
             MacOsWheelDeltaTest::class.java,
             TaoWheelPinchZoomTest::class.java,
             TaoWindowScrollTest::class.java,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/LinuxWheelDeltaTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/LinuxWheelDeltaTest.kt
@@ -1,0 +1,17 @@
+package dev.nucleusframework.window.tao.event
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LinuxWheelDeltaTest {
+    @Test
+    fun popupButton5CarriesThreeLinesPerNotch() {
+        // X11 Button5 (wheel down) is already Compose-signed (+1). DecoratedWindow
+        // Linux reports scrollAmount=3 on SCROLL_LINE; the standalone panel
+        // must match or Compose's LinuxGtkConfig under-scrolls 3×.
+        val event = linuxWheelToAwtScrollEvent(dx = 0f, dy = 1f)
+        assertEquals(0f, event.dxAwt, absoluteTolerance = 0f)
+        assertEquals(1f, event.dyAwt, absoluteTolerance = 0f)
+        assertEquals(LINUX_AWT_SCROLL_AMOUNT_DEFAULT, event.scrollAmount)
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDeltaTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/MacOsWheelDeltaTest.kt
@@ -40,4 +40,20 @@ class MacOsWheelDeltaTest {
         assertEquals(2f, delta.x, absoluteTolerance = 0f)
         assertEquals(0f, delta.y, absoluteTolerance = 0f)
     }
+
+    @Test
+    fun lineDeltaCarriesMacOsScrollAmount() {
+        val event = appKitWheelToAwtScrollEvent(dx = 0f, dy = 1f, precise = false, scale = 2f)
+        assertEquals(0f, event.dxAwt, absoluteTolerance = 0f)
+        assertEquals(-1f, event.dyAwt, absoluteTolerance = 0f)
+        assertEquals(MACOS_AWT_SCROLL_AMOUNT, event.scrollAmount)
+    }
+
+    @Test
+    fun preciseDeltaCarriesMacOsScrollAmount() {
+        val event = appKitWheelToAwtScrollEvent(dx = 0f, dy = 10f, precise = true, scale = 2f)
+        assertEquals(0f, event.dxAwt, absoluteTolerance = 0f)
+        assertEquals(-2f, event.dyAwt, absoluteTolerance = 0f)
+        assertEquals(MACOS_AWT_SCROLL_AMOUNT, event.scrollAmount)
+    }
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/Win32WheelDeltaTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/event/Win32WheelDeltaTest.kt
@@ -20,4 +20,12 @@ class Win32WheelDeltaTest {
         assertEquals(-1f, delta.x, absoluteTolerance = 0f)
         assertEquals(0f, delta.y, absoluteTolerance = 0f)
     }
+
+    @Test
+    fun popupWndProcNotchCarriesWindowScrollAmount() {
+        val event = win32WheelToAwtScrollEvent(dx = 0f, dy = -1f)
+        assertEquals(0f, event.dxAwt, absoluteTolerance = 0f)
+        assertEquals(1f, event.dyAwt, absoluteTolerance = 0f)
+        assertEquals(1, event.scrollAmount)
+    }
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePumpTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePumpTest.kt
@@ -1,0 +1,76 @@
+package dev.nucleusframework.window.tao.popup
+
+import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StandaloneFramePumpTest {
+    @Test
+    fun scheduleOnMainRunsInline() {
+        withPinnedMain {
+            var renders = 0
+            val pump = StandaloneFramePump { renders++ }
+            pump.schedule()
+            assertEquals(1, renders)
+        }
+    }
+
+    @Test
+    fun nestedScheduleFromRenderDoesNotReenter() {
+        withPinnedMain {
+            var renders = 0
+            lateinit var pump: StandaloneFramePump
+            pump =
+                StandaloneFramePump {
+                    renders++
+                    if (renders == 1) pump.schedule()
+                }
+            pump.schedule()
+            assertEquals(1, renders)
+            // Nested [schedule] posted a follow-up; drop it so it cannot
+            // run on the dispatcher fallback thread after this test.
+            pump.disposed = true
+        }
+    }
+
+    @Test
+    fun extraSchedulesWhileRenderingCoalesce() {
+        withPinnedMain {
+            var renders = 0
+            lateinit var pump: StandaloneFramePump
+            pump =
+                StandaloneFramePump {
+                    renders++
+                    if (renders == 1) {
+                        pump.schedule()
+                        pump.schedule()
+                    }
+                }
+            pump.schedule()
+            assertEquals(1, renders)
+            pump.disposed = true
+        }
+    }
+
+    @Test
+    fun scheduleAfterDisposeIsNoOp() {
+        withPinnedMain {
+            var renders = 0
+            val pump = StandaloneFramePump { renders++ }
+            pump.schedule()
+            pump.disposed = true
+            pump.schedule()
+            assertEquals(1, renders)
+        }
+    }
+
+    private fun withPinnedMain(block: () -> Unit) {
+        val previous = TaoMainDispatcher.taoMainThread
+        TaoMainDispatcher.taoMainThread = Thread.currentThread()
+        try {
+            block()
+        } finally {
+            TaoMainDispatcher.taoMainThread = previous
+        }
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePumpTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePumpTest.kt
@@ -1,76 +1,91 @@
 package dev.nucleusframework.window.tao.popup
 
-import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+import java.util.ArrayDeque
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class StandaloneFramePumpTest {
     @Test
     fun scheduleOnMainRunsInline() {
-        withPinnedMain {
-            var renders = 0
-            val pump = StandaloneFramePump { renders++ }
-            pump.schedule()
-            assertEquals(1, renders)
-        }
+        val probe = Probe()
+        probe.pump.schedule()
+        assertEquals(1, probe.renders)
+        assertTrue(probe.posted.isEmpty())
     }
 
     @Test
     fun nestedScheduleFromRenderDoesNotReenter() {
-        withPinnedMain {
-            var renders = 0
-            lateinit var pump: StandaloneFramePump
-            pump =
-                StandaloneFramePump {
-                    renders++
-                    if (renders == 1) pump.schedule()
-                }
-            pump.schedule()
-            assertEquals(1, renders)
-            // Nested [schedule] posted a follow-up; drop it so it cannot
-            // run on the dispatcher fallback thread after this test.
-            pump.disposed = true
-        }
+        val probe =
+            Probe { p ->
+                p.renders++
+                if (p.renders == 1) p.pump.schedule()
+            }
+        probe.pump.schedule()
+        assertEquals(1, probe.renders)
+        assertEquals(1, probe.posted.size)
+        probe.drainPosted()
+        assertEquals(2, probe.renders)
+        assertTrue(probe.posted.isEmpty())
     }
 
     @Test
     fun extraSchedulesWhileRenderingCoalesce() {
-        withPinnedMain {
-            var renders = 0
-            lateinit var pump: StandaloneFramePump
-            pump =
-                StandaloneFramePump {
-                    renders++
-                    if (renders == 1) {
-                        pump.schedule()
-                        pump.schedule()
-                    }
+        val probe =
+            Probe { p ->
+                p.renders++
+                if (p.renders == 1) {
+                    p.pump.schedule()
+                    p.pump.schedule()
                 }
-            pump.schedule()
-            assertEquals(1, renders)
-            pump.disposed = true
-        }
+            }
+        probe.pump.schedule()
+        assertEquals(1, probe.renders)
+        assertEquals(1, probe.posted.size)
+        probe.drainPosted()
+        assertEquals(2, probe.renders)
     }
 
     @Test
     fun scheduleAfterDisposeIsNoOp() {
-        withPinnedMain {
-            var renders = 0
-            val pump = StandaloneFramePump { renders++ }
-            pump.schedule()
-            pump.disposed = true
-            pump.schedule()
-            assertEquals(1, renders)
-        }
+        val probe = Probe()
+        probe.pump.schedule()
+        probe.pump.disposed = true
+        probe.pump.schedule()
+        assertEquals(1, probe.renders)
+        assertTrue(probe.posted.isEmpty())
     }
 
-    private fun withPinnedMain(block: () -> Unit) {
-        val previous = TaoMainDispatcher.taoMainThread
-        TaoMainDispatcher.taoMainThread = Thread.currentThread()
-        try {
-            block()
-        } finally {
-            TaoMainDispatcher.taoMainThread = previous
+    @Test
+    fun disposedPostedFrameIsDropped() {
+        val probe =
+            Probe { p ->
+                p.renders++
+                if (p.renders == 1) p.pump.schedule()
+            }
+        probe.pump.schedule()
+        probe.pump.disposed = true
+        probe.drainPosted()
+        assertEquals(1, probe.renders)
+    }
+
+    /**
+     * In-memory pump: [isOnMain] is always true and [post] records runnables
+     * instead of touching [dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher].
+     */
+    private class Probe(
+        onRender: (Probe) -> Unit = { it.renders++ },
+    ) {
+        val posted = ArrayDeque<Runnable>()
+        var renders = 0
+        val pump: StandaloneFramePump =
+            StandaloneFramePump(
+                isOnMain = { true },
+                post = { posted.addLast(it) },
+            ) { onRender(this) }
+
+        fun drainPosted() {
+            while (posted.isNotEmpty()) posted.removeFirst().run()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Route tray, overlay, and owner-based popup wheel events through one AWT-shaped Compose dispatch (`dispatchAwtShapedScroll`) after platform mapping (Win32 / AppKit / X11 Button4–7).
- Install `TaoWindowsScrollConfig` on the Windows standalone panel so a notch scrolls the same viewport fraction as a `DecoratedWindow` (3 lines/notch).
- Linux standalone panels now report `scrollAmount = 3`, matching `TaoWindow` `SCROLL_LINE`.
- Standalone popup `requestFrame` paints immediately when already on the Tao main thread (`StandaloneFramePump`), so a wheel flood cannot starve `MainEventsCleared`.

## Test plan
- [x] `:decorated-window-tao:ktlintCheck` and `:detekt`
- [x] `:decorated-window-tao:apiDump` (no public ABI change)
- [x] Unit tests: `Win32WheelDeltaTest`, `LinuxWheelDeltaTest`, `MacOsWheelDeltaTest`, `TaoWindowScrollTest`, `TaoSceneTestBatteryDriftTest`
- [ ] Manual: TrayApp Windows — LazyColumn wheel distance and smoothness vs a DecoratedWindow
- [ ] Manual: TrayApp Linux — discrete wheel; macOS trackpad precise deltas