### PR TITLE
feat(tao): native error dialog for fatal exceptions (#622)

### DIFF
--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -118,6 +118,9 @@ val taoHeadfulTest by tasks.registering(JavaExec::class) {
     group = "verification"
     classpath = sourceSets.test.get().runtimeClasspath
     mainClass.set("dev.nucleusframework.window.tao.headful.TaoHeadfulTestSuiteMain")
+    // Unattended: a fatal must fail the suite loudly, not block in the #622
+    // native dialog until the global watchdog halts and eats the real result.
+    systemProperty("nucleus.tao.fatalErrorDialog", "false")
     // Same Kover JVM agent the `test` task uses, so headful window coverage
     // is counted. JavaExec is otherwise invisible to Kover.
     dependsOn(tasks.named("koverFindJar"))
@@ -182,6 +185,8 @@ val taoX11PortalE2E by tasks.registering(JavaExec::class) {
     classpath = sourceSets.test.get().runtimeClasspath
     mainClass.set("dev.nucleusframework.window.tao.headful.TaoHeadfulTestSuiteMain")
     systemProperty("nucleus.tao.headful.filter", "x11 XID")
+    // Unattended — see taoHeadfulTest.
+    systemProperty("nucleus.tao.fatalErrorDialog", "false")
     System.getProperty("nucleus.tao.headful.watchdogMillis")?.let {
         systemProperty("nucleus.tao.headful.watchdogMillis", it)
     }
@@ -194,6 +199,8 @@ val smokeStandalonePanelMac by tasks.registering(JavaExec::class) {
     onlyIf { Os.isFamily(Os.FAMILY_MAC) }
     classpath = sourceSets.test.get().runtimeClasspath
     mainClass.set("dev.nucleusframework.window.tao.StandalonePanelMacSmokeMain")
+    // Unattended — see taoHeadfulTest.
+    systemProperty("nucleus.tao.fatalErrorDialog", "false")
     // Run main() on thread 0 (the macOS main thread). The JVM normally runs
     // main() on a spawned pthread, but AppKit only permits NSWindow/NSPanel
     // creation on the true main thread. -XstartOnFirstThread is the same flag
@@ -213,6 +220,8 @@ val taoTransparentSmoke by tasks.registering(JavaExec::class) {
     group = "verification"
     classpath = sourceSets.test.get().runtimeClasspath
     mainClass.set("dev.nucleusframework.window.tao.headful.TransparentWindowSmokeMain")
+    // Unattended — see taoHeadfulTest.
+    systemProperty("nucleus.tao.fatalErrorDialog", "false")
     // Linux: pin the window to XWayland. Robot goes through the X server, so on
     // a native Wayland session it cannot see the Tao surface (both captures come
     // back byte-identical) and xdg-shell drops setOuterPosition, leaving the
@@ -252,6 +261,27 @@ val taoTransparentSmoke by tasks.registering(JavaExec::class) {
     // -Dnucleus.tao.transparent.smoke.holdMs=10000
     System.getProperty("nucleus.tao.transparent.smoke.holdMs")?.let {
         systemProperty("nucleus.tao.transparent.smoke.holdMs", it)
+    }
+}
+
+// Manual smoke for #622: fatal-exception path end to end — SEVERE log, native
+// error dialog, exit code 1. The expected outcome is Gradle failing with
+// "finished with non-zero exit value 1" after the dialog is dismissed.
+// Not part of `check`.
+val taoFatalDialogSmoke by tasks.registering(JavaExec::class) {
+    description = "Manual smoke: fatal-error path — native dialog then exit code 1 (#622)"
+    group = "verification"
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass.set("dev.nucleusframework.window.tao.headful.FatalErrorDialogSmokeMain")
+    // Forward the crash delay so the window can be looked at first, e.g.
+    // -Dnucleus.tao.fatal.smoke.crashAfterMs=10000
+    System.getProperty("nucleus.tao.fatal.smoke.crashAfterMs")?.let {
+        systemProperty("nucleus.tao.fatal.smoke.crashAfterMs", it)
+    }
+    // Forward the #622 escape hatch so the smoke can also exercise the
+    // dialog-less unattended path: -Dnucleus.tao.fatalErrorDialog=false
+    System.getProperty("nucleus.tao.fatalErrorDialog")?.let {
+        systemProperty("nucleus.tao.fatalErrorDialog", it)
     }
 }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -5,6 +5,9 @@ import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import java.util.logging.Level
+import java.util.logging.Logger
 
 /**
  * Phase 1 entry point for the Tao backend.
@@ -24,19 +27,39 @@ import java.util.concurrent.atomic.AtomicLong
  * [run] does **not** return until [TaoApplication.exit] is called.
  */
 public object TaoApplication {
+    private val logger = Logger.getLogger(TaoApplication::class.java.name)
     private val handleSeq = AtomicLong(1L)
     private val windows = ConcurrentHashMap<Long, TaoWindow>()
     private var onLaunched: ((TaoApplication) -> Unit)? = null
 
     /**
+     * First unhandled [Throwable] that escaped an event dispatch on the Tao
+     * main thread (first report wins). Recorded by [reportFatal]; [run] shows
+     * the native error dialog and rethrows it after the loop exits so the
+     * failure surfaces to the caller instead of vanishing into the JNI
+     * boundary (Rust clears pending exceptions — issue #622).
+     */
+    private val fatalError = AtomicReference<Throwable?>(null)
+
+    /**
      * Takes over the calling thread (must be the macOS main thread) and runs
      * the Tao event loop. Calls [block] once on launch with this object.
+     *
+     * If an exception escapes an event dispatch (including [block] itself),
+     * the default fatal path runs — SEVERE log, native error dialog, clean
+     * loop exit — and the throwable is then **rethrown from this function**
+     * (#622). Callers that leave non-daemon threads alive (AWT/Swing) must
+     * catch it and terminate the process themselves; [taoApplication] does.
      */
     public fun run(block: (TaoApplication) -> Unit) {
         check(NativeTaoBridge.isLoaded) {
             "nucleus_tao native library is not available — supported targets: " +
                 "macOS (arm64/x86_64), Windows (x64/aarch64), Linux (x64/aarch64)."
         }
+        // Fresh run: the native side supports re-running the loop, so a stale
+        // fatal from a previous run must neither rethrow on a clean one nor
+        // make a genuine new fatal take the log-only branch.
+        fatalError.set(null)
         // Capture the Tao main thread eagerly, before the native event loop
         // takes over this thread. Required so `Dispatchers.Main` consumers
         // (notably AndroidX Lifecycle's synchronous `MainDispatcherChecker`)
@@ -57,6 +80,54 @@ public object TaoApplication {
         LifecycleMainDispatcherPriming.primeWithCurrentThread()
         onLaunched = block
         NativeTaoBridge.nativeRunBlocking(EventDispatcher)
+        fatalError.get()?.let { t ->
+            // The loop has exited (reportFatal posted the exit) and every tao
+            // callback frame is unwound — only now is it safe to block in the
+            // app-modal native dialog (a modal pump inside a tao callback
+            // re-enters tao's non-reentrant handler mutex on Dock-reopen /
+            // deep-link events and deadlocks the main thread). Then surface
+            // the failure to the caller like any uncaught exception.
+            showNativeErrorDialog(
+                title = "Fatal Error",
+                message = "The application encountered an unrecoverable error and will close.\n\n$t",
+            )
+            throw t
+        }
+    }
+
+    /**
+     * Default fatal-exception path (#622): an exception that escapes an event
+     * dispatch would otherwise be cleared at the JNI boundary, leaving a
+     * frozen, silent, unclosable window. Records [t] and posts a loop exit;
+     * [run] then shows the native error dialog and rethrows. First report
+     * wins — later ones (including any thrown during the shutdown the first
+     * triggered) are only logged. [exit] is posted *before* logging so the
+     * loop unwinds even if log formatting itself throws (e.g. an
+     * OutOfMemoryError materializing the stack trace). Never freeze.
+     *
+     * Internal so the Compose layer (coroutine exception handler, render
+     * loop) routes its own unrecoverable failures through the same path.
+     */
+    internal fun reportFatal(t: Throwable) {
+        if (!fatalError.compareAndSet(null, t)) {
+            logger.log(Level.SEVERE, "Unhandled exception on the Tao main thread while shutting down", t)
+            return
+        }
+        exit()
+        logger.log(Level.SEVERE, "Unhandled exception on the Tao main thread — closing", t)
+    }
+
+    /** `true` when [t] is the recorded fatal error — already logged and shown. */
+    internal fun isReportedFatal(t: Throwable): Boolean = fatalError.get() === t
+
+    /** Runs [block], routing any escaped [Throwable] to [reportFatal]. */
+    @Suppress("TooGenericExceptionCaught")
+    private inline fun guarded(block: () -> Unit) {
+        try {
+            block()
+        } catch (t: Throwable) {
+            reportFatal(t)
+        }
     }
 
     /** Posts an exit request and unblocks [run]. */
@@ -138,14 +209,16 @@ public object TaoApplication {
             a: Int,
             b: Int,
         ) {
-            when (code) {
-                TaoEventCode.LAUNCHED -> {
-                    val cb = onLaunched
-                    onLaunched = null
-                    cb?.invoke(this@TaoApplication)
+            guarded {
+                when (code) {
+                    TaoEventCode.LAUNCHED -> {
+                        val cb = onLaunched
+                        onLaunched = null
+                        cb?.invoke(this@TaoApplication)
+                    }
+                    TaoEventCode.MAIN_EVENTS_CLEARED -> TaoMainDispatcher.pump()
+                    else -> lookup(handle)?.dispatch(code, a, b)
                 }
-                TaoEventCode.MAIN_EVENTS_CLEARED -> TaoMainDispatcher.pump()
-                else -> lookup(handle)?.dispatch(code, a, b)
             }
         }
 
@@ -157,7 +230,7 @@ public object TaoApplication {
             modifiers: Int,
             codePoint: Int,
         ) {
-            lookup(handle)?.dispatchKey(type, vkCode, keyLocation, modifiers, codePoint)
+            guarded { lookup(handle)?.dispatchKey(type, vkCode, keyLocation, modifiers, codePoint) }
         }
 
         override fun onTrackpadGesture(
@@ -168,7 +241,7 @@ public object TaoApplication {
             yFixed: Int,
             valueFixed: Int,
         ) {
-            lookup(handle)?.dispatchTrackpadGesture(kind, phase, xFixed, yFixed, valueFixed)
+            guarded { lookup(handle)?.dispatchTrackpadGesture(kind, phase, xFixed, yFixed, valueFixed) }
         }
 
         override fun onTouchInput(
@@ -179,7 +252,7 @@ public object TaoApplication {
             yFixed: Int,
             forceFixed: Int,
         ) {
-            lookup(handle)?.dispatchTouchInput(phase, id, xFixed, yFixed, forceFixed)
+            guarded { lookup(handle)?.dispatchTouchInput(phase, id, xFixed, yFixed, forceFixed) }
         }
 
         override fun onImeReplaceCommit(
@@ -188,21 +261,50 @@ public object TaoApplication {
             replacementStart: Long,
             replacementLength: Long,
         ) {
-            lookup(handle)?.dispatchImeReplaceCommit(text, replacementStart, replacementLength)
+            guarded { lookup(handle)?.dispatchImeReplaceCommit(text, replacementStart, replacementLength) }
         }
 
         override fun onImePreedit(
             handle: Long,
             text: String,
         ) {
-            lookup(handle)?.dispatchImePreedit(text)
+            guarded { lookup(handle)?.dispatchImePreedit(text) }
         }
 
         override fun onImeCommit(
             handle: Long,
             text: String,
         ) {
-            lookup(handle)?.dispatchImeCommit(text)
+            guarded { lookup(handle)?.dispatchImeCommit(text) }
         }
+    }
+}
+
+/**
+ * Shows the blocking, app-modal native fatal-error dialog when the Tao
+ * native library is available; no-ops otherwise (the SEVERE log is the
+ * fallback). Never throws — this runs on the fatal path, where a secondary
+ * failure must not mask the clean shutdown. macOS only for now; Windows and
+ * Linux no-op inside the native library (#622).
+ */
+@Suppress("TooGenericExceptionCaught")
+internal fun showNativeErrorDialog(
+    title: String,
+    message: String,
+) {
+    // `nucleus.tao.fatalErrorDialog=false` is the escape hatch for unattended
+    // runs (CI, AOT training): a blocking modal nobody can dismiss would hang
+    // the process there; the SEVERE log is the signal instead.
+    if (!NativeTaoBridge.isLoaded ||
+        !System.getProperty("nucleus.tao.fatalErrorDialog", "true").toBoolean()
+    ) {
+        return
+    }
+    try {
+        NativeTaoBridge.nativeShowErrorDialog(title, message)
+    } catch (t: Throwable) {
+        Logger
+            .getLogger(TaoApplication::class.java.name)
+            .log(Level.WARNING, "Native error dialog failed", t)
     }
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -284,8 +284,8 @@ public object TaoApplication {
  * Shows the blocking, app-modal native fatal-error dialog when the Tao
  * native library is available; no-ops otherwise (the SEVERE log is the
  * fallback). Never throws — this runs on the fatal path, where a secondary
- * failure must not mask the clean shutdown. macOS only for now; Windows and
- * Linux no-op inside the native library (#622).
+ * failure must not mask the clean shutdown. macOS and Windows; Linux still
+ * no-ops inside the native library (#622).
  */
 @Suppress("TooGenericExceptionCaught")
 internal fun showNativeErrorDialog(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -3,7 +3,9 @@ package dev.nucleusframework.window.tao
 import dev.nucleusframework.window.tao.dispatch.LifecycleMainDispatcherPriming
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+import kotlinx.coroutines.CoroutineExceptionHandler
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.logging.Level
@@ -41,6 +43,9 @@ public object TaoApplication {
      */
     private val fatalError = AtomicReference<Throwable?>(null)
 
+    /** Ensures the native dialog is shown at most once per recorded fatal. */
+    private val fatalDialogShown = AtomicBoolean(false)
+
     /**
      * Takes over the calling thread (must be the macOS main thread) and runs
      * the Tao event loop. Calls [block] once on launch with this object.
@@ -60,6 +65,7 @@ public object TaoApplication {
         // fatal from a previous run must neither rethrow on a clean one nor
         // make a genuine new fatal take the log-only branch.
         fatalError.set(null)
+        fatalDialogShown.set(false)
         // Capture the Tao main thread eagerly, before the native event loop
         // takes over this thread. Required so `Dispatchers.Main` consumers
         // (notably AndroidX Lifecycle's synchronous `MainDispatcherChecker`)
@@ -80,19 +86,32 @@ public object TaoApplication {
         LifecycleMainDispatcherPriming.primeWithCurrentThread()
         onLaunched = block
         NativeTaoBridge.nativeRunBlocking(EventDispatcher)
-        fatalError.get()?.let { t ->
-            // The loop has exited (reportFatal posted the exit) and every tao
-            // callback frame is unwound — only now is it safe to block in the
-            // app-modal native dialog (a modal pump inside a tao callback
-            // re-enters tao's non-reentrant handler mutex on Dock-reopen /
-            // deep-link events and deadlocks the main thread). Then surface
-            // the failure to the caller like any uncaught exception.
+        // The loop has exited (reportFatal posted the exit) and every tao
+        // callback frame is unwound — only now is it safe to block in the
+        // app-modal native dialog (a modal pump inside a tao callback
+        // re-enters tao's non-reentrant handler mutex on Dock-reopen /
+        // deep-link events and deadlocks the main thread).
+        rethrowPendingFatal()
+    }
+
+    /**
+     * Shows the native error dialog (once) and rethrows the recorded fatal,
+     * if any. [run] calls it right after the loop exits; [taoApplication]
+     * calls it again just before its clean `exitProcess(0)` to catch a fatal
+     * reported from a non-main thread (the coroutine exception handler runs
+     * on the failing coroutine's thread) after [run]'s check already passed —
+     * without the recheck such a crash would end the process with exit
+     * code 0 as if the user had quit normally.
+     */
+    internal fun rethrowPendingFatal() {
+        val t = fatalError.get() ?: return
+        if (fatalDialogShown.compareAndSet(false, true)) {
             showNativeErrorDialog(
                 title = "Fatal Error",
                 message = "The application encountered an unrecoverable error and will close.\n\n$t",
             )
-            throw t
         }
+        throw t
     }
 
     /**
@@ -110,6 +129,11 @@ public object TaoApplication {
      */
     internal fun reportFatal(t: Throwable) {
         if (!fatalError.compareAndSet(null, t)) {
+            // Re-post the exit: the first report's exit() silently no-ops when
+            // it lands before the event-loop proxy is (re-)installed, and
+            // first-report-wins must never leave the loop running with a
+            // recorded fatal nobody will act on.
+            exit()
             logger.log(Level.SEVERE, "Unhandled exception on the Tao main thread while shutting down", t)
             return
         }
@@ -281,11 +305,35 @@ public object TaoApplication {
 }
 
 /**
+ * Routes unhandled coroutine failures to [TaoApplication.reportFatal] (#622).
+ * Installed by the scene-bundle factories (`TaoSceneBundle.kt` — every scene,
+ * including popup layers and standalone popups, funnels through them, with a
+ * teardown filter), the macOS render loop and the [taoApplication] scope, so
+ * composition-side crashes (LaunchedEffect, recomposition, the render frame)
+ * take the fatal path — without a handler they die in kotlinx's global
+ * handler (stderr only) and the window silently stops recomposing.
+ */
+internal val TaoFatalCoroutineExceptionHandler: CoroutineExceptionHandler =
+    CoroutineExceptionHandler { _, t -> TaoApplication.reportFatal(t) }
+
+/**
+ * Log-only counterpart of [TaoFatalCoroutineExceptionHandler] for scopes
+ * whose children are deliberately isolated (`SupervisorJob` gesture helpers):
+ * a crash there costs one gesture, not the app. SEVERE keeps it loud without
+ * escalating.
+ */
+internal val TaoNonFatalCoroutineExceptionHandler: CoroutineExceptionHandler =
+    CoroutineExceptionHandler { _, t ->
+        Logger
+            .getLogger(TaoApplication::class.java.name)
+            .log(Level.SEVERE, "Unhandled exception in an isolated Tao coroutine", t)
+    }
+
+/**
  * Shows the blocking, app-modal native fatal-error dialog when the Tao
  * native library is available; no-ops otherwise (the SEVERE log is the
  * fallback). Never throws — this runs on the fatal path, where a secondary
- * failure must not mask the clean shutdown. macOS and Windows; Linux still
- * no-ops inside the native library (#622).
+ * failure must not mask the clean shutdown. macOS, Windows and Linux (#622).
  */
 @Suppress("TooGenericExceptionCaught")
 internal fun showNativeErrorDialog(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplicationCompose.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplicationCompose.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -20,6 +21,8 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.logging.Level
+import java.util.logging.Logger
 import kotlin.system.exitProcess
 
 /**
@@ -35,27 +38,60 @@ import kotlin.system.exitProcess
  * `LaunchedEffect`/`DisposableEffect`, observe `MutableState`, etc. The
  * composition lives until [ApplicationScope.exitApplication] is called.
  *
- * The JVM is terminated with `exitProcess(0)` once the Tao event loop
- * returns. Required because Compose/Skiko initialisation indirectly touches
+ * The JVM is terminated once the Tao event loop returns: `exitProcess(0)`
+ * on a normal quit, `exitProcess(1)` after a fatal error (#622 — already
+ * logged at SEVERE and shown in the native error dialog by then). A forced
+ * exit is required because Compose/Skiko initialisation indirectly touches
  * AWT, which spawns the non-daemon EDT, and that thread keeps the JVM alive
  * long after the Tao loop has shut down. Mirrors Compose Desktop's
  * `application { … }` (which also force-exits the process).
  */
 @OptIn(ExperimentalFoundationApi::class)
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
 public fun taoApplication(content: @Composable ApplicationScope.() -> Unit) {
     check(NativeTaoBridge.isLoaded) {
         "nucleus_tao native library is not available — supported targets: " +
             "macOS (arm64/x86_64), Windows (x64/aarch64), Linux (x64/aarch64)."
     }
 
+    // A fatal dispatch failure (#622) is rethrown by TaoApplication.run after
+    // the loop exits — it was already logged at SEVERE and shown in the native
+    // error dialog, so here it only needs to become a non-zero exit. A plain
+    // rethrow would skip exitProcess(0) below and the non-daemon AWT EDT would
+    // keep the dead process alive.
+    try {
+        runTaoComposeLoop(content)
+    } catch (t: Throwable) {
+        // Anything that is NOT the already-handled fatal (broken native lib,
+        // wrong-thread init failure, …) would otherwise vanish with exit
+        // code 1 and zero output — log it before exiting.
+        if (!TaoApplication.isReportedFatal(t)) {
+            composeEntryLogger.log(Level.SEVERE, "taoApplication failed", t)
+        }
+        exitProcess(1)
+    }
+    exitProcess(0)
+}
+
+private val composeEntryLogger: Logger = Logger.getLogger(TaoApplication::class.java.name)
+
+@OptIn(ExperimentalFoundationApi::class)
+private fun runTaoComposeLoop(content: @Composable ApplicationScope.() -> Unit) {
     TaoApplication.run { app ->
         val scope = ComposableApplicationScope(app)
         // CoroutineScope pinned to the Tao main thread. Every `launch` posts
         // the block via TaoMainDispatcher, which queues onto the Tao event
         // loop and runs at the next `MainEventsCleared` pump tick.
+        // Route unhandled coroutine failures — recomposition, LaunchedEffects,
+        // the initial setContent — into the #622 fatal path. Without this they
+        // fall to the thread's default handler (stderr only), the shared Job
+        // cancels the composition coroutine whose `finally` exits the loop, and
+        // the process would end with code 0 as if the user had quit normally.
+        val fatalHandler =
+            CoroutineExceptionHandler { _, t -> TaoApplication.reportFatal(t) }
         val coroutineScope =
             CoroutineScope(
-                TaoMainDispatcher + TaoFrameClock + Job(),
+                TaoMainDispatcher + TaoFrameClock + Job() + fatalHandler,
             )
 
         // Snapshot apply observer: forwards state writes from any thread back
@@ -99,7 +135,6 @@ public fun taoApplication(content: @Composable ApplicationScope.() -> Unit) {
         // Return → Tao event loop continues. Pumps fire MAIN_EVENTS_CLEARED
         // and the Compose machinery resumes between platform events.
     }
-    exitProcess(0)
 }
 
 /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplicationCompose.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplicationCompose.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -61,6 +60,11 @@ public fun taoApplication(content: @Composable ApplicationScope.() -> Unit) {
     // keep the dead process alive.
     try {
         runTaoComposeLoop(content)
+        // Recheck: reportFatal can fire from a non-main thread (the coroutine
+        // exception handler runs on the failing coroutine's thread) after
+        // run()'s own post-loop check already passed — without this a genuine
+        // fatal would fall through to exitProcess(0) below.
+        TaoApplication.rethrowPendingFatal()
     } catch (t: Throwable) {
         // Anything that is NOT the already-handled fatal (broken native lib,
         // wrong-thread init failure, …) would otherwise vanish with exit
@@ -87,11 +91,9 @@ private fun runTaoComposeLoop(content: @Composable ApplicationScope.() -> Unit) 
         // fall to the thread's default handler (stderr only), the shared Job
         // cancels the composition coroutine whose `finally` exits the loop, and
         // the process would end with code 0 as if the user had quit normally.
-        val fatalHandler =
-            CoroutineExceptionHandler { _, t -> TaoApplication.reportFatal(t) }
         val coroutineScope =
             CoroutineScope(
-                TaoMainDispatcher + TaoFrameClock + Job() + fatalHandler,
+                TaoMainDispatcher + TaoFrameClock + Job() + TaoFatalCoroutineExceptionHandler,
             )
 
         // Snapshot apply observer: forwards state writes from any thread back

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/dispatch/TaoMainDispatcher.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/dispatch/TaoMainDispatcher.kt
@@ -9,6 +9,8 @@ import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.logging.Level
+import java.util.logging.Logger
 import kotlin.coroutines.CoroutineContext
 
 private const val FALLBACK_QUIESCE_TIMEOUT_SECONDS = 2L
@@ -26,6 +28,7 @@ private const val FALLBACK_THREAD_NAME = "Nucleus-Tao-Main-Fallback"
  * [TaoApplication] arranges that via the JNI event callback.
  */
 internal object TaoMainDispatcher : CoroutineDispatcher() {
+    private val logger = Logger.getLogger(TaoMainDispatcher::class.java.name)
     private val pending = ConcurrentLinkedQueue<Runnable>()
 
     /**
@@ -246,13 +249,13 @@ internal object TaoMainDispatcher : CoroutineDispatcher() {
         while (!loopRunning) {
             val block = pending.poll() ?: break
             ranAnything = true
-            @Suppress("TooGenericExceptionCaught", "PrintStackTrace")
+            @Suppress("TooGenericExceptionCaught")
             try {
                 block.run()
             } catch (t: Throwable) {
                 // Match pump(): dispatchers swallow synchronous throwables so a
                 // single failing block never kills the drain.
-                t.printStackTrace()
+                logger.log(Level.SEVERE, "Unhandled exception in a block dispatched to the Tao main thread", t)
             }
         }
         if (ranAnything) {
@@ -273,7 +276,7 @@ internal object TaoMainDispatcher : CoroutineDispatcher() {
         // it yield to rendering + the throttled re-arm below.
         val deadlineNs = System.nanoTime() + PUMP_TIME_BUDGET_NS
         var pass = 0
-        @Suppress("TooGenericExceptionCaught", "PrintStackTrace", "LoopWithTooManyJumpStatements")
+        @Suppress("TooGenericExceptionCaught", "LoopWithTooManyJumpStatements")
         while (pass++ < MAX_PUMP_PASSES) {
             var remaining = pending.size
             if (remaining == 0) break
@@ -285,9 +288,10 @@ internal object TaoMainDispatcher : CoroutineDispatcher() {
                     block.run()
                 } catch (t: Throwable) {
                     // Coroutine dispatchers swallow exceptions thrown synchronously
-                    // from `run()`; the runtime reports them via the Recomposer's
-                    // exception handler. Re-throwing here would crash the Tao loop.
-                    t.printStackTrace()
+                    // from `run()`; the runtime reports them via the coroutine
+                    // exception handler (routed to the #622 fatal path by
+                    // taoApplication). Re-throwing here would crash the Tao loop.
+                    logger.log(Level.SEVERE, "Unhandled exception in a block dispatched to the Tao main thread", t)
                 }
                 if (System.nanoTime() >= deadlineNs) {
                     hitDeadline = true

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/dispatch/TaoMainDispatcher.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/dispatch/TaoMainDispatcher.kt
@@ -1,6 +1,7 @@
 package dev.nucleusframework.window.tao.dispatch
 
 import androidx.compose.runtime.snapshots.Snapshot
+import dev.nucleusframework.window.tao.TaoApplication
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import kotlinx.coroutines.CoroutineDispatcher
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -253,8 +254,11 @@ internal object TaoMainDispatcher : CoroutineDispatcher() {
             try {
                 block.run()
             } catch (t: Throwable) {
-                // Match pump(): dispatchers swallow synchronous throwables so a
-                // single failing block never kills the drain.
+                // Unlike pump(), stay log-only: the fallback drain runs while
+                // the loop is NOT running (before it starts or after it
+                // exited), so escalating a leftover block's failure to the
+                // fatal path would race run()'s post-loop rethrow and could
+                // turn a clean quit into exit 1 over teardown noise.
                 logger.log(Level.SEVERE, "Unhandled exception in a block dispatched to the Tao main thread", t)
             }
         }
@@ -287,11 +291,16 @@ internal object TaoMainDispatcher : CoroutineDispatcher() {
                 try {
                     block.run()
                 } catch (t: Throwable) {
-                    // Coroutine dispatchers swallow exceptions thrown synchronously
-                    // from `run()`; the runtime reports them via the coroutine
-                    // exception handler (routed to the #622 fatal path by
-                    // taoApplication). Re-throwing here would crash the Tao loop.
-                    logger.log(Level.SEVERE, "Unhandled exception in a block dispatched to the Tao main thread", t)
+                    // Coroutine dispatches never throw here (DispatchedTask
+                    // reports through the coroutine exception handler), so
+                    // this catch fires only for raw Runnables — framework
+                    // internals like the standalone-popup frame pump and the
+                    // Windows/Linux a11y action dispatch. Those must take the
+                    // #622 fatal path like every other dispatch: log-only
+                    // would leave a popup frozen re-throwing every frame.
+                    // reportFatal never throws and is first-report-wins, so
+                    // the drain survives. Re-throwing would crash the Tao loop.
+                    TaoApplication.reportFatal(t)
                 }
                 if (System.nanoTime() >= deadlineNs) {
                     hitDeadline = true

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -3,6 +3,8 @@ package dev.nucleusframework.window.tao.ffi
 import dev.nucleusframework.core.runtime.NativeLibraryLoader
 import dev.nucleusframework.window.tao.TaoAccessibilityRegistry
 import dev.nucleusframework.window.tao.TaoDeepLinkBridge
+import java.util.logging.Level
+import java.util.logging.Logger
 
 private const val LIBRARY_NAME = "nucleus_tao"
 
@@ -18,9 +20,26 @@ private const val LIBRARY_NAME = "nucleus_tao"
  */
 @Suppress("TooManyFunctions")
 internal object NativeTaoBridge {
+    private val logger = Logger.getLogger(NativeTaoBridge::class.java.name)
     private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeTaoBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
+
+    /**
+     * Guard for native → JVM upcalls outside the [EventCallback] surface
+     * (deep links, a11y actions). An exception escaping into JNI is cleared
+     * silently by the Rust side (#622) — log it at SEVERE instead. These are
+     * one-shot handlers, not the render/dispatch path, so a failure is loud
+     * but non-fatal.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private inline fun upcall(block: () -> Unit) {
+        try {
+            block()
+        } catch (t: Throwable) {
+            logger.log(Level.SEVERE, "Unhandled exception in a native → JVM upcall", t)
+        }
+    }
 
     /**
      * Receives events dispatched from the Rust event loop, called on the
@@ -215,6 +234,21 @@ internal object NativeTaoBridge {
     external fun nativeExit()
 
     /**
+     * Shows a blocking native error dialog — the no-AWT replacement for
+     * Compose Desktop's Swing default (#622). macOS only for now
+     * (CFUserNotificationDisplayAlert: out-of-process, callable from any
+     * thread, no NSApp/run-loop dependency — safe before, during and after
+     * the Tao loop); Windows and Linux are silent no-ops until their
+     * implementations land. Call it only outside tao callback frames — a
+     * modal pump inside one re-enters tao's non-reentrant handler mutex.
+     */
+    @JvmStatic
+    external fun nativeShowErrorDialog(
+        title: String,
+        message: String,
+    )
+
+    /**
      * Wakes the Tao event loop so a coroutine just posted to
      * [TaoMainDispatcher] runs on the next tick. Required because Tao runs
      * with `ControlFlow::Wait` and would otherwise sleep until an OS event
@@ -230,7 +264,7 @@ internal object NativeTaoBridge {
     @JvmStatic
     @Suppress("unused") // called from JNI (macOS Event::Opened → apple_events::dispatch_deep_link)
     fun dispatchDeepLink(uri: String) {
-        TaoDeepLinkBridge.onUrlFromNative(uri)
+        upcall { TaoDeepLinkBridge.onUrlFromNative(uri) }
     }
 
     /**
@@ -846,7 +880,7 @@ internal object NativeTaoBridge {
         nodeId: Long,
         action: Int,
     ) {
-        TaoAccessibilityRegistry.dispatchAction(handle, nodeId, action)
+        upcall { TaoAccessibilityRegistry.dispatchAction(handle, nodeId, action) }
     }
 
     @JvmStatic
@@ -856,7 +890,7 @@ internal object NativeTaoBridge {
         nodeId: Long,
         action: Int,
     ) {
-        TaoAccessibilityRegistry.dispatchActionByNsView(nsView, nodeId, action)
+        upcall { TaoAccessibilityRegistry.dispatchActionByNsView(nsView, nodeId, action) }
     }
 
     @JvmStatic
@@ -866,7 +900,7 @@ internal object NativeTaoBridge {
         nodeId: Long,
         text: String,
     ) {
-        TaoAccessibilityRegistry.dispatchSetText(nsView, nodeId, text)
+        upcall { TaoAccessibilityRegistry.dispatchSetText(nsView, nodeId, text) }
     }
 
     @JvmStatic
@@ -877,7 +911,7 @@ internal object NativeTaoBridge {
         start: Int,
         end: Int,
     ) {
-        TaoAccessibilityRegistry.dispatchSetSelection(nsView, nodeId, start, end)
+        upcall { TaoAccessibilityRegistry.dispatchSetSelection(nsView, nodeId, start, end) }
     }
 
     @JvmStatic
@@ -887,7 +921,7 @@ internal object NativeTaoBridge {
         nodeId: Long,
         index: Int,
     ) {
-        TaoAccessibilityRegistry.dispatchCustomAction(nsView, nodeId, index)
+        upcall { TaoAccessibilityRegistry.dispatchCustomAction(nsView, nodeId, index) }
     }
 
     @JvmStatic
@@ -898,7 +932,7 @@ internal object NativeTaoBridge {
         dx: Float,
         dy: Float,
     ) {
-        TaoAccessibilityRegistry.dispatchScrollBy(nsView, nodeId, dx, dy)
+        upcall { TaoAccessibilityRegistry.dispatchScrollBy(nsView, nodeId, dx, dy) }
     }
 
     /**
@@ -913,6 +947,6 @@ internal object NativeTaoBridge {
         nodeId: Long,
         value: Double,
     ) {
-        TaoAccessibilityRegistry.dispatchSetValue(nsView, nodeId, value)
+        upcall { TaoAccessibilityRegistry.dispatchSetValue(nsView, nodeId, value) }
     }
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -235,12 +235,13 @@ internal object NativeTaoBridge {
 
     /**
      * Shows a blocking native error dialog — the no-AWT replacement for
-     * Compose Desktop's Swing default (#622). macOS only for now
+     * Compose Desktop's Swing default (#622). macOS
      * (CFUserNotificationDisplayAlert: out-of-process, callable from any
      * thread, no NSApp/run-loop dependency — safe before, during and after
-     * the Tao loop); Windows and Linux are silent no-ops until their
-     * implementations land. Call it only outside tao callback frames — a
-     * modal pump inside one re-enters tao's non-reentrant handler mutex.
+     * the Tao loop) and Windows (task-modal MessageBoxW, callable from any
+     * thread); Linux is a silent no-op until its implementation lands.
+     * Call it only outside tao callback frames — a modal pump inside one
+     * re-enters tao's non-reentrant handler mutex.
      */
     @JvmStatic
     external fun nativeShowErrorDialog(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -2,6 +2,7 @@ package dev.nucleusframework.window.tao.ffi
 
 import dev.nucleusframework.core.runtime.NativeLibraryLoader
 import dev.nucleusframework.window.tao.TaoAccessibilityRegistry
+import dev.nucleusframework.window.tao.TaoApplication
 import dev.nucleusframework.window.tao.TaoDeepLinkBridge
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -26,11 +27,10 @@ internal object NativeTaoBridge {
     val isLoaded: Boolean get() = loaded
 
     /**
-     * Guard for native → JVM upcalls outside the [EventCallback] surface
-     * (deep links, a11y actions). An exception escaping into JNI is cleared
-     * silently by the Rust side (#622) — log it at SEVERE instead. These are
-     * one-shot handlers, not the render/dispatch path, so a failure is loud
-     * but non-fatal.
+     * Guard for native → JVM upcalls that run framework plumbing only (deep
+     * links). An exception escaping into JNI is cleared silently by the Rust
+     * side (#622) — log it at SEVERE instead. One-shot handlers, not the
+     * render/dispatch path, so a failure is loud but non-fatal.
      */
     @Suppress("TooGenericExceptionCaught")
     private inline fun upcall(block: () -> Unit) {
@@ -38,6 +38,23 @@ internal object NativeTaoBridge {
             block()
         } catch (t: Throwable) {
             logger.log(Level.SEVERE, "Unhandled exception in a native → JVM upcall", t)
+        }
+    }
+
+    /**
+     * Guard for native → JVM upcalls that run **app code** — a11y actions
+     * invoke the same semantics lambdas (e.g. `Modifier.clickable` onClick)
+     * that are fatal when reached via mouse or keyboard (#622). A crash must
+     * behave identically regardless of input modality, so these route to
+     * [TaoApplication.reportFatal] instead of a log-only swallow that would
+     * leave screen-reader users with an app whose state desynced mid-action.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private inline fun fatalUpcall(block: () -> Unit) {
+        try {
+            block()
+        } catch (t: Throwable) {
+            TaoApplication.reportFatal(t)
         }
     }
 
@@ -238,8 +255,9 @@ internal object NativeTaoBridge {
      * Compose Desktop's Swing default (#622). macOS
      * (CFUserNotificationDisplayAlert: out-of-process, callable from any
      * thread, no NSApp/run-loop dependency — safe before, during and after
-     * the Tao loop) and Windows (task-modal MessageBoxW, callable from any
-     * thread); Linux is a silent no-op until its implementation lands.
+     * the Tao loop), Windows (task-modal MessageBoxW, callable from any
+     * thread) and Linux (modal GtkMessageDialog — GTK-main-thread only,
+     * i.e. the thread that ran the Tao loop).
      * Call it only outside tao callback frames — a modal pump inside one
      * re-enters tao's non-reentrant handler mutex.
      */
@@ -881,7 +899,7 @@ internal object NativeTaoBridge {
         nodeId: Long,
         action: Int,
     ) {
-        upcall { TaoAccessibilityRegistry.dispatchAction(handle, nodeId, action) }
+        fatalUpcall { TaoAccessibilityRegistry.dispatchAction(handle, nodeId, action) }
     }
 
     @JvmStatic
@@ -891,7 +909,7 @@ internal object NativeTaoBridge {
         nodeId: Long,
         action: Int,
     ) {
-        upcall { TaoAccessibilityRegistry.dispatchActionByNsView(nsView, nodeId, action) }
+        fatalUpcall { TaoAccessibilityRegistry.dispatchActionByNsView(nsView, nodeId, action) }
     }
 
     @JvmStatic
@@ -901,7 +919,7 @@ internal object NativeTaoBridge {
         nodeId: Long,
         text: String,
     ) {
-        upcall { TaoAccessibilityRegistry.dispatchSetText(nsView, nodeId, text) }
+        fatalUpcall { TaoAccessibilityRegistry.dispatchSetText(nsView, nodeId, text) }
     }
 
     @JvmStatic
@@ -912,7 +930,7 @@ internal object NativeTaoBridge {
         start: Int,
         end: Int,
     ) {
-        upcall { TaoAccessibilityRegistry.dispatchSetSelection(nsView, nodeId, start, end) }
+        fatalUpcall { TaoAccessibilityRegistry.dispatchSetSelection(nsView, nodeId, start, end) }
     }
 
     @JvmStatic
@@ -922,7 +940,7 @@ internal object NativeTaoBridge {
         nodeId: Long,
         index: Int,
     ) {
-        upcall { TaoAccessibilityRegistry.dispatchCustomAction(nsView, nodeId, index) }
+        fatalUpcall { TaoAccessibilityRegistry.dispatchCustomAction(nsView, nodeId, index) }
     }
 
     @JvmStatic
@@ -933,7 +951,7 @@ internal object NativeTaoBridge {
         dx: Float,
         dy: Float,
     ) {
-        upcall { TaoAccessibilityRegistry.dispatchScrollBy(nsView, nodeId, dx, dy) }
+        fatalUpcall { TaoAccessibilityRegistry.dispatchScrollBy(nsView, nodeId, dx, dy) }
     }
 
     /**
@@ -948,6 +966,6 @@ internal object NativeTaoBridge {
         nodeId: Long,
         value: Double,
     ) {
-        upcall { TaoAccessibilityRegistry.dispatchSetValue(nsView, nodeId, value) }
+        fatalUpcall { TaoAccessibilityRegistry.dispatchSetValue(nsView, nodeId, value) }
     }
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -1371,8 +1371,19 @@ internal class TaoComposeSceneHost(
      * thread (suspending — the Tao main loop stays free for input meanwhile).
      */
     private fun startRenderLoop(handle: Long) {
+        // FrameDispatcher runs ONE long-lived coroutine: an exception in a
+        // frame kills it for good, and the SupervisorJob would swallow the
+        // failure — the window silently stops repainting (#622). Route it to
+        // the fatal path instead (SEVERE log, native dialog, clean exit).
+        val fatalHandler =
+            kotlinx.coroutines.CoroutineExceptionHandler { _, t ->
+                dev.nucleusframework.window.tao.TaoApplication
+                    .reportFatal(t)
+            }
         val scope =
-            kotlinx.coroutines.CoroutineScope(coroutineContext + TaoMainDispatcher + renderLoopJob)
+            kotlinx.coroutines.CoroutineScope(
+                coroutineContext + TaoMainDispatcher + renderLoopJob + fatalHandler,
+            )
         frameDispatcher =
             org.jetbrains.skiko.FrameDispatcher(scope) {
                 renderFrameSuspending(handle)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -25,6 +25,7 @@ import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.MacOSStyle
 import dev.nucleusframework.window.tao.TaoCursorIcon
 import dev.nucleusframework.window.tao.TaoEventCode
+import dev.nucleusframework.window.tao.TaoFatalCoroutineExceptionHandler
 import dev.nucleusframework.window.tao.TaoKeyLocation
 import dev.nucleusframework.window.tao.TaoModifierMask
 import dev.nucleusframework.window.tao.TaoNativeViewHost
@@ -1375,14 +1376,9 @@ internal class TaoComposeSceneHost(
         // frame kills it for good, and the SupervisorJob would swallow the
         // failure — the window silently stops repainting (#622). Route it to
         // the fatal path instead (SEVERE log, native dialog, clean exit).
-        val fatalHandler =
-            kotlinx.coroutines.CoroutineExceptionHandler { _, t ->
-                dev.nucleusframework.window.tao.TaoApplication
-                    .reportFatal(t)
-            }
         val scope =
             kotlinx.coroutines.CoroutineScope(
-                coroutineContext + TaoMainDispatcher + renderLoopJob + fatalHandler,
+                coroutineContext + TaoMainDispatcher + renderLoopJob + TaoFatalCoroutineExceptionHandler,
             )
         frameDispatcher =
             org.jetbrains.skiko.FrameDispatcher(scope) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -27,6 +27,7 @@ import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.TaoEventCode
 import dev.nucleusframework.window.tao.TaoGpuRenderContextConsumers
 import dev.nucleusframework.window.tao.TaoModifierMask
+import dev.nucleusframework.window.tao.TaoNonFatalCoroutineExceptionHandler
 import dev.nucleusframework.window.tao.TaoPointerScrollEvent
 import dev.nucleusframework.window.tao.TaoTouchEvent
 import dev.nucleusframework.window.tao.TaoTrackpadGesture
@@ -992,7 +993,10 @@ internal class TaoComposeSceneHostLinux(
 
     // Ctrl+wheel is a discrete stream with no ENDED phase (unlike a native trackpad
     // gesture), so the synthetic magnify is released by an idle timer on this scope.
-    private val gestureScope = CoroutineScope(coroutineContext + flushingDispatcher + SupervisorJob())
+    // Deliberately NOT on the #622 fatal path: gesture helpers are isolated
+    // (SupervisorJob) — a crash there costs one gesture, logged at SEVERE.
+    private val gestureScope =
+        CoroutineScope(coroutineContext + flushingDispatcher + SupervisorJob() + TaoNonFatalCoroutineExceptionHandler)
     private var wheelZoomEndJob: Job? = null
 
     @OptIn(ExperimentalComposeUiApi::class)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.TaoEventCode
 import dev.nucleusframework.window.tao.TaoModifierMask
+import dev.nucleusframework.window.tao.TaoNonFatalCoroutineExceptionHandler
 import dev.nucleusframework.window.tao.TaoPointerScrollEvent
 import dev.nucleusframework.window.tao.TaoTouchEvent
 import dev.nucleusframework.window.tao.TaoWindow
@@ -197,10 +198,12 @@ internal class TaoComposeSceneHostWindows(
      * Scope for host-owned gesture work (trackpad-pinch idle-end debounce).
      * Runs on [flushingDispatcher] so resumed continuations land on the
      * event-loop thread; `delay` itself ticks on the shared coroutines
-     * scheduler. Cancelled in [detach].
+     * scheduler. Cancelled in [detach]. Deliberately NOT on the #622 fatal
+     * path: gesture helpers are isolated (SupervisorJob) — a crash there
+     * costs one gesture, logged at SEVERE.
      */
     private val gestureScope =
-        CoroutineScope(coroutineContext + flushingDispatcher + SupervisorJob())
+        CoroutineScope(coroutineContext + flushingDispatcher + SupervisorJob() + TaoNonFatalCoroutineExceptionHandler)
 
     /** Floating text-selection bar shown on touch selection. */
     private val textToolbar = TaoTextToolbar()

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
@@ -12,10 +12,15 @@ import androidx.compose.ui.scene.SingleComposeSceneRenderingScope
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import dev.nucleusframework.window.tao.TaoApplication
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import org.jetbrains.skia.Canvas
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.logging.Level
+import java.util.logging.Logger
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -49,6 +54,8 @@ internal class TaoSceneBundle(
     private val edtGuard: RectManagerEdtGuard,
     /** Owns [edtGuard]'s debounce wakeups; cancelled with the scene. */
     private val guardScope: CoroutineScope,
+    /** Flipped first thing in [close] — see [sceneFatalHandler]. */
+    private val closed: AtomicBoolean,
 ) : AutoCloseable {
     /**
      * Recomposes, lays out, and draws one frame into [canvas] — the drop-in
@@ -66,12 +73,42 @@ internal class TaoSceneBundle(
         edtGuard.afterFrame()
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun close() {
+        closed.set(true)
         guardScope.cancel()
-        scene.close()
+        // A DisposableEffect onDispose throwing while the scene is being torn
+        // down must not escalate to the app-fatal path (closing one window
+        // would close the whole app — #622 review) nor skip
+        // frameRecomposer.close().
+        try {
+            scene.close()
+        } catch (t: Throwable) {
+            bundleLogger.log(Level.SEVERE, "Unhandled exception during scene teardown", t)
+        }
         frameRecomposer.close()
     }
 }
+
+private val bundleLogger: Logger = Logger.getLogger(TaoSceneBundle::class.java.name)
+
+/**
+ * Fatal routing (#622) for everything that runs inside this scene's
+ * composition — recomposition, `LaunchedEffect`s, pointer-input coroutines:
+ * a crash takes [TaoApplication.reportFatal] (SEVERE log, native dialog,
+ * clean exit); without a handler it dies in kotlinx's global handler (stderr
+ * only) and the scene silently stops recomposing. Once [closed] is set the
+ * same failures are teardown noise (a cancelled effect's `finally` throwing
+ * while its window closes) and are logged instead of taking the app down.
+ */
+private fun sceneFatalHandler(closed: AtomicBoolean): CoroutineExceptionHandler =
+    CoroutineExceptionHandler { _, t ->
+        if (closed.get()) {
+            bundleLogger.log(Level.SEVERE, "Unhandled exception during scene teardown", t)
+        } else {
+            TaoApplication.reportFatal(t)
+        }
+    }
 
 /**
  * Creates a [CanvasLayersComposeScene] wired to a fresh [FrameRecomposer].
@@ -89,8 +126,10 @@ internal fun canvasLayersSceneBundle(
     requestFrame: () -> Unit,
 ): TaoSceneBundle {
     val renderingScope = SingleComposeSceneRenderingScope(requestFrame)
-    val frameRecomposer = FrameRecomposer(coroutineContext) { requestFrame() }
-    val guardScope = CoroutineScope(coroutineContext + SupervisorJob())
+    val closed = AtomicBoolean(false)
+    val sceneContext = coroutineContext + sceneFatalHandler(closed)
+    val frameRecomposer = FrameRecomposer(sceneContext) { requestFrame() }
+    val guardScope = CoroutineScope(sceneContext + SupervisorJob())
     val edtGuard = RectManagerEdtGuard(guardScope, requestFrame)
     val scene =
         CanvasLayersComposeScene(
@@ -102,7 +141,7 @@ internal fun canvasLayersSceneBundle(
             invalidateLayout = { renderingScope.onSceneInvalidation() },
             invalidateDraw = { renderingScope.onSceneInvalidation() },
         )
-    return TaoSceneBundle(scene, frameRecomposer, renderingScope, edtGuard, guardScope)
+    return TaoSceneBundle(scene, frameRecomposer, renderingScope, edtGuard, guardScope, closed)
 }
 
 /**
@@ -119,8 +158,10 @@ internal fun platformLayersSceneBundle(
     requestFrame: () -> Unit,
 ): TaoSceneBundle {
     val renderingScope = SingleComposeSceneRenderingScope(requestFrame)
-    val frameRecomposer = FrameRecomposer(coroutineContext) { requestFrame() }
-    val guardScope = CoroutineScope(coroutineContext + SupervisorJob())
+    val closed = AtomicBoolean(false)
+    val sceneContext = coroutineContext + sceneFatalHandler(closed)
+    val frameRecomposer = FrameRecomposer(sceneContext) { requestFrame() }
+    val guardScope = CoroutineScope(sceneContext + SupervisorJob())
     val edtGuard = RectManagerEdtGuard(guardScope, requestFrame)
     val scene =
         PlatformLayersComposeScene(
@@ -136,7 +177,7 @@ internal fun platformLayersSceneBundle(
             invalidateLayout = { renderingScope.onSceneInvalidation() },
             invalidateDraw = { renderingScope.onSceneInvalidation() },
         )
-    return TaoSceneBundle(scene, frameRecomposer, renderingScope, edtGuard, guardScope)
+    return TaoSceneBundle(scene, frameRecomposer, renderingScope, edtGuard, guardScope, closed)
 }
 
 /**

--- a/decorated-window-tao/src/main/native/build.rs
+++ b/decorated-window-tao/src/main/native/build.rs
@@ -6,6 +6,7 @@ fn main() {
             .file("macos/window_drag.m")
             .file("macos/touchpad_gestures.m")
             .file("macos/dialog_parent.m")
+            .file("macos/error_dialog.m")
             .file("macos/kotoeri.m")
             .file("macos/text_input_client_probe.m")
             .flag("-fobjc-arc")
@@ -18,6 +19,7 @@ fn main() {
         println!("cargo:rerun-if-changed=macos/window_drag.m");
         println!("cargo:rerun-if-changed=macos/touchpad_gestures.m");
         println!("cargo:rerun-if-changed=macos/dialog_parent.m");
+        println!("cargo:rerun-if-changed=macos/error_dialog.m");
         println!("cargo:rerun-if-changed=macos/kotoeri.m");
         println!("cargo:rerun-if-changed=macos/text_input_client_probe.m");
     }

--- a/decorated-window-tao/src/main/native/macos/error_dialog.m
+++ b/decorated-window-tao/src/main/native/macos/error_dialog.m
@@ -1,0 +1,43 @@
+// error_dialog.m
+//
+// Fatal-error dialog (issue #622) — the no-AWT replacement for Compose
+// Desktop's Swing default. Shown AFTER the Tao event loop has exited:
+// showing a modal from inside a tao callback frame deadlocks (tao's
+// Handler.callback std::Mutex is not re-entrant, and a Dock-reopen or
+// deep-link delivered by the modal's event pump re-locks it on the same
+// thread), and post-loop NSApp is left in a stopped state (tao latches
+// [NSApp stop:] on exit, which makes a subsequent -[NSAlert runModal]
+// session return immediately).
+//
+// CFUserNotificationDisplayAlert is the one AppKit-free primitive built for
+// exactly this: rendered out of process by the user notification server,
+// callable from any thread, no run loop / NSApp / main-thread dependency,
+// and it blocks until the user dismisses the alert.
+//
+// Caveat: not available to App-Sandboxed processes; Nucleus-packaged apps
+// (jpackage / GraalVM native, Developer ID) are not sandboxed. The JVM-side
+// SEVERE log remains the durable record either way.
+
+#include <CoreFoundation/CoreFoundation.h>
+
+void nucleus_tao_show_error_dialog(const char *title, const char *message) {
+    CFStringRef header = CFStringCreateWithCString(
+        NULL, title != NULL ? title : "Error", kCFStringEncodingUTF8);
+    CFStringRef body = CFStringCreateWithCString(
+        NULL, message != NULL ? message : "", kCFStringEncodingUTF8);
+    CFOptionFlags response = 0;
+    // Timeout 0 = no timeout: returns when the user dismisses the alert.
+    CFUserNotificationDisplayAlert(
+        0, kCFUserNotificationStopAlertLevel,
+        NULL, NULL, NULL,
+        header != NULL ? header : CFSTR("Error"),
+        body,
+        NULL /* default button — localized "OK" */, NULL, NULL,
+        &response);
+    if (header != NULL) {
+        CFRelease(header);
+    }
+    if (body != NULL) {
+        CFRelease(body);
+    }
+}

--- a/decorated-window-tao/src/main/native/macos/error_dialog.m
+++ b/decorated-window-tao/src/main/native/macos/error_dialog.m
@@ -21,17 +21,17 @@
 #include <CoreFoundation/CoreFoundation.h>
 
 void nucleus_tao_show_error_dialog(const char *title, const char *message) {
-    CFStringRef header = CFStringCreateWithCString(
-        NULL, title != NULL ? title : "Error", kCFStringEncodingUTF8);
-    CFStringRef body = CFStringCreateWithCString(
-        NULL, message != NULL ? message : "", kCFStringEncodingUTF8);
+    // The Rust caller never passes NULL; the guards below only cover
+    // CFStringCreateWithCString itself failing (invalid UTF-8, allocation).
+    CFStringRef header = CFStringCreateWithCString(NULL, title, kCFStringEncodingUTF8);
+    CFStringRef body = CFStringCreateWithCString(NULL, message, kCFStringEncodingUTF8);
     CFOptionFlags response = 0;
     // Timeout 0 = no timeout: returns when the user dismisses the alert.
     CFUserNotificationDisplayAlert(
         0, kCFUserNotificationStopAlertLevel,
         NULL, NULL, NULL,
         header != NULL ? header : CFSTR("Error"),
-        body,
+        body != NULL ? body : CFSTR(""),
         NULL /* default button — localized "OK" */, NULL, NULL,
         &response);
     if (header != NULL) {

--- a/decorated-window-tao/src/main/native/src/dialog.rs
+++ b/decorated-window-tao/src/main/native/src/dialog.rs
@@ -1,0 +1,46 @@
+// Native fatal-error dialog (issue #622) — the no-AWT replacement for
+// Compose Desktop's Swing `showErrorDialog` default. App-modal, blocks
+// until dismissed. Called from the Kotlin fatal-exception path right
+// before a clean exit, so it must depend on nothing but the OS toolkit.
+
+use jni::objects::{JClass, JString};
+use jni::JNIEnv;
+
+#[no_mangle]
+pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_nativeShowErrorDialog(
+    mut env: JNIEnv,
+    _class: JClass,
+    title: JString,
+    message: JString,
+) {
+    let title: String = match env.get_string(&title) {
+        Ok(s) => s.into(),
+        Err(_) => return,
+    };
+    let message: String = match env.get_string(&message) {
+        Ok(s) => s.into(),
+        Err(_) => return,
+    };
+    show_error_dialog(&title, &message);
+}
+
+#[cfg(target_os = "macos")]
+fn show_error_dialog(title: &str, message: &str) {
+    use std::ffi::CString;
+    use std::os::raw::c_char;
+    extern "C" {
+        // macos/error_dialog.m — app-modal NSAlert, main-thread bounced.
+        fn nucleus_tao_show_error_dialog(title: *const c_char, message: *const c_char);
+    }
+    // Java strings may carry interior NULs; strip them so CString::new
+    // cannot fail.
+    let title = CString::new(title.replace('\0', "")).expect("NULs stripped");
+    let message = CString::new(message.replace('\0', "")).expect("NULs stripped");
+    unsafe { nucleus_tao_show_error_dialog(title.as_ptr(), message.as_ptr()) };
+}
+
+// ponytail: macOS only for now (#622) — Windows (MessageBoxW) and Linux
+// (gtk::MessageDialog) are silent no-ops; the SEVERE log on the JVM side
+// is the only signal there until they are implemented.
+#[cfg(not(target_os = "macos"))]
+fn show_error_dialog(_title: &str, _message: &str) {}

--- a/decorated-window-tao/src/main/native/src/dialog.rs
+++ b/decorated-window-tao/src/main/native/src/dialog.rs
@@ -39,8 +39,42 @@ fn show_error_dialog(title: &str, message: &str) {
     unsafe { nucleus_tao_show_error_dialog(title.as_ptr(), message.as_ptr()) };
 }
 
-// ponytail: macOS only for now (#622) — Windows (MessageBoxW) and Linux
-// (gtk::MessageDialog) are silent no-ops; the SEVERE log on the JVM side
-// is the only signal there until they are implemented.
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+fn show_error_dialog(title: &str, message: &str) {
+    // MessageBoxW reads NUL-terminated wide strings, so an interior NUL from
+    // Java would silently truncate — strip them like the macOS path does.
+    let title = title.replace('\0', "");
+    let message = message.replace('\0', "");
+    // Dedicated thread, same reason macOS goes out of process: the calling
+    // thread just ran (and exited) the Tao event loop, and modal loops on it
+    // return immediately — a leftover quit/thread message in its queue makes
+    // MessageBoxW dismiss itself before the user sees anything. A fresh
+    // thread gets a fresh message queue, so the box actually blocks until
+    // dismissed; join() preserves the blocking contract for the caller.
+    std::thread::spawn(move || {
+        use windows::core::HSTRING;
+        use windows::Win32::UI::WindowsAndMessaging::{
+            MessageBoxW, MB_ICONERROR, MB_OK, MB_SETFOREGROUND, MB_TASKMODAL,
+        };
+        // No owner HWND: the Tao loop has exited and every window is
+        // destroyed by the time the fatal path runs. MB_TASKMODAL keeps the
+        // ownerless box modal to the process; MB_SETFOREGROUND raises it
+        // above the corpse of the app so the user actually sees why it is
+        // closing.
+        unsafe {
+            MessageBoxW(
+                None,
+                &HSTRING::from(message),
+                &HSTRING::from(title),
+                MB_OK | MB_ICONERROR | MB_TASKMODAL | MB_SETFOREGROUND,
+            );
+        }
+    })
+    .join()
+    .ok();
+}
+
+// ponytail: Linux (gtk::MessageDialog / zenity) is still a silent no-op;
+// the SEVERE log on the JVM side is the only signal there (#622).
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn show_error_dialog(_title: &str, _message: &str) {}

--- a/decorated-window-tao/src/main/native/src/dialog.rs
+++ b/decorated-window-tao/src/main/native/src/dialog.rs
@@ -29,7 +29,9 @@ fn show_error_dialog(title: &str, message: &str) {
     use std::ffi::CString;
     use std::os::raw::c_char;
     extern "C" {
-        // macos/error_dialog.m — app-modal NSAlert, main-thread bounced.
+        // macos/error_dialog.m — CFUserNotificationDisplayAlert: rendered out
+        // of process, callable from any thread, no NSApp/run-loop dependency
+        // (NSAlert cannot run after tao latches [NSApp stop:] — see the .m).
         fn nucleus_tao_show_error_dialog(title: *const c_char, message: *const c_char);
     }
     // Java strings may carry interior NULs; strip them so CString::new
@@ -54,19 +56,22 @@ fn show_error_dialog(title: &str, message: &str) {
     std::thread::spawn(move || {
         use windows::core::HSTRING;
         use windows::Win32::UI::WindowsAndMessaging::{
-            MessageBoxW, MB_ICONERROR, MB_OK, MB_SETFOREGROUND, MB_TASKMODAL,
+            MessageBoxW, MB_ICONERROR, MB_OK, MB_SETFOREGROUND,
         };
-        // No owner HWND: the Tao loop has exited and every window is
-        // destroyed by the time the fatal path runs. MB_TASKMODAL keeps the
-        // ownerless box modal to the process; MB_SETFOREGROUND raises it
-        // above the corpse of the app so the user actually sees why it is
-        // closing.
+        // No owner HWND: the Tao loop has exited and every Tao window is
+        // destroyed by the time the fatal path runs. Note the box is NOT
+        // modal to anything — MB_TASKMODAL would only disable top-level
+        // windows of the calling thread, and this fresh thread owns none —
+        // so surviving foreign windows (e.g. a Swing JFrame in the
+        // swing-tao-demo interop mode) stay interactive behind it.
+        // MB_SETFOREGROUND raises it above the corpse of the app so the user
+        // actually sees why it is closing.
         unsafe {
             MessageBoxW(
                 None,
                 &HSTRING::from(message),
                 &HSTRING::from(title),
-                MB_OK | MB_ICONERROR | MB_TASKMODAL | MB_SETFOREGROUND,
+                MB_OK | MB_ICONERROR | MB_SETFOREGROUND,
             );
         }
     })
@@ -74,7 +79,51 @@ fn show_error_dialog(title: &str, message: &str) {
     .ok();
 }
 
-// ponytail: Linux (gtk::MessageDialog / zenity) is still a silent no-op;
-// the SEVERE log on the JVM side is the only signal there (#622).
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(target_os = "linux")]
+fn show_error_dialog(title: &str, message: &str) {
+    use gtk::prelude::*;
+    // The caller is the thread that just ran (and exited) the Tao event loop
+    // — the GTK main thread. GTK survives the loop exit: tao iterates
+    // `gtk_main_iteration_do` on the default MainContext inside
+    // `with_thread_default`, which releases the context on return, so a
+    // recursive `gtk_dialog_run` main loop works here. Guard anyway — a
+    // fatal reached before the loop ever initialized GTK (or a torn-down
+    // display) must not turn the fatal path into a second crash.
+    if !gtk::is_initialized() && gtk::init().is_err() {
+        return;
+    }
+    // No parent: every Tao window is already destroyed when the fatal path
+    // runs. Title goes into the bold primary line as well — a GtkMessageDialog
+    // shows no titlebar text on GNOME, so `set_title` alone would hide it.
+    let dialog = gtk::MessageDialog::new(
+        None::<&gtk::Window>,
+        gtk::DialogFlags::MODAL,
+        gtk::MessageType::Error,
+        gtk::ButtonsType::Ok,
+        title,
+    );
+    dialog.set_title(title);
+    dialog.set_secondary_text(Some(message));
+    // X11 only (no-op on Wayland): raise above the corpse of the app, same
+    // intent as MB_SETFOREGROUND on Windows.
+    dialog.set_keep_above(true);
+    // Blocks in a recursive main loop until OK / close / Escape.
+    dialog.run();
+    unsafe { dialog.destroy() };
+    // Flush the destroy so the dialog leaves the screen even if a non-daemon
+    // JVM thread delays process exit for a moment. Bounded: an always-ready
+    // source left behind by the app (a11y bus, a recurring timeout, a
+    // torn-down display fd) can keep `events_pending()` true forever, and
+    // this runs on the fatal path where a busy-spin would replace the exit.
+    for _ in 0..64 {
+        if !gtk::events_pending() {
+            break;
+        }
+        gtk::main_iteration_do(false);
+    }
+}
+
+// Other unixes (BSDs): still a silent no-op; the SEVERE log on the JVM side
+// is the only signal there (#622).
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 fn show_error_dialog(_title: &str, _message: &str) {}

--- a/decorated-window-tao/src/main/native/src/lib.rs
+++ b/decorated-window-tao/src/main/native/src/lib.rs
@@ -19,6 +19,7 @@
 //   event_loop    — `run_event_loop_blocking()` (Tao loop body)
 //   window_jni    — cross-platform JNI exports for window lifecycle/state
 //   cursor        — cross-platform cursor JNI export
+//   dialog        — native fatal-error dialog JNI export (#622)
 //   keymap        — Tao physical key → AWT VK mapping
 //   platform::macos     — AppKit helpers (FFI, main-thread dance, IME,
 //                         text overlay, Apple events, VoiceOver bridge)
@@ -30,6 +31,7 @@
 mod a11y;
 
 mod cursor;
+mod dialog;
 mod event_loop;
 mod events;
 mod keymap;

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/FatalErrorDialogSmokeMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/FatalErrorDialogSmokeMain.kt
@@ -1,0 +1,49 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.rememberWindowState
+import dev.nucleusframework.window.tao.DecoratedWindow
+import dev.nucleusframework.window.tao.taoApplication
+import kotlinx.coroutines.delay
+
+/**
+ * Manual smoke for the #622 fatal-error path: shows a plain window, then
+ * throws from a `LaunchedEffect` after
+ * `-Dnucleus.tao.fatal.smoke.crashAfterMs=` (default 3000 ms).
+ *
+ * Expected outcome, in order:
+ * 1. SEVERE "Unhandled exception on the Tao main thread — closing" log,
+ * 2. the window closes and the blocking native error dialog appears
+ *    (NSAlert-less CFUserNotification / MessageBoxW / GtkMessageDialog),
+ * 3. dismissing it ends the process with **exit code 1** (Gradle reports
+ *    "finished with non-zero exit value 1" — that is the pass signal).
+ *
+ * Run: `./gradlew :decorated-window-tao:taoFatalDialogSmoke`
+ */
+object FatalErrorDialogSmokeMain {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val crashAfterMs =
+            System.getProperty("nucleus.tao.fatal.smoke.crashAfterMs")?.toLongOrNull() ?: 3_000L
+        taoApplication {
+            DecoratedWindow(
+                onCloseRequest = { /* smoke owns lifecycle — the crash exits */ },
+                state = rememberWindowState(size = DpSize(480.dp, 320.dp)),
+                title = "tao fatal dialog smoke #622",
+            ) {
+                Box(Modifier.fillMaxSize().background(Color(0xFF224466)))
+                LaunchedEffect(Unit) {
+                    delay(crashAfterMs)
+                    error("Deliberate fatal from FatalErrorDialogSmokeMain (#622)")
+                }
+            }
+        }
+    }
+}

--- a/examples/swing-tao-demo/src/main/kotlin/dev/nucleusframework/swingtao/Main.kt
+++ b/examples/swing-tao-demo/src/main/kotlin/dev/nucleusframework/swingtao/Main.kt
@@ -38,10 +38,19 @@ import kotlin.system.exitProcess
  * closing a native Tao window from a Swing action just works.
  */
 fun main() {
-    TaoApplication.run { app ->
-        // This callback fires once, on the Tao main thread.
-        val taoThread = Thread.currentThread().name
-        SwingUtilities.invokeLater { buildFrame(app, taoThread) }
+    try {
+        TaoApplication.run { app ->
+            // This callback fires once, on the Tao main thread.
+            val taoThread = Thread.currentThread().name
+            SwingUtilities.invokeLater { buildFrame(app, taoThread) }
+        }
+    } catch (t: Throwable) {
+        // run() rethrows a fatal dispatch failure after logging it and showing
+        // the native error dialog (#622). Without this catch the throwable
+        // would skip exitProcess(0) below and the non-daemon Swing EDT would
+        // keep the dead process alive.
+        t.printStackTrace()
+        exitProcess(1)
     }
     // run() returned: exit() was called and the Tao loop stopped. Once AWT is
     // up, its non-daemon event-dispatch thread keeps the JVM alive even after

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractGenerateAotCacheTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractGenerateAotCacheTask.kt
@@ -45,6 +45,10 @@ internal fun buildAotJavaArgs(
         add("-XX:AOTCacheOutput=${aotCacheFile.absolutePath}")
         addAll(tuningArgs)
         add("-Dnucleus.aot.mode=training")
+        // Training is unattended: a crash must exit with the SEVERE log, not
+        // block in the Tao fatal-error dialog (#622) until the safety timeout
+        // kills the run.
+        add("-Dnucleus.tao.fatalErrorDialog=false")
         add("-cp")
         add(classpath)
         addAll(javaOptions)

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/AotArgFileSupportTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/AotArgFileSupportTest.kt
@@ -25,11 +25,12 @@ class AotArgFileSupportTest {
 
         assertEquals("-XX:AOTCacheOutput=${aotCacheFile.absolutePath}", args[0])
         assertEquals("-Dnucleus.aot.mode=training", args[1])
-        assertEquals("-cp", args[2])
-        assertEquals("/tmp/lib/a.jar:/tmp/lib/b.jar", args[3])
-        assertEquals("-Xmx1g", args[4])
-        assertEquals("-Dfoo=bar", args[5])
-        assertEquals("com.example.Main", args[6])
+        assertEquals("-Dnucleus.tao.fatalErrorDialog=false", args[2])
+        assertEquals("-cp", args[3])
+        assertEquals("/tmp/lib/a.jar:/tmp/lib/b.jar", args[4])
+        assertEquals("-Xmx1g", args[5])
+        assertEquals("-Dfoo=bar", args[6])
+        assertEquals("com.example.Main", args[7])
     }
 
     @Test
@@ -48,6 +49,7 @@ class AotArgFileSupportTest {
         assertEquals("-XX:+UnlockDiagnosticVMOptions", args[1])
         assertEquals("-XX:-AOTAdapterCaching", args[2])
         assertEquals("-Dnucleus.aot.mode=training", args[3])
+        assertEquals("-Dnucleus.tao.fatalErrorDialog=false", args[4])
         assertEquals("com.example.Main", args.last())
     }
 


### PR DESCRIPTION
Closes #622

## Description

Unhandled exceptions on the Tao main thread used to be cleared at the JNI boundary, leaving a frozen, silent, unclosable window. The default path is now:

1. log the full stack at `SEVERE`
2. show a blocking native error dialog
3. exit the Tao loop cleanly
4. rethrow from `TaoApplication.run` (`taoApplication` turns that into `exitProcess(1)`; `0` stays the normal-quit code)

The dialog lives in the existing `nucleus_tao` crate (no new JNI module). It is shown **after** the loop has exited — a modal pump inside a tao callback re-enters tao's non-reentrant handler mutex (Dock-reopen / deep-link) and deadlocks the main thread.

| OS | Implementation | Why not the obvious API |
| --- | --- | --- |
| macOS | `CFUserNotificationDisplayAlert` | `NSAlert` returns immediately after tao latches `[NSApp stop:]` |
| Windows | `MessageBoxW` on a dedicated thread | the ex-loop thread's queue still holds a quit/thread message, so a box there dismisses itself instantly |
| Linux | modal `GtkMessageDialog` on the GTK main thread | GTK survives the loop exit; a recursive `gtk_dialog_run` works there |

Compose-side crashes (`LaunchedEffect`, recomposition, the macOS render loop) go through a shared `CoroutineExceptionHandler` so they cannot die in kotlinx's global handler and quit with exit code 0. Accessibility actions take the same fatal path as mouse/keyboard (they invoke the same semantics lambdas). Isolated gesture helpers stay log-only.

Unattended runs skip the dialog with `-Dnucleus.tao.fatalErrorDialog=false` (headful tests, AOT training). Manual smoke: `./gradlew :decorated-window-tao:taoFatalDialogSmoke`.

## Motivation and Context

Compose Desktop's AWT path shows a `JOptionPane` and then closes the window. Tao is the no-AWT backend, so that default is not reusable, and drawing an error screen in Compose would depend on the composition that just broke.

Related to #621 (pluggable recover-and-keep-alive handler) but independent: this is the no-handler default — never freeze.

## How Has This Been Tested?

- [x] macOS: raw-run fatal (dialog + rethrow) and Compose `LaunchedEffect` fatal (CEH → dialog → exit 1)
- [x] Windows: injected fatal in `swing-tao-demo` — dialog stays until dismissed, then rethrow and exit 1
- [x] Linux (GNOME Wayland / XWayland): `:decorated-window-tao:taoFatalDialogSmoke` — `LaunchedEffect` fatal → `SEVERE` log → blocking `GtkMessageDialog` ("Fatal Error" + exception) → dismiss → Gradle `finished with non-zero exit value 1`
- [x] CI: native rebuild of `nucleus_tao` on all three platforms

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
