### PR TITLE
fix(tao): stop sub-pixel pointer jitter from eating clicks

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
@@ -207,6 +207,8 @@ internal class TaoPopupSceneLayer(
             size = sceneLayoutSize,
             platformContext =
                 object : TaoPlatformContextBase() {
+                    override val sceneScale: Float get() = _density.density
+
                     override val windowInfo: androidx.compose.ui.platform.WindowInfo
                         get() = popupWindowInfo
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
@@ -180,6 +180,8 @@ internal class TaoPopupSceneLayerLinux(
             size = sceneLayoutSize,
             platformContext =
                 object : TaoPlatformContextBase() {
+                    override val sceneScale: Float get() = _density.density
+
                     override val windowInfo: androidx.compose.ui.platform.WindowInfo
                         get() = popupWindowInfo
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -172,6 +172,8 @@ internal class TaoPopupSceneLayerWindows(
             size = sceneLayoutSize,
             platformContext =
                 object : TaoPlatformContextBase() {
+                    override val sceneScale: Float get() = _density.density
+
                     override val windowInfo: androidx.compose.ui.platform.WindowInfo
                         get() = popupWindowInfo
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -578,6 +578,8 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     private inner class StandalonePopupPlatformContext(
         override val dragAndDropManager: PlatformDragAndDropManager,
     ) : TaoPlatformContextBase() {
+        override val sceneScale: Float get() = this@TaoStandalonePopupHost.scale
+
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHost.windowInfo
 
         // Standalone popup surfaces are always per-pixel transparent, so

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
@@ -567,6 +567,8 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
     private inner class StandalonePopupPlatformContext(
         override val dragAndDropManager: PlatformDragAndDropManager,
     ) : TaoPlatformContextBase() {
+        override val sceneScale: Float get() = this@TaoStandalonePopupHostLinux.scale
+
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostLinux.windowInfo
 
         // Standalone popup surfaces are always per-pixel transparent, so

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
@@ -545,6 +545,8 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
     private inner class StandalonePopupPlatformContext(
         override val dragAndDropManager: PlatformDragAndDropManager,
     ) : TaoPlatformContextBase() {
+        override val sceneScale: Float get() = this@TaoStandalonePopupHostMac.scale
+
         override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostMac.windowInfo
 
         // Standalone popup surfaces are always per-pixel transparent, so

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -204,8 +204,14 @@ internal class TaoComposeSceneHost(
     private var heightPx: Int = 0
     private var scale: Float = 1f
 
-    private var lastPointerX: Float = 0f
-    private var lastPointerY: Float = 0f
+    // Sub-pixel deadband (#615): the wire delivers 1/1024-px positions and
+    // macOS emits a CursorMoved before every mouseDown/mouseUp, so click
+    // jitter under 1 dp must not reach the scene — Compose's mouse slop is
+    // 0.125 dp, and a parent drag gesture consuming that phantom move
+    // cancels the child's tap ("buttons need two clicks"). Every event
+    // dispatched to the scene uses the deadband's position, never the raw
+    // one (SyntheticEventSender would re-inject the difference).
+    private val pointerDeadband = TaoPointerDeadband()
 
     // ── Interop transaction (mirrors UIKitInteropTransaction) ────────
     //
@@ -384,6 +390,7 @@ internal class TaoComposeSceneHost(
                 // above content via z-order. Same fix as Linux (commit 2d8ca500)
                 // and Windows (commit 910879d0).
                 topInsetPx = { 0 },
+                scaleProvider = { scale },
                 windowInfo = windowInfo,
                 semanticsOwnerListener = semanticsOwnerListener,
                 dragAndDropManager = dndManager,
@@ -707,7 +714,7 @@ internal class TaoComposeSceneHost(
             // [isPressed]).
             scene?.sendPointerEvent(
                 eventType = PointerEventType.Release,
-                position = Offset(lastPointerX, lastPointerY),
+                position = Offset(pointerDeadband.x, pointerDeadband.y),
                 type = PointerType.Mouse,
                 keyboardModifiers = currentKeyboardModifiers,
                 button = mapButton(pressedButtonCode),
@@ -956,14 +963,13 @@ internal class TaoComposeSceneHost(
     ) {
         val xPx = aFixed / 1024f
         val yPx = bFixed / 1024f
-        lastPointerX = xPx
-        lastPointerY = yPx
         hasReceivedCursorMove = true
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
+        if (!pointerDeadband.shouldDispatchMove(xPx, yPx, scale)) return
         scene?.sendPointerEvent(
             eventType = PointerEventType.Move,
-            position = Offset(xPx, yPx),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = currentKeyboardModifiers,
         )
@@ -974,7 +980,7 @@ internal class TaoComposeSceneHost(
         windowInfo.keyboardModifiers = currentKeyboardModifiers
         scene?.sendPointerEvent(
             eventType = PointerEventType.Exit,
-            position = Offset(lastPointerX, lastPointerY),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = currentKeyboardModifiers,
         )
@@ -1000,7 +1006,7 @@ internal class TaoComposeSceneHost(
             // See the comment on `isPressed` for the rationale.
             scene?.sendPointerEvent(
                 eventType = PointerEventType.Release,
-                position = Offset(lastPointerX, lastPointerY),
+                position = Offset(pointerDeadband.x, pointerDeadband.y),
                 type = PointerType.Mouse,
                 keyboardModifiers = currentKeyboardModifiers,
                 button = mapButton(pressedButtonCode),
@@ -1014,7 +1020,7 @@ internal class TaoComposeSceneHost(
         if (pressed) nativePointerDispatchedThisEvent = false
         scene?.sendPointerEvent(
             eventType = if (pressed) PointerEventType.Press else PointerEventType.Release,
-            position = Offset(lastPointerX, lastPointerY),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = currentKeyboardModifiers,
             button = composeButton,
@@ -1040,8 +1046,8 @@ internal class TaoComposeSceneHost(
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
         scene?.dispatchAwtShapedScroll(
-            x = lastPointerX,
-            y = lastPointerY,
+            x = pointerDeadband.x,
+            y = pointerDeadband.y,
             event = event,
             keyboardModifiers = currentKeyboardModifiers,
         )
@@ -1616,6 +1622,8 @@ internal class TaoComposeSceneHost(
 private class TaoPlatformContext(
     private val windowHandle: Long,
     private val topInsetPx: () -> Int,
+    /** Live px-per-dp factor of the owning scene — see [TaoPlatformContextBase.sceneScale]. */
+    private val scaleProvider: () -> Float,
     override val windowInfo: androidx.compose.ui.platform.WindowInfo,
     override val semanticsOwnerListener: PlatformContext.SemanticsOwnerListener? = null,
     override val dragAndDropManager: androidx.compose.ui.platform.PlatformDragAndDropManager,
@@ -1627,6 +1635,8 @@ private class TaoPlatformContext(
     // `DesktopPlatformContext` forwarding `windowContext.isWindowTransparent`.
     override val isWindowTransparent: Boolean = false,
 ) : TaoPlatformContextBase() {
+    override val sceneScale: Float get() = scaleProvider()
+
     // Compose's Popup framework reads `LocalPlatformWindowInsets.current.systemBars`
     // when `usePlatformInsets = true` (the default). The popup positioning logic
     // then operates inside `windowSize - insets`, so a `top` inset matching our

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -375,6 +375,15 @@ internal class TaoComposeSceneHostLinux(
     private var lastPointerX: Float = 0f
     private var lastPointerY: Float = 0f
 
+    // Sub-pixel deadband (#615): the wire delivers 1/1024-px positions, so
+    // click jitter under 1 dp must not reach the scene — Compose's mouse
+    // slop is 0.125 dp, and a parent drag gesture consuming that phantom
+    // move cancels the child's tap ("buttons need two clicks"). Mouse events
+    // dispatched to the scene use the deadband's position, never the raw
+    // lastPointerX/Y (SyntheticEventSender would re-inject the difference);
+    // the raw position keeps feeding the resize band and gesture centres.
+    private val pointerDeadband = TaoPointerDeadband()
+
     /**
      * Codes of the currently-pressed mouse buttons. While non-empty a drag is
      * in flight: pointer positions may legitimately be OUTSIDE the window (the
@@ -488,6 +497,7 @@ internal class TaoComposeSceneHostLinux(
                 // the page content but popups (rendered in a higher
                 // ComposeSceneLayer) naturally float above both.
                 topInsetPx = { 0 },
+                scaleProvider = { scale },
                 windowInfo = windowInfo,
                 semanticsOwnerListener = semanticsOwnerListener,
                 dragAndDropManager = dndManager,
@@ -1716,9 +1726,10 @@ internal class TaoComposeSceneHostLinux(
         val direction = if (pressedButtons.isEmpty()) currentResizeDirection(xPx, yPx) else null
         if (resizeDecoration.onMove(direction)) return
 
+        if (!pointerDeadband.shouldDispatchMove(xPx, yPx, scale)) return
         scene?.sendPointerEvent(
             eventType = PointerEventType.Move,
-            position = Offset(xPx, yPx),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = currentKeyboardModifiers,
         )
@@ -1810,7 +1821,7 @@ internal class TaoComposeSceneHostLinux(
         windowInfo.keyboardModifiers = currentKeyboardModifiers
         scene?.sendPointerEvent(
             eventType = if (pressed) PointerEventType.Press else PointerEventType.Release,
-            position = Offset(lastPointerX, lastPointerY),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = currentKeyboardModifiers,
             button = mapButton(buttonCode),
@@ -1878,8 +1889,8 @@ internal class TaoComposeSceneHostLinux(
         }
 
         scene?.dispatchAwtShapedScroll(
-            x = lastPointerX,
-            y = lastPointerY,
+            x = pointerDeadband.x,
+            y = pointerDeadband.y,
             event = event,
             keyboardModifiers = currentKeyboardModifiers,
         )
@@ -2206,8 +2217,10 @@ internal class TaoComposeSceneHostLinux(
                 onPointerButton(button, pressed)
             },
             scrollDispatcher = { xPx, yPx, dx, dy ->
-                lastPointerX = xPx.toFloat()
-                lastPointerY = yPx.toFloat()
+                // Route the position through the regular move dispatch so the
+                // sub-pixel deadband tracks it — the scroll then lands at the
+                // deadband position like every other scene event (#615).
+                onPointerMove(xPx * 1024, yPx * 1024)
                 onPointerScroll(
                     TaoPointerScrollEvent(dxAwt = dx, dyAwt = dy, scrollAmount = 1),
                 )
@@ -2539,6 +2552,8 @@ internal class TaoComposeSceneHostLinux(
 private class LinuxTaoPlatformContext(
     private val windowHandle: Long,
     private val topInsetPx: () -> Int,
+    /** Live px-per-dp factor of the owning scene — see [TaoPlatformContextBase.sceneScale]. */
+    private val scaleProvider: () -> Float,
     override val windowInfo: androidx.compose.ui.platform.WindowInfo,
     override val semanticsOwnerListener: androidx.compose.ui.platform.PlatformContext.SemanticsOwnerListener?,
     override val dragAndDropManager: androidx.compose.ui.platform.PlatformDragAndDropManager,
@@ -2551,6 +2566,8 @@ private class LinuxTaoPlatformContext(
     // `DesktopPlatformContext` forwarding `windowContext.isWindowTransparent`.
     override val isWindowTransparent: Boolean,
 ) : TaoPlatformContextBase() {
+    override val sceneScale: Float get() = scaleProvider()
+
     override val windowInsets: androidx.compose.ui.platform.PlatformWindowInsets =
         object : androidx.compose.ui.platform.PlatformWindowInsets {
             override val systemBars: androidx.compose.ui.platform.PlatformInsets =

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -222,6 +222,15 @@ internal class TaoComposeSceneHostWindows(
     private var lastPointerX: Float = 0f
     private var lastPointerY: Float = 0f
 
+    // Sub-pixel deadband (#615): the wire delivers 1/1024-px positions, so
+    // click jitter under 1 dp must not reach the scene — Compose's mouse
+    // slop is 0.125 dp, and a parent drag gesture consuming that phantom
+    // move cancels the child's tap ("buttons need two clicks"). Mouse events
+    // dispatched to the scene use the deadband's position, never the raw
+    // lastPointerX/Y (SyntheticEventSender would re-inject the difference);
+    // the raw position keeps feeding the pinch-gesture centre.
+    private val pointerDeadband = TaoPointerDeadband()
+
     /**
      * Renderers registered by overlay/popup scenes. Drained AFTER the
      * main scene's render in [onRedrawRequested] so each tick paints
@@ -391,6 +400,7 @@ internal class TaoComposeSceneHostWindows(
                 // overlap the title bar zone; popup scene layers naturally float
                 // above content via z-order. Same fix as Linux (commit 2d8ca500).
                 topInsetPx = { 0 },
+                scaleProvider = { scale },
                 windowInfo = windowInfo,
                 semanticsOwnerListener = semanticsOwnerListener,
                 dragAndDropManager = dndManager,
@@ -1326,9 +1336,10 @@ internal class TaoComposeSceneHostWindows(
         lastPointerY = yPx
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
+        if (!pointerDeadband.shouldDispatchMove(xPx, yPx, scale)) return
         scene?.sendPointerEvent(
             eventType = PointerEventType.Move,
-            position = Offset(xPx, yPx),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = currentKeyboardModifiers,
         )
@@ -1346,7 +1357,7 @@ internal class TaoComposeSceneHostWindows(
         windowInfo.keyboardModifiers = currentKeyboardModifiers
         scene?.sendPointerEvent(
             eventType = PointerEventType.Exit,
-            position = Offset(lastPointerX, lastPointerY),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = currentKeyboardModifiers,
         )
@@ -1361,7 +1372,7 @@ internal class TaoComposeSceneHostWindows(
         windowInfo.keyboardModifiers = currentKeyboardModifiers
         scene?.sendPointerEvent(
             eventType = if (pressed) PointerEventType.Press else PointerEventType.Release,
-            position = Offset(lastPointerX, lastPointerY),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = currentKeyboardModifiers,
             button = mapButton(buttonCode),
@@ -1393,8 +1404,8 @@ internal class TaoComposeSceneHostWindows(
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
         scene?.dispatchAwtShapedScroll(
-            x = lastPointerX,
-            y = lastPointerY,
+            x = pointerDeadband.x,
+            y = pointerDeadband.y,
             event = event,
             keyboardModifiers = currentKeyboardModifiers,
         )
@@ -1778,9 +1789,16 @@ internal class TaoComposeSceneHostWindows(
                     2 -> PointerEventType.Release
                     else -> PointerEventType.Move
                 }
+            // Same sub-pixel deadband as the main stream (#615) — the
+            // overlay WndProc shares the scene's single mouse pointer.
+            if (eventType == PointerEventType.Move &&
+                !pointerDeadband.shouldDispatchMove(x, y, scale)
+            ) {
+                return
+            }
             scene?.sendPointerEvent(
                 eventType = eventType,
-                position = Offset(x, y),
+                position = Offset(pointerDeadband.x, pointerDeadband.y),
                 type = PointerType.Mouse,
                 button = pointerButton,
                 keyboardModifiers = currentKeyboardModifiers,
@@ -1795,11 +1813,14 @@ internal class TaoComposeSceneHostWindows(
         ) {
             lastPointerX = x
             lastPointerY = y
+            // Track the position through the deadband so the scroll lands
+            // where the scene last saw the pointer (#615).
+            pointerDeadband.shouldDispatchMove(x, y, scale)
             // Overlay WndProc reports raw Win32 units; map like TaoWindow
             // then go through the same AWT-shaped dispatch as the window.
             scene?.dispatchAwtShapedScroll(
-                x = x,
-                y = y,
+                x = pointerDeadband.x,
+                y = pointerDeadband.y,
                 event = win32WheelToAwtScrollEvent(dx, dy),
                 keyboardModifiers = currentKeyboardModifiers,
             )
@@ -2012,6 +2033,8 @@ internal class TaoComposeSceneHostWindows(
 private class WindowsTaoPlatformContext(
     private val windowHandle: Long,
     private val topInsetPx: () -> Int,
+    /** Live px-per-dp factor of the owning scene — see [TaoPlatformContextBase.sceneScale]. */
+    private val scaleProvider: () -> Float,
     override val windowInfo: androidx.compose.ui.platform.WindowInfo,
     override val semanticsOwnerListener: androidx.compose.ui.platform.PlatformContext.SemanticsOwnerListener? = null,
     override val dragAndDropManager: androidx.compose.ui.platform.PlatformDragAndDropManager,
@@ -2024,6 +2047,8 @@ private class WindowsTaoPlatformContext(
     // `DesktopPlatformContext` forwarding `windowContext.isWindowTransparent`.
     override val isWindowTransparent: Boolean = false,
 ) : TaoPlatformContextBase() {
+    override val sceneScale: Float get() = scaleProvider()
+
     override val windowInsets: androidx.compose.ui.platform.PlatformWindowInsets =
         object : androidx.compose.ui.platform.PlatformWindowInsets {
             override val systemBars: androidx.compose.ui.platform.PlatformInsets =

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoKeepScreenOn.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoKeepScreenOn.kt
@@ -2,6 +2,7 @@ package dev.nucleusframework.window.tao.scene
 
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.ViewConfiguration
 import dev.nucleusframework.energymanager.AwakeHandle
 import dev.nucleusframework.energymanager.AwakeMode
 import dev.nucleusframework.energymanager.EnergyManager
@@ -49,11 +50,12 @@ internal object TaoKeepScreenOn {
 
 /**
  * [PlatformContext] that forwards Compose's `isKeepScreenOnEnabled` to
- * [TaoKeepScreenOn] / [EnergyManager].
+ * [TaoKeepScreenOn] / [EnergyManager] and reports a density-scaled
+ * [viewConfiguration].
  *
  * Every Tao scene (window, popup, overlay) must extend this instead of
  * [PlatformContext.Empty] so `Modifier.keepScreenOn()` actually keeps the
- * display awake.
+ * display awake and gesture thresholds match the AWT backend.
  */
 @OptIn(InternalComposeUiApi::class)
 internal abstract class TaoPlatformContextBase : PlatformContext.Empty() {
@@ -65,5 +67,24 @@ internal abstract class TaoPlatformContextBase : PlatformContext.Empty() {
             if (keepScreenOn == value) return
             keepScreenOn = value
             TaoKeepScreenOn.setEnabled(value)
+        }
+
+    /**
+     * The owning scene's px-per-dp factor, read live so [viewConfiguration]
+     * tracks display-scale changes. Hosts override with their current scale.
+     */
+    protected open val sceneScale: Float get() = 1f
+
+    /**
+     * Density-scaled thresholds — AWT/Android parity (#615).
+     * [PlatformContext.Empty] inherits [PlatformContext.DefaultViewConfiguration],
+     * whose `touchSlop` is 18 RAW pixels, while the AWT backend uses
+     * `18.dp.toPx()`: on a 2× display that halves every drag/scroll slop and
+     * the derived mouse slop.
+     */
+    override val viewConfiguration: ViewConfiguration =
+        object : ViewConfiguration by PlatformContext.DefaultViewConfiguration {
+            override val touchSlop: Float
+                get() = PlatformContext.DefaultViewConfiguration.touchSlop * sceneScale
         }
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoPointerDeadband.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoPointerDeadband.kt
@@ -1,0 +1,60 @@
+package dev.nucleusframework.window.tao.scene
+
+/**
+ * Sub-pixel deadband for the Tao mouse stream (#615).
+ *
+ * Tao delivers cursor positions with sub-pixel precision (1/1024 px wire
+ * format) and macOS emits a CursorMoved before every mouseDown/mouseUp, so a
+ * click whose cursor drifts a fraction of a pixel between press and release
+ * produces a real Move delta. Compose's mouse slop is only
+ * `touchSlop × (0.125.dp / 18.dp)` (foundation `DragGestureDetector.kt`), so
+ * ~0.2 px of drift starts any parent drag gesture, which consumes the move;
+ * a child `clickable` then sees the consumed change in the Final pass and
+ * cancels the tap — observed as "buttons need two clicks". The AWT backend
+ * never sees this because it quantizes positions to integer logical points —
+ * a de-facto 1 dp deadband.
+ *
+ * This class gives the Tao stream the same deadband without giving up
+ * sub-pixel precision on real motion: Moves whose delta from the last
+ * *dispatched* position is under 1 dp are suppressed, and the first Move past
+ * the deadband dispatches its exact sub-pixel position.
+ *
+ * Press/Release/Exit/Scroll must be dispatched at [x]/[y] (the last
+ * dispatched position), not the raw one: Compose's `SyntheticEventSender`
+ * re-injects any position difference as a synthetic Move, which would
+ * reintroduce the suppressed delta.
+ */
+internal class TaoPointerDeadband {
+    /** X of the last Move actually dispatched to the scene (physical px). */
+    var x: Float = 0f
+        private set
+
+    /** Y of the last Move actually dispatched to the scene (physical px). */
+    var y: Float = 0f
+        private set
+
+    private var hasDispatched = false
+
+    /**
+     * Whether a Move to ([rawX], [rawY]) physical px should reach the scene;
+     * records it as the new dispatched position when it should. [scale] is
+     * the scene's px-per-dp factor — the deadband is 1 dp, matching the
+     * de-facto precision of the AWT backend's integer-point stream.
+     */
+    fun shouldDispatchMove(
+        rawX: Float,
+        rawY: Float,
+        scale: Float,
+    ): Boolean {
+        if (hasDispatched) {
+            val threshold = if (scale > 0f) scale else 1f
+            val dx = rawX - x
+            val dy = rawY - y
+            if (dx * dx + dy * dy < threshold * threshold) return false
+        }
+        x = rawX
+        y = rawY
+        hasDispatched = true
+        return true
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -17,6 +17,7 @@ import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
 import dev.nucleusframework.window.tao.scene.TaoSceneKeyboardTest
 import dev.nucleusframework.window.tao.scene.TaoSceneOuterLocalsBridgeTest
+import dev.nucleusframework.window.tao.scene.TaoScenePointerSlopTest
 import dev.nucleusframework.window.tao.scene.TaoScenePointerTest
 import dev.nucleusframework.window.tao.scene.TaoScenePopupTest
 import dev.nucleusframework.window.tao.scene.TaoSceneRenderTest
@@ -277,6 +278,24 @@ public object TaoSceneTestBattery {
         }
         run("TaoScenePointerTest: hover exit resets hover state via exitPointer") {
             TaoScenePointerTest().`hover exit resets hover state via exitPointer`()
+        }
+        run("TaoScenePointerSlopTest: sub-pixel jitter between press and release must not eat the click") {
+            TaoScenePointerSlopTest().`sub-pixel jitter between press and release must not eat the click`()
+        }
+        run("TaoScenePointerSlopTest: sub-pixel jitter must not eat the click on a HiDPI display") {
+            TaoScenePointerSlopTest().`sub-pixel jitter must not eat the click on a HiDPI display`()
+        }
+        run("TaoScenePointerSlopTest: real motion past the deadband still drags and cancels the click") {
+            TaoScenePointerSlopTest().`real motion past the deadband still drags and cancels the click`()
+        }
+        run("TaoScenePointerSlopTest: moves below one dp are suppressed and real motion keeps sub-pixel precision") {
+            TaoScenePointerSlopTest().`moves below one dp are suppressed and real motion keeps sub-pixel precision`()
+        }
+        run("TaoScenePointerSlopTest: press after suppressed jitter dispatches at the last dispatched position") {
+            TaoScenePointerSlopTest().`press after suppressed jitter dispatches at the last dispatched position`()
+        }
+        run("TaoScenePointerSlopTest: touch slop is density-scaled like the AWT backend") {
+            TaoScenePointerSlopTest().`touch slop is density-scaled like the AWT backend`()
         }
         run("TitleBarHitTestTest: opaque overlay bar does not leak clicks to the content below") {
             TitleBarHitTestTest().`opaque overlay bar does not leak clicks to the content below`()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -17,6 +17,7 @@ import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
 import dev.nucleusframework.window.tao.scene.TaoSceneKeyboardTest
 import dev.nucleusframework.window.tao.scene.TaoSceneOuterLocalsBridgeTest
+import dev.nucleusframework.window.tao.scene.TaoScenePointerSlopTest
 import dev.nucleusframework.window.tao.scene.TaoScenePointerTest
 import dev.nucleusframework.window.tao.scene.TaoScenePopupTest
 import dev.nucleusframework.window.tao.scene.TaoSceneRectManagerRaceTest
@@ -59,6 +60,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoSceneKeyboardTest::class.java,
             TaoSceneImeTest::class.java,
             TaoScenePointerTest::class.java,
+            TaoScenePointerSlopTest::class.java,
             TaoSceneScrollTest::class.java,
             TaoScenePopupTest::class.java,
             TaoSceneOuterLocalsBridgeTest::class.java,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoScenePointerSlopTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoScenePointerSlopTest.kt
@@ -1,0 +1,181 @@
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for #615 — "PointerInput consumes touches (Tao backend)".
+ *
+ * Tao delivers sub-pixel cursor positions (1/1024 px wire format) and macOS
+ * emits a CursorMoved before every mouseDown/mouseUp, so a click whose cursor
+ * drifts a fraction of a pixel between press and release produces a real Move
+ * delta. Compose's mouse slop is only `touchSlop × (0.125.dp / 18.dp)`
+ * (foundation `DragGestureDetector.kt`), so ~0.2 px of drift starts a parent
+ * drag gesture which consumes the move; a child `clickable` then sees the
+ * consumed change in the Final pass and cancels the tap — "buttons need two
+ * clicks". The AWT backend never sees this because it quantizes positions to
+ * integer points, a de-facto 1 dp deadband.
+ *
+ * Contract under test (host + harness share the same dispatch shapes):
+ *  - Moves under 1 dp from the last *dispatched* position are suppressed;
+ *  - press/release dispatch at the last dispatched position (otherwise
+ *    Compose's SyntheticEventSender re-injects the suppressed delta);
+ *  - motion past the deadband keeps its exact sub-pixel position;
+ *  - `viewConfiguration.touchSlop` is 18.dp in physical px (AWT parity),
+ *    not 18 raw px.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class TaoScenePointerSlopTest {
+    @Test
+    fun `sub-pixel jitter between press and release must not eat the click`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            var clicks = 0
+            var dragStarts = 0
+            setContent {
+                DragParentWithClickableChild(
+                    onDragStart = { dragStarts++ },
+                    onClick = { clicks++ },
+                )
+            }
+            moveMouse(30f, 30f)
+            pointerButton(PointerButton.Primary, pressed = true)
+            // macOS view.rs emits a CursorMoved before every mouseUp — a
+            // trackpad click that slides 0.2 px reports this exact stream.
+            moveMouse(30.2f, 30f)
+            pointerButton(PointerButton.Primary, pressed = false)
+            assertEquals(0, dragStarts, "sub-pixel jitter must not start a drag")
+            assertEquals(1, clicks, "the click must reach the child clickable")
+        }
+
+    @Test
+    fun `sub-pixel jitter must not eat the click on a HiDPI display`() =
+        runTaoSceneTest(width = 200, height = 200, density = 2f) {
+            var clicks = 0
+            var dragStarts = 0
+            setContent {
+                DragParentWithClickableChild(
+                    onDragStart = { dragStarts++ },
+                    onClick = { clicks++ },
+                )
+            }
+            moveMouse(30f, 30f)
+            pointerButton(PointerButton.Primary, pressed = true)
+            moveMouse(30.2f, 30f)
+            pointerButton(PointerButton.Primary, pressed = false)
+            assertEquals(0, dragStarts, "sub-pixel jitter must not start a drag")
+            assertEquals(1, clicks, "the click must reach the child clickable")
+        }
+
+    @Test
+    fun `real motion past the deadband still drags and cancels the click`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            var clicks = 0
+            var dragStarts = 0
+            setContent {
+                DragParentWithClickableChild(
+                    onDragStart = { dragStarts++ },
+                    onClick = { clicks++ },
+                )
+            }
+            moveMouse(30f, 30f)
+            pointerButton(PointerButton.Primary, pressed = true)
+            moveMouse(33f, 30f)
+            moveMouse(36f, 30f)
+            pointerButton(PointerButton.Primary, pressed = false)
+            assertEquals(1, dragStarts, "real motion must start the drag")
+            assertEquals(0, clicks, "a drag must still cancel the click")
+        }
+
+    @Test
+    fun `moves below one dp are suppressed and real motion keeps sub-pixel precision`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            val moves = mutableListOf<Offset>()
+            setContent {
+                Box(
+                    Modifier.fillMaxSize().onPointerEvent(PointerEventType.Move) {
+                        moves += it.changes.first().position
+                    },
+                )
+            }
+            moveMouse(100f, 100f)
+            moveMouse(100.4f, 100f) // 0.4 px from last dispatched — jitter
+            moveMouse(100.8f, 100f) // still < 1 dp from last dispatched
+            moveMouse(101.5f, 100f) // 1.5 px from last dispatched — real motion
+            assertTrue(
+                moves.none { it.x > 100f && it.x < 101.5f },
+                "sub-dp jitter must be suppressed (got $moves)",
+            )
+            assertEquals(
+                101.5f,
+                moves.last().x,
+                "motion past the deadband must keep its exact sub-pixel position",
+            )
+        }
+
+    @Test
+    fun `press after suppressed jitter dispatches at the last dispatched position`() =
+        runTaoSceneTest(width = 200, height = 200) {
+            var pressPosition: Offset? = null
+            setContent {
+                Box(
+                    Modifier.fillMaxSize().onPointerEvent(PointerEventType.Press) {
+                        pressPosition = it.changes.first().position
+                    },
+                )
+            }
+            moveMouse(100f, 100f)
+            moveMouse(100.3f, 100f) // suppressed
+            pointerButton(PointerButton.Primary, pressed = true)
+            pointerButton(PointerButton.Primary, pressed = false)
+            // Anywhere else and SyntheticEventSender re-injects the suppressed
+            // delta as a synthetic Move right before the Press.
+            assertEquals(Offset(100f, 100f), pressPosition)
+        }
+
+    @Test
+    fun `touch slop is density-scaled like the AWT backend`() =
+        runTaoSceneTest(width = 200, height = 200, density = 2f) {
+            var touchSlop = 0f
+            setContent {
+                touchSlop = LocalViewConfiguration.current.touchSlop
+            }
+            assertEquals(36f, touchSlop, "touchSlop must be 18.dp in physical px (18 × density)")
+        }
+
+    /** The #615 repro shape: parent drag detector, child clickable. */
+    @Composable
+    private fun DragParentWithClickableChild(
+        onDragStart: () -> Unit,
+        onClick: () -> Unit,
+    ) {
+        Box(Modifier.fillMaxSize()) {
+            Box(
+                Modifier
+                    .size(100.dp)
+                    .pointerInput(Unit) {
+                        detectDragGestures(onDragStart = { onDragStart() }) { change, _ ->
+                            change.consume()
+                        }
+                    },
+            ) {
+                Box(Modifier.size(60.dp).clickable { onClick() })
+            }
+        }
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneTestHarness.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneTestHarness.kt
@@ -53,7 +53,8 @@ import kotlin.coroutines.CoroutineContext
  * What is replicated from the host (kept in sync deliberately): the thin
  * `sendPointerEvent` dispatch shapes of `onPointerMove` / `onPointerButton` /
  * `onPointerScroll`, including the cursor-move-before-click and press-dedup
- * guards, so a regression in those contracts fails here first.
+ * guards and the sub-pixel deadband ([TaoPointerDeadband], #615), so a
+ * regression in those contracts fails here first.
  *
  * Time is fully synthetic: [frame] advances a virtual clock, pumps the
  * single-threaded dispatcher, delivers frame-clock ticks and
@@ -188,7 +189,7 @@ private class QueueDispatcher :
 internal class TaoSceneTestScope(
     val width: Int,
     val height: Int,
-    density: Float,
+    val density: Float,
 ) {
     private val dispatcher = QueueDispatcher()
     private var timeNanos = 0L
@@ -207,6 +208,8 @@ internal class TaoSceneTestScope(
 
     private val platformContext =
         object : TaoPlatformContextBase() {
+            override val sceneScale: Float get() = this@TaoSceneTestScope.density
+
             override val windowInfo: TaoWindowInfo = this@TaoSceneTestScope.windowInfo
 
             // Mirrors `TaoPlatformContext.startInputMethod`: publish the text-input
@@ -255,8 +258,7 @@ internal class TaoSceneTestScope(
     val scene: ComposeScene get() = sceneBundle.scene
 
     // ── Host-mirrored pointer state (same guards as TaoComposeSceneHost) ────
-    private var lastPointerX = 0f
-    private var lastPointerY = 0f
+    private val pointerDeadband = TaoPointerDeadband()
     private var hasReceivedCursorMove = false
     private var isPressed = false
     private var modifierState = 0
@@ -337,20 +339,25 @@ internal class TaoSceneTestScope(
         modifierState = modifiers
     }
 
-    /** Mirrors `TaoComposeSceneHost.onPointerMove` (fixed-point 1024 wire format). */
+    /**
+     * Mirrors `TaoComposeSceneHost.onPointerMove` (fixed-point 1024 wire
+     * format), including the sub-pixel deadband (#615).
+     */
     fun moveMouseFixed(
         aFixed: Int,
         bFixed: Int,
     ) {
         val xPx = aFixed / FIXED_POINT_SCALE
         val yPx = bFixed / FIXED_POINT_SCALE
-        lastPointerX = xPx
-        lastPointerY = yPx
         hasReceivedCursorMove = true
         windowInfo.keyboardModifiers = taoKeyboardModifiers(modifierState)
+        if (!pointerDeadband.shouldDispatchMove(xPx, yPx, density)) {
+            frame()
+            return
+        }
         scene.sendPointerEvent(
             eventType = PointerEventType.Move,
-            position = Offset(xPx, yPx),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = taoKeyboardModifiers(modifierState),
         )
@@ -372,7 +379,7 @@ internal class TaoSceneTestScope(
         if (pressed && isPressed) {
             scene.sendPointerEvent(
                 eventType = PointerEventType.Release,
-                position = Offset(lastPointerX, lastPointerY),
+                position = Offset(pointerDeadband.x, pointerDeadband.y),
                 type = PointerType.Mouse,
                 keyboardModifiers = modifiers,
                 button = button,
@@ -383,7 +390,7 @@ internal class TaoSceneTestScope(
         isPressed = pressed
         scene.sendPointerEvent(
             eventType = if (pressed) PointerEventType.Press else PointerEventType.Release,
-            position = Offset(lastPointerX, lastPointerY),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = modifiers,
             button = button,
@@ -404,7 +411,7 @@ internal class TaoSceneTestScope(
     fun exitPointer() {
         scene.sendPointerEvent(
             eventType = PointerEventType.Exit,
-            position = Offset(lastPointerX, lastPointerY),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = taoKeyboardModifiers(modifierState),
         )
@@ -416,15 +423,15 @@ internal class TaoSceneTestScope(
         val modifiers = taoKeyboardModifiers(modifierState)
         scene.sendPointerEvent(
             eventType = PointerEventType.Scroll,
-            position = Offset(lastPointerX, lastPointerY),
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
             scrollDelta = Offset(event.dxAwt, event.dyAwt),
             type = PointerType.Mouse,
             keyboardModifiers = modifiers,
             nativeEvent =
                 TaoSyntheticMouseWheelEvent.create(
                     event = event,
-                    x = lastPointerX,
-                    y = lastPointerY,
+                    x = pointerDeadband.x,
+                    y = pointerDeadband.y,
                     keyboardModifiers = modifiers,
                 ),
         )


### PR DESCRIPTION
Fixes #615.

## Summary

- **Root cause**: Tao ships sub-pixel cursor positions (1/1024-px wire format) and macOS emits a `CursorMoved` before every `mouseDown`/`mouseUp`, so ~0.2 px of drift between press and release crosses Compose's mouse slop (`touchSlop × 0.125.dp/18.dp`). A parent drag detector then consumes the move and the child `clickable` cancels the tap — "selections need two clicks". The AWT backend never sees this because it quantizes positions to integer points, a de-facto 1 dp deadband.
- **`TaoPointerDeadband`**: Moves under 1 dp from the last *dispatched* position are suppressed; press/release/exit/scroll dispatch at the last dispatched position (anything else and Compose's `SyntheticEventSender` re-injects the suppressed delta as a synthetic Move); motion past the deadband keeps its exact sub-pixel position — strictly better than AWT's rounding. Wired into all three window hosts, including the Windows blending-overlay stream and the Linux overlay scroll dispatcher.
- **Density-scaled `viewConfiguration`** on `TaoPlatformContextBase` (second, standalone bug): `touchSlop` is now `18.dp` in physical px (AWT/Android parity) instead of the 18 raw px inherited from `PlatformContext.Empty`, which halved every drag/scroll threshold on 2× displays. `sceneScale` is provided live by each window host and popup layer, so it tracks display-scale changes.
- **Regression tests**: `TaoScenePointerSlopTest` replays the issue's parent-drag + child-clickable shape through the offscreen scene harness (which now mirrors the hosts' deadband dispatch) and is registered in the native-image test battery.

## Test plan

- [x] New `TaoScenePointerSlopTest` written first and confirmed failing on `main` (0.2 px jitter → `clicks=0 dragStarts=1`; `touchSlop=18` at 2×)
- [x] All 6 tests pass after the fix, at density 1× and 2×
- [x] Guard test: real motion past the deadband still starts the drag and cancels the click
- [x] Full `:decorated-window-tao:test` suite green (177 tests, battery drift check included)
- [x] `:decorated-window-tao:check` green (detekt, ktlint, apiCheck — no public ABI change, everything is `internal`)