### PR TITLE
test(tao): stop the headful suite hanging on blocked Robot injection

### DIFF
--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   windows:
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -189,6 +190,7 @@ jobs:
 
   macos:
     runs-on: macos-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -346,6 +348,7 @@ jobs:
 
   linux:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -23,6 +23,11 @@ jobs:
   gradle:
     needs: build-natives
     runs-on: ubuntu-latest
+    # `preMerge` normally finishes in 6-10 min. Without an explicit cap a task
+    # that blocks on a native call sits until Actions' 6h default and holds the
+    # concurrency slot the whole time — `:launcher-linux:test` has done exactly
+    # that three times (g_bus_get_sync on a runner with no session bus).
+    timeout-minutes: 30
     env:
       GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
       GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
@@ -208,6 +213,7 @@ jobs:
   # native-load failures are common, so we want all three OS results.
   tao-tests:
     needs: build-natives
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -243,6 +249,7 @@ jobs:
   # three display-stack runners for nothing.
   tao-headful:
     needs: [build-natives, gradle, tao-tests]
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -311,6 +318,7 @@ jobs:
   # Gated on gradle + tao-tests — same rationale as tao-headful.
   tao-a11y:
     needs: [build-natives, gradle, tao-tests]
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AnimatedWindowSizeHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AnimatedWindowSizeHeadfulCases.kt
@@ -283,11 +283,75 @@ internal object AnimatedWindowSizeHeadfulCases {
                 ?.key
                 ?: (samples.first().outerH - samples.first().sceneH)
 
+        val m = measureTremble(animated, chrome)
+
+        System.err.println(
+            "[#576] metric maxTitleY=${m.maxTitleY} maxContentGap=${m.maxContentGap} " +
+                "maxSceneVsInner=${m.maxSceneVsInner} (over ${m.sceneVsInnerSamples} frames) " +
+                "maxLayoutVsScene=${m.maxLayoutVsScene} " +
+                "maxSceneVsOuter=${m.maxSceneVsOuter} (chrome=$chrome) " +
+                "heightReversals=${m.nativeHeightReversals} originOsc=${m.maxOriginOscillation} " +
+                "animatedFrames=${animated.size}",
+        )
+
+        // Without comparable frames the scene-vs-inner gate below is vacuous.
+        check(m.sceneVsInnerSamples >= MIN_ANIM_SAMPLES) {
+            "only ${m.sceneVsInnerSamples} of ${animated.size} animated frames had an " +
+                "onResized inner height matching the live outer size — cannot judge tremble"
+        }
+
+        val failures = mutableListOf<String>()
+        if (m.maxTitleY > PX_TOLERANCE) {
+            failures += "TitleBar origin Y jumped ${m.maxTitleY}px (window-top pin)"
+        }
+        if (m.maxContentGap > PX_TOLERANCE) {
+            failures += "content did not stay immediately under TitleBar (gap ${m.maxContentGap}px)"
+        }
+        if (m.maxLayoutVsScene > PX_TOLERANCE) {
+            failures += "TitleBar+content height drifted from scene by ${m.maxLayoutVsScene}px"
+        }
+        if (m.maxSceneVsInner > PX_TOLERANCE) {
+            failures += "Compose scene height drifted from native inner size by ${m.maxSceneVsInner}px"
+        }
+        if (m.maxSceneVsOuter > PX_TOLERANCE) {
+            failures +=
+                "Compose scene height drifted from native outer size by " +
+                "${m.maxSceneVsOuter}px (chrome $chrome)"
+        }
+        if (m.nativeHeightReversals > 0) {
+            failures += "native height reversed ${m.nativeHeightReversals} time(s) while the animation only grew"
+        }
+        if (m.maxOriginOscillation > PX_TOLERANCE) {
+            failures += "window/content origin oscillated by ${m.maxOriginOscillation}px"
+        }
+        check(failures.isEmpty()) {
+            failures.joinToString("; ")
+        }
+    }
+
+    /** Worst-case drift seen across the animated frames. */
+    private data class TrembleMetrics(
+        val maxTitleY: Int,
+        val maxContentGap: Int,
+        val maxSceneVsInner: Int,
+        val sceneVsInnerSamples: Int,
+        val maxLayoutVsScene: Int,
+        val maxSceneVsOuter: Int,
+        val maxOriginOscillation: Int,
+        val nativeHeightReversals: Int,
+    )
+
+    private fun measureTremble(
+        animated: List<Sample>,
+        chrome: Int,
+    ): TrembleMetrics {
         var maxTitleY = 0
         var maxContentGap = 0
         var maxSceneVsInner = 0
+        var sceneVsInnerSamples = 0
         var maxLayoutVsScene = 0
         var maxSceneVsOuter = 0
+        var outerDriftRun = 0
         var maxOriginOscillation = 0
         var nativeHeightReversals = 0
         var prevInnerH = animated.first().innerH.takeIf { it > 0 } ?: animated.first().sceneH
@@ -304,9 +368,18 @@ internal object AnimatedWindowSizeHeadfulCases {
             val liveInner = s.outerH - chrome
             if (s.innerH > 0 && abs(s.innerH - liveInner) <= PX_TOLERANCE) {
                 maxSceneVsInner = maxOf(maxSceneVsInner, abs(s.sceneH - s.innerH))
+                sceneVsInnerSamples++
             }
-            maxSceneVsInner = maxOf(maxSceneVsInner, abs(s.sceneH - liveInner))
-            maxSceneVsOuter = maxOf(maxSceneVsOuter, abs(s.outerH - s.sceneH - chrome))
+            // `chrome` is a baseline constant, but GTK CSD frame extents are
+            // not: outer bounds can take the new size a frame before the
+            // resize event reaches Compose (52/52/…/56/52 on GNOME Wayland).
+            // A one-frame skew is sampling, tremble is sustained — so only
+            // count a drift that survives consecutive animated frames.
+            val outerDrift = abs(s.outerH - s.sceneH - chrome)
+            outerDriftRun = if (outerDrift > PX_TOLERANCE) outerDriftRun + 1 else 0
+            if (outerDriftRun >= SUSTAINED_FRAMES) {
+                maxSceneVsOuter = maxOf(maxSceneVsOuter, outerDrift)
+            }
             maxOriginOscillation = maxOf(maxOriginOscillation, abs(s.titleX), abs(s.contentX))
 
             val nativeH = if (s.innerH > 0) s.innerH else s.sceneH
@@ -327,39 +400,16 @@ internal object AnimatedWindowSizeHeadfulCases {
             prevOuterY = s.outerY
         }
 
-        System.err.println(
-            "[#576] metric maxTitleY=$maxTitleY maxContentGap=$maxContentGap " +
-                "maxSceneVsInner=$maxSceneVsInner maxLayoutVsScene=$maxLayoutVsScene " +
-                "maxSceneVsOuter=$maxSceneVsOuter (chrome=$chrome) " +
-                "heightReversals=$nativeHeightReversals originOsc=$maxOriginOscillation " +
-                "animatedFrames=${animated.size}",
+        return TrembleMetrics(
+            maxTitleY = maxTitleY,
+            maxContentGap = maxContentGap,
+            maxSceneVsInner = maxSceneVsInner,
+            sceneVsInnerSamples = sceneVsInnerSamples,
+            maxLayoutVsScene = maxLayoutVsScene,
+            maxSceneVsOuter = maxSceneVsOuter,
+            maxOriginOscillation = maxOriginOscillation,
+            nativeHeightReversals = nativeHeightReversals,
         )
-
-        val failures = mutableListOf<String>()
-        if (maxTitleY > PX_TOLERANCE) {
-            failures += "TitleBar origin Y jumped ${maxTitleY}px (window-top pin)"
-        }
-        if (maxContentGap > PX_TOLERANCE) {
-            failures += "content did not stay immediately under TitleBar (gap ${maxContentGap}px)"
-        }
-        if (maxLayoutVsScene > PX_TOLERANCE) {
-            failures += "TitleBar+content height drifted from scene by ${maxLayoutVsScene}px"
-        }
-        if (maxSceneVsInner > PX_TOLERANCE) {
-            failures += "Compose scene height drifted from native inner size by ${maxSceneVsInner}px"
-        }
-        if (maxSceneVsOuter > PX_TOLERANCE) {
-            failures += "Compose scene height drifted from native outer size by ${maxSceneVsOuter}px (chrome $chrome)"
-        }
-        if (nativeHeightReversals > 0) {
-            failures += "native height reversed $nativeHeightReversals time(s) while the animation only grew"
-        }
-        if (maxOriginOscillation > PX_TOLERANCE) {
-            failures += "window/content origin oscillated by ${maxOriginOscillation}px"
-        }
-        check(failures.isEmpty()) {
-            failures.joinToString("; ")
-        }
     }
 
     private const val WINDOW_WIDTH_DP = 420
@@ -372,5 +422,8 @@ internal object AnimatedWindowSizeHeadfulCases {
     private const val MIN_SAMPLES = 20
     private const val MIN_ANIM_SAMPLES = 8
     private const val PX_TOLERANCE = 1
+
+    /** Consecutive animated frames a scene-vs-outer drift must survive to count. */
+    private const val SUSTAINED_FRAMES = 2
     private const val CONTENT_ARGB = 0xFF203040.toInt()
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AnimatedWindowSizeHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AnimatedWindowSizeHeadfulCases.kt
@@ -273,15 +273,27 @@ internal object AnimatedWindowSizeHeadfulCases {
                 "(start=$startH, samples=${samples.size}, animated=${animated.size})"
         }
 
-        val baseline = samples.takeWhile { abs(it.requestedH - startH) <= 0 }
+        // A window's outer box always contains the scene it hosts, so a
+        // negative chrome means the outer bounds were not real yet — openbox
+        // under Xvfb reports a 1px outer height for a while after mapping, and
+        // a baseline mode of -359 turned every gate below into noise. Estimate
+        // only from frames where the invariant holds, falling back to the whole
+        // run when the baseline window caught none of them.
+        val realOuter = { s: Sample -> s.outerH >= s.sceneH }
+        val baseline = samples.takeWhile { abs(it.requestedH - startH) <= 0 }.filter(realOuter)
+        val chromeFrames = baseline.ifEmpty { samples.filter(realOuter) }
+        check(chromeFrames.isNotEmpty()) {
+            "no frame where the outer height covers the scene — the window never " +
+                "reported real outer bounds (first sample outerH=${samples.first().outerH} " +
+                "sceneH=${samples.first().sceneH})"
+        }
         val chrome =
-            baseline
+            chromeFrames
                 .map { it.outerH - it.sceneH }
                 .groupingBy { it }
                 .eachCount()
-                .maxByOrNull { it.value }
-                ?.key
-                ?: (samples.first().outerH - samples.first().sceneH)
+                .maxByOrNull { it.value }!!
+                .key
 
         val m = measureTremble(animated, chrome)
 

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ChromeReviewHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/ChromeReviewHeadfulCases.kt
@@ -327,6 +327,27 @@ internal object ChromeReviewHeadfulCases {
     }
 
     /**
+     * Synthetic press-drag at screen coordinates, run off the Tao event loop
+     * by [HeadfulRobot]. Returns null when the host cannot inject input.
+     */
+    private suspend fun pressDrag(
+        startX: Int,
+        startY: Int,
+        dx: Int,
+    ): Unit? =
+        HeadfulRobot.inject { robot ->
+            robot.mouseMove(startX, startY)
+            Thread.sleep(PRESS_SETTLE_MILLIS)
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+            // Several moves — some hosts only arm after a threshold.
+            for (step in 1..DRAG_STEPS) {
+                robot.mouseMove(startX + dx * step / DRAG_STEPS, startY + step)
+                Thread.sleep(DRAG_STEP_MILLIS)
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+        }
+
+    /**
      * Review P0: `noWindowDrag` must stop an ancestor `windowDragArea` from
      * arming a move. Probes: [TaoWindow.onDragWindow] counter + AWT Robot
      * press-drag over the opt-out zone vs the bare drag strip.
@@ -399,28 +420,17 @@ internal object ChromeReviewHeadfulCases {
                 val (noDragX, stripY) = px(8f + 24f, 28f)
                 val (dragX, _) = px(280f, 28f)
 
-                val robot = Robot()
-                robot.autoDelay = 30
-                robot.isAutoWaitForIdle = true
-
-                suspend fun pressDrag(
-                    startX: Int,
-                    startY: Int,
-                    dx: Int,
-                ) {
-                    robot.mouseMove(startX, startY)
-                    settle(80)
-                    robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-                    // Several moves — some hosts only arm after a threshold.
-                    for (step in 1..6) {
-                        robot.mouseMove(startX + dx * step / 6, startY + step)
-                        settle(40)
-                    }
-                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
-                }
-
                 // Positive control first: bare strip must arm dragWindow.
-                pressDrag(dragX, stripY, 120)
+                if (pressDrag(dragX, stripY, DRAG_DX_PX) == null) {
+                    // A host that cannot inject input (macOS without the
+                    // Accessibility grant, Wayland with a refused RemoteDesktop
+                    // portal session) proves nothing either way — and must not
+                    // wedge the event loop while it finds out.
+                    System.err.println(
+                        "[VERDICT] INCONCLUSIVE — ${HeadfulRobot.unavailableReason}",
+                    )
+                    return@TaoWindowTestCase
+                }
                 settle(500)
                 val afterBare = dragCount.get()
                 System.err.println(
@@ -442,7 +452,10 @@ internal object ChromeReviewHeadfulCases {
 
                 dragCount.set(0)
                 // Press-drag on the noWindowDrag child — must NOT arm another move.
-                pressDrag(noDragX, stripY, 120)
+                checkNotNull(pressDrag(noDragX, stripY, DRAG_DX_PX)) {
+                    "Robot injection died between the two gestures: " +
+                        "${HeadfulRobot.unavailableReason}"
+                }
                 settle(400)
                 val afterNoDrag = dragCount.get()
                 System.err.println("[probe] dragCount after noWindowDrag child=$afterNoDrag")
@@ -694,4 +707,9 @@ internal object ChromeReviewHeadfulCases {
             }
         }
     }
+
+    private const val DRAG_DX_PX = 120
+    private const val DRAG_STEPS = 6
+    private const val PRESS_SETTLE_MILLIS = 80L
+    private const val DRAG_STEP_MILLIS = 40L
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/HeadfulRobot.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/HeadfulRobot.kt
@@ -1,0 +1,79 @@
+package dev.nucleusframework.window.tao.headful
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.Robot
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * AWT Robot input injection for the headful suite, driven off the Tao
+ * event-loop thread.
+ *
+ * Case drivers run on the Tao main thread, so a Robot call that never returns
+ * freezes the event loop and the global watchdog halts the JVM — every result
+ * of the run is lost, not just the offending case. Two real hosts do exactly
+ * that:
+ *
+ * - macOS without the Accessibility TCC grant: `new Robot()` blocks.
+ * - Wayland: the JDK routes injection through the XDG RemoteDesktop portal
+ *   (`sun.awt.screencast.ScreencastHelper`). When the compositor refuses the
+ *   session ("Session is not allowed to call NotifyPointer methods"),
+ *   `mousePress` blocks forever inside the native call.
+ *
+ * So every gesture runs on [Dispatchers.IO] under a timeout, and the first
+ * timeout latches [unavailableReason] — later calls fail fast instead of
+ * parking another thread on the same wedged native lock.
+ */
+internal object HeadfulRobot {
+    @Volatile
+    private var unavailable: String? = null
+
+    @Volatile
+    private var cached: Robot? = null
+
+    /** Why input injection is unusable on this host, or null while it works. */
+    val unavailableReason: String?
+        get() = unavailable
+
+    /**
+     * Runs [gesture] with a shared [Robot] off the event loop, giving up after
+     * [timeoutMillis]. Returns null when the host cannot inject input — the
+     * call blocked, threw, or an earlier call already latched unavailable.
+     *
+     * [gesture] runs on an IO thread, so blocking `Thread.sleep` pauses between
+     * synthetic events are fine (and are what Robot's own autoDelay does).
+     */
+    suspend fun <T : Any> inject(
+        timeoutMillis: Long = INJECT_TIMEOUT_MILLIS,
+        gesture: (Robot) -> T,
+    ): T? {
+        if (unavailable != null) return null
+        return withContext(Dispatchers.IO) {
+            // supplyAsync, not a plain call: a wedged native injection must be
+            // abandonable, and only a separate thread can be left behind.
+            val future = CompletableFuture.supplyAsync { gesture(robot()) }
+            try {
+                future.get(timeoutMillis, TimeUnit.MILLISECONDS)
+            } catch (_: TimeoutException) {
+                unavailable = "AWT Robot injection blocked for ${timeoutMillis}ms (see HeadfulRobot)"
+                null
+            } catch (e: ExecutionException) {
+                unavailable = "AWT Robot injection failed: ${e.cause ?: e}"
+                null
+            }
+        }
+    }
+
+    private fun robot(): Robot =
+        cached ?: Robot()
+            .apply {
+                autoDelay = AUTO_DELAY_MILLIS
+                isAutoWaitForIdle = true
+            }.also { cached = it }
+
+    private const val INJECT_TIMEOUT_MILLIS = 5_000L
+    private const val AUTO_DELAY_MILLIS = 30
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -474,8 +474,17 @@ public object TaoHeadfulTestSuiteMain {
                                 dialogHolder = dialogHolder,
                                 waitForDialog = running.dialogContent != null,
                             )
-                        running.driver(published)
+                        // Per-case budget: a driver that never completes must
+                        // fail its own case, not run out the global watchdog
+                        // and take every other result down with it.
+                        kotlinx.coroutines.withTimeout(running.timeoutMillis) {
+                            running.driver(published)
+                        }
                         null
+                    } catch (t: kotlinx.coroutines.TimeoutCancellationException) {
+                        // Ordered before CancellationException: this one is the
+                        // case's own deadline, not app teardown.
+                        IllegalStateException("case timed out after ${running.timeoutMillis}ms", t)
                     } catch (c: kotlinx.coroutines.CancellationException) {
                         throw c // app teardown — never record as a test failure
                     } catch (


### PR DESCRIPTION
## Summary

`:decorated-window-tao:taoHeadfulTest` died at case 12 of 48 with exit 42 (global watchdog) and reported **zero** results. `jstack` on the wedged JVM:

```
"main" runnable
  sun.awt.screencast.ScreencastHelper.remoteDesktopMouseButtonImpl (Native Method)
  sun.awt.screencast.XdgDesktopPortalRobot.mouseButton
  java.awt.Robot.mousePress
  ChromeReviewHeadfulCases$noWindowDragBlocksAncestorDragArea
  TaoMainDispatcher.pump → NativeTaoBridge.nativeRunBlocking
```

JDK 25 routes `Robot` through the XDG RemoteDesktop portal on Wayland. GNOME refuses the session (`Session is not allowed to call NotifyPointer methods`), `mouseMove` returns after printing that error but `mousePress` blocks in the native method forever — on the Tao event-loop thread, so the whole suite froze.

- **`HeadfulRobot`** (new) runs gestures on `Dispatchers.IO` under a 5s timeout and latches the first failure, so later calls fail fast instead of parking another thread on the same wedged native lock. The existing `awtRobotAvailable()` guard could not have caught this: `new Robot()` succeeds on such a host, only injection blocks. `noWindowDragBlocksAncestorDragArea` now reports INCONCLUSIVE through its existing path.
- **`TaoWindowTestCase.timeoutMillis` was dead config** — declared and documented, never applied. Drivers now run under `withTimeout`, with `TimeoutCancellationException` caught *before* the `CancellationException` rethrow so a case deadline fails that case instead of tearing down the app.
- **`#576` tremble metric produced a false positive**, not a regression. `sceneH == innerH` on all 786 samples (max deviation 0); `outerH - innerH` was 52 on 783 samples, 53 twice, **56 once** — GTK CSD frame extents shift during a resize and outer bounds lead the resize event by a frame. Two defects: `maxSceneVsInner` was overwritten by an outer-derived value (a silent duplicate of `maxSceneVsOuter`, never comparing the scene to the reported inner size), and a constant-chrome model flagged the single skewed frame. Fixed with a sample-count guard so the inner gate cannot pass vacuously, and a 2-consecutive-frame requirement on the outer drift — tremble is sustained by definition.

`measureTremble` was extracted from `assertNoTremble` to stay under detekt's complexity/length limits.

## Test plan

- [x] `:decorated-window-tao:taoHeadfulTest` — **32 run, 16 skipped, 0 failed**, exit 0, under the stock 240s watchdog (was: exit 42, 12 cases, no report)
- [x] `#576` metric now `maxSceneVsInner=0 (over 774 frames) maxSceneVsOuter=0` — the inner gate is exercised on 774/774 animated frames, not vacuous
- [x] `noWindowDrag` case completes in 5.8s instead of wedging the loop
- [x] `:decorated-window-tao:test`
- [x] `:decorated-window-tao:ktlintCheck` + `:decorated-window-tao:detekt`
- [ ] Not covered locally: the macOS and Windows legs. 16 cases skip on this Linux/Wayland host, including every `#494`/`#507`/`#595` macOS probe and the Windows backdrop probes — CI runners exercise those.