### PR TITLE
feat(tao): LCD/ClearType text on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ examples/tao-demo/src/main/native/windows/build_log.txt
 **/graalvm/libraryMetadata/
 **/graalvm/metadataRepoDirs.txt
 
+# Compiled Python caches (local helper scripts)
+__pycache__/
+
 # JVM crash logs
 hs_err_pid*.log
 replay_pid*.log

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
@@ -306,4 +306,16 @@ internal object NativeTaoWindowsDecoBridge {
         startScreenX: Int,
         startScreenY: Int,
     ): LongArray?
+
+    /**
+     * Windows ClearType pixel geometry for Skia LCD text.
+     *
+     * `0` = font smoothing off or not ClearType, `1` = RGB_H, `2` = BGR_H.
+     */
+    @JvmStatic
+    external fun nativeFontSmoothingPixelGeometry(): Int
+
+    const val FONT_SMOOTHING_UNKNOWN: Int = 0
+    const val FONT_SMOOTHING_RGB: Int = 1
+    const val FONT_SMOOTHING_BGR: Int = 2
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
@@ -480,6 +480,9 @@ internal class TaoPopupSceneLayerLinux(
             heightPx = heightPx,
             directContext = ctx,
             clearColorArgb = 0x00000000,
+            // Per-pixel-alpha popup surface (no-op on Linux today, but the
+            // alpha mode must be stated — see renderGlFrame).
+            windowTransparent = true,
             present = {
                 if (frame != IntRect.Zero) NativeTaoEglBridge.nativePresent(attachment)
             },

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -403,6 +403,8 @@ internal class TaoPopupSceneLayerWindows(
             heightPx = heightPx,
             directContext = directContext,
             clearColorArgb = 0x00000000,
+            // Per-pixel-alpha DComp surface — no LCD SurfaceProps.
+            windowTransparent = true,
             present = { PopupNativeBridgeWindows.nativeSwapBuffers(panelHandle) },
         ) { canvas, nanoTime ->
             canvas.save()

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHost.kt
@@ -424,6 +424,8 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
                 heightPx = heightPx,
                 directContext = ctx,
                 clearColorArgb = 0x00000000,
+                // Per-pixel-alpha DComp surface — no LCD SurfaceProps.
+                windowTransparent = true,
                 present = { PopupNativeBridgeWindows.nativeSwapBuffers(panel) },
             ) { canvas, _ ->
                 bundle.render(canvas, frameNs)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoStandalonePopupHostLinux.kt
@@ -400,6 +400,9 @@ internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
                 heightPx = heightPx,
                 directContext = ctx,
                 clearColorArgb = 0x00000000,
+                // Per-pixel-alpha popup surface (no-op on Linux today, but the
+                // alpha mode must be stated — see renderGlFrame).
+                windowTransparent = true,
                 present = { NativeTaoEglBridge.nativePresent(attachment) },
             ) { canvas, _ ->
                 bundle.render(canvas, frameNs)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/GlSceneRenderer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/GlSceneRenderer.kt
@@ -25,6 +25,10 @@ internal inline fun renderGlFrame(
     directContext: DirectContext,
     bundle: TaoSceneBundle,
     clearColorArgb: Int,
+    // No default on purpose: `false` attaches LCD SurfaceProps on Windows, and
+    // silently inheriting it on a per-pixel-alpha surface ships color-fringed
+    // text. Every call site must state its surface's alpha mode.
+    windowTransparent: Boolean,
     crossinline present: () -> Unit,
 ) {
     renderGlFrame(
@@ -32,17 +36,34 @@ internal inline fun renderGlFrame(
         heightPx = heightPx,
         directContext = directContext,
         clearColorArgb = clearColorArgb,
+        windowTransparent = windowTransparent,
         present = present,
     ) { canvas, nanoTime ->
         bundle.render(canvas, nanoTime)
     }
 }
 
+internal fun makeTaoGlSurface(
+    context: DirectContext,
+    rt: BackendRenderTarget,
+    windowTransparent: Boolean,
+): Surface? =
+    Surface.makeFromBackendRenderTarget(
+        context = context,
+        rt = rt,
+        origin = SurfaceOrigin.BOTTOM_LEFT,
+        colorFormat = SurfaceColorFormat.RGBA_8888,
+        colorSpace = ColorSpace.sRGB,
+        surfaceProps = lcdSurfaceProps(windowTransparent),
+    )
+
 internal inline fun renderGlFrame(
     widthPx: Int,
     heightPx: Int,
     directContext: DirectContext,
     clearColorArgb: Int,
+    // No default on purpose — see the overload above.
+    windowTransparent: Boolean,
     crossinline present: () -> Unit,
     crossinline render: (org.jetbrains.skia.Canvas, Long) -> Unit,
 ) {
@@ -57,13 +78,7 @@ internal inline fun renderGlFrame(
             fbFormat = FramebufferFormat.GR_GL_RGBA8,
         )
     val surface =
-        Surface.makeFromBackendRenderTarget(
-            context = directContext,
-            rt = rt,
-            origin = SurfaceOrigin.BOTTOM_LEFT,
-            colorFormat = SurfaceColorFormat.RGBA_8888,
-            colorSpace = ColorSpace.sRGB,
-        ) ?: run {
+        makeTaoGlSurface(directContext, rt, windowTransparent) ?: run {
             rt.close()
             return
         }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/LcdText.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/LcdText.kt
@@ -1,0 +1,55 @@
+package dev.nucleusframework.window.tao.scene
+
+import dev.nucleusframework.core.runtime.Platform
+import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
+import org.jetbrains.skia.PixelGeometry
+import org.jetbrains.skia.SurfaceProps
+
+/**
+ * LCD / ClearType text for Tao on Windows (Compose issue #875) — the surface
+ * half of the feature.
+ *
+ * Skia only paints chromatic glyph edges when BOTH the GPU surface has a
+ * known pixel geometry AND the paragraph requests
+ * `FontSmoothing.SubpixelAntiAlias`. The paragraph half is handled at build
+ * time by the Nucleus Gradle plugin (`LcdTextDefaultTransform` patches
+ * Compose's `FontRasterizationSettings.PlatformDefault` on Windows), so the
+ * backend only attaches the pixel geometry here — and only on opaque Windows
+ * windows. Transparent windows, popups (per-pixel-alpha DComp surfaces), and
+ * every other OS keep an unknown geometry, which makes Skia fall back to
+ * grayscale regardless of what paragraphs request.
+ */
+internal fun lcdSurfaceProps(
+    windowTransparent: Boolean,
+    platform: Platform = Platform.Current,
+    windowsLcdGeometry: () -> PixelGeometry? = ::windowsLcdPixelGeometry,
+): SurfaceProps? {
+    if (windowTransparent) return null
+    if (platform != Platform.Windows) return null
+    val geometry = windowsLcdGeometry() ?: return null
+    return SurfaceProps(isDeviceIndependentFonts = false, pixelGeometry = geometry)
+}
+
+internal fun windowsLcdPixelGeometry(): PixelGeometry? = cachedWindowsLcdGeometry
+
+// The smoothing answer is effectively static for the app's lifetime, and this
+// sits inside per-frame surface creation — one JNI query, not 1-3 syscalls per
+// rendered frame of every host/overlay/popup.
+private val cachedWindowsLcdGeometry: PixelGeometry? by lazy(::queryWindowsLcdPixelGeometry)
+
+private fun queryWindowsLcdPixelGeometry(): PixelGeometry? {
+    // Unknown smoothing state (lib missing or query failure) means grayscale,
+    // never an assumed RGB stripe order.
+    if (!NativeTaoWindowsDecoBridge.isLoaded) return null
+    val code =
+        try {
+            NativeTaoWindowsDecoBridge.nativeFontSmoothingPixelGeometry()
+        } catch (_: UnsatisfiedLinkError) {
+            return null
+        }
+    return when (code) {
+        NativeTaoWindowsDecoBridge.FONT_SMOOTHING_RGB -> PixelGeometry.RGB_H
+        NativeTaoWindowsDecoBridge.FONT_SMOOTHING_BGR -> PixelGeometry.BGR_H
+        else -> null
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -62,7 +62,6 @@ import kotlinx.coroutines.launch
 import org.jetbrains.skia.BackendRenderTarget
 import org.jetbrains.skia.BlendMode
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.ColorSpace
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.FramebufferFormat
 import org.jetbrains.skia.GLAssembledInterface
@@ -72,8 +71,6 @@ import org.jetbrains.skia.PathFillMode
 import org.jetbrains.skia.RRect
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.Surface
-import org.jetbrains.skia.SurfaceColorFormat
-import org.jetbrains.skia.SurfaceOrigin
 import org.jetbrains.skia.makeGLWithInterface
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
@@ -1616,14 +1613,7 @@ internal class TaoComposeSceneHostLinux(
                 fbId = 0,
                 fbFormat = FramebufferFormat.GR_GL_RGBA8,
             )
-        val surface =
-            Surface.makeFromBackendRenderTarget(
-                context = ctx,
-                rt = rt,
-                origin = SurfaceOrigin.BOTTOM_LEFT,
-                colorFormat = SurfaceColorFormat.RGBA_8888,
-                colorSpace = ColorSpace.sRGB,
-            )
+        val surface = makeTaoGlSurface(ctx, rt, fullyTransparent)
         if (surface == null) {
             rt.close()
             NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -57,15 +57,11 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BackendRenderTarget
-import org.jetbrains.skia.ColorSpace
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.FramebufferFormat
 import org.jetbrains.skia.GLAssembledInterface
 import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Rect
-import org.jetbrains.skia.Surface
-import org.jetbrains.skia.SurfaceColorFormat
-import org.jetbrains.skia.SurfaceOrigin
 import org.jetbrains.skia.makeGLWithInterface
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.coroutines.CoroutineContext
@@ -1253,14 +1249,13 @@ internal class TaoComposeSceneHostWindows(
                 fbId = 0,
                 fbFormat = FramebufferFormat.GR_GL_RGBA8,
             )
+        // Mica/Acrylic backdrops arm transparentBackgroundState at runtime and
+        // the clear becomes a translucent tint over the DWM material — the
+        // surface must drop LCD SurfaceProps then too, not only for
+        // creation-time transparent windows. Re-evaluated every frame since
+        // the surface is recreated per frame.
         val surface =
-            Surface.makeFromBackendRenderTarget(
-                context = ctx,
-                rt = rt,
-                origin = SurfaceOrigin.BOTTOM_LEFT,
-                colorFormat = SurfaceColorFormat.RGBA_8888,
-                colorSpace = ColorSpace.sRGB,
-            ) ?: run {
+            makeTaoGlSurface(ctx, rt, fullyTransparent || transparentBackgroundState.value) ?: run {
                 rt.close()
                 return
             }
@@ -1751,6 +1746,10 @@ internal class TaoComposeSceneHostWindows(
                 heightPx = this@TaoComposeSceneHostWindows.heightPx,
                 directContext = ctx,
                 clearColorArgb = 0,
+                // The blending overlay is unconditionally a per-pixel-alpha
+                // DComp swapchain (DXGI_ALPHA_MODE_PREMULTIPLIED) regardless of
+                // the window's own transparency — no LCD SurfaceProps.
+                windowTransparent = true,
                 present = { NativeTaoWindowsOverlayBridge.nativeSwapBuffers(overlayHandle) },
             ) { canvas, nanoTime ->
                 // Clip to the union of NativeView rects — SetWindowRgn

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -1938,3 +1938,46 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeSetWin
         SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 }
 
+#ifndef SPI_GETFONTSMOOTHINGTYPE
+#define SPI_GETFONTSMOOTHINGTYPE 0x200A
+#endif
+#ifndef FE_FONTSMOOTHINGCLEARTYPE
+#define FE_FONTSMOOTHINGCLEARTYPE 0x0002
+#endif
+#ifndef SPI_GETFONTSMOOTHINGORIENTATION
+#define SPI_GETFONTSMOOTHINGORIENTATION 0x2012
+#endif
+#ifndef FE_FONTSMOOTHINGORIENTATIONBGR
+#define FE_FONTSMOOTHINGORIENTATIONBGR 0x0000
+#endif
+#ifndef FE_FONTSMOOTHINGORIENTATIONRGB
+#define FE_FONTSMOOTHINGORIENTATIONRGB 0x0001
+#endif
+
+/* 0 = grayscale / unknown, 1 = RGB_H, 2 = BGR_H. Used by Tao LCD text. */
+JNIEXPORT jint JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeFontSmoothingPixelGeometry(
+    JNIEnv *env, jclass clazz)
+{
+    (void)env; (void)clazz;
+    BOOL smoothing = FALSE;
+    if (!SystemParametersInfo(SPI_GETFONTSMOOTHING, 0, &smoothing, 0) || !smoothing) {
+        return 0;
+    }
+    UINT type = 0;
+    if (!SystemParametersInfo(SPI_GETFONTSMOOTHINGTYPE, 0, &type, 0) ||
+        type != FE_FONTSMOOTHINGCLEARTYPE) {
+        return 0;
+    }
+    UINT orientation = 0;
+    if (!SystemParametersInfo(SPI_GETFONTSMOOTHINGORIENTATION, 0, &orientation, 0)) {
+        /* Unknown stripe order: degrade to grayscale, never assume RGB —
+         * a wrong guess on a BGR panel inverts every fringe. */
+        return 0;
+    }
+    if (orientation == FE_FONTSMOOTHINGORIENTATIONBGR) {
+        return 2;
+    }
+    return 1;
+}
+

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -244,6 +244,10 @@
                         "int",
                         "int"
                     ]
+                },
+                {
+                    "name": "nativeFontSmoothingPixelGeometry",
+                    "parameterTypes": []
                 }
             ]
         },

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelNativeSmokeTest.kt
@@ -1,6 +1,7 @@
 package dev.nucleusframework.window.tao
 
 import dev.nucleusframework.window.tao.ffi.NativeTaoGlBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge
 import dev.nucleusframework.window.tao.ffi.PopupNativeBridgeWindows
 import org.jetbrains.skia.DirectContext
@@ -63,6 +64,15 @@ class StandalonePanelNativeSmokeTest {
             val rc = NativeTaoWindowsDndBridge.nativeRegister(hwnd, NoOpInboundDnDCallback())
             assertEquals(0, rc, "RegisterDragDrop on standalone panel failed (rc=$rc)")
             NativeTaoWindowsDndBridge.nativeRevoke(hwnd)
+
+            assertTrue(NativeTaoWindowsDecoBridge.isLoaded, "nucleus_tao_windows_deco failed to load")
+            val geometry = NativeTaoWindowsDecoBridge.nativeFontSmoothingPixelGeometry()
+            assertTrue(
+                geometry == NativeTaoWindowsDecoBridge.FONT_SMOOTHING_UNKNOWN ||
+                    geometry == NativeTaoWindowsDecoBridge.FONT_SMOOTHING_RGB ||
+                    geometry == NativeTaoWindowsDecoBridge.FONT_SMOOTHING_BGR,
+                "unexpected font-smoothing geometry $geometry",
+            )
         } finally {
             PopupNativeBridgeWindows.nativeRelease(panel)
         }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -13,6 +13,7 @@ import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.event.Win32WheelDeltaTest
 import dev.nucleusframework.window.tao.popup.StandaloneFramePumpTest
 import dev.nucleusframework.window.tao.popup.StandalonePopupRenderReentryTest
+import dev.nucleusframework.window.tao.scene.LcdTextTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneExceptionHandlerTest
@@ -490,6 +491,22 @@ public object TaoSceneTestBattery {
         }
         run("TaoA11yProjectionTest: projected snapshot round-trips through the v7 wire format") {
             TaoA11yProjectionTest().`projected snapshot round-trips through the v7 wire format`()
+        }
+
+        run("LcdTextTest: transparent windows disable LCD surface props") {
+            LcdTextTest().`transparent windows disable LCD surface props`()
+        }
+        run("LcdTextTest: opaque windows on Windows keep RGB or BGR geometry") {
+            LcdTextTest().`opaque windows on Windows keep RGB or BGR geometry`()
+        }
+        run("LcdTextTest: macOS and Linux stay grayscale") {
+            LcdTextTest().`macOS and Linux stay grayscale`()
+        }
+        run("LcdTextTest: ClearType off means no LCD surface props") {
+            LcdTextTest().`ClearType off means no LCD surface props`()
+        }
+        run("LcdTextTest: Compose LCD text on an RGB surface has chromatic edges") {
+            LcdTextTest().`Compose LCD text on an RGB surface has chromatic edges`()
         }
 
         return results

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -13,6 +13,8 @@ import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.event.Win32WheelDeltaTest
 import dev.nucleusframework.window.tao.popup.StandaloneFramePumpTest
 import dev.nucleusframework.window.tao.popup.StandalonePopupRenderReentryTest
+import dev.nucleusframework.window.tao.scene.LcdTextCaptureTest
+import dev.nucleusframework.window.tao.scene.LcdTextTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneContentSwapTest
 import dev.nucleusframework.window.tao.scene.TaoSceneExceptionHandlerTest
@@ -75,6 +77,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoSceneSemanticsTest::class.java,
             TaoA11yProjectionTest::class.java,
             TitleBarHitTestTest::class.java,
+            LcdTextTest::class.java,
         )
 
     /** Classes that must stay out of the battery, with the reason. */
@@ -105,6 +108,8 @@ class TaoSceneTestBatteryDriftTest {
                 "pure-Kotlin portal parent / xdg_foreign handle formatting, no scene",
             dev.nucleusframework.window.ChromeLogicTest::class.java to
                 "unit tests for chrome helpers; no ComposeScene",
+            LcdTextCaptureTest::class.java to
+                "writes an AWT comparison PNG; diagnostic, not a scene behaviour",
         )
 
     private fun testMethodNames(cls: Class<*>): List<String> =

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/LcdTestTextStyle.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/LcdTestTextStyle.kt
@@ -1,0 +1,35 @@
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.FontHinting
+import androidx.compose.ui.text.FontRasterizationSettings
+import androidx.compose.ui.text.FontSmoothing
+import androidx.compose.ui.text.PlatformParagraphStyle
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+
+/**
+ * Test twin of the ClearType default the Nucleus Gradle plugin bakes into
+ * `FontRasterizationSettings.PlatformDefault` (`LcdTextDefaultTransform`).
+ * Library tests run against the unpatched Compose artifact, so LCD-rendering
+ * tests request subpixel rasterization explicitly through this style.
+ */
+@OptIn(ExperimentalTextApi::class)
+internal fun taoLcdTextStyle(): TextStyle =
+    TextStyle(
+        color = Color.Unspecified,
+        platformStyle =
+            PlatformTextStyle(
+                spanStyle = null,
+                paragraphStyle =
+                    PlatformParagraphStyle(
+                        FontRasterizationSettings(
+                            smoothing = FontSmoothing.SubpixelAntiAlias,
+                            hinting = FontHinting.Normal,
+                            subpixelPositioning = true,
+                            autoHintingForced = false,
+                        ),
+                    ),
+            ),
+    )

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/LcdTextCaptureTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/LcdTextCaptureTest.kt
@@ -1,0 +1,179 @@
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.PixelGeometry
+import org.jetbrains.skia.SurfaceProps
+import java.awt.Font
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Writes a GitHub-issue-style side-by-side zoom of grayscale vs ClearType text.
+ * Output: `decorated-window-tao/build/lcd-text-comparison.png`
+ */
+class LcdTextCaptureTest {
+    @Test
+    fun `write zoomed grayscale vs LCD comparison png`() {
+        val gray = renderText(lcd = false)
+        val lcd = renderText(lcd = true)
+        val out = writeComparison(gray, lcd)
+        assertTrue(Files.exists(out) && Files.size(out) > 0L, "missing $out")
+        println("LCD comparison written to $out")
+    }
+}
+
+private fun renderText(lcd: Boolean): BufferedImage {
+    lateinit var bitmap: Bitmap
+    runTaoSceneTest(width = SAMPLE_WIDTH, height = SAMPLE_HEIGHT) {
+        setContent {
+            SampleLines(lcd)
+        }
+        bitmap =
+            renderToBitmap(
+                surfaceProps =
+                    if (lcd) {
+                        SurfaceProps(isDeviceIndependentFonts = false, pixelGeometry = PixelGeometry.RGB_H)
+                    } else {
+                        SurfaceProps()
+                    },
+            )
+    }
+    return bitmap.toBufferedImage()
+}
+
+@Composable
+private fun SampleLines(lcd: Boolean) {
+    Box(Modifier.fillMaxSize().background(Color.White).padding(12.dp)) {
+        Column {
+            Text("File   Edit   View   Help", style = sampleStyle(lcd, 13.sp, FontWeight.Normal))
+            Text("The five boxing wizards jump", style = sampleStyle(lcd, 14.sp, FontWeight.Normal))
+            Text("fun main() { println(\"Hello\") }", style = sampleStyle(lcd, 13.sp, FontWeight.Normal))
+        }
+    }
+}
+
+private fun sampleStyle(
+    lcd: Boolean,
+    size: androidx.compose.ui.unit.TextUnit,
+    weight: FontWeight,
+): TextStyle {
+    val base = TextStyle(color = Color.Black, fontSize = size, fontWeight = weight)
+    return if (lcd) taoLcdTextStyle().merge(base) else base
+}
+
+private fun writeComparison(
+    gray: BufferedImage,
+    lcd: BufferedImage,
+): Path {
+    val crop = cropToContent(gray).union(cropToContent(lcd))
+    val grayCrop = gray.getSubimage(crop.x, crop.y, crop.w, crop.h)
+    val lcdCrop = lcd.getSubimage(crop.x, crop.y, crop.w, crop.h)
+    val zoomedGray = nearestZoom(grayCrop, ZOOM)
+    val zoomedLcd = nearestZoom(lcdCrop, ZOOM)
+
+    val labelH = 36
+    val gap = 16
+    val panelW = zoomedGray.width
+    val panelH = zoomedGray.height
+    val outW = panelW * 2 + gap + 32
+    val outH = labelH + panelH + 24
+    val out = BufferedImage(outW, outH, BufferedImage.TYPE_INT_RGB)
+    val g = out.createGraphics()
+    g.color = java.awt.Color(0xF3, 0xF3, 0xF3)
+    g.fillRect(0, 0, outW, outH)
+    g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+    g.font = Font("Segoe UI", Font.BOLD, 16)
+    g.color = java.awt.Color(0x33, 0x33, 0x33)
+    g.drawString("Grayscale (avant — #875)", 16, 24)
+    g.drawString("ClearType LCD (Tao)", 16 + panelW + gap, 24)
+    g.drawImage(zoomedGray, 16, labelH, null)
+    g.drawImage(zoomedLcd, 16 + panelW + gap, labelH, null)
+    g.dispose()
+
+    val path = Path.of(System.getProperty("user.dir"), "build", "lcd-text-comparison.png")
+    Files.createDirectories(path.parent)
+    ImageIO.write(out, "png", path.toFile())
+    return path
+}
+
+private fun Bitmap.toBufferedImage(): BufferedImage {
+    val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until height) {
+        for (x in 0 until width) {
+            img.setRGB(x, y, getColor(x, y))
+        }
+    }
+    return img
+}
+
+private data class Crop(
+    val x: Int,
+    val y: Int,
+    val w: Int,
+    val h: Int,
+) {
+    fun union(other: Crop): Crop {
+        val left = minOf(x, other.x)
+        val top = minOf(y, other.y)
+        val right = maxOf(x + w, other.x + other.w)
+        val bottom = maxOf(y + h, other.y + other.h)
+        return Crop(left, top, right - left, bottom - top)
+    }
+}
+
+private fun cropToContent(img: BufferedImage): Crop {
+    var minX = img.width
+    var minY = img.height
+    var maxX = 0
+    var maxY = 0
+    for (y in 0 until img.height) {
+        for (x in 0 until img.width) {
+            if (img.getRGB(x, y) and 0x00FFFFFF != 0x00FFFFFF) {
+                if (x < minX) minX = x
+                if (y < minY) minY = y
+                if (x > maxX) maxX = x
+                if (y > maxY) maxY = y
+            }
+        }
+    }
+    val pad = 4
+    val x = (minX - pad).coerceAtLeast(0)
+    val y = (minY - pad).coerceAtLeast(0)
+    val w = (maxX + pad + 1 - x).coerceAtMost(img.width - x)
+    val h = (maxY + pad + 1 - y).coerceAtMost(img.height - y)
+    return Crop(x, y, w, h)
+}
+
+private fun nearestZoom(
+    src: BufferedImage,
+    zoom: Int,
+): BufferedImage {
+    val dst = BufferedImage(src.width * zoom, src.height * zoom, BufferedImage.TYPE_INT_RGB)
+    val g = dst.createGraphics()
+    g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR)
+    g.drawImage(src, 0, 0, dst.width, dst.height, null)
+    g.dispose()
+    return dst
+}
+
+private const val SAMPLE_WIDTH = 420
+private const val SAMPLE_HEIGHT = 110
+private const val ZOOM = 8

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/LcdTextTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/LcdTextTest.kt
@@ -1,0 +1,132 @@
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.nucleusframework.core.runtime.Platform
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.PixelGeometry
+import org.jetbrains.skia.SurfaceProps
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LcdTextTest {
+    @Test
+    fun `transparent windows disable LCD surface props`() {
+        assertNull(
+            lcdSurfaceProps(
+                windowTransparent = true,
+                platform = Platform.Windows,
+                windowsLcdGeometry = { PixelGeometry.RGB_H },
+            ),
+        )
+        assertNull(
+            lcdSurfaceProps(
+                windowTransparent = true,
+                platform = Platform.Windows,
+                windowsLcdGeometry = { PixelGeometry.BGR_H },
+            ),
+        )
+    }
+
+    @Test
+    fun `opaque windows on Windows keep RGB or BGR geometry`() {
+        assertNotNull(
+            lcdSurfaceProps(
+                windowTransparent = false,
+                platform = Platform.Windows,
+                windowsLcdGeometry = { PixelGeometry.RGB_H },
+            ),
+        )
+        assertNotNull(
+            lcdSurfaceProps(
+                windowTransparent = false,
+                platform = Platform.Windows,
+                windowsLcdGeometry = { PixelGeometry.BGR_H },
+            ),
+        )
+    }
+
+    @Test
+    fun `macOS and Linux stay grayscale`() {
+        assertNull(
+            lcdSurfaceProps(
+                windowTransparent = false,
+                platform = Platform.MacOS,
+                windowsLcdGeometry = { PixelGeometry.RGB_H },
+            ),
+        )
+        assertNull(
+            lcdSurfaceProps(
+                windowTransparent = false,
+                platform = Platform.Linux,
+                windowsLcdGeometry = { PixelGeometry.RGB_H },
+            ),
+        )
+    }
+
+    @Test
+    fun `ClearType off means no LCD surface props`() {
+        assertNull(
+            lcdSurfaceProps(
+                windowTransparent = false,
+                platform = Platform.Windows,
+                windowsLcdGeometry = { null },
+            ),
+        )
+    }
+
+    @Test
+    fun `Compose LCD text on an RGB surface has chromatic edges`() =
+        runTaoSceneTest(width = 240, height = 64) {
+            setContent {
+                Box(Modifier.fillMaxSize().background(Color.White).padding(8.dp)) {
+                    Text(
+                        "Hamburg",
+                        style =
+                            taoLcdTextStyle().merge(
+                                TextStyle(color = Color.Black, fontSize = 22.sp),
+                            ),
+                    )
+                }
+            }
+            val lcd =
+                renderToBitmap(
+                    surfaceProps =
+                        SurfaceProps(isDeviceIndependentFonts = false, pixelGeometry = PixelGeometry.RGB_H),
+                )
+            val gray = renderToBitmap(surfaceProps = SurfaceProps())
+            val lcdScore = chromaticScore(lcd)
+            val grayScore = chromaticScore(gray)
+            assertTrue(
+                lcdScore > grayScore,
+                "Tao LCD text should fringe on RGB_H (lcd=$lcdScore gray=$grayScore)",
+            )
+        }
+}
+
+private fun chromaticScore(bitmap: Bitmap): Int {
+    var score = 0
+    for (y in 0 until bitmap.height) {
+        for (x in 0 until bitmap.width) {
+            val color = bitmap.getColor(x, y)
+            val r = (color ushr 16) and 0xFF
+            val g = (color ushr 8) and 0xFF
+            val b = color and 0xFF
+            val spread = maxOf(r, g, b) - minOf(r, g, b)
+            if (spread > CHROMA_THRESHOLD) score++
+        }
+    }
+    return score
+}
+
+private const val CHROMA_THRESHOLD = 12

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneTestHarness.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneTestHarness.kt
@@ -595,9 +595,17 @@ internal class TaoSceneTestScope(
     // ── Pixels ──────────────────────────────────────────────────────────────
 
     /** Rasterizes the last recorded frame (CPU) and returns it as a Skia bitmap. */
-    fun renderToBitmap(clearColor: Int = COLOR_WHITE): Bitmap {
+    fun renderToBitmap(
+        clearColor: Int = COLOR_WHITE,
+        surfaceProps: org.jetbrains.skia.SurfaceProps? = null,
+    ): Bitmap {
         val picture = lastPicture ?: frame()
-        val surface = Surface.makeRasterN32Premul(width, height)
+        val surface =
+            Surface.makeRaster(
+                ImageInfo.makeN32Premul(width, height),
+                0,
+                surfaceProps,
+            )
         surface.canvas.clear(clearColor)
         surface.canvas.drawPicture(picture)
         val bitmap = Bitmap()

--- a/examples/jewel-demo/src/main/kotlin/jewelsample/Main.kt
+++ b/examples/jewel-demo/src/main/kotlin/jewelsample/Main.kt
@@ -3,7 +3,6 @@ package jewelsample
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -16,19 +15,14 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
-import dev.nucleusframework.application.DecoratedWindow
 import dev.nucleusframework.application.nucleusApplication
 import dev.nucleusframework.darkmodedetector.isSystemInDarkMode
-import dev.nucleusframework.window.NucleusDecoratedWindowTheme
-import dev.nucleusframework.window.jewel.ProvideJewelSpellcheckMenu
-import dev.nucleusframework.window.jewel.rememberJewelTitleBarStyle
-import dev.nucleusframework.window.jewel.rememberJewelWindowStyle
+import dev.nucleusframework.window.jewel.JewelDecoratedWindow
 import jewelsample.view.TitleBarView
 import jewelsample.viewmodel.MainViewModel
 import jewelsample.viewmodel.MainViewModel.currentView
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.decodeToSvgPainter
-import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.util.JewelLogger
 import org.jetbrains.jewel.intui.markdown.standalone.ProvideMarkdownStyling
@@ -62,57 +56,46 @@ fun main() =
         val contentTheme = if (isDark) darkTheme else lightTheme
         val titleBarTheme = if (isTitleBarDark) darkTheme else lightTheme
 
-        DecoratedWindow(
-            onCloseRequest = { exitApplication() },
-            title = "Jewel standalone sample",
-            icon = icon,
-            state =
-                rememberWindowState(
-                    position = WindowPosition.Aligned(Alignment.Center),
-                ),
-            minimumSize = DpSize(800.dp, 400.dp),
-            onKeyEvent = { keyEvent ->
-                processKeyShortcuts(keyEvent = keyEvent, onNavigateTo = MainViewModel::onNavigateTo)
-            },
-            content = {
+        // The title-bar theme wraps the window: JewelDecoratedWindow reads it at
+        // the call site for the native deco + TitleBar styling, and the Tao
+        // scene bridge re-exposes it to the content inside the window.
+        IntUiTheme(
+            theme = titleBarTheme,
+            styling = ComponentStyling.default(),
+            swingCompatMode = MainViewModel.swingCompat,
+        ) {
+            JewelDecoratedWindow(
+                onCloseRequest = { exitApplication() },
+                title = "Jewel standalone sample",
+                icon = icon,
+                state =
+                    rememberWindowState(
+                        position = WindowPosition.Aligned(Alignment.Center),
+                    ),
+                minimumSize = DpSize(800.dp, 400.dp),
+                onKeyEvent = { keyEvent ->
+                    processKeyShortcuts(keyEvent = keyEvent, onNavigateTo = MainViewModel::onNavigateTo)
+                },
+            ) {
+                // JewelDecoratedWindow already installs the Jewel spellcheck
+                // text-context menu; capture it before the content theme below
+                // re-provides Jewel's stock one, and restore it inside.
                 @Suppress("DEPRECATION")
-                val defaultTextContextMenu = androidx.compose.foundation.text.LocalTextContextMenu.current
-                IntUiTheme(
-                    theme = titleBarTheme,
-                    styling = ComponentStyling.default(),
-                    swingCompatMode = MainViewModel.swingCompat,
-                ) {
-                    val jewelTitleBarStyle = rememberJewelTitleBarStyle()
-                    val jewelWindowStyle = rememberJewelWindowStyle()
-                    val titleBarIsDark = jewelTitleBarStyle.colors.background.luminance() < 0.5f
-                    NucleusDecoratedWindowTheme(
-                        isDark = titleBarIsDark,
-                        windowStyle = jewelWindowStyle,
-                        titleBarStyle = jewelTitleBarStyle,
-                    ) {
-                        androidx.compose.runtime.CompositionLocalProvider(
-                            androidx.compose.foundation.text.LocalTextContextMenu provides defaultTextContextMenu,
-                        ) {
-                            TitleBarView()
-                        }
-                    }
-                }
+                val windowTextContextMenu = androidx.compose.foundation.text.LocalTextContextMenu.current
+                TitleBarView()
                 IntUiTheme(
                     theme = contentTheme,
                     styling = ComponentStyling.default(),
                     swingCompatMode = MainViewModel.swingCompat,
                 ) {
-                    @OptIn(ExperimentalJewelApi::class)
                     androidx.compose.runtime.CompositionLocalProvider(
-                        androidx.compose.foundation.text.LocalTextContextMenu provides defaultTextContextMenu,
+                        androidx.compose.foundation.text.LocalTextContextMenu provides windowTextContextMenu,
                     ) {
-                        ProvideJewelSpellcheckMenu {
-                            ProvideMarkdownStyling { currentView.content() }
-                        }
+                        ProvideMarkdownStyling { currentView.content() }
                     }
                 }
-            },
-        )
+            }
+        }
     }
 
 /*

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
@@ -11,6 +11,7 @@ import dev.nucleusframework.desktop.application.dsl.AotCacheCompatibility
 import dev.nucleusframework.desktop.application.dsl.AotCacheSettings
 import dev.nucleusframework.desktop.application.dsl.PackagingBackend
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import dev.nucleusframework.desktop.application.internal.transforms.configureLcdTextDefaultTransform
 import dev.nucleusframework.desktop.application.internal.validation.validateMacBundleName
 import dev.nucleusframework.desktop.application.internal.validation.validatePackageVersions
 import dev.nucleusframework.desktop.application.tasks.AbstractCheckNativeDistributionRuntime
@@ -85,6 +86,10 @@ internal fun JvmApplicationContext.configureJvmApplication() {
     if (app.nativeDistributions.cleanupNativeLibs) {
         registerCleanNativeLibsTransform(project)
     }
+
+    // LCD / ClearType text on Windows (#875): patch Compose's hardcoded
+    // grayscale PlatformDefault at build time — see LcdTextDefaultTransform.
+    configureLcdTextDefaultTransform(project)
 
     validatePackageVersions()
     validateMacBundleName()

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/transforms/LcdTextDefaultTransform.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/transforms/LcdTextDefaultTransform.kt
@@ -1,0 +1,399 @@
+package dev.nucleusframework.desktop.application.internal.transforms
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.transform.CacheableTransform
+import org.gradle.api.artifacts.transform.InputArtifact
+import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformOutputs
+import org.gradle.api.artifacts.transform.TransformParameters
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Classpath
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import java.io.File
+import java.util.jar.JarFile
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+
+/**
+ * Enables LCD / ClearType text on Windows (Compose issue #875) by patching
+ * `FontRasterizationSettings.PlatformDefault` in `ui-text-desktop` at build
+ * time.
+ *
+ * Compose hardcodes grayscale (`FontSmoothing.AntiAlias`) as the Windows
+ * default — its own source comments it wants ClearType but cannot query the
+ * OS. There is no runtime hook (no CompositionLocal, no system property), so
+ * this artifact transform rewrites the single choke point every paragraph
+ * falls back to: `FontRasterizationSettings.Companion.getPlatformDefault()`.
+ * The original getter is kept (renamed) and a wrapper is generated that, on
+ * Windows, returns `SubpixelAntiAlias` settings unless the app opts out with
+ * `-Dnucleus.text.lcd=false`; every other OS delegates to the original.
+ *
+ * The subpixel request alone never causes fringes: Skia only rasterizes LCD
+ * glyphs on surfaces whose `SurfaceProps` carry a known pixel geometry, and
+ * the Tao backend attaches geometry only to opaque Windows window surfaces
+ * (queried from the OS ClearType settings — see `decorated-window-tao`
+ * `LcdText.kt`). Transparent windows, popups, and offscreen surfaces keep an
+ * unknown geometry and Skia falls back to grayscale there.
+ *
+ * Because the patch is plain bytecode on the classpath, it needs no runtime
+ * reflection and works identically under HotSpot, ProGuard, and GraalVM
+ * native-image.
+ */
+@CacheableTransform
+internal abstract class LcdTextDefaultTransform : TransformAction<TransformParameters.None> {
+    /** The jar being transformed; only `ui-text-desktop-*.jar` is rewritten. */
+    @get:Classpath
+    @get:InputArtifact
+    abstract val inputArtifact: Provider<FileSystemLocation>
+
+    override fun transform(outputs: TransformOutputs) {
+        val input = inputArtifact.get().asFile
+        if (!input.name.startsWith(UI_TEXT_ARTIFACT_PREFIX) || input.extension != "jar") {
+            // Identity: hand the original artifact through without copying.
+            outputs.file(inputArtifact)
+            return
+        }
+        val output = outputs.file("${input.nameWithoutExtension}$PATCHED_JAR_SUFFIX.jar")
+        LcdTextClassPatcher.patchJar(input, output)
+    }
+}
+
+private const val UI_TEXT_ARTIFACT_PREFIX = "ui-text-desktop"
+private const val PATCHED_JAR_SUFFIX = "-nucleus-lcd"
+
+/**
+ * Marks jars whose `FontRasterizationSettings.PlatformDefault` has been
+ * patched by [LcdTextDefaultTransform]. Runtime classpaths request `true`,
+ * plain jars default to `false`, and the transform bridges the two.
+ */
+private val LCD_TEXT_PATCHED: Attribute<Boolean> =
+    Attribute.of("dev.nucleusframework.lcd-text-default", Boolean::class.javaObjectType)
+
+/** Gradle property that skips the whole build-time patch when set to `false`. */
+private const val PATCH_OPT_OUT_PROPERTY = "nucleus.text.lcd.patch"
+
+/**
+ * Registers [LcdTextDefaultTransform] and requests the patched variant on
+ * every non-test runtime classpath of [project] (`runtimeClasspath`,
+ * `jvmRuntimeClasspath`, …) — which is what `run`, packaging, ProGuard, and
+ * the GraalVM native-image classpath all resolve.
+ *
+ * Configuration exclusions and the KMP jar-variant pinning mirror
+ * `registerCleanNativeLibsTransform`, which needed them for exactly this
+ * attribute-on-runtimeClasspath pattern: Android configurations resolve
+ * dexing directory variants, and the Compose Hot Reload dev classpaths
+ * consume custom-usage project variants — both fail resolution when an
+ * extra requested attribute is added.
+ *
+ * Build-time opt-out: `-Pnucleus.text.lcd.patch=false` (the runtime
+ * `-Dnucleus.text.lcd=false` only disables the already-patched default).
+ */
+internal fun configureLcdTextDefaultTransform(project: Project) {
+    val enabled =
+        project.providers
+            .gradleProperty(PATCH_OPT_OUT_PROPERTY)
+            .map { it != "false" }
+            .getOrElse(true)
+    if (!enabled) return
+
+    project.dependencies.registerTransform(LcdTextDefaultTransform::class.java) { spec ->
+        spec.from.attribute(LCD_TEXT_PATCHED, false)
+        spec.to.attribute(LCD_TEXT_PATCHED, true)
+    }
+
+    // KMP desktop runtime classpaths resolve project dependencies to their
+    // `classes`/`resources` directory sub-variants, which carry no LCD
+    // attribute — requesting it would make artifact selection ambiguous.
+    // Pinning the jar LibraryElements restores plain-JVM resolution (same
+    // reasoning as registerCleanNativeLibsTransform).
+    val isMultiplatform = project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
+    val jarLibraryElements =
+        project.objects.named(LibraryElements::class.java, LibraryElements.JAR)
+
+    project.configurations.configureEach { configuration ->
+        val name = configuration.name
+        if (name.endsWith("RuntimeClasspath", ignoreCase = true) && !name.contains("Test", ignoreCase = true)) {
+            val isAndroid = configuration.attributes.keySet().any { it.name.startsWith("com.android") }
+            val isHotReload = name.contains("HotReload", ignoreCase = true)
+            if (!isAndroid && !isHotReload) {
+                configuration.attributes.attribute(LCD_TEXT_PATCHED, true)
+                if (isMultiplatform) {
+                    configuration.attributes.attribute(
+                        LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                        jarLibraryElements,
+                    )
+                }
+            }
+        }
+    }
+
+    project.dependencies.artifactTypes.configureEach { artifactType ->
+        if (artifactType.name == "jar") {
+            artifactType.attributes.attribute(LCD_TEXT_PATCHED, false)
+        }
+    }
+}
+
+/**
+ * The ASM surgery for [LcdTextDefaultTransform]: renames the original
+ * `getPlatformDefault()` and generates a caching wrapper in its place.
+ */
+internal object LcdTextClassPatcher {
+    private const val FRS = "androidx/compose/ui/text/FontRasterizationSettings"
+    private const val COMPANION = "$FRS\$Companion"
+    private const val COMPANION_ENTRY = "$COMPANION.class"
+    private const val GETTER = "getPlatformDefault"
+    private const val GETTER_DESC = "()L$FRS;"
+    private const val ORIGINAL = "nucleus\$originalPlatformDefault"
+    private const val CACHE_FIELD = "nucleus\$lcdDefault"
+    private const val CACHE_FIELD_DESC = "L$FRS;"
+    private const val FONT_SMOOTHING = "androidx/compose/ui/text/FontSmoothing"
+    private const val FONT_HINTING = "androidx/compose/ui/text/FontHinting"
+    private const val CTOR_DESC = "(L$FONT_SMOOTHING;L$FONT_HINTING;ZZ)V"
+
+    /** System property that disables the patched ClearType default at runtime. */
+    private const val OPT_OUT_PROPERTY = "nucleus.text.lcd"
+
+    /**
+     * Rewrites [input] into [output], patching the Companion class and
+     * verifying every member the generated wrapper references (constructor,
+     * enum fields) still exists in the artifact — so a Compose layout change
+     * fails the build instead of throwing `NoSuchMethodError` at the app's
+     * first text layout.
+     */
+    fun patchJar(
+        input: File,
+        output: File,
+    ) {
+        var patched = false
+        var ctorPresent = false
+        var smoothingPresent = false
+        var hintingPresent = false
+        JarFile(input).use { jar ->
+            JarOutputStream(output.outputStream().buffered()).use { out ->
+                for (entry in jar.entries()) {
+                    val bytes = jar.getInputStream(entry).use { it.readBytes() }
+                    out.putNextEntry(ZipEntry(entry.name))
+                    when (entry.name) {
+                        COMPANION_ENTRY -> {
+                            out.write(patchCompanion(bytes))
+                            patched = true
+                        }
+                        "$FRS.class" -> {
+                            ctorPresent = hasMethod(bytes, "<init>", CTOR_DESC)
+                            out.write(bytes)
+                        }
+                        "$FONT_SMOOTHING.class" -> {
+                            smoothingPresent = hasField(bytes, "SubpixelAntiAlias")
+                            out.write(bytes)
+                        }
+                        "$FONT_HINTING.class" -> {
+                            hintingPresent = hasField(bytes, "Normal")
+                            out.write(bytes)
+                        }
+                        else -> out.write(bytes)
+                    }
+                    out.closeEntry()
+                }
+            }
+        }
+        val missing =
+            buildList {
+                if (!patched) add(COMPANION_ENTRY)
+                if (!ctorPresent) add("FontRasterizationSettings.<init>$CTOR_DESC")
+                if (!smoothingPresent) add("FontSmoothing.SubpixelAntiAlias")
+                if (!hintingPresent) add("FontHinting.Normal")
+            }
+        check(missing.isEmpty()) {
+            "Nucleus LCD text patch: ${missing.joinToString()} not found in ${input.name}. " +
+                "The Compose ui-text layout changed — update LcdTextDefaultTransform " +
+                "or disable the patch with -Pnucleus.text.lcd.patch=false."
+        }
+    }
+
+    private fun hasMethod(
+        classBytes: ByteArray,
+        name: String,
+        descriptor: String,
+    ): Boolean {
+        var found = false
+        ClassReader(classBytes).accept(
+            object : ClassVisitor(Opcodes.ASM9) {
+                override fun visitMethod(
+                    access: Int,
+                    methodName: String,
+                    methodDescriptor: String,
+                    signature: String?,
+                    exceptions: Array<out String>?,
+                ): MethodVisitor? {
+                    if (methodName == name && methodDescriptor == descriptor) found = true
+                    return null
+                }
+            },
+            ClassReader.SKIP_CODE,
+        )
+        return found
+    }
+
+    private fun hasField(
+        classBytes: ByteArray,
+        name: String,
+    ): Boolean {
+        var found = false
+        ClassReader(classBytes).accept(
+            object : ClassVisitor(Opcodes.ASM9) {
+                override fun visitField(
+                    access: Int,
+                    fieldName: String,
+                    descriptor: String,
+                    signature: String?,
+                    value: Any?,
+                ): org.objectweb.asm.FieldVisitor? {
+                    if (fieldName == name) found = true
+                    return null
+                }
+            },
+            ClassReader.SKIP_CODE,
+        )
+        return found
+    }
+
+    /** Patches the Companion class bytes; fails loudly if the getter is missing. */
+    fun patchCompanion(classBytes: ByteArray): ByteArray {
+        val reader = ClassReader(classBytes)
+        val writer =
+            object : ClassWriter(reader, COMPUTE_FRAMES) {
+                // COMPUTE_FRAMES only merges identical reference types here; never
+                // load application classes to compute a common supertype.
+                override fun getCommonSuperClass(
+                    type1: String,
+                    type2: String,
+                ): String = if (type1 == type2) type1 else "java/lang/Object"
+            }
+        var renamed = false
+        val visitor =
+            object : ClassVisitor(Opcodes.ASM9, writer) {
+                override fun visitMethod(
+                    access: Int,
+                    name: String,
+                    descriptor: String,
+                    signature: String?,
+                    exceptions: Array<out String>?,
+                ): MethodVisitor {
+                    if (name == GETTER && descriptor == GETTER_DESC) {
+                        renamed = true
+                        return super.visitMethod(access, ORIGINAL, descriptor, signature, exceptions)
+                    }
+                    return super.visitMethod(access, name, descriptor, signature, exceptions)
+                }
+
+                override fun visitEnd() {
+                    cv
+                        .visitField(
+                            Opcodes.ACC_PRIVATE or Opcodes.ACC_STATIC or
+                                Opcodes.ACC_VOLATILE or Opcodes.ACC_SYNTHETIC,
+                            CACHE_FIELD,
+                            CACHE_FIELD_DESC,
+                            null,
+                            null,
+                        ).visitEnd()
+                    generateWrapper(cv)
+                    super.visitEnd()
+                }
+            }
+        reader.accept(visitor, 0)
+        check(renamed) {
+            "Nucleus LCD text patch: method $GETTER$GETTER_DESC not found in " +
+                "FontRasterizationSettings\$Companion. The Compose ui-text API " +
+                "changed — update LcdTextDefaultTransform or disable the patch " +
+                "with -Pnucleus.text.lcd.patch=false."
+        }
+        return writer.toByteArray()
+    }
+
+    // Generates:
+    //   public final FontRasterizationSettings getPlatformDefault() {
+    //       FontRasterizationSettings v = nucleus$lcdDefault;
+    //       if (v != null) return v;
+    //       v = (os.name startsWith "Windows" && !"false".equals(getProperty("nucleus.text.lcd")))
+    //           ? new FontRasterizationSettings(SubpixelAntiAlias, Normal, true, false)
+    //           : nucleus$originalPlatformDefault();
+    //       nucleus$lcdDefault = v;   // benign race: idempotent value
+    //       return v;
+    //   }
+    @Suppress("LongMethod")
+    private fun generateWrapper(cv: ClassVisitor) {
+        val mv = cv.visitMethod(Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL, GETTER, GETTER_DESC, null, null)
+        val compute = Label()
+        val fallback = Label()
+        val store = Label()
+        mv.visitCode()
+        mv.visitFieldInsn(Opcodes.GETSTATIC, COMPANION, CACHE_FIELD, CACHE_FIELD_DESC)
+        mv.visitVarInsn(Opcodes.ASTORE, 1)
+        mv.visitVarInsn(Opcodes.ALOAD, 1)
+        mv.visitJumpInsn(Opcodes.IFNULL, compute)
+        mv.visitVarInsn(Opcodes.ALOAD, 1)
+        mv.visitInsn(Opcodes.ARETURN)
+        mv.visitLabel(compute)
+        mv.visitLdcInsn("os.name")
+        mv.visitLdcInsn("")
+        mv.visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            "java/lang/System",
+            "getProperty",
+            "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+            false,
+        )
+        mv.visitLdcInsn("Windows")
+        mv.visitMethodInsn(
+            Opcodes.INVOKEVIRTUAL,
+            "java/lang/String",
+            "startsWith",
+            "(Ljava/lang/String;)Z",
+            false,
+        )
+        mv.visitJumpInsn(Opcodes.IFEQ, fallback)
+        mv.visitLdcInsn("false")
+        mv.visitLdcInsn(OPT_OUT_PROPERTY)
+        mv.visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            "java/lang/System",
+            "getProperty",
+            "(Ljava/lang/String;)Ljava/lang/String;",
+            false,
+        )
+        mv.visitMethodInsn(
+            Opcodes.INVOKEVIRTUAL,
+            "java/lang/String",
+            "equals",
+            "(Ljava/lang/Object;)Z",
+            false,
+        )
+        mv.visitJumpInsn(Opcodes.IFNE, fallback)
+        mv.visitTypeInsn(Opcodes.NEW, FRS)
+        mv.visitInsn(Opcodes.DUP)
+        mv.visitFieldInsn(Opcodes.GETSTATIC, FONT_SMOOTHING, "SubpixelAntiAlias", "L$FONT_SMOOTHING;")
+        mv.visitFieldInsn(Opcodes.GETSTATIC, FONT_HINTING, "Normal", "L$FONT_HINTING;")
+        mv.visitInsn(Opcodes.ICONST_1)
+        mv.visitInsn(Opcodes.ICONST_0)
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, FRS, "<init>", CTOR_DESC, false)
+        mv.visitJumpInsn(Opcodes.GOTO, store)
+        mv.visitLabel(fallback)
+        mv.visitVarInsn(Opcodes.ALOAD, 0)
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, COMPANION, ORIGINAL, GETTER_DESC, false)
+        mv.visitLabel(store)
+        mv.visitInsn(Opcodes.DUP)
+        mv.visitFieldInsn(Opcodes.PUTSTATIC, COMPANION, CACHE_FIELD, CACHE_FIELD_DESC)
+        mv.visitInsn(Opcodes.ARETURN)
+        mv.visitMaxs(0, 0)
+        mv.visitEnd()
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/transforms/LcdTextDefaultTransformTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/transforms/LcdTextDefaultTransformTest.kt
@@ -1,0 +1,110 @@
+package dev.nucleusframework.desktop.application.internal.transforms
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+
+/**
+ * Regression canary for the LCD/ClearType bytecode patch: runs
+ * [LcdTextClassPatcher] against the *real* `ui-text-desktop` artifacts — the
+ * Compose version the plugin ships with AND the one the main repo's
+ * consumers resolve (see `test-analysis-libraries.gradle.kts`) — loads each
+ * patched jar, and checks all three runtime paths of the generated
+ * `getPlatformDefault()` wrapper. If a Compose bump changes the class
+ * layout, `patchJar` throws and this test fails loudly.
+ */
+class LcdTextDefaultTransformTest {
+    @Test
+    fun `patched default is SubpixelAntiAlias on Windows`() {
+        forEachPatchedJar { loader ->
+            withSystemProperties(osName = "Windows 11", lcdProperty = null) {
+                assertEquals("SubpixelAntiAlias", loader.platformDefaultSmoothing())
+            }
+        }
+    }
+
+    @Test
+    fun `patched default caches and stays stable across calls`() {
+        forEachPatchedJar { loader ->
+            withSystemProperties(osName = "Windows 11", lcdProperty = null) {
+                assertEquals("SubpixelAntiAlias", loader.platformDefaultSmoothing())
+                assertEquals("SubpixelAntiAlias", loader.platformDefaultSmoothing())
+            }
+        }
+    }
+
+    @Test
+    fun `opt-out property falls back to the original grayscale default`() {
+        forEachPatchedJar { loader ->
+            withSystemProperties(osName = "Windows 11", lcdProperty = "false") {
+                assertEquals("AntiAlias", loader.platformDefaultSmoothing())
+            }
+        }
+    }
+
+    @Test
+    fun `non-Windows platforms delegate to the original default`() {
+        forEachPatchedJar { loader ->
+            withSystemProperties(osName = "Linux", lcdProperty = null) {
+                assertEquals("AntiAlias", loader.platformDefaultSmoothing())
+            }
+        }
+    }
+
+    /** Runs [block] with a fresh classloader over every patched jar. */
+    private fun forEachPatchedJar(block: (URLClassLoader) -> Unit) {
+        for (jar in patchedJars) {
+            URLClassLoader(arrayOf(jar.toURI().toURL()), javaClass.classLoader).use { loader ->
+                block(loader)
+            }
+        }
+    }
+
+    private fun URLClassLoader.platformDefaultSmoothing(): String {
+        val frsClass = loadClass("androidx.compose.ui.text.FontRasterizationSettings")
+        val companion = frsClass.getField("Companion").get(null)
+        val settings = companion.javaClass.getMethod("getPlatformDefault").invoke(companion)
+        return settings.javaClass.getMethod("getSmoothing").invoke(settings).toString()
+    }
+
+    private fun <T> withSystemProperties(
+        osName: String,
+        lcdProperty: String?,
+        block: () -> T,
+    ): T {
+        val previousOs = System.getProperty("os.name")
+        val previousLcd = System.getProperty("nucleus.text.lcd")
+        System.setProperty("os.name", osName)
+        if (lcdProperty != null) System.setProperty("nucleus.text.lcd", lcdProperty)
+        try {
+            return block()
+        } finally {
+            System.setProperty("os.name", previousOs)
+            if (previousLcd != null) {
+                System.setProperty("nucleus.text.lcd", previousLcd)
+            } else {
+                System.clearProperty("nucleus.text.lcd")
+            }
+        }
+    }
+
+    private companion object {
+        val patchedJars: List<File> by lazy {
+            val sourceJars =
+                checkNotNull(System.getProperty("test.lcd.uitext.jars")) {
+                    "test.lcd.uitext.jars system property not set (see test-analysis-libraries.gradle.kts)"
+                }.split(File.pathSeparator).map(::File)
+            assertTrue("no ui-text-desktop jars resolved", sourceJars.isNotEmpty())
+            sourceJars.map { sourceJar ->
+                assertTrue("ui-text-desktop jar missing: $sourceJar", sourceJar.isFile)
+                val output = Files.createTempFile("ui-text-desktop-patched", ".jar").toFile()
+                output.deleteOnExit()
+                LcdTextClassPatcher.patchJar(sourceJar, output)
+                output
+            }
+        }
+    }
+}

--- a/plugin-build/plugin/test-analysis-libraries.gradle.kts
+++ b/plugin-build/plugin/test-analysis-libraries.gradle.kts
@@ -102,6 +102,37 @@ dependencies {
     testZayitLibraries("org.jetbrains.kotlin:kotlin-stdlib:2.3.20")
 }
 
+// Real ui-text-desktop jars for LcdTextDefaultTransformTest — the LCD patch is
+// bytecode surgery, so the regression test must run against the actual
+// artifact shapes users resolve: the Compose version the plugin ships with AND
+// the version the main repo's consumers/examples use (parsed from the root
+// version catalog; a bump there is exactly when the class layout may drift).
+val testLcdPatchLibraries: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+}
+
+val testLcdPatchLibrariesConsumer: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+}
+
+val lcdPluginComposeVersion = project.findProperty("compose.version")?.toString() ?: "1.10.0"
+val lcdConsumerComposeVersion =
+    rootDir
+        .resolve("../gradle/libs.versions.toml")
+        .takeIf { it.isFile }
+        ?.readLines()
+        ?.firstNotNullOfOrNull { Regex("""^compose\s*=\s*"([^"]+)"""").find(it)?.groupValues?.get(1) }
+        ?: lcdPluginComposeVersion
+
+dependencies {
+    testLcdPatchLibraries("org.jetbrains.compose.ui:ui-text-desktop:$lcdPluginComposeVersion")
+    testLcdPatchLibrariesConsumer("org.jetbrains.compose.ui:ui-text-desktop:$lcdConsumerComposeVersion")
+}
+
 val testOracleRepo: Configuration by configurations.creating {
     isCanBeResolved = true
     isCanBeConsumed = false
@@ -115,6 +146,13 @@ dependencies {
 tasks.withType<Test> {
     maxHeapSize = "1g"
     systemProperty("test.analysis.libraries", testAnalysisLibraries.asPath)
+    systemProperty(
+        "test.lcd.uitext.jars",
+        (testLcdPatchLibraries.files + testLcdPatchLibrariesConsumer.files)
+            .map { it.absolutePath }
+            .distinct()
+            .joinToString(java.io.File.pathSeparator),
+    )
     systemProperty("test.oracle.repo.zip", testOracleRepo.singleFile.absolutePath)
     systemProperty("test.zayit.libraries", testZayitLibraries.asPath)
     val zayitMetadataDir =


### PR DESCRIPTION
## Summary

Compose Desktop hardcodes grayscale antialiasing as the Windows font-smoothing default (JetBrains/compose-multiplatform#875, tracked upstream as [CMP-5359](https://youtrack.jetbrains.com/issue/CMP-5359) — their own source comments they want ClearType but never wired the OS query). This PR enables LCD/ClearType text end to end, with **no runtime reflection**, working identically under HotSpot, ProGuard, and GraalVM native-image.

### Paragraph half — Gradle plugin bytecode patch
- `LcdTextDefaultTransform`: a Gradle artifact transform that rewrites `FontRasterizationSettings$Companion.getPlatformDefault()` in `ui-text-desktop` jars via ASM — the original getter is kept (renamed) and a cached wrapper returns `SubpixelAntiAlias` on Windows, delegating everywhere else.
- Opt-outs: `-Dnucleus.text.lcd=false` (runtime), `-Pnucleus.text.lcd.patch=false` (build-time, skips the transform entirely).
- Applied to non-test `*RuntimeClasspath` only, with the same Android / Compose Hot Reload / KMP-jar-variant guards as `registerCleanNativeLibsTransform` (verified: `:examples:cmp-demo` resolves).
- Compose layout drift fails the build loudly: the patcher verifies the getter, the constructor descriptor, and the enum fields it references. The regression test patches the real artifact for both the plugin's Compose version and the consumer version parsed from the root version catalog.

### Surface half — Tao backend
- `lcdSurfaceProps` attaches the OS-queried pixel geometry (new `SPI_GETFONTSMOOTHING*` native query; cached; RGB/BGR; grayscale on any unknown, including a failed orientation query) to **opaque Windows window surfaces only**.
- Per-pixel-alpha surfaces keep an unknown geometry so Skia falls back to grayscale: popups (DComp premultiplied swapchains), the NativeView blending overlay, Mica/Acrylic backdrops (runtime `transparentBackgroundState`), and transparent windows.
- `renderGlFrame` now requires `windowTransparent` explicitly — no unsafe default.

### Misc
- jewel-demo refactored to `JewelDecoratedWindow` (theme outside the window, ~20 lines of hand-rolled deco theming removed).
- `__pycache__/` gitignored.

## Test plan
- [x] `LcdTextDefaultTransformTest` — patches real ui-text-desktop jars (Compose 1.10.0 + 1.12.0), asserts SubpixelAntiAlias on Windows, cache stability, runtime opt-out, non-Windows delegation
- [x] `LcdTextTest` — surface-props gating (transparent/off-Windows/ClearType-off ⇒ null) + pixel-level chromatic-fringe assertion
- [x] `LcdTextCaptureTest` — grayscale vs ClearType comparison PNG
- [x] `:examples:cmp-demo:dependencies` resolves (Android + Hot Reload guards)
- [x] `:examples:jewel-demo:createDistributable` ships the patched `ui-text-desktop-*-nucleus-lcd.jar`
- [x] ktlint / detekt / apiCheck green on all touched modules; Windows natives rebuilt
