### PR TITLE
fix(tao): standalone popup crash on scrollbar drag (re-entrant render)

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePump.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePump.kt
@@ -12,7 +12,8 @@ import kotlin.coroutines.EmptyCoroutineContext
  * Runs [render] immediately when already on the Tao main thread and not
  * already inside a frame. A WndProc / NSEvent flood otherwise starves
  * `MainEventsCleared` and a queued frame never paints. Nested [schedule]
- * calls from inside [render] are posted, not re-entered.
+ * calls from inside [render] or a [nonReentrant] block are posted, not
+ * re-entered.
  */
 internal class StandaloneFramePump(
     private val isOnMain: () -> Boolean = {
@@ -40,6 +41,29 @@ internal class StandaloneFramePump(
             runRender()
         } else {
             post(Runnable { runRender() })
+        }
+    }
+
+    /**
+     * Runs [block] with inline rendering suppressed: a [schedule] arriving
+     * while the block is on the stack is posted instead of run re-entrantly.
+     *
+     * Wraps every scene entry point of the standalone hosts (pointer, scroll
+     * and key dispatch, `setContent`): a scrollbar drag forces a measure pass
+     * synchronously inside the pointer event, and a coroutine dispatched from
+     * within that pass (the `LaunchedEffect` of a freshly subcomposed lazy
+     * item) lands in the scene dispatcher, whose dispatch schedules a frame.
+     * Rendering that frame inline would call `measureAndLayout` while the
+     * first pass is still on the stack — Compose throws
+     * `performMeasureAndLayout called during measure layout`.
+     */
+    fun <T> nonReentrant(block: () -> T): T {
+        val outer = rendering
+        rendering = true
+        try {
+            return block()
+        } finally {
+            rendering = outer
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -192,7 +192,10 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     }
 
     override fun setContent(content: @Composable () -> Unit) {
-        scene?.setContent(content = content)
+        // Initial composition dispatches coroutines (LaunchedEffects) into the
+        // scene dispatcher; rendering inline from those would race the apply
+        // pass still on the stack. Same guard as the input entry points below.
+        framePump.nonReentrant { scene?.setContent(content = content) }
         scheduleRender()
     }
 
@@ -430,6 +433,10 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
 
     // ── Input ─────────────────────────────────────────────────────────────
 
+    // Every scene dispatch below runs inside framePump.nonReentrant: a drag
+    // gesture can force a measure pass synchronously (scrollbar drag →
+    // LazyListState.onScroll → forceRemeasure), and a coroutine dispatched
+    // from within it must post the next frame instead of rendering inline.
     private inner class PanelEventCallback : PopupNativeBridgeWindows.EventCallback {
         override fun onPointerEvent(
             type: Int,
@@ -451,12 +458,14 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
                     TaoNativeWireFormat.PTR_UP -> PointerEventType.Release
                     else -> PointerEventType.Move
                 }
-            sc.sendPointerEvent(
-                eventType = eventType,
-                position = Offset(x, y),
-                type = PointerType.Mouse,
-                button = pointerButton,
-            )
+            framePump.nonReentrant {
+                sc.sendPointerEvent(
+                    eventType = eventType,
+                    position = Offset(x, y),
+                    type = PointerType.Mouse,
+                    button = pointerButton,
+                )
+            }
         }
 
         override fun onScroll(
@@ -465,7 +474,9 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
             dx: Float,
             dy: Float,
         ) {
-            scene?.dispatchAwtShapedScroll(x, y, win32WheelToAwtScrollEvent(dx, dy))
+            framePump.nonReentrant {
+                scene?.dispatchAwtShapedScroll(x, y, win32WheelToAwtScrollEvent(dx, dy))
+            }
         }
 
         override fun onKeyEvent(
@@ -474,14 +485,16 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
             codePoint: Int,
             modifiers: Int,
         ) {
-            scene?.dispatchNativeKeyEvent(
-                type = type,
-                vkCode = vkCode,
-                codePoint = codePoint,
-                modifiers = modifiers,
-                onPreviewKeyEvent = onPreviewKeyEvent,
-                onKeyEvent = onKeyEvent,
-            )
+            framePump.nonReentrant {
+                scene?.dispatchNativeKeyEvent(
+                    type = type,
+                    vkCode = vkCode,
+                    codePoint = codePoint,
+                    modifiers = modifiers,
+                    onPreviewKeyEvent = onPreviewKeyEvent,
+                    onKeyEvent = onKeyEvent,
+                )
+            }
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
@@ -210,7 +210,10 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
     }
 
     override fun setContent(content: @Composable () -> Unit) {
-        scene?.setContent(content = content)
+        // Initial composition dispatches coroutines (LaunchedEffects) into the
+        // scene dispatcher; rendering inline from those would race the apply
+        // pass still on the stack. Same guard as the input entry points below.
+        framePump.nonReentrant { scene?.setContent(content = content) }
         scheduleRender()
     }
 
@@ -408,7 +411,11 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
 
     /**
      * Arrives on the panel's X event thread; every scene interaction hops
-     * to the Tao main thread (the scene is not thread-safe).
+     * to the Tao main thread (the scene is not thread-safe). Once there, the
+     * scene dispatch runs inside `framePump.nonReentrant`: a drag gesture can
+     * force a measure pass synchronously (scrollbar drag →
+     * `LazyListState.onScroll` → `forceRemeasure`), and a coroutine dispatched
+     * from within it must post the next frame instead of rendering inline.
      */
     private inner class PanelEventCallback : PopupNativeBridgeLinux.EventCallback {
         override fun onPointerEvent(
@@ -433,12 +440,14 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
                         TaoNativeWireFormat.PTR_UP -> PointerEventType.Release
                         else -> PointerEventType.Move
                     }
-                sc.sendPointerEvent(
-                    eventType = eventType,
-                    position = Offset(x, y),
-                    type = PointerType.Mouse,
-                    button = pointerButton,
-                )
+                framePump.nonReentrant {
+                    sc.sendPointerEvent(
+                        eventType = eventType,
+                        position = Offset(x, y),
+                        type = PointerType.Mouse,
+                        button = pointerButton,
+                    )
+                }
             }
         }
 
@@ -450,7 +459,9 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
         ) {
             TaoMainDispatcher.dispatch(EmptyCoroutineContext) {
                 if (disposed) return@dispatch
-                scene?.dispatchAwtShapedScroll(x, y, linuxWheelToAwtScrollEvent(dx, dy))
+                framePump.nonReentrant {
+                    scene?.dispatchAwtShapedScroll(x, y, linuxWheelToAwtScrollEvent(dx, dy))
+                }
             }
         }
 
@@ -462,14 +473,16 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
         ) {
             TaoMainDispatcher.dispatch(EmptyCoroutineContext) {
                 if (disposed) return@dispatch
-                scene?.dispatchNativeKeyEvent(
-                    type = type,
-                    vkCode = vkCode,
-                    codePoint = codePoint,
-                    modifiers = modifiers,
-                    onPreviewKeyEvent = onPreviewKeyEvent,
-                    onKeyEvent = onKeyEvent,
-                )
+                framePump.nonReentrant {
+                    scene?.dispatchNativeKeyEvent(
+                        type = type,
+                        vkCode = vkCode,
+                        codePoint = codePoint,
+                        modifiers = modifiers,
+                        onPreviewKeyEvent = onPreviewKeyEvent,
+                        onKeyEvent = onKeyEvent,
+                    )
+                }
             }
         }
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostMac.kt
@@ -169,7 +169,10 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
     }
 
     override fun setContent(content: @Composable () -> Unit) {
-        scene?.setContent(content = content)
+        // Initial composition dispatches coroutines (LaunchedEffects) into the
+        // scene dispatcher; rendering inline from those would race the apply
+        // pass still on the stack. Same guard as the input entry points below.
+        framePump.nonReentrant { scene?.setContent(content = content) }
         scheduleRender()
     }
 
@@ -394,6 +397,10 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
 
     // ── Input ─────────────────────────────────────────────────────────────
 
+    // Every scene dispatch below runs inside framePump.nonReentrant: a drag
+    // gesture can force a measure pass synchronously (scrollbar drag →
+    // LazyListState.onScroll → forceRemeasure), and a coroutine dispatched
+    // from within it must post the next frame instead of rendering inline.
     private inner class PanelEventCallback : PopupNativeBridge.EventCallback {
         override fun onPointerEvent(
             type: Int,
@@ -415,12 +422,14 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
                     TaoNativeWireFormat.PTR_UP -> PointerEventType.Release
                     else -> PointerEventType.Move
                 }
-            sc.sendPointerEvent(
-                eventType = eventType,
-                position = Offset(x, y),
-                type = PointerType.Mouse,
-                button = pointerButton,
-            )
+            framePump.nonReentrant {
+                sc.sendPointerEvent(
+                    eventType = eventType,
+                    position = Offset(x, y),
+                    type = PointerType.Mouse,
+                    button = pointerButton,
+                )
+            }
         }
 
         override fun onScroll(
@@ -430,11 +439,13 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
             dy: Float,
             precise: Boolean,
         ) {
-            scene?.dispatchAwtShapedScroll(
-                x,
-                y,
-                appKitWheelToAwtScrollEvent(dx, dy, precise, scale),
-            )
+            framePump.nonReentrant {
+                scene?.dispatchAwtShapedScroll(
+                    x,
+                    y,
+                    appKitWheelToAwtScrollEvent(dx, dy, precise, scale),
+                )
+            }
         }
 
         override fun onKeyEvent(
@@ -443,14 +454,16 @@ internal class TaoStandalonePopupHostMac : StandalonePopupHost {
             codePoint: Int,
             modifiers: Int,
         ) {
-            scene?.dispatchNativeKeyEvent(
-                type = type,
-                vkCode = vkCode,
-                codePoint = codePoint,
-                modifiers = modifiers,
-                onPreviewKeyEvent = onPreviewKeyEvent,
-                onKeyEvent = onKeyEvent,
-            )
+            framePump.nonReentrant {
+                scene?.dispatchNativeKeyEvent(
+                    type = type,
+                    vkCode = vkCode,
+                    codePoint = codePoint,
+                    modifiers = modifiers,
+                    onPreviewKeyEvent = onPreviewKeyEvent,
+                    onKeyEvent = onKeyEvent,
+                )
+            }
         }
     }
 

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -12,6 +12,7 @@ import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.event.Win32WheelDeltaTest
 import dev.nucleusframework.window.tao.popup.StandaloneFramePumpTest
+import dev.nucleusframework.window.tao.popup.StandalonePopupRenderReentryTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
@@ -148,11 +149,31 @@ public object TaoSceneTestBattery {
         run("StandaloneFramePumpTest: extraSchedulesWhileRenderingCoalesce") {
             StandaloneFramePumpTest().extraSchedulesWhileRenderingCoalesce()
         }
+        run("StandaloneFramePumpTest: scheduleInsideNonReentrantBlockIsPosted") {
+            StandaloneFramePumpTest().scheduleInsideNonReentrantBlockIsPosted()
+        }
+        run("StandaloneFramePumpTest: inlineRenderResumesAfterNonReentrantBlock") {
+            StandaloneFramePumpTest().inlineRenderResumesAfterNonReentrantBlock()
+        }
         run("StandaloneFramePumpTest: scheduleAfterDisposeIsNoOp") {
             StandaloneFramePumpTest().scheduleAfterDisposeIsNoOp()
         }
         run("StandaloneFramePumpTest: disposedPostedFrameIsDropped") {
             StandaloneFramePumpTest().disposedPostedFrameIsDropped()
+        }
+        run(
+            "StandalonePopupRenderReentryTest: guarded scrollbar drag posts the frame " +
+                "instead of re-entering the render pass",
+        ) {
+            StandalonePopupRenderReentryTest()
+                .`guarded scrollbar drag posts the frame instead of re-entering the render pass`()
+        }
+        run(
+            "StandalonePopupRenderReentryTest: unguarded scene dispatch re-enters the render pass " +
+                "- the failure mode the guard exists for",
+        ) {
+            StandalonePopupRenderReentryTest()
+                .`unguarded scene dispatch re-enters the render pass - the failure mode the guard exists for`()
         }
         run("TaoWheelPinchZoomTest: fullWheelDeltaProducesModerateZoomStep") {
             TaoWheelPinchZoomTest().fullWheelDeltaProducesModerateZoomStep()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -12,6 +12,7 @@ import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.event.Win32WheelDeltaTest
 import dev.nucleusframework.window.tao.popup.StandaloneFramePumpTest
+import dev.nucleusframework.window.tao.popup.StandalonePopupRenderReentryTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
@@ -52,6 +53,7 @@ class TaoSceneTestBatteryDriftTest {
             LinuxWheelDeltaTest::class.java,
             MacOsWheelDeltaTest::class.java,
             StandaloneFramePumpTest::class.java,
+            StandalonePopupRenderReentryTest::class.java,
             TaoWheelPinchZoomTest::class.java,
             TaoWindowScrollTest::class.java,
             TaoWindowResizableTest::class.java,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePumpTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/popup/StandaloneFramePumpTest.kt
@@ -47,6 +47,27 @@ class StandaloneFramePumpTest {
     }
 
     @Test
+    fun scheduleInsideNonReentrantBlockIsPosted() {
+        val probe = Probe()
+        probe.pump.nonReentrant {
+            probe.pump.schedule()
+            assertEquals(0, probe.renders)
+        }
+        assertEquals(1, probe.posted.size)
+        probe.drainPosted()
+        assertEquals(1, probe.renders)
+    }
+
+    @Test
+    fun inlineRenderResumesAfterNonReentrantBlock() {
+        val probe = Probe()
+        probe.pump.nonReentrant { }
+        probe.pump.schedule()
+        assertEquals(1, probe.renders)
+        assertTrue(probe.posted.isEmpty())
+    }
+
+    @Test
     fun scheduleAfterDisposeIsNoOp() {
         val probe = Probe()
         probe.pump.schedule()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/popup/StandalonePopupRenderReentryTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/popup/StandalonePopupRenderReentryTest.kt
@@ -1,0 +1,241 @@
+@file:OptIn(InternalComposeUiApi::class)
+
+package dev.nucleusframework.window.tao.popup
+
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.WindowInfo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import dev.nucleusframework.window.tao.GlobalLayoutDirection
+import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
+import dev.nucleusframework.window.tao.scene.TaoSceneBundle
+import dev.nucleusframework.window.tao.scene.TaoWindowInfo
+import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
+import dev.nucleusframework.window.tao.scene.recordSceneToPicture
+import kotlinx.coroutines.CoroutineDispatcher
+import java.util.ArrayDeque
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Repro for the TrayApp scrollbar-drag crash: dragging a LazyColumn scrollbar
+ * thumb scrolls synchronously inside the pointer event
+ * (`LazyListState.onScroll` → `forceRemeasure`), subcomposing new items whose
+ * `LaunchedEffect`s dispatch into the scene dispatcher. The standalone hosts'
+ * flushing dispatcher schedules a frame on every dispatch — rendered inline,
+ * that frame re-enters `measureAndLayout` while the first pass is still on
+ * the stack and Compose throws
+ * `performMeasureAndLayout called during measure layout`.
+ *
+ * The fixture mirrors the standalone hosts' wiring (`FlushingDispatcher` +
+ * [StandaloneFramePump] whose render drains then measures/draws through the
+ * production record path), including the [StandaloneFramePump.nonReentrant]
+ * guard around scene entry points — kept in sync deliberately, like the
+ * pointer dispatch shapes in `TaoSceneTestHarness`.
+ */
+class StandalonePopupRenderReentryTest {
+    @Test
+    fun `guarded scrollbar drag posts the frame instead of re-entering the render pass`() {
+        Fixture().use { f ->
+            f.setContent()
+            f.dragThumb(guarded = true)
+            assertEquals(0, f.reentrantRenders, "no frame may render while a scene entry is on the stack")
+            assertTrue(
+                f.listState.firstVisibleItemIndex > 0,
+                "the drag must actually have scrolled the list",
+            )
+        }
+    }
+
+    @Test
+    fun `unguarded scene dispatch re-enters the render pass - the failure mode the guard exists for`() {
+        Fixture().use { f ->
+            f.setContent()
+            // The re-entrant measureAndLayout throws inside the effect
+            // coroutine; depending on the Compose version the Recomposer
+            // captures it ("Error was captured in composition") or it
+            // propagates out of sendPointerEvent — either way the re-entry
+            // itself is what the counter pins down.
+            runCatching { f.dragThumb(guarded = false) }
+            assertTrue(
+                f.reentrantRenders > 0,
+                "an inline render from inside the drag's measure pass should have re-entered the render pass",
+            )
+        }
+    }
+
+    private class Fixture : AutoCloseable {
+        val listState = LazyListState()
+
+        /** Frames rendered while a scene entry (pointer dispatch) was still on the stack. */
+        var reentrantRenders = 0
+            private set
+        private var sceneEntryDepth = 0
+
+        private val queue = ConcurrentLinkedQueue<Runnable>()
+        private val posted = ArrayDeque<Runnable>()
+        private var timeNanos = 0L
+        private var bundle: TaoSceneBundle? = null
+
+        // isOnMain is always true: the test thread stands in for the Tao main
+        // thread, exactly like StandaloneFramePumpTest's probe.
+        private val pump: StandaloneFramePump =
+            StandaloneFramePump(
+                isOnMain = { true },
+                post = { posted.addLast(it) },
+            ) { renderNow() }
+
+        // Mirrors the hosts' FlushingDispatcher: queue the block, schedule a frame.
+        private val dispatcher =
+            object : CoroutineDispatcher() {
+                override fun dispatch(
+                    context: CoroutineContext,
+                    block: Runnable,
+                ) {
+                    queue.add(block)
+                    pump.schedule()
+                }
+            }
+
+        init {
+            bundle =
+                canvasLayersSceneBundle(
+                    coroutineContext = dispatcher,
+                    density = Density(1f),
+                    layoutDirection = GlobalLayoutDirection,
+                    size = IntSize(WIDTH, HEIGHT),
+                    platformContext =
+                        object : TaoPlatformContextBase() {
+                            override val windowInfo: WindowInfo =
+                                TaoWindowInfo().apply {
+                                    isWindowFocused = true
+                                    containerSize = IntSize(WIDTH, HEIGHT)
+                                }
+                        },
+                    requestFrame = { pump.schedule() },
+                )
+        }
+
+        /** Mirrors `TaoStandalonePopupHost.renderNow`: drain, then measure + draw. */
+        private fun renderNow() {
+            if (sceneEntryDepth > 0) reentrantRenders++
+            var remaining = queue.size
+            while (remaining-- > 0) queue.poll()?.run()
+            val b = bundle ?: return
+            timeNanos += FRAME_NANOS
+            recordSceneToPicture(b, WIDTH, HEIGHT, timeNanos)
+        }
+
+        fun setContent() {
+            pump.nonReentrant {
+                bundle!!.scene.setContent {
+                    Row(Modifier.fillMaxSize()) {
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.weight(1f).fillMaxHeight(),
+                        ) {
+                            items(ITEM_COUNT) { index ->
+                                // The crash needs a coroutine dispatched from inside
+                                // the drag's measure pass: the LaunchedEffect of a
+                                // freshly subcomposed item is exactly that.
+                                LaunchedEffect(index) { }
+                                Box(Modifier.fillMaxWidth().height(ITEM_HEIGHT_DP.dp))
+                            }
+                        }
+                        VerticalScrollbar(
+                            adapter = rememberScrollbarAdapter(listState),
+                            modifier = Modifier.fillMaxHeight(),
+                        )
+                    }
+                }
+            }
+            pump.schedule()
+            drainPosted()
+        }
+
+        /**
+         * Grabs the scrollbar thumb and drags it down in mouse-sized steps,
+         * like a real drag: each delta scrolls synchronously (`scrollBy` →
+         * `forceRemeasure`), subcomposing a batch of fresh items mid-measure.
+         * A single huge jump would take the adapter's snap path instead and
+         * miss the re-entrancy window.
+         */
+        fun dragThumb(guarded: Boolean) {
+            val x = WIDTH - 4f
+            pointer(PointerEventType.Move, x, THUMB_Y, button = null, guarded = guarded)
+            pointer(PointerEventType.Press, x, THUMB_Y, button = PointerButton.Primary, guarded = guarded)
+            var y = THUMB_Y
+            while (y < DRAG_TO_Y) {
+                y += DRAG_STEP
+                pointer(PointerEventType.Move, x, y, button = null, guarded = guarded)
+            }
+            pointer(PointerEventType.Release, x, y, button = PointerButton.Primary, guarded = guarded)
+        }
+
+        private fun pointer(
+            eventType: PointerEventType,
+            x: Float,
+            y: Float,
+            button: PointerButton?,
+            guarded: Boolean,
+        ) {
+            val send = {
+                sceneEntryDepth++
+                try {
+                    bundle!!.scene.sendPointerEvent(
+                        eventType = eventType,
+                        position = Offset(x, y),
+                        type = PointerType.Mouse,
+                        button = button,
+                    )
+                } finally {
+                    sceneEntryDepth--
+                }
+            }
+            if (guarded) pump.nonReentrant(send) else send()
+            drainPosted()
+        }
+
+        private fun drainPosted() {
+            while (posted.isNotEmpty()) posted.removeFirst().run()
+        }
+
+        override fun close() {
+            // The unguarded test leaves the scene mid-crash; teardown must not
+            // mask the assertion.
+            runCatching { bundle?.close() }
+            bundle = null
+        }
+
+        private companion object {
+            const val WIDTH = 300
+            const val HEIGHT = 300
+            const val ITEM_COUNT = 400
+            const val ITEM_HEIGHT_DP = 20
+            const val THUMB_Y = 8f
+            const val DRAG_TO_Y = 240f
+            const val DRAG_STEP = 8f
+            const val FRAME_NANOS = 16_666_667L
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Bug**: dragging a LazyColumn scrollbar inside a TrayApp popup crashes with `IllegalArgumentException: performMeasureAndLayout called during measure layout`, followed by `entered drag with non-zero pending scroll` from the corrupted drag state. Reported from a real app (AeroDL, Windows), same code path on all three platforms.
- **Cause**: the drag scrolls synchronously inside the pointer event (`LazyListState.onScroll` → `forceRemeasure`); freshly subcomposed items' `LaunchedEffect`s dispatch into the scene dispatcher, whose `dispatch` schedules a frame. `StandaloneFramePump`'s re-entrancy guard only covered renders it started itself, so the frame rendered **inline** — `measureAndLayout` re-entered while the first pass was still on the stack.
- **Fix**: new `StandaloneFramePump.nonReentrant {}` wraps every scene entry point of the three standalone hosts (pointer / scroll / key dispatch, `setContent`). A `schedule()` arriving mid-pass is posted to the Tao main queue instead of rendered inline — one event-loop turn of latency at worst.

## Test plan
- [x] `StandalonePopupRenderReentryTest`: scene-harness repro mirroring the hosts' pump wiring — a real thumb drag (mouse-sized steps; a single big jump takes the adapter's snap path and misses the window) over a 400-item LazyColumn with per-item `LaunchedEffect`s. Guarded run: zero re-entrant renders, list actually scrolled. Unguarded run: re-entry counter pins the failure mode.
- [x] Pump unit tests for `nonReentrant` (schedule inside the block is posted; inline rendering resumes after).
- [x] Both registered in `TaoSceneTestBattery` (+ drift test).
- [x] Verified the repro fails with the guard neutralized and passes with it restored.
- [x] `./gradlew :decorated-window-tao:check` green (ktlint, detekt, apiCheck, kover).