### PR TITLE
fix(msi): forward the Windows installer settings to electron-builder

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/MsiSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/MsiSettings.kt
@@ -19,4 +19,33 @@ abstract class MsiSettings {
     // Tracks whether the user set the value explicitly, so the deprecated
     // windows.perUserInstall flag can still take effect when this one is untouched.
     internal var explicitPerMachine: Boolean? = null
+
+    /**
+     * One-click installer: install immediately without showing a wizard. Default: true.
+     *
+     * Set to `false` for an assisted installer that shows the usual welcome/progress/finish
+     * pages, which is what jpackage-produced MSI packages did.
+     */
+    var oneClick: Boolean = true
+
+    /** Run the app once the installer finishes. Default: true */
+    var runAfterFinish: Boolean = true
+
+    /** Create a desktop shortcut. Default: true */
+    var createDesktopShortcut: Boolean = true
+
+    /** Create a start menu shortcut. Default: true */
+    var createStartMenuShortcut: Boolean = true
+
+    /**
+     * Start menu submenu (and program files subdirectory) holding the shortcut.
+     *
+     * `null` (default) puts the shortcut directly under the start menu root. When left unset,
+     * [WindowsPlatformSettings.menuGroup] is used instead, so the group declared for
+     * jpackage-based packaging keeps working on the MSI target.
+     */
+    var menuCategory: String? = null
+
+    /** Name used for the shortcuts. Defaults to the application name. */
+    var shortcutName: String? = null
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -277,7 +277,8 @@ internal class ElectronBuilderConfigGenerator {
         val height: Int,
     )
 
-    private fun generateWindowsConfig(
+    // internal (like generateLinuxConfig) so the rendered YAML can be asserted in unit tests
+    internal fun generateWindowsConfig(
         yaml: StringBuilder,
         distributions: JvmApplicationDistributions,
         targetFormat: TargetFormat,
@@ -312,12 +313,21 @@ internal class ElectronBuilderConfigGenerator {
                 generateNsisSettings(yaml, distributions.windows.nsis, "  ", nsisProtocolInclude)
             }
             TargetFormat.Msi -> {
+                val msi = distributions.windows.msi
                 yaml.appendLine("msi:")
                 appendIfNotNull(yaml, "  upgradeCode", distributions.windows.upgradeUuid)
                 @Suppress("DEPRECATION")
-                val perMachine = distributions.windows.msi.explicitPerMachine
+                val perMachine = msi.explicitPerMachine
                     ?: !distributions.windows.perUserInstall
                 yaml.appendLine("  perMachine: $perMachine")
+                yaml.appendLine("  oneClick: ${msi.oneClick}")
+                yaml.appendLine("  runAfterFinish: ${msi.runAfterFinish}")
+                yaml.appendLine("  createDesktopShortcut: ${msi.createDesktopShortcut}")
+                yaml.appendLine("  createStartMenuShortcut: ${msi.createStartMenuShortcut}")
+                // windows.menuGroup is the jpackage-era name for the same concept, so it acts as
+                // the default here; without it the shortcut lands in the start menu root.
+                appendIfNotNull(yaml, "  menuCategory", msi.menuCategory ?: distributions.windows.menuGroup)
+                appendIfNotNull(yaml, "  shortcutName", msi.shortcutName)
             }
             TargetFormat.AppX -> generateAppXConfig(yaml, distributions.windows.appx)
             TargetFormat.Portable -> {

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/dsl/MsiSettingsTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/dsl/MsiSettingsTest.kt
@@ -27,4 +27,15 @@ class MsiSettingsTest {
         assertTrue(msi.perMachine)
         assertEquals(true, msi.explicitPerMachine)
     }
+
+    @Test
+    fun `installer options default to the electron-builder defaults`() {
+        val msi = msiSettings()
+        assertTrue(msi.oneClick)
+        assertTrue(msi.runAfterFinish)
+        assertTrue(msi.createDesktopShortcut)
+        assertTrue(msi.createStartMenuShortcut)
+        assertNull(msi.menuCategory)
+        assertNull(msi.shortcutName)
+    }
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderMsiConfigTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderMsiConfigTest.kt
@@ -1,0 +1,104 @@
+package dev.nucleusframework.desktop.application.internal.electronbuilder
+
+import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
+import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import dev.nucleusframework.internal.utils.Arch
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The MSI target only forwarded `upgradeCode` and `perMachine` to electron-builder, so every other
+ * Windows installer setting fell back to an electron-builder default: the shortcut landed in the
+ * start menu root instead of `windows.menuGroup`, the installer ran without a wizard and the app
+ * was launched as soon as it finished. These assert the settings actually reach the config.
+ */
+class ElectronBuilderMsiConfigTest {
+    private fun distributions(): JvmApplicationDistributions =
+        ProjectBuilder.builder().build().objects.newInstance(JvmApplicationDistributions::class.java)
+
+    private fun renderWindows(
+        distributions: JvmApplicationDistributions,
+        targetFormat: TargetFormat = TargetFormat.Msi,
+    ): String {
+        val yaml = StringBuilder()
+        ElectronBuilderConfigGenerator().generateWindowsConfig(
+            yaml = yaml,
+            distributions = distributions,
+            targetFormat = targetFormat,
+            targetArch = Arch.X64,
+            windowsIconOverride = null,
+            executableName = "nucleusdemo",
+            nsisProtocolInclude = null,
+        )
+        return yaml.toString()
+    }
+
+    @Test
+    fun `msi keeps the electron-builder defaults when nothing is configured`() {
+        val yaml = renderWindows(distributions())
+
+        assertTrue(yaml, yaml.contains("msi:"))
+        assertTrue(yaml, yaml.contains("oneClick: true"))
+        assertTrue(yaml, yaml.contains("runAfterFinish: true"))
+        assertTrue(yaml, yaml.contains("createDesktopShortcut: true"))
+        assertTrue(yaml, yaml.contains("createStartMenuShortcut: true"))
+        assertFalse(yaml, yaml.contains("menuCategory"))
+        assertFalse(yaml, yaml.contains("shortcutName"))
+    }
+
+    @Test
+    fun `msi settings are forwarded`() {
+        val distributions = distributions()
+        distributions.windows.msi.oneClick = false
+        distributions.windows.msi.runAfterFinish = false
+        distributions.windows.msi.createDesktopShortcut = false
+        distributions.windows.msi.createStartMenuShortcut = false
+        distributions.windows.msi.menuCategory = "Acme Apps"
+        distributions.windows.msi.shortcutName = "Acme"
+
+        val yaml = renderWindows(distributions)
+
+        assertTrue(yaml, yaml.contains("oneClick: false"))
+        assertTrue(yaml, yaml.contains("runAfterFinish: false"))
+        assertTrue(yaml, yaml.contains("createDesktopShortcut: false"))
+        assertTrue(yaml, yaml.contains("createStartMenuShortcut: false"))
+        assertTrue(yaml, yaml.contains("menuCategory: \"Acme Apps\""))
+        assertTrue(yaml, yaml.contains("shortcutName: \"Acme\""))
+    }
+
+    @Test
+    fun `windows menuGroup is used as the menu category`() {
+        val distributions = distributions()
+        distributions.windows.menuGroup = "Acme Apps"
+
+        val yaml = renderWindows(distributions)
+
+        assertTrue(yaml, yaml.contains("menuCategory: \"Acme Apps\""))
+    }
+
+    @Test
+    fun `explicit menu category wins over menuGroup`() {
+        val distributions = distributions()
+        distributions.windows.menuGroup = "From menuGroup"
+        distributions.windows.msi.menuCategory = "From msi"
+
+        val yaml = renderWindows(distributions)
+
+        assertTrue(yaml, yaml.contains("menuCategory: \"From msi\""))
+        assertFalse(yaml, yaml.contains("From menuGroup"))
+    }
+
+    @Test
+    fun `nsis target is unaffected by the msi settings`() {
+        val distributions = distributions()
+        distributions.windows.menuGroup = "Acme Apps"
+
+        val yaml = renderWindows(distributions, TargetFormat.Nsis)
+
+        assertTrue(yaml, yaml.contains("nsis:"))
+        assertFalse(yaml, yaml.contains("msi:"))
+        assertFalse(yaml, yaml.contains("menuCategory"))
+    }
+}


### PR DESCRIPTION
### Problem

The MSI target forwards only `upgradeCode` and `perMachine` to electron-builder, so every other
Windows installer setting falls back to an electron-builder default. Projects that migrated from
jpackage-based packaging silently lose three behaviours:

| Setting | Before (jpackage) | Now (electron-builder MSI) |
| --- | --- | --- |
| `windows.menuGroup` | `--win-menu-group` → shortcut in a start menu folder | ignored → shortcut lands in the start menu **root** |
| installer UI | welcome / progress / finish pages | `oneClick` defaults to `true` → installs with no UI at all |
| after install | nothing | `runAfterFinish` defaults to `true` → the app is launched |

`windows { menuGroup / menu / shortcut / dirChooser }` are still read by `AbstractJPackageTask`,
but `TargetFormat.Msi` is `PackagingBackend.ELECTRON_BUILDER`, so nothing in that block reaches
the MSI. There is also no way to set these from a build script, since the electron-builder config
is generated from the DSL inside the task and no user config is merged.

Comparing the MSI tables of the same app built before and after the migration:

```
before: Shortcut          → dir6433… | ProgramMenuFolder | AppName   (start menu folder)
        InstallUISequence → WelcomeDlg / ProgressDlg / ExitDialog …
after:  Shortcut          → startMenuShortcut | ProgramMenuFolder | AppName   (root)
        InstallUISequence → CostInitialize / ExecuteAction only        (no dialogs)
```

### Fix

Add the remaining `CommonWindowsInstallerConfiguration` options to `MsiSettings` and emit them:

```kotlin
windows {
  menuGroup = "MyApp"          // already existed; now honored by the MSI target too
  msi {
    perMachine = false
    oneClick = false           // show the installer wizard
    runAfterFinish = false     // don't launch the app when the installer finishes
  }
}
```

- Every new option defaults to the electron-builder default, so **generated MSIs are unchanged
  unless a project sets one** — with one intended exception: `windows.menuGroup` now acts as the
  default for `msi.menuCategory`, which is the jpackage-era name for the same concept. Projects
  that declared a menu group get their start menu folder back; projects that never set it are
  unaffected (`menuCategory` stays unset and nothing is emitted).
- `windows.menu` / `windows.shortcut` are deliberately **not** mapped. Their jpackage defaults
  (`false`) are the opposite of electron-builder's (`true`), so mapping them would silently drop
  shortcuts for projects that are happy with today's output. `msi.createStartMenuShortcut` /
  `msi.createDesktopShortcut` give explicit control instead.
- Only the MSI target is touched. `NsisSettings` already exposes `oneClick` / `runAfterFinish` /
  `createStartMenuShortcut` / `createDesktopShortcut`; it is missing `menuCategory` and
  `shortcutName`, which I'm happy to add in a follow-up if you want the two targets aligned.

Verified against electron-builder's `MsiTarget.ts`:
`menuCategory` emits `<Directory Id="AppProgramMenuDir" Name="ProgramMenuFolder:\<category>\"/>`
and anchors `startMenuShortcut` there (plus a `RemoveFolder` on uninstall), `oneClick === false`
adds `-ext WixUIExtension` to the light args, and `runAfterFinish` drives `isRunAfterFinish` in the
WiX template.

Also verified end to end: I published the patched plugin to Maven Local and rebuilt the same app
with `menuGroup` plus `msi { oneClick = false; runAfterFinish = false }`. The MSI tables come out
as expected, and installing it behaves like the jpackage-era package again:

| | before this PR | after |
| --- | --- | --- |
| Shortcut | `startMenuShortcut \| ProgramMenuFolder` | `startMenuShortcut \| AppProgramMenuDir` (folder `ProgramMenuFolder\ZonePane`) |
| InstallUISequence | Cost*/ExecuteAction only (no UI) | WelcomeDlg / ProgressDlg / ExitDialog / MaintenanceWelcomeDlg / ResumeDlg |
| CustomAction | `runAfterFinish \| 210 \| mainExecutable` | (absent) |
| UpgradeCode / per-user | unchanged | unchanged (`MSIINSTALLPERUSER=1`, same UpgradeCode) |

One observable side effect of `oneClick = false`, inherent to electron-builder's template: the
assisted installer nests the install directory one level deeper
(`…\Programs\<app>` → `…\Programs\<company>\<app>`), same as it does for NSIS assisted installs.

### Tests

- `ElectronBuilderMsiConfigTest` (new, 5 cases): defaults are unchanged, each option is forwarded,
  `windows.menuGroup` is used as the menu category, an explicit `msi.menuCategory` wins over it,
  and the NSIS target is unaffected.
- `MsiSettingsTest`: added a defaults case for the new options.

`generateWindowsConfig` is now `internal` so the rendered YAML can be asserted, matching
`generateLinuxConfig` which is already `internal` for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)