### PR TITLE
feat(tao): fatal dialog with scrollable stack trace and copy button

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -108,7 +108,8 @@ public object TaoApplication {
         if (fatalDialogShown.compareAndSet(false, true)) {
             showNativeErrorDialog(
                 title = "Fatal Error",
-                message = "The application encountered an unrecoverable error and will close.\n\n$t",
+                message = "The application encountered an unrecoverable error and will close.",
+                detail = t.stackTraceToString(),
             )
         }
         throw t
@@ -334,11 +335,14 @@ internal val TaoNonFatalCoroutineExceptionHandler: CoroutineExceptionHandler =
  * native library is available; no-ops otherwise (the SEVERE log is the
  * fallback). Never throws — this runs on the fatal path, where a secondary
  * failure must not mask the clean shutdown. macOS, Windows and Linux (#622).
+ * [detail] carries the full stack trace — see
+ * [NativeTaoBridge.nativeShowErrorDialog] for the per-platform rendering.
  */
 @Suppress("TooGenericExceptionCaught")
 internal fun showNativeErrorDialog(
     title: String,
     message: String,
+    detail: String,
 ) {
     // `nucleus.tao.fatalErrorDialog=false` is the escape hatch for unattended
     // runs (CI, AOT training): a blocking modal nobody can dismiss would hang
@@ -349,7 +353,7 @@ internal fun showNativeErrorDialog(
         return
     }
     try {
-        NativeTaoBridge.nativeShowErrorDialog(title, message)
+        NativeTaoBridge.nativeShowErrorDialog(title, message, detail)
     } catch (t: Throwable) {
         Logger
             .getLogger(TaoApplication::class.java.name)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -252,15 +252,16 @@ internal object NativeTaoBridge {
 
     /**
      * Shows a blocking native error dialog — the no-AWT replacement for
-     * Compose Desktop's Swing default (#622). macOS
-     * (CFUserNotificationDisplayAlert: out-of-process, callable from any
-     * thread, no NSApp/run-loop dependency — safe before, during and after
-     * the Tao loop), Windows (task-modal MessageBoxW, callable from any
-     * thread) and Linux (modal GtkMessageDialog — GTK-main-thread only,
+     * Compose Desktop's Swing default (#622). macOS (NSAlert run by an
+     * out-of-process osascript child — our own NSApp is unusable after the
+     * Tao loop; falls back to a compact CFUserNotificationDisplayAlert when
+     * the child cannot run), Windows (task-modal MessageBoxW, callable from
+     * any thread) and Linux (modal GtkMessageDialog — GTK-main-thread only,
      * i.e. the thread that ran the Tao loop).
-     * [detail] is the full stack trace: Linux renders it in a scrollable
-     * monospace view with a Copy button; macOS and Windows keep the compact
-     * alert and show only its first `toString()` line after [message].
+     * [detail] is the full stack trace: macOS and Linux render it in a
+     * scrollable monospace view with a Copy button; Windows (and the macOS
+     * fallback) keeps the compact alert and shows only its first
+     * `toString()` line after [message].
      * Call it only outside tao callback frames — a modal pump inside one
      * re-enters tao's non-reentrant handler mutex.
      */

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -258,6 +258,9 @@ internal object NativeTaoBridge {
      * the Tao loop), Windows (task-modal MessageBoxW, callable from any
      * thread) and Linux (modal GtkMessageDialog — GTK-main-thread only,
      * i.e. the thread that ran the Tao loop).
+     * [detail] is the full stack trace: Linux renders it in a scrollable
+     * monospace view with a Copy button; macOS and Windows keep the compact
+     * alert and show only its first `toString()` line after [message].
      * Call it only outside tao callback frames — a modal pump inside one
      * re-enters tao's non-reentrant handler mutex.
      */
@@ -265,6 +268,7 @@ internal object NativeTaoBridge {
     external fun nativeShowErrorDialog(
         title: String,
         message: String,
+        detail: String,
     )
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -255,12 +255,13 @@ internal object NativeTaoBridge {
      * Compose Desktop's Swing default (#622). macOS (NSAlert run by an
      * out-of-process osascript child — our own NSApp is unusable after the
      * Tao loop; falls back to a compact CFUserNotificationDisplayAlert when
-     * the child cannot run), Windows (task-modal MessageBoxW, callable from
-     * any thread) and Linux (modal GtkMessageDialog — GTK-main-thread only,
-     * i.e. the thread that ran the Tao loop).
-     * [detail] is the full stack trace: macOS and Linux render it in a
-     * scrollable monospace view with a Copy button; Windows (and the macOS
-     * fallback) keeps the compact alert and shows only its first
+     * the child cannot run), Windows (in-memory DLGTEMPLATE dialog run on a
+     * fresh thread; falls back to a compact MessageBoxW when the dialog
+     * cannot be created) and Linux (modal GtkMessageDialog —
+     * GTK-main-thread only, i.e. the thread that ran the Tao loop).
+     * [detail] is the full stack trace: all three platforms render it in a
+     * scrollable monospace view with a Copy button; the macOS and Windows
+     * fallbacks keep the compact alert and show only its first
      * `toString()` line after [message].
      * Call it only outside tao callback frames — a modal pump inside one
      * re-enters tao's non-reentrant handler mutex.

--- a/decorated-window-tao/src/main/native/Cargo.toml
+++ b/decorated-window-tao/src/main/native/Cargo.toml
@@ -56,6 +56,7 @@ x11-dl = "2"
 accesskit_windows = "0.34.0"
 windows = { version = "0.62", features = [
     "Win32_Foundation",
+    "Win32_Graphics_Gdi",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
 ] }

--- a/decorated-window-tao/src/main/native/macos/error_dialog.m
+++ b/decorated-window-tao/src/main/native/macos/error_dialog.m
@@ -1,13 +1,17 @@
 // error_dialog.m
 //
-// Fatal-error dialog (issue #622) — the no-AWT replacement for Compose
-// Desktop's Swing default. Shown AFTER the Tao event loop has exited:
-// showing a modal from inside a tao callback frame deadlocks (tao's
-// Handler.callback std::Mutex is not re-entrant, and a Dock-reopen or
-// deep-link delivered by the modal's event pump re-locks it on the same
-// thread), and post-loop NSApp is left in a stopped state (tao latches
-// [NSApp stop:] on exit, which makes a subsequent -[NSAlert runModal]
-// session return immediately).
+// Fatal-error dialog (issue #622), FALLBACK path — the primary macOS dialog
+// is an NSAlert with a scrollable stack trace run by an osascript child
+// (see dialog.rs); this compact alert only runs when that child cannot
+// (osascript blocked by MDM policy, spawn failure, JXA error).
+//
+// Both are out of process for the same reason: the dialog is shown AFTER
+// the Tao event loop has exited — showing a modal from inside a tao
+// callback frame deadlocks (tao's Handler.callback std::Mutex is not
+// re-entrant, and a Dock-reopen or deep-link delivered by the modal's event
+// pump re-locks it on the same thread), and post-loop NSApp is left in a
+// stopped state (tao latches [NSApp stop:] on exit, which makes a
+// subsequent -[NSAlert runModal] session return immediately).
 //
 // CFUserNotificationDisplayAlert is the one AppKit-free primitive built for
 // exactly this: rendered out of process by the user notification server,

--- a/decorated-window-tao/src/main/native/src/dialog.rs
+++ b/decorated-window-tao/src/main/native/src/dialog.rs
@@ -30,9 +30,10 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_
 }
 
 /// `detail` is `Throwable.stackTraceToString()`: the throwable's `toString()`
-/// (possibly multi-line) followed by "\n\tat ..." frames. macOS and Windows
-/// keep their compact one-shot alert, so they show only the `toString()`
-/// part after the sentence — the frames would not fit a system alert.
+/// (possibly multi-line) followed by "\n\tat ..." frames. Windows and the
+/// macOS CFUserNotification fallback keep their compact one-shot alert, so
+/// they show only the `toString()` part after the sentence — the frames
+/// would not fit a system alert.
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn message_with_summary(message: &str, detail: &str) -> String {
     let summary = detail.split("\n\tat ").next().unwrap_or("").trim_end();
@@ -42,6 +43,61 @@ fn message_with_summary(message: &str, detail: &str) -> String {
         format!("{message}\n\n{summary}")
     }
 }
+
+/// NSAlert with the stack trace in a scrollable monospace accessory view and
+/// a Copy button — the macOS twin of the Linux GtkMessageDialog below. Run
+/// by an `osascript -l JavaScript` child: our own NSApp cannot host it (tao
+/// latches [NSApp stop:] on loop exit, so an in-process runModal returns
+/// immediately — see error_dialog.m), while the child gets a fresh NSApp.
+/// argv: title, message, detail.
+///
+/// JXA traps encoded below, in rendering order:
+///   - osascript is an agent process: without the Accessory activation
+///     policy + activate, the panel can open buried behind other apps.
+///   - horizontal scrolling needs the full non-tracking text-container
+///     dance; a bare NSTextView wraps at 560px and hides frame tails.
+///   - `runModal` bridges to a JS *string* ("1001"), so a `===` against the
+///     NSAlertSecondButtonReturn number never matches — coerce first.
+///   - the general pasteboard is held by the pboard server, so the copied
+///     trace survives the child's exit (no X11-style store dance needed).
+#[cfg(target_os = "macos")]
+const FATAL_ALERT_JXA: &str = r#"
+ObjC.import('Cocoa')
+function run(argv) {
+  const title = argv[0], message = argv[1], detail = argv[2]
+  const alert = $.NSAlert.alloc.init
+  alert.alertStyle = $.NSAlertStyleCritical
+  alert.messageText = title
+  alert.informativeText = message
+  alert.addButtonWithTitle('Close')
+  alert.addButtonWithTitle('Copy')
+  if (detail.length > 0) {
+    const view = $.NSTextView.alloc.initWithFrame($.NSMakeRect(0, 0, 560, 160))
+    view.editable = false
+    view.font = $.NSFont.userFixedPitchFontOfSize(11)
+    view.string = detail
+    view.horizontallyResizable = true
+    view.textContainer.widthTracksTextView = false
+    view.textContainer.containerSize = $.NSMakeSize(10000000, 10000000)
+    view.maxSize = $.NSMakeSize(10000000, 10000000)
+    const scroll = $.NSScrollView.alloc.initWithFrame($.NSMakeRect(0, 0, 560, 160))
+    scroll.hasVerticalScroller = true
+    scroll.hasHorizontalScroller = true
+    scroll.borderType = $.NSBezelBorder
+    scroll.documentView = view
+    alert.accessoryView = scroll
+  }
+  const app = $.NSApplication.sharedApplication
+  app.setActivationPolicy($.NSApplicationActivationPolicyAccessory)
+  app.activateIgnoringOtherApps(true)
+  alert.window.level = 8 // NSModalPanelWindowLevel: above the corpse of the app
+  while (Number(alert.runModal) === 1001) { // NSAlertSecondButtonReturn: Copy
+    const pasteboard = $.NSPasteboard.generalPasteboard
+    pasteboard.clearContents
+    pasteboard.setStringForType($(detail), $.NSPasteboardTypeString)
+  }
+}
+"#;
 
 #[cfg(target_os = "macos")]
 fn show_error_dialog(title: &str, message: &str, detail: &str) {
@@ -53,11 +109,29 @@ fn show_error_dialog(title: &str, message: &str, detail: &str) {
         // (NSAlert cannot run after tao latches [NSApp stop:] — see the .m).
         fn nucleus_tao_show_error_dialog(title: *const c_char, message: *const c_char);
     }
-    let message = message_with_summary(message, detail);
-    // Java strings may carry interior NULs; strip them so CString::new
-    // cannot fail.
-    let title = CString::new(title.replace('\0', "")).expect("NULs stripped");
-    let message = CString::new(message.replace('\0', "")).expect("NULs stripped");
+    // Java strings may carry interior NULs; strip them so neither the child
+    // argv (spawn refuses interior NULs) nor CString::new can fail.
+    let title = title.replace('\0', "");
+    let message = message.replace('\0', "");
+    let detail = detail.replace('\0', "");
+    // Primary path: the JXA NSAlert child. Blocks until dismissed, like the
+    // other platforms. `success()` is only false when the dialog could not
+    // run at all (osascript blocked by MDM policy, no WindowServer session,
+    // JXA exception) — Close and Copy+Close both exit 0.
+    let shown = std::process::Command::new("/usr/bin/osascript")
+        .args(["-l", "JavaScript", "-e", FATAL_ALERT_JXA, "--"])
+        .args([&title, &message, &detail])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    if shown {
+        return;
+    }
+    // Fallback: the compact CFUserNotification alert — no scrollable view,
+    // so only the `toString()` summary fits after the sentence.
+    let message = message_with_summary(&message, &detail);
+    let title = CString::new(title).expect("NULs stripped");
+    let message = CString::new(message).expect("NULs stripped");
     unsafe { nucleus_tao_show_error_dialog(title.as_ptr(), message.as_ptr()) };
 }
 

--- a/decorated-window-tao/src/main/native/src/dialog.rs
+++ b/decorated-window-tao/src/main/native/src/dialog.rs
@@ -12,6 +12,7 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_
     _class: JClass,
     title: JString,
     message: JString,
+    detail: JString,
 ) {
     let title: String = match env.get_string(&title) {
         Ok(s) => s.into(),
@@ -21,11 +22,29 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_
         Ok(s) => s.into(),
         Err(_) => return,
     };
-    show_error_dialog(&title, &message);
+    let detail: String = match env.get_string(&detail) {
+        Ok(s) => s.into(),
+        Err(_) => return,
+    };
+    show_error_dialog(&title, &message, &detail);
+}
+
+/// `detail` is `Throwable.stackTraceToString()`: the throwable's `toString()`
+/// (possibly multi-line) followed by "\n\tat ..." frames. macOS and Windows
+/// keep their compact one-shot alert, so they show only the `toString()`
+/// part after the sentence — the frames would not fit a system alert.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn message_with_summary(message: &str, detail: &str) -> String {
+    let summary = detail.split("\n\tat ").next().unwrap_or("").trim_end();
+    if summary.is_empty() {
+        message.to_string()
+    } else {
+        format!("{message}\n\n{summary}")
+    }
 }
 
 #[cfg(target_os = "macos")]
-fn show_error_dialog(title: &str, message: &str) {
+fn show_error_dialog(title: &str, message: &str, detail: &str) {
     use std::ffi::CString;
     use std::os::raw::c_char;
     extern "C" {
@@ -34,6 +53,7 @@ fn show_error_dialog(title: &str, message: &str) {
         // (NSAlert cannot run after tao latches [NSApp stop:] — see the .m).
         fn nucleus_tao_show_error_dialog(title: *const c_char, message: *const c_char);
     }
+    let message = message_with_summary(message, detail);
     // Java strings may carry interior NULs; strip them so CString::new
     // cannot fail.
     let title = CString::new(title.replace('\0', "")).expect("NULs stripped");
@@ -42,11 +62,11 @@ fn show_error_dialog(title: &str, message: &str) {
 }
 
 #[cfg(target_os = "windows")]
-fn show_error_dialog(title: &str, message: &str) {
+fn show_error_dialog(title: &str, message: &str, detail: &str) {
     // MessageBoxW reads NUL-terminated wide strings, so an interior NUL from
     // Java would silently truncate — strip them like the macOS path does.
     let title = title.replace('\0', "");
-    let message = message.replace('\0', "");
+    let message = message_with_summary(message, detail).replace('\0', "");
     // Dedicated thread, same reason macOS goes out of process: the calling
     // thread just ran (and exited) the Tao event loop, and modal loops on it
     // return immediately — a leftover quit/thread message in its queue makes
@@ -80,7 +100,7 @@ fn show_error_dialog(title: &str, message: &str) {
 }
 
 #[cfg(target_os = "linux")]
-fn show_error_dialog(title: &str, message: &str) {
+fn show_error_dialog(title: &str, message: &str, detail: &str) {
     use gtk::prelude::*;
     // The caller is the thread that just ran (and exited) the Tao event loop
     // — the GTK main thread. GTK survives the loop exit: tao iterates
@@ -92,23 +112,73 @@ fn show_error_dialog(title: &str, message: &str) {
     if !gtk::is_initialized() && gtk::init().is_err() {
         return;
     }
+    // glib's &str → C-string conversion panics on interior NULs (Java strings
+    // may carry them) — strip like the macOS/Windows paths do.
+    let title = title.replace('\0', "");
+    let message = message.replace('\0', "");
+    let detail = detail.replace('\0', "");
     // No parent: every Tao window is already destroyed when the fatal path
-    // runs. Title goes into the bold primary line as well — a GtkMessageDialog
-    // shows no titlebar text on GNOME, so `set_title` alone would hide it.
+    // runs. The title goes only to the window title; the bold primary line is
+    // the short sentence — putting the title in both printed "Fatal Error"
+    // twice on WMs that draw dialog titlebars.
     let dialog = gtk::MessageDialog::new(
         None::<&gtk::Window>,
         gtk::DialogFlags::MODAL,
         gtk::MessageType::Error,
-        gtk::ButtonsType::Ok,
-        title,
+        gtk::ButtonsType::None,
+        &message,
     );
-    dialog.set_title(title);
-    dialog.set_secondary_text(Some(message));
+    dialog.set_title(&title);
+    // The stack trace goes in a bounded scrollable monospace view, not the
+    // secondary label — a Compose stack trace in the label used to size the
+    // dialog to the whole screen.
+    let buffer = gtk::TextBuffer::new(None::<&gtk::TextTagTable>);
+    buffer.set_text(&detail);
+    let view = gtk::TextView::with_buffer(&buffer);
+    view.set_editable(false);
+    view.set_cursor_visible(false);
+    view.set_monospace(true);
+    view.set_left_margin(8);
+    view.set_right_margin(8);
+    view.set_top_margin(8);
+    view.set_bottom_margin(8);
+    let scroll = gtk::ScrolledWindow::new(None::<&gtk::Adjustment>, None::<&gtk::Adjustment>);
+    scroll.set_policy(gtk::PolicyType::Automatic, gtk::PolicyType::Automatic);
+    scroll.set_shadow_type(gtk::ShadowType::In);
+    scroll.set_min_content_width(560);
+    scroll.set_min_content_height(160);
+    scroll.set_margin_start(12);
+    scroll.set_margin_end(12);
+    scroll.set_margin_bottom(6);
+    scroll.add(&view);
+    dialog.content_area().pack_start(&scroll, true, true, 0);
+    // MessageDialogs are non-resizable by default; a stack trace is worth
+    // enlarging for.
+    dialog.set_resizable(true);
+
+    let copy_response = gtk::ResponseType::Other(1);
+    dialog.add_button("_Copy", copy_response);
+    dialog.add_button("_Close", gtk::ResponseType::Close);
+    dialog.set_default_response(gtk::ResponseType::Close);
     // X11 only (no-op on Wayland): raise above the corpse of the app, same
     // intent as MB_SETFOREGROUND on Windows.
     dialog.set_keep_above(true);
-    // Blocks in a recursive main loop until OK / close / Escape.
-    dialog.run();
+    // `gtk_dialog_run` only shows the dialog itself, not children added after
+    // construction (the scroller).
+    dialog.show_all();
+    // Blocks in a recursive main loop until Close / titlebar close / Escape.
+    // Copy puts the stack trace on the clipboard and keeps the dialog open.
+    loop {
+        if dialog.run() != copy_response {
+            break;
+        }
+        let clipboard = gtk::Clipboard::get(&gtk::gdk::SELECTION_CLIPBOARD);
+        clipboard.set_text(&detail);
+        // Hand the contents over to the clipboard manager (if one runs): the
+        // process exits right after the dialog closes, and an unstored
+        // X11/Wayland selection dies with its owner.
+        clipboard.store();
+    }
     unsafe { dialog.destroy() };
     // Flush the destroy so the dialog leaves the screen even if a non-daemon
     // JVM thread delays process exit for a moment. Bounded: an always-ready
@@ -126,4 +196,4 @@ fn show_error_dialog(title: &str, message: &str) {
 // Other unixes (BSDs): still a silent no-op; the SEVERE log on the JVM side
 // is the only signal there (#622).
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
-fn show_error_dialog(_title: &str, _message: &str) {}
+fn show_error_dialog(_title: &str, _message: &str, _detail: &str) {}

--- a/decorated-window-tao/src/main/native/src/dialog.rs
+++ b/decorated-window-tao/src/main/native/src/dialog.rs
@@ -30,18 +30,26 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoBridge_
 }
 
 /// `detail` is `Throwable.stackTraceToString()`: the throwable's `toString()`
-/// (possibly multi-line) followed by "\n\tat ..." frames. Windows and the
-/// macOS CFUserNotification fallback keep their compact one-shot alert, so
-/// they show only the `toString()` part after the sentence — the frames
-/// would not fit a system alert.
+/// (possibly multi-line) followed by "\n\tat ..." frames. The compact
+/// fallback alerts (macOS CFUserNotification, Windows MessageBoxW) show only
+/// the `toString()` part after the sentence — the frames would not fit a
+/// system alert. The summary itself is capped at 2000 chars: a VerifyError's
+/// `toString()` is a ~100 KB bytecode dump with no "\n\tat " before the end,
+/// and MessageBoxW silently fails (never shows) on a string that large.
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn message_with_summary(message: &str, detail: &str) -> String {
     let summary = detail.split("\n\tat ").next().unwrap_or("").trim_end();
     if summary.is_empty() {
-        message.to_string()
-    } else {
-        format!("{message}\n\n{summary}")
+        return message.to_string();
     }
+    if summary.len() <= 2000 {
+        return format!("{message}\n\n{summary}");
+    }
+    let mut end = 2000;
+    while !summary.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{message}\n\n{}…", &summary[..end])
 }
 
 /// NSAlert with the stack trace in a scrollable monospace accessory view and
@@ -135,31 +143,315 @@ fn show_error_dialog(title: &str, message: &str, detail: &str) {
     unsafe { nucleus_tao_show_error_dialog(title.as_ptr(), message.as_ptr()) };
 }
 
+// Control ids for the Windows fatal dialog (IDCANCEL = 2 is the stock Close
+// id so Esc and the titlebar X both route through it).
+#[cfg(target_os = "windows")]
+const FATAL_DLG_ID_ICON: u16 = 101;
+#[cfg(target_os = "windows")]
+const FATAL_DLG_ID_TRACE: u16 = 102;
+#[cfg(target_os = "windows")]
+const FATAL_DLG_ID_COPY: u16 = 103;
+
+/// Builds the in-memory `DLGTEMPLATE` for the fatal dialog: error icon +
+/// message line up top, the stack trace in a read-only multiline EDIT with
+/// both scrollbars (no `ES_AUTOHSCROLL` word-wrap — frame tails matter), and
+/// Copy / Close buttons. Returned as `Vec<u32>` because `DLGTEMPLATE` needs
+/// DWORD alignment and `Vec<u16>` only guarantees 2 bytes.
+///
+/// The trace text is deliberately NOT part of the template: templates choke
+/// on large item strings (`DialogBoxIndirectParamW` returns -1 outright for
+/// a ~100 KB VerifyError dump), so the EDIT starts empty and the dialog proc
+/// fills it from `dwInitParam` via `SetWindowTextW`, which has no such limit.
+///
+/// Everything below is in dialog units (Segoe UI 9pt ⇒ ~1.75×1.9 px/DLU),
+/// sized to match the 560×160 px trace views on macOS and Linux.
+#[cfg(target_os = "windows")]
+fn fatal_dialog_template(title: &str, message: &str) -> Vec<u32> {
+    // Raw style bits, spelled out because the template wants untyped u32s
+    // (the windows-crate consts come as WINDOW_STYLE / i32 grab-bags).
+    const WS_POPUP: u32 = 0x8000_0000;
+    const WS_VISIBLE: u32 = 0x1000_0000;
+    const WS_CAPTION: u32 = 0x00C0_0000;
+    const WS_SYSMENU: u32 = 0x0008_0000;
+    const WS_CHILD: u32 = 0x4000_0000;
+    const WS_BORDER: u32 = 0x0080_0000;
+    const WS_VSCROLL: u32 = 0x0020_0000;
+    const WS_HSCROLL: u32 = 0x0010_0000;
+    const WS_TABSTOP: u32 = 0x0001_0000;
+    const DS_SETFONT: u32 = 0x0040;
+    const DS_MODALFRAME: u32 = 0x0080;
+    const DS_CENTER: u32 = 0x0800;
+    // Raise above the corpse of the app, same intent as MB_SETFOREGROUND.
+    const DS_SETFOREGROUND: u32 = 0x0200;
+    const SS_ICON: u32 = 0x0003;
+    // Exception messages may contain '&' — don't turn it into an accelerator.
+    const SS_NOPREFIX: u32 = 0x0080;
+    const ES_MULTILINE: u32 = 0x0004;
+    const ES_AUTOVSCROLL: u32 = 0x0040;
+    const ES_READONLY: u32 = 0x0800;
+    const BS_DEFPUSHBUTTON: u32 = 0x0001;
+    // Window-class ordinals for template items.
+    const CLASS_BUTTON: u16 = 0x0080;
+    const CLASS_EDIT: u16 = 0x0081;
+    const CLASS_STATIC: u16 = 0x0082;
+    const IDCANCEL: u16 = 2;
+
+    let mut w: Vec<u16> = Vec::with_capacity(256 + title.len() + message.len());
+    let push_u32 = |w: &mut Vec<u16>, v: u32| {
+        w.push(v as u16);
+        w.push((v >> 16) as u16);
+    };
+    let push_wstr = |w: &mut Vec<u16>, s: &str| {
+        w.extend(s.encode_utf16());
+        w.push(0);
+    };
+    // DLGTEMPLATE header.
+    push_u32(
+        &mut w,
+        DS_SETFONT
+            | DS_MODALFRAME
+            | DS_CENTER
+            | DS_SETFOREGROUND
+            | WS_POPUP
+            | WS_CAPTION
+            | WS_SYSMENU,
+    );
+    push_u32(&mut w, 0); // dwExtendedStyle
+    w.push(5); // cdit: icon, message, trace, Copy, Close
+    w.extend([0u16, 0]); // x, y (DS_CENTER positions it)
+    w.extend([320u16, 154]); // cx, cy
+    w.push(0); // no menu
+    w.push(0); // default dialog class
+    push_wstr(&mut w, title);
+    w.push(9); // DS_SETFONT point size
+    push_wstr(&mut w, "Segoe UI");
+
+    let push_item =
+        |w: &mut Vec<u16>, style: u32, rect: [u16; 4], id: u16, class: u16, text: &str| {
+            if w.len() % 2 == 1 {
+                w.push(0); // DLGITEMTEMPLATE entries are DWORD-aligned
+            }
+            push_u32(w, style);
+            push_u32(w, 0); // dwExtendedStyle
+            w.extend(rect);
+            w.push(id);
+            w.extend([0xFFFF, class]);
+            push_wstr(w, text);
+            w.push(0); // no creation data
+        };
+    push_item(
+        &mut w,
+        WS_CHILD | WS_VISIBLE | SS_ICON,
+        [7, 7, 21, 20],
+        FATAL_DLG_ID_ICON,
+        CLASS_STATIC,
+        "",
+    );
+    push_item(
+        &mut w,
+        WS_CHILD | WS_VISIBLE | SS_NOPREFIX,
+        [36, 9, 277, 16],
+        0xFFFF, // stock "don't care" static id
+        CLASS_STATIC,
+        message,
+    );
+    push_item(
+        &mut w,
+        WS_CHILD
+            | WS_VISIBLE
+            | WS_BORDER
+            | WS_VSCROLL
+            | WS_HSCROLL
+            | WS_TABSTOP
+            | ES_MULTILINE
+            | ES_AUTOVSCROLL
+            | ES_READONLY,
+        [7, 30, 306, 96],
+        FATAL_DLG_ID_TRACE,
+        CLASS_EDIT,
+        "", // filled in WM_INITDIALOG — see the doc comment above
+    );
+    push_item(
+        &mut w,
+        WS_CHILD | WS_VISIBLE | WS_TABSTOP,
+        [205, 133, 52, 14],
+        FATAL_DLG_ID_COPY,
+        CLASS_BUTTON,
+        "Copy",
+    );
+    push_item(
+        &mut w,
+        WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON,
+        [261, 133, 52, 14],
+        IDCANCEL,
+        CLASS_BUTTON,
+        "Close",
+    );
+
+    // Re-home into a Vec<u32> for the DWORD alignment DLGTEMPLATE requires.
+    let mut aligned: Vec<u32> = vec![0; w.len().div_ceil(2)];
+    // SAFETY: the destination is freshly allocated and at least w.len() u16s.
+    unsafe {
+        std::ptr::copy_nonoverlapping(w.as_ptr(), aligned.as_mut_ptr().cast::<u16>(), w.len());
+    }
+    aligned
+}
+
+/// Dialog procedure for the fatal dialog. `WM_INITDIALOG`'s lParam
+/// (`dwInitParam`) carries the NUL-terminated wide trace text, set into the
+/// EDIT here because the template cannot carry it (see
+/// [`fatal_dialog_template`]). Copy selects-all + `WM_COPY` on the trace EDIT
+/// (works on read-only edits, and the selection doubles as visual feedback)
+/// and keeps the dialog open, matching macOS and Linux; Close / Esc /
+/// titlebar X all arrive as IDCANCEL and end the dialog with 1 so the caller
+/// can tell "dismissed" from "failed to create" (0 / -1).
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn fatal_dialog_proc(
+    hwnd: windows::Win32::Foundation::HWND,
+    msg: u32,
+    wparam: windows::Win32::Foundation::WPARAM,
+    lparam: windows::Win32::Foundation::LPARAM,
+) -> isize {
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::{LPARAM, WPARAM};
+    use windows::Win32::Graphics::Gdi::{
+        CreateFontW, CLEARTYPE_QUALITY, CLIP_DEFAULT_PRECIS, DEFAULT_CHARSET, FF_MODERN,
+        FIXED_PITCH, FW_NORMAL, OUT_DEFAULT_PRECIS,
+    };
+    use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EndDialog, GetDlgItem, LoadIconW, SendMessageW, SetWindowTextW, IDI_ERROR, STM_SETICON,
+        WM_COMMAND, WM_COPY, WM_INITDIALOG, WM_SETFONT,
+    };
+    // Lives in UI::Controls in the windows crate — not worth the feature.
+    const EM_SETSEL: u32 = 0x00B1;
+    const IDCANCEL: u16 = 2;
+    match msg {
+        WM_INITDIALOG => {
+            if let Ok(icon) = LoadIconW(None, IDI_ERROR) {
+                if let Ok(item) = GetDlgItem(Some(hwnd), FATAL_DLG_ID_ICON as i32) {
+                    SendMessageW(
+                        item,
+                        STM_SETICON,
+                        Some(WPARAM(icon.0 as usize)),
+                        Some(LPARAM(0)),
+                    );
+                }
+            }
+            if let Ok(trace) = GetDlgItem(Some(hwnd), FATAL_DLG_ID_TRACE as i32) {
+                if lparam.0 != 0 {
+                    let _ = SetWindowTextW(trace, PCWSTR(lparam.0 as *const u16));
+                }
+                // Monospace trace like the other platforms. Deliberately not
+                // freed: the process exits right after the fatal dialog.
+                let face: Vec<u16> = "Consolas\0".encode_utf16().collect();
+                let font = CreateFontW(
+                    -12,
+                    0,
+                    0,
+                    0,
+                    FW_NORMAL.0 as i32,
+                    0,
+                    0,
+                    0,
+                    DEFAULT_CHARSET,
+                    OUT_DEFAULT_PRECIS,
+                    CLIP_DEFAULT_PRECIS,
+                    CLEARTYPE_QUALITY,
+                    FIXED_PITCH.0 as u32 | FF_MODERN.0 as u32,
+                    PCWSTR(face.as_ptr()),
+                );
+                if !font.is_invalid() {
+                    SendMessageW(
+                        trace,
+                        WM_SETFONT,
+                        Some(WPARAM(font.0 as usize)),
+                        Some(LPARAM(1)),
+                    );
+                }
+            }
+            // Focus Close, not the trace edit — the dialog manager would
+            // otherwise select the whole trace on open. Returning 0 tells it
+            // we set focus ourselves.
+            if let Ok(close) = GetDlgItem(Some(hwnd), IDCANCEL as i32) {
+                let _ = SetFocus(Some(close));
+            }
+            0
+        }
+        WM_COMMAND => {
+            match (wparam.0 & 0xFFFF) as u16 {
+                FATAL_DLG_ID_COPY => {
+                    if let Ok(trace) = GetDlgItem(Some(hwnd), FATAL_DLG_ID_TRACE as i32) {
+                        SendMessageW(trace, EM_SETSEL, Some(WPARAM(0)), Some(LPARAM(-1)));
+                        SendMessageW(trace, WM_COPY, None, None);
+                    }
+                }
+                IDCANCEL => {
+                    let _ = EndDialog(hwnd, 1);
+                }
+                _ => return 0,
+            }
+            1
+        }
+        _ => 0,
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn show_error_dialog(title: &str, message: &str, detail: &str) {
-    // MessageBoxW reads NUL-terminated wide strings, so an interior NUL from
-    // Java would silently truncate — strip them like the macOS path does.
+    // The dialog manager and MessageBoxW read NUL-terminated wide strings, so
+    // an interior NUL from Java would silently truncate — strip them like the
+    // macOS path does.
     let title = title.replace('\0', "");
-    let message = message_with_summary(message, detail).replace('\0', "");
+    let message = message.replace('\0', "");
+    // EDIT controls only break lines on CRLF; a bare '\n' renders as a box.
+    let detail = detail
+        .replace('\0', "")
+        .replace("\r\n", "\n")
+        .replace('\n', "\r\n");
     // Dedicated thread, same reason macOS goes out of process: the calling
     // thread just ran (and exited) the Tao event loop, and modal loops on it
     // return immediately — a leftover quit/thread message in its queue makes
-    // MessageBoxW dismiss itself before the user sees anything. A fresh
-    // thread gets a fresh message queue, so the box actually blocks until
+    // the dialog dismiss itself before the user sees anything. A fresh
+    // thread gets a fresh message queue, so it actually blocks until
     // dismissed; join() preserves the blocking contract for the caller.
     std::thread::spawn(move || {
         use windows::core::HSTRING;
+        use windows::Win32::Foundation::LPARAM;
         use windows::Win32::UI::WindowsAndMessaging::{
-            MessageBoxW, MB_ICONERROR, MB_OK, MB_SETFOREGROUND,
+            DialogBoxIndirectParamW, MessageBoxW, DLGTEMPLATE, MB_ICONERROR, MB_OK,
+            MB_SETFOREGROUND,
         };
-        // No owner HWND: the Tao loop has exited and every Tao window is
-        // destroyed by the time the fatal path runs. Note the box is NOT
-        // modal to anything — MB_TASKMODAL would only disable top-level
-        // windows of the calling thread, and this fresh thread owns none —
-        // so surviving foreign windows (e.g. a Swing JFrame in the
-        // swing-tao-demo interop mode) stay interactive behind it.
+        // Primary path: the scrollable-trace dialog — the Windows twin of the
+        // macOS NSAlert accessory / Linux GtkMessageDialog. No owner HWND:
+        // the Tao loop has exited and every Tao window is destroyed by the
+        // time the fatal path runs. Note the dialog is NOT modal to anything
+        // (this fresh thread owns no other windows), so surviving foreign
+        // windows (e.g. a Swing JFrame in the swing-tao-demo interop mode)
+        // stay interactive behind it.
+        if !detail.is_empty() {
+            let template = fatal_dialog_template(&title, &message);
+            // The trace goes through dwInitParam, not the template (see
+            // fatal_dialog_template). `detail_w` outlives the modal call.
+            let detail_w: Vec<u16> = detail.encode_utf16().chain(std::iter::once(0)).collect();
+            let dismissed = unsafe {
+                DialogBoxIndirectParamW(
+                    None,
+                    template.as_ptr().cast::<DLGTEMPLATE>(),
+                    None,
+                    Some(fatal_dialog_proc),
+                    LPARAM(detail_w.as_ptr() as isize),
+                )
+            } > 0;
+            if dismissed {
+                return;
+            }
+        }
+        // Fallback (no detail, or the dialog could not be created): the
+        // compact one-shot MessageBoxW with only the `toString()` summary.
         // MB_SETFOREGROUND raises it above the corpse of the app so the user
         // actually sees why it is closing.
+        let message = message_with_summary(&message, &detail);
         unsafe {
             MessageBoxW(
                 None,


### PR DESCRIPTION
## Summary
- Split the fatal-dialog payload into a short message plus a `detail` stack trace (`Throwable.stackTraceToString()`) passed through `nativeShowErrorDialog`
- **macOS**: NSAlert with the trace in a scrollable monospace accessory view and a Copy button, run by an `osascript -l JavaScript` child (our own NSApp is unusable after tao latches `[NSApp stop:]`); falls back to the compact CFUserNotification alert when the child cannot run
- **Windows**: in-memory `DLGTEMPLATE` dialog on a fresh thread — error icon, read-only multiline Consolas EDIT with both scrollbars, Copy / Close buttons (Copy = select-all + `WM_COPY`, keeps the dialog open); falls back to the compact `MessageBoxW`
- **Linux**: GtkMessageDialog with the trace in a bounded scrollable monospace `GtkTextView`, `_Copy` / `_Close` buttons, clipboard handed to the clipboard manager so it survives process exit
- Large-trace hardening: the Windows trace goes through `dwInitParam` + `SetWindowTextW` because `DialogBoxIndirectParamW` returns -1 outright for large template item strings (a VerifyError `toString()` is a ~100 KB bytecode dump), and the compact-fallback summary is capped at 2000 chars — `MessageBoxW` silently never shows on a string that large

## Test plan
- [x] Rust unit tests (temporary, removed): dialog opens and closes programmatically on Windows, including with a ~120 KB VerifyError-style detail; capped `MessageBoxW` fallback appears
- [x] `:decorated-window-tao:test` (headless) green
- [x] `:decorated-window-tao:taoHeadfulTest` green (26 run, 0 failed)
- [x] ktlint + detekt + `apiDump` clean (no public API change)
- [x] Manual crash check on macOS and Linux