### PR TITLE
fix(autolaunch): order the systemd unit after GNOME publishes Xft.dpi

### DIFF
--- a/autolaunch/src/main/kotlin/dev/nucleusframework/autolaunch/linux/SystemdUserBackend.kt
+++ b/autolaunch/src/main/kotlin/dev/nucleusframework/autolaunch/linux/SystemdUserBackend.kt
@@ -143,7 +143,7 @@ internal object SystemdUserBackend : AutoLaunchBackend {
                 null
             }
 
-    private fun buildUnitContent(execPath: String): String {
+    internal fun buildUnitContent(execPath: String): String {
         val description = NucleusApp.appName ?: NucleusApp.appId
         // systemd ExecStart accepts a double-quoted string for paths with spaces;
         // internal double quotes are backslash-escaped per systemd.unit(5).
@@ -152,10 +152,30 @@ internal object SystemdUserBackend : AutoLaunchBackend {
         // / XAUTHORITY into the user systemd environment (gnome-session, plasma-workspace,
         // etc. call `systemctl --user import-environment` early in session setup). Firing
         // before that yields HeadlessException in AWT/Compose.
+        //
+        // The environment is imported by then, but the *appearance* settings are not: on
+        // GNOME, gsd-xsettings publishes Xft.dpi into the X resource database later still.
+        // Toolkits that sample the display scale once at startup (skiko's autodpi freezes
+        // sun.java2d.uiScale at library load) then read an empty resource database and stay
+        // at 1.0 for the life of the process — a HiDPI app auto-started at login renders at
+        // half size while a manual launch is always correct.
+        //
+        // gnome-session-x11-services-ready.target is the synchronization point ordered AFTER
+        // org.gnome.SettingsDaemon.XSettings.service (which declares
+        // `Before=gnome-session-x11-services-ready.target`); the non-"ready" target is ordered
+        // *before* it, so both names are listed and only the ready one actually closes the gap.
+        // It is active on Wayland sessions too, since Xwayland clients need XSETTINGS. systemd
+        // silently ignores ordering dependencies on units that do not exist, so this is a no-op
+        // on non-GNOME desktops and on pure-Wayland sessions that publish no Xft.dpi anyway.
+        //
+        // Caveat: XSettings.service is Type=dbus, so systemd considers it active once the bus
+        // name is acquired, not once RESOURCE_MANAGER has been written to the root window. This
+        // narrows the race to sub-second rather than provably closing it.
         return """
             |[Unit]
             |Description=$description autostart
             |After=graphical-session.target
+            |After=gnome-session-x11-services.target gnome-session-x11-services-ready.target
             |PartOf=graphical-session.target
             |
             |[Service]

--- a/autolaunch/src/test/kotlin/dev/nucleusframework/autolaunch/linux/SystemdUserBackendNativeTest.kt
+++ b/autolaunch/src/test/kotlin/dev/nucleusframework/autolaunch/linux/SystemdUserBackendNativeTest.kt
@@ -29,6 +29,26 @@ class SystemdUserBackendNativeTest {
     }
 
     @Test
+    fun `generated unit waits for the DE appearance settings before starting`() {
+        val unit = SystemdUserBackend.buildUnitContent("/opt/demo/bin/demo")
+
+        assertTrue(unit.contains("After=graphical-session.target"))
+        // gsd-xsettings publishes Xft.dpi only once this target is reached; without it a
+        // login-started app freezes sun.java2d.uiScale at 1.0 on HiDPI GNOME sessions.
+        assertTrue(unit.contains("gnome-session-x11-services-ready.target"))
+        assertTrue(unit.contains("PartOf=graphical-session.target"))
+        assertTrue(unit.contains("WantedBy=graphical-session.target"))
+        assertTrue(unit.contains("""ExecStart="/opt/demo/bin/demo""""))
+    }
+
+    @Test
+    fun `generated unit quotes an executable path with spaces and quotes`() {
+        val unit = SystemdUserBackend.buildUnitContent("""/opt/my app/bin/"demo"""")
+
+        assertTrue(unit.contains("""ExecStart="/opt/my app/bin/\"demo\"""""))
+    }
+
+    @Test
     fun `native constants stay aligned with the jni contract`() {
         assertEquals(0, NativeAutoLaunchLinuxBridge.RC_OK)
         assertEquals(-1, NativeAutoLaunchLinuxBridge.RC_ERROR)


### PR DESCRIPTION
Closes #614.

## Summary

`SystemdUserBackend.buildUnitContent()` ordered the generated unit with `After=graphical-session.target` only. That target is reached before `gsd-xsettings` writes `Xft.dpi` into the X resource database, so an app auto-started at login loses a race a manual launch always wins.

Anything sampling the display scale once at startup then gets the wrong answer permanently — skiko's `autodpi` reads `Xft.dpi` at library load and freezes the quotient into `sun.java2d.uiScale`, which AWT caches at toolkit init. Probing an empty database yields `1.0` for the life of the process, and the whole UI renders at half size on a 2x display.

The existing comment's reasoning (wait for the DE's `systemctl --user import-environment`, else `HeadlessException`) was right but incomplete: by `graphical-session.target` the environment is imported, the *appearance* settings are not.

- Order the unit after `gnome-session-x11-services-ready.target`.
- Make `buildUnitContent` `internal` so it can be tested. The enclosing object is already `internal`, so the public ABI is unchanged and `apiCheck` passes.

## Correction to the target name suggested in the issue

The issue proposed `After=gnome-session-x11-services.target`. That is the target ordered *before* `gsd-xsettings`, so on its own it would still let the unit start too early. From the GNOME 50 unit:

```
# /usr/lib/systemd/user/org.gnome.SettingsDaemon.XSettings.service
After=gnome-session-x11-services.target         # starts after this one
Before=gnome-session-x11-services-ready.target  # so this is the rendez-vous
```

`-ready` is what actually closes the gap. Both names are listed — the first is harmless and documents the batch of services involved.

## Safety

- No ordering cycle: `x11-services -> ready -> gnome-session.target -> graphical-session.target -> our unit`, consistent with the existing `PartOf` / `WantedBy=graphical-session.target`.
- systemd silently ignores ordering dependencies on units that are not loaded, so this is a no-op on non-GNOME desktops.
- Active on Wayland sessions too, since Xwayland clients need XSETTINGS. A pure-Wayland session that never starts it has no `Xft.dpi` to wait for either, so behaviour stays consistent.

## Known limitations

- `XSettings.service` is `Type=dbus`, so systemd considers it active once the bus name is acquired, not once `RESOURCE_MANAGER` has been written to the root window. This narrows the race to sub-second rather than provably closing it.
- No other desktop environments added speculatively — the issue reporter could only reproduce on GNOME, and Plasma applies its DPI settings from `kcminit` ahead of `graphical-session.target`, so it likely has no race at all.
- Possibly a second, deeper cause worth its own issue: `applyLinuxHiDpiScale()` (`linux-hidpi`, called from `GraalVmInitializer.initialize()` on every `nucleusApplication` start) consults Mutter's DBus `DisplayConfig` and GSettings *before* falling back to `Xft.dpi` — both live well before `gsd-xsettings`. That the reporter still saw `1.0` suggests their app either bypasses `nucleusApplication` or that detection returned `0.0`.

## Test plan

- [x] `./gradlew :autolaunch:test :autolaunch:detekt :autolaunch:apiCheck` passes
- [x] New test pins the `gnome-session-x11-services-ready.target` ordering
- [x] New test covers `ExecStart` quoting of paths with spaces and double quotes (previously uncovered)
- [x] `systemd-analyze verify --user` on the generated unit reports nothing beyond the expected "not executable" for a dummy `ExecStart` path — no ordering-cycle or unknown-key errors
- [ ] Reboot into a HiDPI GNOME session with autostart enabled and confirm `jcmd <pid> VM.system_properties | grep uiScale` reports `2.0` (needs the reporter's setup)