### PR TITLE
feat(tao): add WindowExceptionHandlerFactory for Tao windows

### DIFF
--- a/decorated-window-tao/api/decorated-window-tao.api
+++ b/decorated-window-tao/api/decorated-window-tao.api
@@ -205,6 +205,12 @@ public final class dev/nucleusframework/window/tao/DecoratedWindowKt {
 	public static final fun getLocalTaoWindow ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
+public final class dev/nucleusframework/window/tao/DefaultWindowExceptionHandlerFactory : dev/nucleusframework/window/tao/WindowExceptionHandlerFactory {
+	public static final field $stable I
+	public static final field INSTANCE Ldev/nucleusframework/window/tao/DefaultWindowExceptionHandlerFactory;
+	public fun exceptionHandler (Ldev/nucleusframework/window/tao/TaoWindow;)Landroidx/compose/ui/window/WindowExceptionHandler;
+}
+
 public final class dev/nucleusframework/window/tao/DmaBufTestTextureProducer : java/lang/AutoCloseable {
 	public static final field $stable I
 	public static final field Companion Ldev/nucleusframework/window/tao/DmaBufTestTextureProducer$Companion;
@@ -801,6 +807,14 @@ public final class dev/nucleusframework/window/tao/TextureViewKt {
 }
 
 public abstract interface class dev/nucleusframework/window/tao/TextureViewSource {
+}
+
+public abstract interface class dev/nucleusframework/window/tao/WindowExceptionHandlerFactory {
+	public abstract fun exceptionHandler (Ldev/nucleusframework/window/tao/TaoWindow;)Landroidx/compose/ui/window/WindowExceptionHandler;
+}
+
+public final class dev/nucleusframework/window/tao/WindowExceptionHandlerFactoryKt {
+	public static final fun getLocalWindowExceptionHandlerFactory ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
 public final class dev/nucleusframework/window/tao/XdgForeignExport : java/lang/AutoCloseable {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -1,5 +1,8 @@
 @file:Suppress("MagicNumber")
-@file:OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+@file:OptIn(
+    androidx.compose.ui.InternalComposeUiApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+)
 
 package dev.nucleusframework.window.tao
 
@@ -24,6 +27,7 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.window.WindowExceptionHandler
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.DecoratedWindowState
@@ -47,6 +51,7 @@ import dev.nucleusframework.window.tao.popup.LocalTaoPopupHost
 import dev.nucleusframework.window.tao.scene.TaoComposeSceneHost
 import dev.nucleusframework.window.tao.scene.TaoComposeSceneHostLinux
 import dev.nucleusframework.window.tao.scene.TaoComposeSceneHostWindows
+import dev.nucleusframework.window.tao.scene.catchExceptions
 import kotlin.math.roundToInt
 
 /**
@@ -264,6 +269,12 @@ internal fun ApplicationScope.openDecoratedWindow(
     // Linux only: give this window an X11 surface even on a native Wayland
     // session — see DecoratedWindow(forceX11 = …).
     forceX11: Boolean = false,
+    // Builds the handler that catches exceptions raised by user code inside
+    // this window (frames, input, IME, a11y). Read once, in the parent
+    // composition, from [LocalWindowExceptionHandlerFactory] — the handler is
+    // then held in a plain field on the host, because it must also cover
+    // exceptions that break the composition it would otherwise be read from.
+    exceptionHandlerFactory: WindowExceptionHandlerFactory = DefaultWindowExceptionHandlerFactory,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     // hiddenFromDock rides on the GTK skip-taskbar/skip-pager hint, which
@@ -344,6 +355,8 @@ internal fun ApplicationScope.openDecoratedWindow(
         TaoHotReloadIntegration.trackWindow(window, title, alwaysOnTop)
     }
 
+    val exceptionHandler = exceptionHandlerFactory.exceptionHandler(window)
+
     if (Platform.Current == Platform.Windows) {
         return openDecoratedWindowWindows(
             window,
@@ -363,6 +376,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             initialCompositionLocalContext,
             nativePopupLayers,
             transparent,
+            exceptionHandler,
             hotReloadContent,
         )
     }
@@ -386,6 +400,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             initialCompositionLocalContext,
             nativePopupLayers,
             transparent,
+            exceptionHandler,
             hotReloadContent,
         )
     }
@@ -400,6 +415,7 @@ internal fun ApplicationScope.openDecoratedWindow(
     host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
+    host.exceptionHandler = exceptionHandler
     host.setSceneCompositionLocalContext(initialCompositionLocalContext)
 
     // Trackpad pinch / rotate / smart-magnify, intercepted before AppKit
@@ -407,7 +423,9 @@ internal fun ApplicationScope.openDecoratedWindow(
     // these events). Synthesised as two-finger Touch pointers in the host
     // so cross-platform `detectTransformGestures` reacts uniformly.
     window.onTrackpadGesture { kind, phase, x, y, value ->
-        if (enabled) host.onTrackpadGesture(kind, phase, x, y, value)
+        exceptionHandler.catchExceptions {
+            if (enabled) host.onTrackpadGesture(kind, phase, x, y, value)
+        }
     }
 
     // ── macOS accessibility ────────────────────────────────────────────────
@@ -565,12 +583,18 @@ internal fun ApplicationScope.openDecoratedWindow(
         host.detach()
     }
     window.onScaleFactorChanged { host.onScaleFactorChanged(it) }
-    window.onPointerMoved { x, y -> if (enabled) host.onPointerMove(x, y) }
-    window.onPointerExited { if (enabled) host.onPointerExited() }
-    window.onPointerButton { b, p -> if (enabled) host.onPointerButton(b, p) }
-    window.onPointerScroll { event -> if (enabled) host.onPointerScroll(event) }
+    // Input dispatch runs app code (gesture callbacks, key handlers), so every
+    // entry is guarded — the Tao counterpart of AWT's `catchExceptions`-wrapped
+    // `onMouseEvent` / `onKeyEvent`. Frames are guarded one level down, inside
+    // `TaoSceneBundle.render`.
+    window.onPointerMoved { x, y -> exceptionHandler.catchExceptions { if (enabled) host.onPointerMove(x, y) } }
+    window.onPointerExited { exceptionHandler.catchExceptions { if (enabled) host.onPointerExited() } }
+    window.onPointerButton { b, p -> exceptionHandler.catchExceptions { if (enabled) host.onPointerButton(b, p) } }
+    window.onPointerScroll { event -> exceptionHandler.catchExceptions { if (enabled) host.onPointerScroll(event) } }
     window.onKeyEvent { type, vk, loc, mods, cp ->
-        if (enabled) host.onKeyEvent(type, vk, loc, mods, cp) else false
+        exceptionHandler.catchExceptions(fallback = false) {
+            if (enabled) host.onKeyEvent(type, vk, loc, mods, cp) else false
+        }
     }
     window.onRedrawRequested { host.requestFrame() }
     window.onFocusChanged { focused ->
@@ -636,12 +660,14 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     initialCompositionLocalContext: CompositionLocalContext?,
     nativePopupLayers: Boolean,
     transparent: Boolean,
+    exceptionHandler: WindowExceptionHandler,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     val host = TaoComposeSceneHostLinux(window, fullyTransparent = transparent)
     host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
+    host.exceptionHandler = exceptionHandler
     // Yaru-style hidden-titlebar CSD (native GTK shadow ring): created via
     // `undecoratedShadow = !undecorated` at openWindow time; the host aligns
     // the frame radius and extends the resize band over the ring. Only
@@ -867,19 +893,29 @@ private fun ApplicationScope.openDecoratedWindowLinux(
             stateHolder.value = stateHolder.value.copy(active = settled)
         }
     }
+    // Input dispatch runs app code (gesture callbacks, key handlers), so every
+    // entry is guarded — the Tao counterpart of AWT's `catchExceptions`-wrapped
+    // `onMouseEvent` / `onKeyEvent`. Frames are guarded one level down, inside
+    // `TaoSceneBundle.render`.
     window.onPointerMoved { x, y ->
-        if (enabled) host.onPointerMove(x, y)
-        settleAfterGrab()
+        exceptionHandler.catchExceptions {
+            if (enabled) host.onPointerMove(x, y)
+            settleAfterGrab()
+        }
     }
-    window.onPointerExited { if (enabled) host.onPointerExited() }
+    window.onPointerExited { exceptionHandler.catchExceptions { if (enabled) host.onPointerExited() } }
     window.onPointerButton { b, p ->
-        if (enabled) host.onPointerButton(b, p)
-        settleAfterGrab()
+        exceptionHandler.catchExceptions {
+            if (enabled) host.onPointerButton(b, p)
+            settleAfterGrab()
+        }
     }
-    window.onPointerScroll { event -> if (enabled) host.onPointerScroll(event) }
+    window.onPointerScroll { event -> exceptionHandler.catchExceptions { if (enabled) host.onPointerScroll(event) } }
     window.onDragWindow { host.onNativeWindowDragStarted() }
     window.onKeyEvent { type, vk, loc, mods, cp ->
-        if (enabled) host.onKeyEvent(type, vk, loc, mods, cp) else false
+        exceptionHandler.catchExceptions(fallback = false) {
+            if (enabled) host.onKeyEvent(type, vk, loc, mods, cp) else false
+        }
     }
     window.onRedrawRequested { host.onRedrawRequested() }
     window.onFocusChanged { focused ->
@@ -1042,6 +1078,7 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     initialCompositionLocalContext: CompositionLocalContext?,
     nativePopupLayers: Boolean,
     transparent: Boolean,
+    exceptionHandler: WindowExceptionHandler,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     val host =
@@ -1053,6 +1090,7 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
+    host.exceptionHandler = exceptionHandler
     host.setSceneCompositionLocalContext(initialCompositionLocalContext)
 
     // Trackpad pinch-to-zoom. Windows delivers a precision-touchpad pinch (and
@@ -1061,7 +1099,9 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     // two-finger Touch pinch so cross-platform `detectTransformGestures` zooms
     // uniformly — same model as macOS.
     window.onTrackpadGesture { kind, phase, x, y, value ->
-        if (enabled) host.onTrackpadGesture(kind, phase, x, y, value)
+        exceptionHandler.catchExceptions {
+            if (enabled) host.onTrackpadGesture(kind, phase, x, y, value)
+        }
     }
 
     // ── Windows accessibility (AccessKit → UIA) ────────────────────────────
@@ -1366,10 +1406,14 @@ private fun ApplicationScope.openDecoratedWindowWindows(
                 NativeTaoWindowsNativeViewBridge.isLoaded &&
                     NativeTaoWindowsNativeViewBridge.nativeIsFocusInTree(window.nativeHandle)
             )
-    window.onPointerMoved { x, y -> if (enabled) host.onPointerMove(x, y) }
-    window.onPointerExited { if (enabled) host.onPointerExited() }
-    window.onPointerButton { b, p -> if (enabled) host.onPointerButton(b, p) }
-    window.onPointerScroll { event -> if (enabled) host.onPointerScroll(event) }
+    // Input dispatch runs app code (gesture callbacks, key handlers), so every
+    // entry is guarded — the Tao counterpart of AWT's `catchExceptions`-wrapped
+    // `onMouseEvent` / `onKeyEvent`. Frames are guarded one level down, inside
+    // `TaoSceneBundle.render`.
+    window.onPointerMoved { x, y -> exceptionHandler.catchExceptions { if (enabled) host.onPointerMove(x, y) } }
+    window.onPointerExited { exceptionHandler.catchExceptions { if (enabled) host.onPointerExited() } }
+    window.onPointerButton { b, p -> exceptionHandler.catchExceptions { if (enabled) host.onPointerButton(b, p) } }
+    window.onPointerScroll { event -> exceptionHandler.catchExceptions { if (enabled) host.onPointerScroll(event) } }
     // WM_ENTERSIZEMOVE / WM_EXITSIZEMOVE brackets the modal MOVE and RESIZE
     // loops exactly, so it is the only mask signal needed here — unlike Linux,
     // no pointer-driven fallback is required, and using one would be harmful:
@@ -1388,7 +1432,9 @@ private fun ApplicationScope.openDecoratedWindowWindows(
         host.onResizeLoopChanged(active)
     }
     window.onKeyEvent { type, vk, loc, mods, cp ->
-        if (enabled) host.onKeyEvent(type, vk, loc, mods, cp) else false
+        exceptionHandler.catchExceptions(fallback = false) {
+            if (enabled) host.onKeyEvent(type, vk, loc, mods, cp) else false
+        }
     }
     window.onRedrawRequested { host.onRedrawRequested() }
     window.onFocusChanged { focused ->

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -55,6 +55,7 @@ import kotlin.math.roundToInt
  *    propagates via snapshot but does not share a CompositionContext.
  */
 @Suppress("LongParameterList", "FunctionNaming", "LongMethod", "CyclomaticComplexMethod")
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
 public fun ApplicationScope.DecoratedWindow(
     onCloseRequest: () -> Unit,
@@ -196,6 +197,12 @@ public fun ApplicationScope.DecoratedWindow(
                 .toArgb(),
         )
 
+    // Read here, in the parent composition, exactly like Compose Desktop's
+    // `SwingWindow`: the resulting handler is stored as a plain field on the
+    // scene host, so it still applies when the window's own composition is the
+    // thing that failed.
+    val windowExceptionHandlerFactory = LocalWindowExceptionHandlerFactory.current
+
     state.inflateToMinimumSize(minimumSize)
     state.applyMacOsInitialMaximizedSize()
 
@@ -261,6 +268,7 @@ public fun ApplicationScope.DecoratedWindow(
                     hiddenFromDock = hiddenFromDock,
                     initialCompositionLocalContext = compositionLocalContext,
                     forceX11 = forceX11,
+                    exceptionHandlerFactory = windowExceptionHandlerFactory,
                     content = {
                         val backgroundArgb = latestWindowBackgroundArgb.value
                         val clearColorLayers = LocalWindowClearColorLayers.current

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowExceptionHandlerFactory.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowExceptionHandlerFactory.kt
@@ -30,7 +30,7 @@ import java.util.logging.Level
  */
 @ExperimentalComposeUiApi
 public fun interface WindowExceptionHandlerFactory {
-    /** Creates an exception handler for [window]. Handlers run on the Tao main thread. */
+    /** Creates an exception handler for [window]. Handlers are invoked on the thread the failure occurred on. */
     public fun exceptionHandler(window: TaoWindow): WindowExceptionHandler
 }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowExceptionHandlerFactory.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowExceptionHandlerFactory.kt
@@ -1,0 +1,64 @@
+package dev.nucleusframework.window.tao
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.WindowExceptionHandler
+import java.util.logging.Level
+
+/**
+ * Factory of window exception handlers, the Tao mirror of Compose Desktop's
+ * `androidx.compose.ui.window.WindowExceptionHandlerFactory` — same contract,
+ * with [TaoWindow] where the AWT backend takes a `java.awt.Window`.
+ *
+ * The handlers it produces catch exceptions thrown while rendering frames
+ * (composition, layout, draw), dispatching input, running IME callbacks, or
+ * walking the accessibility tree of the window they were created for.
+ *
+ * **Not every failure is survivable.** Layout, draw, input, IME and
+ * accessibility failures are caught around the offending pass, so a handler
+ * that returns normally really does resume: the frame is dropped, a new one is
+ * requested, and later state changes still reach the screen. A failure *inside
+ * composition* is different — Compose intercepts it in
+ * `Recomposer.processCompositionError` and stops the recomposition loop before
+ * the backend ever sees the exception, and that loop cannot be restarted (the
+ * recovery path Compose uses for hot reload is internal to
+ * `androidx.compose.runtime`). Returning normally cannot revive such a window,
+ * so the backend logs the fact at [Level.SEVERE] instead of leaving a window
+ * that silently paints its last frame forever. A handler that intends to keep
+ * the app running should close and recreate the window in that case.
+ */
+@ExperimentalComposeUiApi
+public fun interface WindowExceptionHandlerFactory {
+    /** Creates an exception handler for [window]. Handlers run on the Tao main thread. */
+    public fun exceptionHandler(window: TaoWindow): WindowExceptionHandler
+}
+
+/**
+ * Default [WindowExceptionHandlerFactory]: rethrows, which hands the failure to
+ * the app-fatal path — SEVERE log, native error dialog, clean exit (#622). An
+ * app that installs nothing therefore gets a diagnosable crash instead of the
+ * silent, frozen window this used to leave behind.
+ *
+ * Deliberately does not log: `TaoApplication.reportFatal` already logs the same
+ * throwable at [Level.SEVERE], and logging here too would double every entry.
+ *
+ * Provide your own factory through [LocalWindowExceptionHandlerFactory] to keep
+ * the window alive instead — a handler that returns normally swallows the
+ * exception, the offending frame is dropped, and a new one is requested. See
+ * [WindowExceptionHandlerFactory] for the one failure class that cannot resume.
+ */
+@ExperimentalComposeUiApi
+public object DefaultWindowExceptionHandlerFactory : WindowExceptionHandlerFactory {
+    override fun exceptionHandler(window: TaoWindow): WindowExceptionHandler =
+        WindowExceptionHandler { throwable -> throw throwable }
+}
+
+/**
+ * The CompositionLocal that provides the [WindowExceptionHandlerFactory] used
+ * by every `DecoratedWindow` / `DecoratedDialog` composed below it — including
+ * the separate native windows `nativePopupLayers = true` popups live in.
+ */
+@ExperimentalComposeUiApi
+public val LocalWindowExceptionHandlerFactory: ProvidableCompositionLocal<WindowExceptionHandlerFactory> =
+    staticCompositionLocalOf { DefaultWindowExceptionHandlerFactory }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHost.kt
@@ -2,9 +2,11 @@ package dev.nucleusframework.window.tao.popup
 
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.window.WindowExceptionHandler
 import dev.nucleusframework.window.tao.scene.TaoRecordedSurface
 import kotlin.coroutines.CoroutineContext
 
@@ -15,6 +17,7 @@ import kotlin.coroutines.CoroutineContext
  *
  * Threading: every call must run on the macOS main thread.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 internal interface TaoPopupHost {
     /** NSView pointer of the host window's content view. */
     val parentNsView: Long
@@ -50,6 +53,14 @@ internal interface TaoPopupHost {
 
     /** Coroutine context to feed inner scenes (parent context + frame clock + flushing dispatcher). */
     val sceneCoroutineContext: CoroutineContext
+
+    /**
+     * The owner window's exception handler, so a popup scene reports failures
+     * through the same channel as the window it belongs to. Mirrors Compose
+     * Desktop's `WindowComposeSceneLayer`, which forwards
+     * `composeContainer.exceptionHandler` into its own mediator.
+     */
+    val exceptionHandler: WindowExceptionHandler? get() = null
 
     /**
      * Offset added to a popup's `boundsInWindow` before positioning the

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostLinux.kt
@@ -1,9 +1,11 @@
 package dev.nucleusframework.window.tao.popup
 
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.window.WindowExceptionHandler
 import dev.nucleusframework.window.tao.TaoWindow
 import kotlin.coroutines.CoroutineContext
 
@@ -19,9 +21,17 @@ import kotlin.coroutines.CoroutineContext
  *
  * Threading: every call must run on the Tao event-loop thread.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 internal interface TaoPopupHostLinux {
     /** Tao window hosting the main scene — the popup windows' `popupOf` parent. */
     val parentWindow: TaoWindow
+
+    /**
+     * The owner window's exception handler, so a popup scene reports failures
+     * through the same channel as the window it belongs to. See
+     * [TaoPopupHost.exceptionHandler].
+     */
+    val exceptionHandler: WindowExceptionHandler? get() = null
 
     /** Backing-scale factor (logical→physical multiplier). */
     val scale: Float

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostWindows.kt
@@ -2,9 +2,11 @@ package dev.nucleusframework.window.tao.popup
 
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.window.WindowExceptionHandler
 import org.jetbrains.skia.DirectContext
 import kotlin.coroutines.CoroutineContext
 
@@ -19,6 +21,7 @@ import kotlin.coroutines.CoroutineContext
  * Threading: every call must run on the host HWND's UI thread.
  */
 @Suppress("TooManyFunctions")
+@OptIn(ExperimentalComposeUiApi::class)
 internal interface TaoPopupHostWindows {
     /** HWND of the host (Tao main) window. */
     val parentHwnd: Long
@@ -41,6 +44,13 @@ internal interface TaoPopupHostWindows {
 
     /** Coroutine context to feed inner scenes. */
     val sceneCoroutineContext: CoroutineContext
+
+    /**
+     * The owner window's exception handler, so a popup scene reports failures
+     * through the same channel as the window it belongs to. See
+     * [TaoPopupHost.exceptionHandler].
+     */
+    val exceptionHandler: WindowExceptionHandler? get() = null
 
     /**
      * Offset added to a popup's `boundsInWindow` before positioning the

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
@@ -33,6 +33,7 @@ import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoRecordedSurface
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
+import dev.nucleusframework.window.tao.scene.catchExceptions
 import dev.nucleusframework.window.tao.scene.recordSceneToPicture
 import org.jetbrains.skia.DirectContext
 
@@ -73,7 +74,7 @@ import org.jetbrains.skia.DirectContext
  *
  * Threading: every method must run on the macOS main thread.
  */
-@OptIn(InternalComposeUiApi::class)
+@OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 internal class TaoPopupSceneLayer(
     private val host: TaoPopupHost,
     initialDensity: Density,
@@ -222,7 +223,10 @@ internal class TaoPopupSceneLayer(
                     }
                 },
             requestFrame = { host.requestRedraw() },
-        )
+        ).apply {
+            // Report through the owner window's channel — see [TaoPopupHost.exceptionHandler].
+            exceptionHandler = host.exceptionHandler
+        }
 
     private val innerScene: ComposeScene get() = sceneBundle.scene
 
@@ -234,6 +238,9 @@ internal class TaoPopupSceneLayer(
      * Named inner class so GraalVM JNI reachability metadata can register
      * it explicitly. Anonymous-object subclasses of a JNI-accessed
      * interface aren't picked up by `GetMethodID` under native-image.
+     *
+     * Every method is guarded: these are AppKit callbacks into the panel's own
+     * scene, not nested inside the owner window's guarded frame pass.
      */
     private inner class PopupEventCallback : PopupNativeBridge.EventCallback {
         override fun onPointerEvent(
@@ -242,7 +249,7 @@ internal class TaoPopupSceneLayer(
             y: Float,
             button: Int,
             modifiers: Int,
-        ) {
+        ) = host.exceptionHandler.catchExceptions {
             val pointerButton =
                 when (button) {
                     TaoNativeWireFormat.BUTTON_PRIMARY -> PointerButton.Primary
@@ -269,7 +276,7 @@ internal class TaoPopupSceneLayer(
             dx: Float,
             dy: Float,
             precise: Boolean,
-        ) {
+        ) = host.exceptionHandler.catchExceptions {
             innerScene.dispatchAwtShapedScroll(
                 x,
                 y,
@@ -282,7 +289,7 @@ internal class TaoPopupSceneLayer(
             vkCode: Int,
             codePoint: Int,
             modifiers: Int,
-        ) {
+        ) = host.exceptionHandler.catchExceptions {
             innerScene.dispatchNativeKeyEvent(
                 type = type,
                 vkCode = vkCode,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
@@ -36,6 +36,7 @@ import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.alignToBufferScale
 import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
+import dev.nucleusframework.window.tao.scene.catchExceptions
 import dev.nucleusframework.window.tao.scene.preservingEglBinding
 import dev.nucleusframework.window.tao.scene.renderGlFrame
 import dev.nucleusframework.window.tao.scene.withEglContextCurrent
@@ -79,7 +80,7 @@ import kotlin.math.roundToInt
  *
  * Threading: every method must run on the Tao event-loop thread.
  */
-@OptIn(InternalComposeUiApi::class)
+@OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Suppress("TooManyFunctions")
 internal class TaoPopupSceneLayerLinux(
     private val host: TaoPopupHostLinux,
@@ -200,7 +201,10 @@ internal class TaoPopupSceneLayerLinux(
                     }
                 },
             requestFrame = { host.requestRedraw() },
-        )
+        ).apply {
+            // Report through the owner window's channel — see [TaoPopupHost.exceptionHandler].
+            exceptionHandler = host.exceptionHandler
+        }
 
     private val innerScene: ComposeScene get() = sceneBundle.scene
 
@@ -493,6 +497,8 @@ internal class TaoPopupSceneLayerLinux(
 
     // ── Input — the popup window receives its own pointer events ──────────
 
+    // Guarded: these are Tao popup-window callbacks into this popup's own
+    // scene, not nested inside the owner window's guarded frame pass.
     private fun registerInput() {
         popupWindow.onPointerMoved { xFixed, yFixed ->
             sendPointer(PointerEventType.Move, xFixed / POSITION_SCALE, yFixed / POSITION_SCALE, null)
@@ -506,14 +512,16 @@ internal class TaoPopupSceneLayerLinux(
             )
         }
         popupWindow.onPointerScroll { event ->
-            if (released) return@onPointerScroll
-            val pos = scenePosition(lastX, lastY)
-            innerScene.dispatchAwtShapedScroll(
-                x = pos.x,
-                y = pos.y,
-                event = event,
-                keyboardModifiers = taoKeyboardModifiers(host.parentWindow.modifierState),
-            )
+            host.exceptionHandler.catchExceptions {
+                if (released) return@catchExceptions
+                val pos = scenePosition(lastX, lastY)
+                innerScene.dispatchAwtShapedScroll(
+                    x = pos.x,
+                    y = pos.y,
+                    event = event,
+                    keyboardModifiers = taoKeyboardModifiers(host.parentWindow.modifierState),
+                )
+            }
         }
     }
 
@@ -525,8 +533,8 @@ internal class TaoPopupSceneLayerLinux(
         xPx: Float,
         yPx: Float,
         button: PointerButton?,
-    ) {
-        if (released) return
+    ) = host.exceptionHandler.catchExceptions {
+        if (released) return@catchExceptions
         lastX = xPx
         lastY = yPx
         innerScene.sendPointerEvent(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -30,6 +30,7 @@ import dev.nucleusframework.window.tao.ffi.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.scene.TaoPlatformContextBase
 import dev.nucleusframework.window.tao.scene.TaoSceneBundle
 import dev.nucleusframework.window.tao.scene.canvasLayersSceneBundle
+import dev.nucleusframework.window.tao.scene.catchExceptions
 import dev.nucleusframework.window.tao.scene.renderGlFrame
 import org.jetbrains.skia.DirectContext
 
@@ -53,7 +54,7 @@ import org.jetbrains.skia.DirectContext
  *    [innerScene]'s [androidx.compose.ui.platform.LocalDensity], ensuring font rasterization
  *    and container measurement stay synchronized across displays.
  */
-@OptIn(InternalComposeUiApi::class)
+@OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 internal class TaoPopupSceneLayerWindows(
     private val host: TaoPopupHostWindows,
     initialDensity: Density,
@@ -184,7 +185,10 @@ internal class TaoPopupSceneLayerWindows(
                     override val isWindowTransparent: Boolean get() = true
                 },
             requestFrame = { host.requestRedraw() },
-        )
+        ).apply {
+            // Report through the owner window's channel — see [TaoPopupHost.exceptionHandler].
+            exceptionHandler = host.exceptionHandler
+        }
 
     private val innerScene: ComposeScene get() = sceneBundle.scene
 
@@ -192,6 +196,10 @@ internal class TaoPopupSceneLayerWindows(
     private var onKeyEvent: ((KeyEvent) -> Boolean)? = null
     private var onOutsidePointerEvent: ((PointerEventType, PointerButton?) -> Unit)? = null
 
+    /**
+     * Every method is guarded: these are WndProc callbacks into the popup's own
+     * scene, not nested inside the owner window's guarded frame pass.
+     */
     private inner class PopupEventCallback : PopupNativeBridgeWindows.EventCallback {
         override fun onPointerEvent(
             type: Int,
@@ -199,7 +207,7 @@ internal class TaoPopupSceneLayerWindows(
             y: Float,
             button: Int,
             modifiers: Int,
-        ) {
+        ) = host.exceptionHandler.catchExceptions {
             val pointerButton =
                 when (button) {
                     TaoNativeWireFormat.BUTTON_PRIMARY -> PointerButton.Primary
@@ -225,7 +233,7 @@ internal class TaoPopupSceneLayerWindows(
             y: Float,
             dx: Float,
             dy: Float,
-        ) {
+        ) = host.exceptionHandler.catchExceptions {
             val pos = scenePosition(x, y)
             innerScene.dispatchAwtShapedScroll(pos.x, pos.y, win32WheelToAwtScrollEvent(dx, dy))
         }
@@ -235,7 +243,7 @@ internal class TaoPopupSceneLayerWindows(
             vkCode: Int,
             codePoint: Int,
             modifiers: Int,
-        ) {
+        ) = host.exceptionHandler.catchExceptions {
             innerScene.dispatchNativeKeyEvent(
                 type = type,
                 vkCode = vkCode,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/AbstractTaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/AbstractTaoComposeSceneHost.kt
@@ -1,6 +1,8 @@
 package dev.nucleusframework.window.tao.scene
 
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.window.WindowExceptionHandler
 import dev.nucleusframework.window.tao.TaoMouseButton
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
@@ -19,7 +21,24 @@ import java.util.concurrent.TimeUnit
  * The one place the shared a11y code touches the platform is the debounced
  * walk dispatch, exposed as the [dispatchA11yWalk] hook.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 internal abstract class AbstractTaoComposeSceneHost {
+    /**
+     * Handler for exceptions raised by user code reached through this host —
+     * input dispatch, IME callbacks and the accessibility walk. Frames and the
+     * scene's own coroutines are covered one level down, by the same handler
+     * installed on [TaoSceneBundle], which every platform funnels through.
+     *
+     * Set once when the window opens, from the
+     * [dev.nucleusframework.window.tao.LocalWindowExceptionHandlerFactory] read
+     * in the parent composition — a plain field rather than a CompositionLocal
+     * read, because it must also cover exceptions that break the composition
+     * itself. Volatile: written on the Tao main thread before `attach()`, read
+     * on the platform render thread on Windows/Linux.
+     */
+    @Volatile
+    var exceptionHandler: WindowExceptionHandler? = null
+
     // The SemanticsOwner walk in TaoSemanticsObserver is O(N); during a scroll
     // `onLayoutChange`/`onSemanticsChange` fire every frame, so a per-frame walk
     // stutters scrolling — most visibly once an AX client (PopClip, VoiceOver,
@@ -73,7 +92,9 @@ internal abstract class AbstractTaoComposeSceneHost {
                             a11yFirstRequestNs = 0L
                             if (b != null) {
                                 // Hop to the platform UI thread — the walk touches Compose state.
-                                dispatchA11yWalk(b)
+                                // Guarded there, not here: the block runs on the UI thread, which
+                                // is where the window's handler is contractually invoked.
+                                dispatchA11yWalk { exceptionHandler.catchExceptions(b) }
                             }
                         } else {
                             // No AT client is listening: park the walk and poll the

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowExceptionHandler
 import dev.nucleusframework.window.WindowTransparencyMode
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.MacOSStyle
@@ -86,7 +87,7 @@ import kotlin.coroutines.CoroutineContext as KCoroutineContext
  * stable on the JVM target of Compose Multiplatform 1.10+. Some are annotated
  * `@InternalComposeUiApi`; we opt-in below.
  */
-@OptIn(InternalComposeUiApi::class)
+@OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Suppress("TooManyFunctions", "LargeClass")
 internal class TaoComposeSceneHost(
     private val window: TaoWindow,
@@ -370,9 +371,14 @@ internal class TaoComposeSceneHost(
                 outboundLauncher = ::launchMacOsOutboundDrag,
             )
 
-        window.imeReplaceCommit = imeSession::replaceCommit
-        window.imePreedit = imeSession::preedit
-        window.imeCommit = imeSession::commit
+        // IME callbacks edit the focused field through `TextEditingScope`, i.e.
+        // they run user code straight off a native AppKit callback — the Tao
+        // counterpart of AWT's guarded `inputMethodTextChanged`.
+        window.imeReplaceCommit = { text, start, length ->
+            exceptionHandler.catchExceptions { imeSession.replaceCommit(text, start, length) }
+        }
+        window.imePreedit = { text -> exceptionHandler.catchExceptions { imeSession.preedit(text) } }
+        window.imeCommit = { text -> exceptionHandler.catchExceptions { imeSession.commit(text) } }
         val taoPlatformContext =
             TaoPlatformContext(
                 windowHandle = window.handle,
@@ -449,6 +455,9 @@ internal class TaoComposeSceneHost(
                 )
             }
         scene?.compositionLocalContext = pendingCompositionLocalContext
+        // Frame failures (recomposition / layout / draw) are caught inside the
+        // bundle, the single seam all three platforms render through.
+        sceneBundle?.exceptionHandler = exceptionHandler
 
         registerInboundDnD()
     }
@@ -620,24 +629,28 @@ internal class TaoComposeSceneHost(
      */
     var onTextSelectionForA11y: ((text: String, editable: Boolean, sourceId: Int) -> Unit)? = null
 
-    fun setContent(content: @Composable () -> Unit) {
-        scene?.setContent {
-            TaoTextToolbarHost(textToolbar) {
-                val onSel = onTextSelectionForA11y
-                // Expose the publisher so themed wrappers (nucleus-application) can
-                // re-install the observer inside their theme's own LocalTextContextMenu.
-                androidx.compose.runtime.CompositionLocalProvider(
-                    LocalTaoTextSelectionA11yPublisher provides onSel,
-                ) {
-                    if (onSel != null) {
-                        TaoSelectionAccessibilityObserver(onSelection = onSel, content = content)
-                    } else {
-                        content()
+    // Guarded like AWT's `ComposeSceneMediator.setContent`: the first
+    // composition runs inside this call, so content that throws while mounting
+    // must reach the window's handler instead of unwinding into the Tao loop.
+    fun setContent(content: @Composable () -> Unit) =
+        exceptionHandler.catchExceptions {
+            scene?.setContent {
+                TaoTextToolbarHost(textToolbar) {
+                    val onSel = onTextSelectionForA11y
+                    // Expose the publisher so themed wrappers (nucleus-application) can
+                    // re-install the observer inside their theme's own LocalTextContextMenu.
+                    androidx.compose.runtime.CompositionLocalProvider(
+                        LocalTaoTextSelectionA11yPublisher provides onSel,
+                    ) {
+                        if (onSel != null) {
+                            TaoSelectionAccessibilityObserver(onSelection = onSel, content = content)
+                        } else {
+                            content()
+                        }
                     }
                 }
             }
         }
-    }
 
     /**
      * Forwards a parent composition's locals into this scene via
@@ -878,6 +891,9 @@ internal class TaoComposeSceneHost(
             }
             override val sceneCoroutineContext: CoroutineContext
                 get() = outer.coroutineContext + outer.flushingDispatcher
+
+            override val exceptionHandler: WindowExceptionHandler?
+                get() = outer.exceptionHandler
 
             override fun requestRedraw() = outer.window.requestRedraw()
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowExceptionHandler
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.TaoEventCode
@@ -103,7 +104,7 @@ import kotlin.coroutines.CoroutineContext as KCoroutineContext
  * area. The EGL content subsurface is positioned at GTK's content-area origin
  * (see [applyContentOffset]); X11 keeps the flat undecorated presentation.
  */
-@OptIn(InternalComposeUiApi::class)
+@OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Suppress("LargeClass", "TooManyFunctions")
 internal class TaoComposeSceneHostLinux(
     private val window: TaoWindow,
@@ -476,8 +477,11 @@ internal class TaoComposeSceneHostLinux(
                 getRootNode = { scene!!.rootDragAndDropNode },
                 outboundLauncher = ::launchLinuxOutboundDrag,
             )
-        window.imePreedit = imeSession::preedit
-        window.imeCommit = imeSession::commit
+        // IME callbacks edit the focused field through `TextEditingScope`, i.e.
+        // they run user code straight off a GTK IM callback — the Tao
+        // counterpart of AWT's guarded `inputMethodTextChanged`.
+        window.imePreedit = { text -> exceptionHandler.catchExceptions { imeSession.preedit(text) } }
+        window.imeCommit = { text -> exceptionHandler.catchExceptions { imeSession.commit(text) } }
         val platformContext =
             LinuxTaoPlatformContext(
                 windowHandle = window.handle,
@@ -542,6 +546,9 @@ internal class TaoComposeSceneHostLinux(
                 )
             }
         scene?.compositionLocalContext = pendingCompositionLocalContext
+        // Frame failures (recomposition / layout / draw) are caught inside the
+        // bundle, the single seam all three platforms render through.
+        sceneBundle?.exceptionHandler = exceptionHandler
 
         // Notify popup layers when the host window moves on screen — X11
         // popups are positioned in root coordinates and don't auto-track.
@@ -1112,26 +1119,30 @@ internal class TaoComposeSceneHostLinux(
         requestRedrawCoalesced()
     }
 
-    fun setContent(content: @Composable () -> Unit) {
-        scene?.setContent {
-            // Capture the standard FocusManager from the composition
-            // so the overlay controller can call `clearFocus(force =
-            // true)` to break a `BasicTextField`'s "Captured" focus
-            // state when a context menu dismisses (the scene-level
-            // `releaseFocus()` only clears Active/ActiveParent and
-            // leaves the caret visible).
-            val fm = androidx.compose.ui.platform.LocalFocusManager.current
-            androidx.compose.runtime.SideEffect {
-                capturedFocusManager = fm
-            }
-            // GTK clipboard instead of AWT's X11-only one: the window lives on
-            // whichever GDK backend the session provides, and on Wayland the
-            // two selections are not the same one (issue #582).
-            ProvideTaoClipboard {
-                TaoTextToolbarHost(textToolbar, content)
+    // Guarded like AWT's `ComposeSceneMediator.setContent`: the first
+    // composition runs inside this call, so content that throws while mounting
+    // must reach the window's handler instead of unwinding into the Tao loop.
+    fun setContent(content: @Composable () -> Unit) =
+        exceptionHandler.catchExceptions {
+            scene?.setContent {
+                // Capture the standard FocusManager from the composition
+                // so the overlay controller can call `clearFocus(force =
+                // true)` to break a `BasicTextField`'s "Captured" focus
+                // state when a context menu dismisses (the scene-level
+                // `releaseFocus()` only clears Active/ActiveParent and
+                // leaves the caret visible).
+                val fm = androidx.compose.ui.platform.LocalFocusManager.current
+                androidx.compose.runtime.SideEffect {
+                    capturedFocusManager = fm
+                }
+                // GTK clipboard instead of AWT's X11-only one: the window lives on
+                // whichever GDK backend the session provides, and on Wayland the
+                // two selections are not the same one (issue #582).
+                ProvideTaoClipboard {
+                    TaoTextToolbarHost(textToolbar, content)
+                }
             }
         }
-    }
 
     /**
      * Forwards a parent composition's locals into this scene via
@@ -1990,6 +2001,8 @@ internal class TaoComposeSceneHostLinux(
         return object : TaoPopupHostLinux {
             override val parentWindow: TaoWindow get() = outer.window
             override val scale: Float get() = outer.scale
+            override val exceptionHandler: WindowExceptionHandler?
+                get() = outer.exceptionHandler
             override val parentWindowSize: IntSize get() = IntSize(outer.widthPx, outer.heightPx)
             override val workAreaSize: IntSize get() =
                 NativeTaoBridge

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowExceptionHandler
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
+import dev.nucleusframework.window.tao.TaoApplication
 import dev.nucleusframework.window.tao.TaoEventCode
 import dev.nucleusframework.window.tao.TaoGpuRenderContextConsumers
 import dev.nucleusframework.window.tao.TaoModifierMask
@@ -919,60 +920,67 @@ internal class TaoComposeSceneHostLinux(
             ysFixed: LongArray,
             pressedMask: Long,
         ) {
-            val sc = scene ?: return
-            if (count <= 0) return
+            // Touch runs user pointer-input code exactly like the mouse path,
+            // but this bridge calls back outside `EventDispatcher.guarded`, so
+            // both of the mouse wire's layers are reproduced by the guard: the
+            // window's handler gets the first look, and a rethrow takes the
+            // fatal path instead of unwinding into the JNI callback frame.
+            guardBridgeCallback {
+                val sc = scene ?: return
+                if (count <= 0) return
 
-            // Single-finger press in the resize edge band starts a native resize
-            // drag — mirrors the mouse path in [onPointerButton]. The press is
-            // consumed (never forwarded to Compose) so the compositor owns the
-            // whole sequence, exactly like the mouse-driven resize. Positions are
-            // physical px (`/ TOUCH_POSITION_SCALE`), matching what
-            // [currentResizeDirection] expects. `begin_resize_drag` works during a
-            // touch grab the same way `begin_move_drag` does for title-bar touch
-            // drag (see the compositor pointer-grab note in [onNativeWindowDragStarted]).
-            if (eventType == TaoTouchEvent.PRESS && count == 1) {
-                val direction =
-                    currentResizeDirection(
-                        xsFixed[0] / TOUCH_POSITION_SCALE,
-                        ysFixed[0] / TOUCH_POSITION_SCALE,
-                        forTouch = true,
+                // Single-finger press in the resize edge band starts a native resize
+                // drag — mirrors the mouse path in [onPointerButton]. The press is
+                // consumed (never forwarded to Compose) so the compositor owns the
+                // whole sequence, exactly like the mouse-driven resize. Positions are
+                // physical px (`/ TOUCH_POSITION_SCALE`), matching what
+                // [currentResizeDirection] expects. `begin_resize_drag` works during a
+                // touch grab the same way `begin_move_drag` does for title-bar touch
+                // drag (see the compositor pointer-grab note in [onNativeWindowDragStarted]).
+                if (eventType == TaoTouchEvent.PRESS && count == 1) {
+                    val direction =
+                        currentResizeDirection(
+                            xsFixed[0] / TOUCH_POSITION_SCALE,
+                            ysFixed[0] / TOUCH_POSITION_SCALE,
+                            forTouch = true,
+                        )
+                    if (resizeDecoration.onLeftPress(direction)) {
+                        compositorDragActive = true
+                        return
+                    }
+                }
+
+                val pointers = ArrayList<ComposeScenePointer>(count)
+                for (i in 0 until count) {
+                    val pressed = (pressedMask and (1L shl i)) != 0L
+                    pointers.add(
+                        ComposeScenePointer(
+                            id = PointerId(ids[i]),
+                            position =
+                                Offset(
+                                    xsFixed[i] / TOUCH_POSITION_SCALE,
+                                    ysFixed[i] / TOUCH_POSITION_SCALE,
+                                ),
+                            pressed = pressed,
+                            type = PointerType.Touch,
+                        ),
                     )
-                if (resizeDecoration.onLeftPress(direction)) {
-                    compositorDragActive = true
-                    return
                 }
-            }
-
-            val pointers = ArrayList<ComposeScenePointer>(count)
-            for (i in 0 until count) {
-                val pressed = (pressedMask and (1L shl i)) != 0L
-                pointers.add(
-                    ComposeScenePointer(
-                        id = PointerId(ids[i]),
-                        position =
-                            Offset(
-                                xsFixed[i] / TOUCH_POSITION_SCALE,
-                                ysFixed[i] / TOUCH_POSITION_SCALE,
-                            ),
-                        pressed = pressed,
-                        type = PointerType.Touch,
-                    ),
+                val composeType =
+                    when (eventType) {
+                        TaoTouchEvent.PRESS -> PointerEventType.Press
+                        TaoTouchEvent.MOVE -> PointerEventType.Move
+                        TaoTouchEvent.RELEASE, TaoTouchEvent.CANCEL -> PointerEventType.Release
+                        else -> return
+                    }
+                sc.sendPointerEvent(
+                    eventType = composeType,
+                    pointers = pointers,
+                    keyboardModifiers = currentKeyboardModifiers,
                 )
-            }
-            val composeType =
-                when (eventType) {
-                    TaoTouchEvent.PRESS -> PointerEventType.Press
-                    TaoTouchEvent.MOVE -> PointerEventType.Move
-                    TaoTouchEvent.RELEASE, TaoTouchEvent.CANCEL -> PointerEventType.Release
-                    else -> return
+                if (eventType == TaoTouchEvent.CANCEL) {
+                    sc.cancelPointerInput()
                 }
-            sc.sendPointerEvent(
-                eventType = composeType,
-                pointers = pointers,
-                keyboardModifiers = currentKeyboardModifiers,
-            )
-            if (eventType == TaoTouchEvent.CANCEL) {
-                sc.cancelPointerInput()
             }
         }
 
@@ -984,7 +992,20 @@ internal class TaoComposeSceneHostLinux(
             yFixed: Long,
             valueFixed: Long,
         ) {
-            dispatchTrackpadGesture(kind, phase, xFixed, yFixed, valueFixed)
+            guardBridgeCallback { dispatchTrackpadGesture(kind, phase, xFixed, yFixed, valueFixed) }
+        }
+
+        // The native bridge invokes these callbacks directly from its JNI
+        // thread, outside `EventDispatcher.guarded`, so reproduce the mouse
+        // wire's two layers here: the window's handler first, then the fatal
+        // path for anything it rethrows.
+        @Suppress("TooGenericExceptionCaught") // a rethrowing handler may throw anything
+        private inline fun guardBridgeCallback(block: () -> Unit) {
+            try {
+                exceptionHandler.catchExceptions(block)
+            } catch (t: Throwable) {
+                TaoApplication.reportFatal(t)
+            }
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -521,8 +521,12 @@ internal class TaoComposeSceneHostWindows(
     private val activeTouches = LinkedHashMap<Long, ActiveTouch>()
 
     private fun registerTouchInput() {
+        // Touch runs user pointer-input code (clickable, drag) exactly like the
+        // mouse path, so it gets the same guard as the pointer wraps in
+        // DecoratedWindow; a rethrow unwinds into `EventDispatcher.guarded`,
+        // i.e. the fatal path, just like every other input entry.
         window.onTouchInput { phase, id, xFixed, yFixed, forceFixed ->
-            onTouchInput(phase, id, xFixed, yFixed, forceFixed)
+            exceptionHandler.catchExceptions { onTouchInput(phase, id, xFixed, yFixed, forceFixed) }
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowExceptionHandler
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.TaoEventCode
 import dev.nucleusframework.window.tao.TaoModifierMask
@@ -384,8 +385,11 @@ internal class TaoComposeSceneHostWindows(
         // custom title bar path. NativeView overlay scenes can still opt into
         // TaoComposeSceneContextWindows when they need popups outside their
         // overlay bounds.
-        window.imePreedit = imeSession::preedit
-        window.imeCommit = imeSession::commit
+        // IME callbacks edit the focused field through `TextEditingScope`, i.e.
+        // they run user code straight off an IMM32 callback — the Tao
+        // counterpart of AWT's guarded `inputMethodTextChanged`.
+        window.imePreedit = { text -> exceptionHandler.catchExceptions { imeSession.preedit(text) } }
+        window.imeCommit = { text -> exceptionHandler.catchExceptions { imeSession.commit(text) } }
         val platformContext =
             WindowsTaoPlatformContext(
                 windowHandle = window.handle,
@@ -446,6 +450,9 @@ internal class TaoComposeSceneHostWindows(
                 )
             }
         scene?.compositionLocalContext = pendingCompositionLocalContext
+        // Frame failures (recomposition / layout / draw) are caught inside the
+        // bundle, the single seam all three platforms render through.
+        sceneBundle?.exceptionHandler = exceptionHandler
 
         publishWindowsTextureHost()
         registerInboundDnD()
@@ -913,21 +920,25 @@ internal class TaoComposeSceneHostWindows(
         }
     }
 
-    fun setContent(content: @Composable () -> Unit) {
-        scene?.setContent {
-            // Stock Compose Desktop Windows wheel behavior; only the
-            // lines-per-notch factor is reapplied (see TaoWindowsScrollConfig).
-            ProvideTaoWindowsScrollConfig {
-                TaoTextToolbarHost(textToolbar) {
-                    CompositionLocalProvider(
-                        LocalDensity provides Density(scaleState.value),
-                    ) {
-                        content()
+    // Guarded like AWT's `ComposeSceneMediator.setContent`: the first
+    // composition runs inside this call, so content that throws while mounting
+    // must reach the window's handler instead of unwinding into the Tao loop.
+    fun setContent(content: @Composable () -> Unit) =
+        exceptionHandler.catchExceptions {
+            scene?.setContent {
+                // Stock Compose Desktop Windows wheel behavior; only the
+                // lines-per-notch factor is reapplied (see TaoWindowsScrollConfig).
+                ProvideTaoWindowsScrollConfig {
+                    TaoTextToolbarHost(textToolbar) {
+                        CompositionLocalProvider(
+                            LocalDensity provides Density(scaleState.value),
+                        ) {
+                            content()
+                        }
                     }
                 }
             }
         }
-    }
 
     /**
      * Forwards a parent composition's locals into this scene via
@@ -1517,6 +1528,9 @@ internal class TaoComposeSceneHostWindows(
             override val sceneCoroutineContext: kotlin.coroutines.CoroutineContext
                 get() = outer.coroutineContext + outer.flushingDispatcher
             override val hostDirectContext: DirectContext get() = ctx
+
+            override val exceptionHandler: WindowExceptionHandler?
+                get() = outer.exceptionHandler
 
             override fun requestRedraw() = outer.window.requestRedraw()
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoExceptionGuard.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoExceptionGuard.kt
@@ -1,0 +1,151 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.WindowExceptionHandler
+import dev.nucleusframework.window.tao.TaoApplication
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.logging.Level
+import java.util.logging.Logger
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Runs [block], routing anything it throws to this handler — the Tao mirror of
+ * Compose Desktop's `ComposeSceneMediator.catchExceptions`.
+ *
+ * Contract, identical to the AWT backend's: a handler that returns normally
+ * swallows the failure and the calling thread carries on; a handler that
+ * rethrows propagates it. A `null` handler always propagates, which is what
+ * every entry point did before this existed.
+ *
+ * [CancellationException] is never handed to the handler: on the render path
+ * the block spans coroutine suspension points, and a swallowed cancellation
+ * would let an already-cancelled frame loop keep running.
+ */
+@Suppress("TooGenericExceptionCaught") // catching everything is the whole point of the guard
+internal inline fun WindowExceptionHandler?.catchExceptions(block: () -> Unit) {
+    try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        this?.onException(e) ?: throw e
+    }
+}
+
+/**
+ * [catchExceptions] for entry points that answer "did the scene consume this
+ * event?". A swallowed failure reports [fallback] — `false` at every current
+ * call site, so a key the scene failed on falls through to the app's own
+ * handlers instead of being reported as consumed.
+ */
+@Suppress("TooGenericExceptionCaught") // see catchExceptions
+internal inline fun WindowExceptionHandler?.catchExceptions(
+    fallback: Boolean,
+    block: () -> Boolean,
+): Boolean =
+    try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        this?.onException(e) ?: throw e
+        fallback
+    }
+
+/**
+ * The single [CoroutineExceptionHandler] every Tao scene carries, chaining the
+ * per-window handler of #621 in front of the app-fatal path of #622.
+ *
+ * Why a coroutine handler is needed at all: a failing composition never leaves
+ * `ComposeScene.render`. `Recomposer.processCompositionError` intercepts it,
+ * logs it, and rethrows into the `runCatching` inside `withFrameNanos`, so it
+ * arrives here as a *coroutine* failure of the recomposition loop rather than
+ * out of the frame call that [catchExceptions] wraps. The same interception is
+ * why such a failure is **not survivable**: it ends
+ * `Recomposer.runRecomposeAndApplyChanges`, and nothing outside
+ * `androidx.compose.runtime` can restart it (`setHotReloadEnabled` /
+ * `retryFailedCompositions` are internal).
+ *
+ * The chain, in order:
+ *  1. **Teardown** ([closed] set) — a cancelled effect's `finally` throwing as
+ *     its window closes is noise; log at SEVERE, never take the app down (#622).
+ *  2. **The window's [handler]**, when the app installed one. Returning
+ *     normally means "swallow and continue", and that is honoured — but if the
+ *     scene cannot recompose any more ([sceneIsAlive]) the window is frozen, so
+ *     say so at SEVERE instead of leaving it silent. Rethrowing from the
+ *     handler falls through to step 3 with whatever it threw.
+ *  3. **Fatal** ([onFatal] → `TaoApplication.reportFatal`): SEVERE log, native
+ *     error dialog, clean loop exit. This is also what an app that installs no
+ *     factory gets, since the default one rethrows.
+ *
+ * [handler] and [sceneIsAlive] are mutable because the scene's coroutine
+ * context is built before either is known; they are written at window-open time
+ * and read from whichever thread the failing coroutine ran on.
+ */
+internal class TaoSceneExceptionRouter(
+    private val closed: AtomicBoolean,
+    /** Seam for tests; production always routes to the #622 fatal path. */
+    private val onFatal: (Throwable) -> Unit = TaoApplication::reportFatal,
+) : AbstractCoroutineContextElement(CoroutineExceptionHandler),
+    CoroutineExceptionHandler {
+    @Volatile
+    var handler: WindowExceptionHandler? = null
+
+    /**
+     * Reports whether the scene can still recompose. Installed by the bundle
+     * factory once the bundle exists (the router has to be built first, to go
+     * into the scene's coroutine context).
+     */
+    @Volatile
+    var sceneIsAlive: () -> Boolean = { true }
+
+    @Suppress("TooGenericExceptionCaught") // a rethrowing handler may throw anything
+    override fun handleException(
+        context: CoroutineContext,
+        exception: Throwable,
+    ) {
+        if (closed.get()) {
+            sceneExceptionLogger.log(Level.SEVERE, "Unhandled exception during scene teardown", exception)
+            return
+        }
+        val handler = this.handler
+        if (handler == null) {
+            onFatal(exception)
+            return
+        }
+        val rethrown =
+            try {
+                handler.onException(exception)
+                null
+            } catch (t: Throwable) {
+                t
+            }
+        if (rethrown != null) {
+            onFatal(rethrown)
+            return
+        }
+        // The handler chose to continue. Only some coroutine failures allow
+        // that (an effect launched off a live dispatcher, say); a recomposition
+        // failure has already shut the recomposer down, and staying quiet here
+        // is exactly how a window ends up frozen with no diagnostic. The app
+        // asked to swallow, so this stops short of the fatal dialog.
+        if (!sceneIsAlive()) {
+            sceneExceptionLogger.log(
+                Level.SEVERE,
+                "The Compose recomposer did not survive this exception, so the window will no " +
+                    "longer update. Compose terminates the recomposition loop on a composition " +
+                    "failure and it cannot be restarted in place — close and recreate the window, " +
+                    "or rethrow from the WindowExceptionHandler to take the fatal path instead.",
+                exception,
+            )
+        }
+    }
+}
+
+private val sceneExceptionLogger: Logger =
+    Logger.getLogger("dev.nucleusframework.window.tao.exception")

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
@@ -1,5 +1,7 @@
 package dev.nucleusframework.window.tao.scene
 
+import androidx.compose.runtime.Recomposer
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.platform.FrameRecomposer
@@ -12,8 +14,7 @@ import androidx.compose.ui.scene.SingleComposeSceneRenderingScope
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
-import dev.nucleusframework.window.tao.TaoApplication
-import kotlinx.coroutines.CoroutineExceptionHandler
+import androidx.compose.ui.window.WindowExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -46,7 +47,7 @@ import kotlin.coroutines.CoroutineContext
  * RectManager's delayed dispatch off the AWT EDT (issue #551) — see that class
  * for the full story.
  */
-@OptIn(InternalComposeUiApi::class)
+@OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
 internal class TaoSceneBundle(
     val scene: ComposeScene,
     val frameRecomposer: FrameRecomposer,
@@ -54,9 +55,50 @@ internal class TaoSceneBundle(
     private val edtGuard: RectManagerEdtGuard,
     /** Owns [edtGuard]'s debounce wakeups; cancelled with the scene. */
     private val guardScope: CoroutineScope,
-    /** Flipped first thing in [close] — see [sceneFatalHandler]. */
+    /** Flipped first thing in [close] — see [TaoSceneExceptionRouter]. */
     private val closed: AtomicBoolean,
+    /** Installed in the scene's coroutine context; also stores [exceptionHandler]. */
+    private val exceptionRouter: TaoSceneExceptionRouter,
+    /** The owner's coalescing frame scheduler; re-armed after a swallowed frame failure. */
+    private val requestFrame: () -> Unit,
 ) : AutoCloseable {
+    /**
+     * Catches what user code throws in this scene: [render] covers layout and
+     * draw, the [TaoSceneExceptionRouter] in the scene's coroutine context
+     * covers recomposition and everything else the scene's coroutines run.
+     * Together they are the one seam every Tao host and popup layer shares.
+     *
+     * Installed from
+     * [dev.nucleusframework.window.tao.LocalWindowExceptionHandlerFactory] by
+     * whoever owns the bundle; `null` lets the failure escape, as it always did.
+     */
+    var exceptionHandler: WindowExceptionHandler?
+        get() = exceptionRouter.handler
+        set(value) {
+            exceptionRouter.handler = value
+        }
+
+    /**
+     * Whether the scene can still recompose.
+     *
+     * `Idle` and `PendingWork` are the two states in which a recomposition loop
+     * is actually running. Everything else means there is none: in particular
+     * `Recomposer.processCompositionError` records an error state, which
+     * `deriveStateLocked` immediately derives to `Inactive` — so a composition
+     * failure flips this to false the moment it happens, before the throw has
+     * even finished unwinding. Such a scene still draws its last tree and still
+     * hit-tests, but no state change will ever reach the screen again, so it
+     * must not be mistaken for a recovered one.
+     */
+    val isRecomposerAlive: Boolean
+        get() =
+            when ((frameRecomposer.compositionContext as? Recomposer)?.currentState?.value) {
+                Recomposer.State.Idle, Recomposer.State.PendingWork -> true
+                // Not a Recomposer — cannot happen today; assume usable.
+                null -> true
+                else -> false
+            }
+
     /**
      * Recomposes, lays out, and draws one frame into [canvas] — the drop-in
      * replacement for the pre-1.12 `scene.render(canvas.asComposeCanvas(), nanoTime)`.
@@ -67,10 +109,21 @@ internal class TaoSceneBundle(
         canvas: Canvas,
         nanoTime: Long,
     ) {
-        with(renderingScope) {
-            scene.render(frameRecomposer, canvas.asComposeCanvas(), nanoTime)
+        var swallowed = true
+        exceptionHandler.catchExceptions {
+            with(renderingScope) {
+                scene.render(frameRecomposer, canvas.asComposeCanvas(), nanoTime)
+            }
+            edtGuard.afterFrame()
+            swallowed = false
         }
-        edtGuard.afterFrame()
+        // The handler chose to continue: this frame's recording is incomplete,
+        // so it is dropped and the scheduler re-armed. Without the re-arm the
+        // scene can stay invalidated forever — the invalidation that produced
+        // this frame was consumed by the pass that just aborted. Skipped once
+        // the recomposer is gone: the next frame would be identical, so this
+        // would be a repaint spin rather than a retry.
+        if (swallowed && isRecomposerAlive) requestFrame()
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -93,24 +146,6 @@ internal class TaoSceneBundle(
 private val bundleLogger: Logger = Logger.getLogger(TaoSceneBundle::class.java.name)
 
 /**
- * Fatal routing (#622) for everything that runs inside this scene's
- * composition — recomposition, `LaunchedEffect`s, pointer-input coroutines:
- * a crash takes [TaoApplication.reportFatal] (SEVERE log, native dialog,
- * clean exit); without a handler it dies in kotlinx's global handler (stderr
- * only) and the scene silently stops recomposing. Once [closed] is set the
- * same failures are teardown noise (a cancelled effect's `finally` throwing
- * while its window closes) and are logged instead of taking the app down.
- */
-private fun sceneFatalHandler(closed: AtomicBoolean): CoroutineExceptionHandler =
-    CoroutineExceptionHandler { _, t ->
-        if (closed.get()) {
-            bundleLogger.log(Level.SEVERE, "Unhandled exception during scene teardown", t)
-        } else {
-            TaoApplication.reportFatal(t)
-        }
-    }
-
-/**
  * Creates a [CanvasLayersComposeScene] wired to a fresh [FrameRecomposer].
  * [requestFrame] is invoked whenever the scene needs to be repainted
  * (recomposition, relayout, redraw, or a pending animation frame); callers
@@ -127,7 +162,11 @@ internal fun canvasLayersSceneBundle(
 ): TaoSceneBundle {
     val renderingScope = SingleComposeSceneRenderingScope(requestFrame)
     val closed = AtomicBoolean(false)
-    val sceneContext = coroutineContext + sceneFatalHandler(closed)
+    // Every coroutine the scene owns carries the router: a recomposition
+    // failure is offered to the window's handler first (#621) and falls
+    // through to the app-fatal path (#622) when nothing swallows it.
+    val exceptionRouter = TaoSceneExceptionRouter(closed)
+    val sceneContext = coroutineContext + exceptionRouter
     val frameRecomposer = FrameRecomposer(sceneContext) { requestFrame() }
     val guardScope = CoroutineScope(sceneContext + SupervisorJob())
     val edtGuard = RectManagerEdtGuard(guardScope, requestFrame)
@@ -141,7 +180,16 @@ internal fun canvasLayersSceneBundle(
             invalidateLayout = { renderingScope.onSceneInvalidation() },
             invalidateDraw = { renderingScope.onSceneInvalidation() },
         )
-    return TaoSceneBundle(scene, frameRecomposer, renderingScope, edtGuard, guardScope, closed)
+    return TaoSceneBundle(
+        scene,
+        frameRecomposer,
+        renderingScope,
+        edtGuard,
+        guardScope,
+        closed,
+        exceptionRouter,
+        requestFrame,
+    ).also { bundle -> exceptionRouter.sceneIsAlive = { bundle.isRecomposerAlive } }
 }
 
 /**
@@ -158,8 +206,10 @@ internal fun platformLayersSceneBundle(
     requestFrame: () -> Unit,
 ): TaoSceneBundle {
     val renderingScope = SingleComposeSceneRenderingScope(requestFrame)
+    // See canvasLayersSceneBundle.
     val closed = AtomicBoolean(false)
-    val sceneContext = coroutineContext + sceneFatalHandler(closed)
+    val exceptionRouter = TaoSceneExceptionRouter(closed)
+    val sceneContext = coroutineContext + exceptionRouter
     val frameRecomposer = FrameRecomposer(sceneContext) { requestFrame() }
     val guardScope = CoroutineScope(sceneContext + SupervisorJob())
     val edtGuard = RectManagerEdtGuard(guardScope, requestFrame)
@@ -177,7 +227,16 @@ internal fun platformLayersSceneBundle(
             invalidateLayout = { renderingScope.onSceneInvalidation() },
             invalidateDraw = { renderingScope.onSceneInvalidation() },
         )
-    return TaoSceneBundle(scene, frameRecomposer, renderingScope, edtGuard, guardScope, closed)
+    return TaoSceneBundle(
+        scene,
+        frameRecomposer,
+        renderingScope,
+        edtGuard,
+        guardScope,
+        closed,
+        exceptionRouter,
+        requestFrame,
+    ).also { bundle -> exceptionRouter.sceneIsAlive = { bundle.isRecomposerAlive } }
 }
 
 /**

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -15,6 +15,8 @@ import dev.nucleusframework.window.tao.popup.StandaloneFramePumpTest
 import dev.nucleusframework.window.tao.popup.StandalonePopupRenderReentryTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
+import dev.nucleusframework.window.tao.scene.TaoSceneExceptionHandlerTest
+import dev.nucleusframework.window.tao.scene.TaoSceneExceptionRouterTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
 import dev.nucleusframework.window.tao.scene.TaoSceneKeyboardTest
 import dev.nucleusframework.window.tao.scene.TaoSceneOuterLocalsBridgeTest
@@ -423,6 +425,61 @@ public object TaoSceneTestBattery {
         }
         run("TaoSceneContentSwapTest: clicking a tab remounts the body without a RectList crash") {
             TaoSceneContentSwapTest().`clicking a tab remounts the body without a RectList crash`()
+        }
+
+        run("TaoSceneExceptionHandlerTest: composition failure reaches the handler") {
+            TaoSceneExceptionHandlerTest().`composition failure reaches the handler`()
+        }
+        run("TaoSceneExceptionHandlerTest: a swallowed composition failure leaves the scene unable to recompose") {
+            TaoSceneExceptionHandlerTest()
+                .`a swallowed composition failure leaves the scene unable to recompose`()
+        }
+        run("TaoSceneExceptionHandlerTest: a dead scene does not spin the frame scheduler") {
+            TaoSceneExceptionHandlerTest().`a dead scene does not spin the frame scheduler`()
+        }
+        run("TaoSceneExceptionHandlerTest: layout failure reaches the handler") {
+            TaoSceneExceptionHandlerTest().`layout failure reaches the handler`()
+        }
+        run("TaoSceneExceptionHandlerTest: draw failure reaches the handler and the scene keeps rendering") {
+            TaoSceneExceptionHandlerTest().`draw failure reaches the handler and the scene keeps rendering`()
+        }
+        run("TaoSceneExceptionHandlerTest: a swallowed draw failure keeps state updates flowing") {
+            TaoSceneExceptionHandlerTest().`a swallowed draw failure keeps state updates flowing`()
+        }
+        run("TaoSceneExceptionHandlerTest: a scene that survived a swallowed failure still accepts new content") {
+            TaoSceneExceptionHandlerTest().`a scene that survived a swallowed failure still accepts new content`()
+        }
+        run("TaoSceneExceptionHandlerTest: input dispatch failure reaches the handler") {
+            TaoSceneExceptionHandlerTest().`input dispatch failure reaches the handler`()
+        }
+        run("TaoSceneExceptionHandlerTest: a handler that rethrows propagates the failure") {
+            TaoSceneExceptionHandlerTest().`a handler that rethrows propagates the failure`()
+        }
+        run("TaoSceneExceptionHandlerTest: without a handler the failure propagates") {
+            TaoSceneExceptionHandlerTest().`without a handler the failure propagates`()
+        }
+
+        run("TaoSceneExceptionRouterTest: a failure with no window handler takes the fatal path") {
+            TaoSceneExceptionRouterTest().`a failure with no window handler takes the fatal path`()
+        }
+        run("TaoSceneExceptionRouterTest: a handler that rethrows takes the fatal path") {
+            TaoSceneExceptionRouterTest().`a handler that rethrows takes the fatal path`()
+        }
+        run("TaoSceneExceptionRouterTest: a handler may substitute the throwable it rethrows") {
+            TaoSceneExceptionRouterTest().`a handler may substitute the throwable it rethrows`()
+        }
+        run("TaoSceneExceptionRouterTest: a handler that returns normally swallows the failure") {
+            TaoSceneExceptionRouterTest().`a handler that returns normally swallows the failure`()
+        }
+        run("TaoSceneExceptionRouterTest: swallowing a failure the scene cannot survive is logged") {
+            TaoSceneExceptionRouterTest().`swallowing a failure the scene cannot survive is logged`()
+        }
+        run("TaoSceneExceptionRouterTest: swallowing a survivable failure is not logged") {
+            TaoSceneExceptionRouterTest().`swallowing a survivable failure is not logged`()
+        }
+        run("TaoSceneExceptionRouterTest: a failure during teardown is logged instead of taking the app down") {
+            TaoSceneExceptionRouterTest()
+                .`a failure during teardown is logged instead of taking the app down`()
         }
 
         run("TaoA11yProjectionTest: compose semantics are projected into the a11y node snapshot") {

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -15,6 +15,8 @@ import dev.nucleusframework.window.tao.popup.StandaloneFramePumpTest
 import dev.nucleusframework.window.tao.popup.StandalonePopupRenderReentryTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
+import dev.nucleusframework.window.tao.scene.TaoSceneExceptionHandlerTest
+import dev.nucleusframework.window.tao.scene.TaoSceneExceptionRouterTest
 import dev.nucleusframework.window.tao.scene.TaoSceneImeTest
 import dev.nucleusframework.window.tao.scene.TaoSceneKeyboardTest
 import dev.nucleusframework.window.tao.scene.TaoSceneOuterLocalsBridgeTest
@@ -68,6 +70,8 @@ class TaoSceneTestBatteryDriftTest {
             TaoSceneOuterLocalsBridgeTest::class.java,
             TaoSceneAnimationTest::class.java,
             TaoSceneContentSwapTest::class.java,
+            TaoSceneExceptionHandlerTest::class.java,
+            TaoSceneExceptionRouterTest::class.java,
             TaoSceneSemanticsTest::class.java,
             TaoA11yProjectionTest::class.java,
             TitleBarHitTestTest::class.java,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneExceptionHandlerTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneExceptionHandlerTest.kt
@@ -1,0 +1,370 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowExceptionHandler
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Stage-1 coverage for the window exception handler (#621), the Tao mirror of
+ * Compose Desktop's `LocalWindowExceptionHandlerFactory`.
+ *
+ * Frames run through the production guard: the harness installs the handler on
+ * the [TaoSceneBundle] exactly like every scene host does, so
+ * `recordSceneToPicture` → `TaoSceneBundle.render` is the real code under test.
+ * Input and IME entries mirror the host's guarded dispatch, the same way the
+ * harness already mirrors the host's pointer guards.
+ *
+ * Two failure classes behave differently, and the tests pin both down:
+ *  - layout / draw / input failures leave the scene fully usable — swallowing
+ *    them is what #621 asked for;
+ *  - a composition failure is intercepted by `Recomposer.processCompositionError`,
+ *    which tears the recomposition loop down before we ever see it. Swallowing
+ *    that one cannot resurrect the window, so the scene reports itself dead and
+ *    the router logs it instead of leaving a silently frozen window.
+ *
+ * The routing chain in front of the #622 fatal path is covered separately, in
+ * [TaoSceneExceptionRouterTest], where the fatal step can be observed without
+ * touching `TaoApplication`'s process-wide state.
+ */
+class TaoSceneExceptionHandlerTest {
+    /** Collects what the handler saw, and swallows it so the scene continues. */
+    private class Collector : WindowExceptionHandler {
+        val seen = mutableListOf<Throwable>()
+
+        override fun onException(throwable: Throwable) {
+            seen += throwable
+        }
+    }
+
+    @Test
+    fun `composition failure reaches the handler`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            val collector = Collector()
+            exceptionHandler = collector
+            var failing by mutableStateOf(false)
+
+            setContent {
+                if (failing) error("composition boom")
+                Box(Modifier.fillMaxSize().background(Color.Green))
+            }
+            assertTrue(collector.seen.isEmpty(), "a healthy composition must not report anything")
+
+            failing = true
+            // A failed recomposition never leaves `render`: Compose rethrows it
+            // into the `runCatching` inside `withFrameNanos`, so it arrives as a
+            // failure of the recomposition loop's coroutine — hence the
+            // [TaoSceneExceptionRouter] — one pump after the frame that ran it.
+            frame()
+            pumpUntilIdle()
+
+            assertEquals(1, collector.seen.size, "the composition failure must reach the handler")
+            assertEquals("composition boom", collector.seen.single().message)
+        }
+
+    @Test
+    fun `a swallowed composition failure leaves the scene unable to recompose`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            val collector = Collector()
+            exceptionHandler = collector
+            val log = CapturedLog()
+            var failing by mutableStateOf(false)
+            var color by mutableStateOf(Color.Green)
+
+            setContent {
+                if (failing) error("composition boom")
+                Box(Modifier.fillMaxSize().background(color))
+            }
+            assertTrue(isRecomposerAlive, "the scene starts alive")
+
+            failing = true
+            frame()
+            log.use { pumpUntilIdle() }
+
+            assertEquals(1, collector.seen.size, "the failure still reaches the handler")
+            assertFalse(
+                isRecomposerAlive,
+                "Compose shuts the recomposition loop down on a composition failure; " +
+                    "swallowing it cannot bring it back",
+            )
+            assertTrue(
+                log.records.any { it.level == Level.SEVERE },
+                "the unrecoverable case must be logged, not silently swallowed — " +
+                    "this is the frozen-window report from ZonePane",
+            )
+
+            // The regression itself: the app healed its state, and the window
+            // still never updates again.
+            failing = false
+            color = Color.Blue
+            repeat(FRAMES_AFTER_FAILURE) {
+                frame()
+                pumpUntilIdle()
+            }
+            assertEquals(GREEN, pixelAt(20, 20), "a dead recomposer can no longer paint state changes")
+        }
+
+    @Test
+    fun `a dead scene does not spin the frame scheduler`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            exceptionHandler = Collector()
+            var failing by mutableStateOf(false)
+
+            setContent {
+                if (failing) error("composition boom")
+                Box(Modifier.fillMaxSize().background(Color.Green))
+            }
+
+            failing = true
+            frame()
+            pumpUntilIdle()
+            assertFalse(isRecomposerAlive, "precondition: the scene is dead")
+
+            repeat(FRAMES_AFTER_FAILURE) {
+                frame()
+                pumpUntilIdle()
+            }
+            assertFalse(
+                isSceneInvalidated,
+                "a scene that can never change again must not keep asking for frames",
+            )
+        }
+
+    @Test
+    fun `layout failure reaches the handler`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            val collector = Collector()
+            exceptionHandler = collector
+            var failing by mutableStateOf(false)
+
+            setContent {
+                Box(Modifier.fillMaxSize().background(Color.Green)) {
+                    ThrowingLayout(shouldThrow = { failing })
+                }
+            }
+            assertTrue(collector.seen.isEmpty(), "a healthy layout pass must not report anything")
+
+            failing = true
+            frame()
+
+            assertEquals(1, collector.seen.size, "the layout failure must reach the handler")
+            assertEquals("layout boom", collector.seen.single().message)
+        }
+
+    @Test
+    fun `draw failure reaches the handler and the scene keeps rendering`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            val collector = Collector()
+            exceptionHandler = collector
+            var failing by mutableStateOf(false)
+
+            setContent {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color.Green)
+                        .drawBehind { if (failing) error("draw boom") },
+                )
+            }
+            assertEquals(GREEN, pixelAt(20, 20))
+
+            // The recoverable case #621 is about: a decoder throwing mid-draw
+            // (CMP's "A partial image was generated") used to freeze the window.
+            failing = true
+            frame()
+            assertEquals(1, collector.seen.size, "the draw failure must reach the handler")
+
+            // Handler returned normally, so the frame is dropped and a new one
+            // requested — the scene must still be alive and paint again.
+            failing = false
+            frameUntilIdle()
+            assertEquals(GREEN, pixelAt(20, 20), "the scene must keep painting after a swallowed failure")
+            assertEquals(1, collector.seen.size, "recovery must not report a second failure")
+        }
+
+    @Test
+    fun `a swallowed draw failure keeps state updates flowing`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            val collector = Collector()
+            exceptionHandler = collector
+            var failing by mutableStateOf(false)
+            var color by mutableStateOf(Color.Green)
+
+            setContent {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .background(color)
+                        .drawBehind { if (failing) error("draw boom") },
+                )
+            }
+
+            failing = true
+            frame()
+            assertEquals(1, collector.seen.size)
+            assertTrue(isRecomposerAlive, "a draw failure must not take the recomposer down")
+
+            // Not just "renders again" — recomposition of a state change must
+            // still reach the screen, which is what a live recomposer buys.
+            failing = false
+            color = Color.Blue
+            frameUntilIdle()
+            assertEquals(BLUE, pixelAt(20, 20), "state changes must still repaint after a swallowed draw failure")
+        }
+
+    @Test
+    fun `a scene that survived a swallowed failure still accepts new content`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            val collector = Collector()
+            exceptionHandler = collector
+            var failing by mutableStateOf(true)
+
+            setContent {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color.Green)
+                        .drawBehind { if (failing) error("draw boom") },
+                )
+            }
+            assertTrue(collector.seen.isNotEmpty(), "the first frame already fails")
+
+            failing = false
+            setContent { Box(Modifier.fillMaxSize().background(Color.Blue)) }
+            frameUntilIdle()
+
+            assertEquals(BLUE, pixelAt(20, 20), "content swap must work after a swallowed failure")
+        }
+
+    @Test
+    fun `input dispatch failure reaches the handler`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            val collector = Collector()
+            exceptionHandler = collector
+
+            setContent {
+                Box(Modifier.fillMaxSize().background(Color.Green)) {
+                    Box(
+                        Modifier
+                            .size(40.dp)
+                            .clickable { error("click boom") },
+                    )
+                }
+            }
+
+            click(20f, 20f)
+
+            assertEquals(1, collector.seen.size, "the click handler failure must reach the handler")
+            assertEquals("click boom", collector.seen.single().message)
+        }
+
+    @Test
+    fun `a handler that rethrows propagates the failure`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            exceptionHandler = WindowExceptionHandler { throw it }
+            var failing by mutableStateOf(false)
+
+            setContent {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color.Green)
+                        .drawBehind { if (failing) error("draw boom") },
+                )
+            }
+
+            failing = true
+            val failure = assertFailsWith<IllegalStateException> { frame() }
+            assertEquals("draw boom", failure.message)
+        }
+
+    /**
+     * Propagating out of the guard is what feeds #622: in a real window this
+     * unwinds into the `guarded { }` Tao event dispatch (or the render loop's
+     * fatal coroutine handler), which logs, shows the native dialog and exits.
+     * The default factory rethrows for exactly this reason.
+     */
+    @Test
+    fun `without a handler the failure propagates`() =
+        runTaoSceneTest(width = 40, height = 40) {
+            var failing by mutableStateOf(false)
+
+            setContent {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color.Green)
+                        .drawBehind { if (failing) error("draw boom") },
+                )
+            }
+
+            failing = true
+            val failure = assertFailsWith<IllegalStateException> { frame() }
+            assertEquals("draw boom", failure.message)
+        }
+
+    /** Throws from the measure pass on demand — a layout-phase failure source. */
+    @Composable
+    private fun ThrowingLayout(shouldThrow: () -> Boolean) {
+        Layout(content = {}) { _, constraints ->
+            if (shouldThrow()) error("layout boom")
+            layout(constraints.minWidth, constraints.minHeight) {}
+        }
+    }
+
+    /** Captures what the scene-exception logger emits while [use] runs. */
+    private class CapturedLog {
+        val records = mutableListOf<LogRecord>()
+
+        fun use(block: () -> Unit) {
+            val logger = Logger.getLogger("dev.nucleusframework.window.tao.exception")
+            val handler =
+                object : Handler() {
+                    override fun publish(record: LogRecord) {
+                        records += record
+                    }
+
+                    override fun flush() = Unit
+
+                    override fun close() = Unit
+                }
+            logger.addHandler(handler)
+            try {
+                block()
+            } finally {
+                logger.removeHandler(handler)
+            }
+        }
+    }
+
+    private companion object {
+        const val GREEN = 0xFF00FF00.toInt()
+        const val BLUE = 0xFF0000FF.toInt()
+
+        /** Enough frames that a live scene would certainly have repainted. */
+        const val FRAMES_AFTER_FAILURE = 5
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneExceptionRouterTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneExceptionRouterTest.kt
@@ -1,0 +1,152 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.WindowExceptionHandler
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The routing chain that sits in every Tao scene's coroutine context: the
+ * per-window handler of #621 in front of the app-fatal path of #622.
+ *
+ * The fatal step is injected here rather than exercised through
+ * `TaoApplication.reportFatal`, which records a process-wide first-report-wins
+ * throwable and posts a native loop exit — not something a unit test should
+ * leave behind for the tests that run after it.
+ */
+class TaoSceneExceptionRouterTest {
+    @Test
+    fun `a failure with no window handler takes the fatal path`() {
+        val fatal = mutableListOf<Throwable>()
+        val router = router(onFatal = fatal::add)
+        val boom = RuntimeException("boom")
+
+        router.handleException(EmptyCoroutineContext, boom)
+
+        assertEquals(1, fatal.size, "no handler means the app-fatal path — dialog and clean exit")
+        assertSame(boom, fatal.single())
+    }
+
+    @Test
+    fun `a handler that rethrows takes the fatal path`() {
+        val fatal = mutableListOf<Throwable>()
+        val router = router(onFatal = fatal::add)
+        router.handler = WindowExceptionHandler { throw it }
+        val boom = RuntimeException("boom")
+
+        router.handleException(EmptyCoroutineContext, boom)
+
+        assertEquals(1, fatal.size, "rethrowing is how a handler opts into the fatal path")
+        assertSame(boom, fatal.single())
+    }
+
+    @Test
+    fun `a handler may substitute the throwable it rethrows`() {
+        val fatal = mutableListOf<Throwable>()
+        val router = router(onFatal = fatal::add)
+        val wrapper = IllegalStateException("wrapped")
+        router.handler = WindowExceptionHandler { throw wrapper }
+
+        router.handleException(EmptyCoroutineContext, RuntimeException("boom"))
+
+        assertSame(wrapper, fatal.single(), "the fatal path reports what the handler actually threw")
+    }
+
+    @Test
+    fun `a handler that returns normally swallows the failure`() {
+        val fatal = mutableListOf<Throwable>()
+        val seen = mutableListOf<Throwable>()
+        val router = router(onFatal = fatal::add)
+        router.handler = WindowExceptionHandler { seen += it }
+        val boom = RuntimeException("boom")
+
+        router.handleException(EmptyCoroutineContext, boom)
+
+        assertSame(boom, seen.single(), "the handler is asked first")
+        assertTrue(fatal.isEmpty(), "an app that swallows must not get the fatal dialog")
+    }
+
+    @Test
+    fun `swallowing a failure the scene cannot survive is logged`() {
+        val fatal = mutableListOf<Throwable>()
+        val router = router(onFatal = fatal::add)
+        router.handler = WindowExceptionHandler { }
+        router.sceneIsAlive = { false }
+        val log = CapturedLog()
+
+        log.use { router.handleException(EmptyCoroutineContext, RuntimeException("boom")) }
+
+        assertTrue(fatal.isEmpty(), "the app asked to continue; that choice is honoured")
+        assertTrue(
+            log.records.any { it.level == Level.SEVERE },
+            "a window that can never update again must not be left silent",
+        )
+    }
+
+    @Test
+    fun `swallowing a survivable failure is not logged`() {
+        val router = router(onFatal = { })
+        router.handler = WindowExceptionHandler { }
+        router.sceneIsAlive = { true }
+        val log = CapturedLog()
+
+        log.use { router.handleException(EmptyCoroutineContext, RuntimeException("boom")) }
+
+        assertNull(
+            log.records.firstOrNull { it.level == Level.SEVERE },
+            "a recovered scene must not be reported as frozen",
+        )
+    }
+
+    @Test
+    fun `a failure during teardown is logged instead of taking the app down`() {
+        val fatal = mutableListOf<Throwable>()
+        val closed = AtomicBoolean(true)
+        val router = TaoSceneExceptionRouter(closed, onFatal = fatal::add)
+        router.handler = WindowExceptionHandler { throw it }
+        val log = CapturedLog()
+
+        log.use { router.handleException(EmptyCoroutineContext, RuntimeException("boom")) }
+
+        assertTrue(fatal.isEmpty(), "closing one window must never close the whole app (#622)")
+        assertTrue(log.records.any { it.level == Level.SEVERE }, "teardown noise is still logged")
+    }
+
+    private fun router(onFatal: (Throwable) -> Unit) = TaoSceneExceptionRouter(AtomicBoolean(false), onFatal)
+
+    /** Captures what the scene-exception logger emits while [use] runs. */
+    private class CapturedLog {
+        val records = mutableListOf<LogRecord>()
+
+        fun use(block: () -> Unit) {
+            val logger = Logger.getLogger("dev.nucleusframework.window.tao.exception")
+            val handler =
+                object : Handler() {
+                    override fun publish(record: LogRecord) {
+                        records += record
+                    }
+
+                    override fun flush() = Unit
+
+                    override fun close() = Unit
+                }
+            logger.addHandler(handler)
+            try {
+                block()
+            } finally {
+                logger.removeHandler(handler)
+            }
+        }
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneTestHarness.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneTestHarness.kt
@@ -1,4 +1,4 @@
-@file:OptIn(InternalComposeUiApi::class)
+@file:OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 
 package dev.nucleusframework.window.tao.scene
 
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowExceptionHandler
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
 import dev.nucleusframework.window.tao.TaoPointerScrollEvent
@@ -257,6 +258,25 @@ internal class TaoSceneTestScope(
 
     val scene: ComposeScene get() = sceneBundle.scene
 
+    /**
+     * Mirrors the scene host's `exceptionHandler` field (#621): installed on the
+     * bundle, so frames go through the production guard in
+     * [TaoSceneBundle.render], and consulted at the input / IME entry points the
+     * host guards in `DecoratedWindow`. `null` — the default — propagates, like
+     * a window whose app installed no factory and whose default one rethrows.
+     */
+    var exceptionHandler: WindowExceptionHandler? = null
+        set(value) {
+            field = value
+            sceneBundle.exceptionHandler = value
+        }
+
+    /** See [TaoSceneBundle.isRecomposerAlive] — false once the scene can no longer recompose. */
+    val isRecomposerAlive: Boolean get() = sceneBundle.isRecomposerAlive
+
+    /** True while the scene has asked for another frame — the host's repaint signal. */
+    val isSceneInvalidated: Boolean get() = invalidated
+
     // ── Host-mirrored pointer state (same guards as TaoComposeSceneHost) ────
     private val pointerDeadband = TaoPointerDeadband()
     private var hasReceivedCursorMove = false
@@ -267,7 +287,7 @@ internal class TaoSceneTestScope(
         private set
 
     fun setContent(content: @Composable () -> Unit) {
-        scene.setContent(content = content)
+        exceptionHandler.catchExceptions { scene.setContent(content = content) }
         frame()
     }
 
@@ -355,12 +375,14 @@ internal class TaoSceneTestScope(
             frame()
             return
         }
-        scene.sendPointerEvent(
-            eventType = PointerEventType.Move,
-            position = Offset(pointerDeadband.x, pointerDeadband.y),
-            type = PointerType.Mouse,
-            keyboardModifiers = taoKeyboardModifiers(modifierState),
-        )
+        exceptionHandler.catchExceptions {
+            scene.sendPointerEvent(
+                eventType = PointerEventType.Move,
+                position = Offset(pointerDeadband.x, pointerDeadband.y),
+                type = PointerType.Mouse,
+                keyboardModifiers = taoKeyboardModifiers(modifierState),
+            )
+        }
         frame()
     }
 
@@ -388,13 +410,15 @@ internal class TaoSceneTestScope(
             return // host guard: stray release
         }
         isPressed = pressed
-        scene.sendPointerEvent(
-            eventType = if (pressed) PointerEventType.Press else PointerEventType.Release,
-            position = Offset(pointerDeadband.x, pointerDeadband.y),
-            type = PointerType.Mouse,
-            keyboardModifiers = modifiers,
-            button = button,
-        )
+        exceptionHandler.catchExceptions {
+            scene.sendPointerEvent(
+                eventType = if (pressed) PointerEventType.Press else PointerEventType.Release,
+                position = Offset(pointerDeadband.x, pointerDeadband.y),
+                type = PointerType.Mouse,
+                keyboardModifiers = modifiers,
+                button = button,
+            )
+        }
         frame()
     }
 
@@ -449,7 +473,9 @@ internal class TaoSceneTestScope(
         codePoint: Int = 0,
         modifiers: Int = modifierState,
     ) {
-        scene.dispatchNativeKeyEvent(TaoNativeWireFormat.KEY_DOWN, vkCode, codePoint, modifiers)
+        exceptionHandler.catchExceptions {
+            scene.dispatchNativeKeyEvent(TaoNativeWireFormat.KEY_DOWN, vkCode, codePoint, modifiers)
+        }
         frame()
     }
 
@@ -458,7 +484,9 @@ internal class TaoSceneTestScope(
         codePoint: Int = 0,
         modifiers: Int = modifierState,
     ) {
-        scene.dispatchNativeKeyEvent(TaoNativeWireFormat.KEY_UP, vkCode, codePoint, modifiers)
+        exceptionHandler.catchExceptions {
+            scene.dispatchNativeKeyEvent(TaoNativeWireFormat.KEY_UP, vkCode, codePoint, modifiers)
+        }
         frame()
     }
 
@@ -498,7 +526,7 @@ internal class TaoSceneTestScope(
      * `window.imePreedit` wiring. An empty [text] is `unmarkText`.
      */
     fun imePreedit(text: String) {
-        imeSession.preedit(text)
+        exceptionHandler.catchExceptions { imeSession.preedit(text) }
         frame()
     }
 
@@ -508,7 +536,7 @@ internal class TaoSceneTestScope(
      * wiring (`TextEditingScope.commitText`).
      */
     fun imeCommit(text: String) {
-        imeSession.commit(text)
+        exceptionHandler.catchExceptions { imeSession.commit(text) }
         frame()
     }
 


### PR DESCRIPTION
Implements #621 with the API shape you specified there — the AWT mirror, verbatim — rebased on top of #623 so the two designs chain instead of colliding.

```kotlin
// dev.nucleusframework.window.tao — @ExperimentalComposeUiApi, as upstream
public fun interface WindowExceptionHandlerFactory {
    public fun exceptionHandler(window: TaoWindow): WindowExceptionHandler
}
public object DefaultWindowExceptionHandlerFactory : WindowExceptionHandlerFactory // rethrow → #623's fatal dialog
public val LocalWindowExceptionHandlerFactory: ProvidableCompositionLocal<WindowExceptionHandlerFactory>
```

Handlers reuse `androidx.compose.ui.window.WindowExceptionHandler`, so the AWT contract carries over unchanged: returning normally swallows and the window carries on, `throw it` propagates. Our app's AWT-era handler moved over by changing only the import.

## How this composes with #623

The window's handler gets the first look; everything it does not swallow takes #623's fatal path — the "swap the dialog in on top" plan from #622, realized:

```
scene exception
 ├─ tearing down            → SEVERE log only            (#623 behaviour, kept)
 ├─ handler swallows        → window carries on          (SEVERE diagnostic if the recomposer did not survive — see below)
 └─ handler rethrows / none → TaoApplication.reportFatal (#623: SEVERE log + native dialog + clean exit)
```

- `#623`'s `sceneFatalHandler` and this PR's router wanted the same seat (the scene's `CoroutineExceptionHandler`), so they are merged into one element; the `closed` teardown guard is preserved as-is.
- The synchronous entry-point guards compose for free: a rethrow propagates into `TaoApplication.EventDispatcher`'s `guarded { }` boundary (verified for all seven callbacks — pointer, key, trackpad, touch, IME×3 — plus the macOS render loop's `TaoFatalCoroutineExceptionHandler`), so it reaches `reportFatal` exactly like an unhandled exception does today.
- **One deliberate deviation from the issue sketch**: `DefaultWindowExceptionHandlerFactory` rethrows but does not log — `reportFatal` already logs the same throwable at SEVERE, and doing both duplicated every entry. An app that installs nothing gets exactly #623's behaviour, log included, once.

## Where the guards sit

- **Frames** — one `try`/`catch` in `TaoSceneBundle.render`, the single seam every host (macOS/Windows/Linux) and every popup layer renders through. A swallowed failure drops the frame and re-arms the frame scheduler.
- **Recomposition and scene coroutines** — the merged router described above.
- **Input dispatch** (pointer / key / trackpad), **IME callbacks** (`imePreedit` / `imeCommit` / `imeReplaceCommit`), **`setContent`** and the debounced **a11y walk** are wrapped at their entry points in the shared host layer.
- **Popup layers** get the owner window's handler through `TaoPopupHost{,Windows,Linux}` — the same forwarding `WindowComposeSceneLayer` does on AWT — so `nativePopupLayers = true` windows are covered.
- The handler is read from the local once, in the parent composition, and stored in a plain field on the host, as you specified. `DecoratedDialog` inherits it.
- No Rust changes. No public-ABI change beyond the three new declarations (`apiDump` committed).

## A finding worth flagging: composition failures are unsurvivable — on every backend

While verifying in our real app (not just the harness) we found that a failure thrown **during recomposition** cannot be recovered from, and that this is Compose's own design, not something a backend can fix:

`Recomposer.processCompositionError` intercepts the exception, logs it to stderr, records `errorState` (which derives the recomposer to `Inactive`), and rethrows — into the `runCatching` inside `withFrameNanos`, so it never reaches the caller's synchronous catch. The recomposition loop then ends. The only recovery paths (`setHotReloadEnabled` / `retryFailedCompositions`) are `internal` to `androidx.compose.runtime`. The AWT backend behaves identically — its handler sees the failure via the coroutine handler, but the window silently stops updating afterwards.

Rather than inherit that silent freeze, this PR makes the contract honest:

- `TaoSceneBundle.isRecomposerAlive` reports the recomposer's actual state.
- When a handler swallows a failure the recomposer did not survive, the router logs at SEVERE: *"the window will no longer update — close and recreate the window, or rethrow to take the fatal path"*. The fatal dialog is deliberately not raised there: the app explicitly chose to swallow.
- `render` stops re-arming frames for a scene that can never change again.
- The KDoc on the public API spells out the split: layout / draw / input / IME / a11y failures are genuinely survivable; composition failures are not.

The practical impact is nil for the #621 motivation: all four real-world CMP bugs we swallow in production (`A partial image was generated`, the a11y paragraph-index crash, the IME `Expected start=` crash, the LazyLayout unattached-node crash) occur in survivable phases.

## Testing

- `TaoSceneExceptionHandlerTest` (10 cases): composition / layout / draw / input failures reach the handler; a swallowed **draw** failure keeps the recomposer alive and *state changes* still repaint (the pre-existing "accepts new content" pattern only exercised `setContent`, which masks a dead recomposer); a swallowed **composition** failure reports the scene as unable to recompose, logs the SEVERE diagnostic, and does not spin the frame scheduler; a rethrowing or absent handler propagates out of the seam.
- `TaoSceneExceptionRouterTest` (7 cases): the full chain above, with the fatal path injected — no handler → fatal, rethrow → fatal (including a substituted throwable), swallow → no fatal, dead-scene swallow → SEVERE, live-scene swallow → quiet, teardown → log only.
- Both registered in `TaoSceneTestBattery`; `test` / `ktlintCheck` / `detekt` / `apiCheck` all green.
- Verified end-to-end in our app (ZonePane, macOS) with on-demand exception probes: a draw-phase failure with our production handler is swallowed and the app keeps running normally (scrolling, typing, IME all fine); a composition-phase failure produces the SEVERE diagnostic instead of a silent freeze; an unknown exception takes #623's dialog-and-exit path.

Follow-up candidates (out of scope here): scene recreation to actually survive a composition failure (feasible but touches all three hosts + popup interop, and the failure surfaces mid-render so recreation must be deferred a loop turn); and routing the popup-native callbacks (macOS `PopupNativeBridge`, Linux popup pointer callbacks) into `reportFatal` — they bypass `EventDispatcher`, a pre-existing gap from before this PR.
