### PR TITLE
feat(nsis): add menuCategory and shortcutName to the NSIS targets

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/NsisSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/NsisSettings.kt
@@ -31,6 +31,18 @@ abstract class NsisSettings {
     /** Create start menu shortcut. Default: true */
     var createStartMenuShortcut: Boolean = true
 
+    /**
+     * Start menu submenu (and program files subdirectory) holding the shortcut.
+     *
+     * `null` (default) puts the shortcut directly under the start menu root. When left unset,
+     * [WindowsPlatformSettings.menuGroup] is used instead, so the group declared for
+     * jpackage-based packaging keeps working on the NSIS targets. Mirrors [MsiSettings.menuCategory].
+     */
+    var menuCategory: String? = null
+
+    /** Name used for the shortcuts. Defaults to the application name. */
+    var shortcutName: String? = null
+
     /** Run app after install finishes. Default: true */
     var runAfterFinish: Boolean = true
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -306,11 +306,23 @@ internal class ElectronBuilderConfigGenerator {
         when (targetFormat) {
             TargetFormat.Nsis, TargetFormat.Exe -> {
                 yaml.appendLine("nsis:")
-                generateNsisSettings(yaml, distributions.windows.nsis, "  ", nsisProtocolInclude)
+                generateNsisSettings(
+                    yaml,
+                    distributions.windows.nsis,
+                    "  ",
+                    nsisProtocolInclude,
+                    menuCategoryDefault = distributions.windows.menuGroup,
+                )
             }
             TargetFormat.NsisWeb -> {
                 yaml.appendLine("nsisWeb:")
-                generateNsisSettings(yaml, distributions.windows.nsis, "  ", nsisProtocolInclude)
+                generateNsisSettings(
+                    yaml,
+                    distributions.windows.nsis,
+                    "  ",
+                    nsisProtocolInclude,
+                    menuCategoryDefault = distributions.windows.menuGroup,
+                )
             }
             TargetFormat.Msi -> {
                 val msi = distributions.windows.msi
@@ -431,6 +443,7 @@ internal class ElectronBuilderConfigGenerator {
         nsis: NsisSettings,
         indent: String,
         protocolInclude: File? = null,
+        menuCategoryDefault: String? = null,
     ) {
         yaml.appendLine("${indent}oneClick: ${nsis.oneClick}")
         yaml.appendLine("${indent}allowElevation: ${nsis.allowElevation}")
@@ -439,6 +452,10 @@ internal class ElectronBuilderConfigGenerator {
         yaml.appendLine("${indent}createDesktopShortcut: ${nsis.createDesktopShortcut}")
         yaml.appendLine("${indent}createStartMenuShortcut: ${nsis.createStartMenuShortcut}")
         yaml.appendLine("${indent}runAfterFinish: ${nsis.runAfterFinish}")
+        // windows.menuGroup is the jpackage-era name for the same concept, so it acts as
+        // the default here; without it the shortcut lands in the start menu root.
+        appendIfNotNull(yaml, "${indent}menuCategory", nsis.menuCategory ?: menuCategoryDefault)
+        appendIfNotNull(yaml, "${indent}shortcutName", nsis.shortcutName)
         yaml.appendLine("${indent}deleteAppDataOnUninstall: ${nsis.deleteAppDataOnUninstall}")
         yaml.appendLine("${indent}warningsAsErrors: false")
 

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderMsiConfigTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderMsiConfigTest.kt
@@ -93,12 +93,15 @@ class ElectronBuilderMsiConfigTest {
     @Test
     fun `nsis target is unaffected by the msi settings`() {
         val distributions = distributions()
-        distributions.windows.menuGroup = "Acme Apps"
+        distributions.windows.msi.oneClick = false
+        distributions.windows.msi.menuCategory = "From msi"
 
         val yaml = renderWindows(distributions, TargetFormat.Nsis)
 
         assertTrue(yaml, yaml.contains("nsis:"))
         assertFalse(yaml, yaml.contains("msi:"))
-        assertFalse(yaml, yaml.contains("menuCategory"))
+        // the nsis block keeps its own defaults; nothing leaks over from msi {}
+        assertTrue(yaml, yaml.contains("oneClick: true"))
+        assertFalse(yaml, yaml.contains("From msi"))
     }
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderNsisConfigTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderNsisConfigTest.kt
@@ -1,0 +1,93 @@
+package dev.nucleusframework.desktop.application.internal.electronbuilder
+
+import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
+import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import dev.nucleusframework.internal.utils.Arch
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The NSIS targets exposed most installer settings but not `menuCategory` / `shortcutName`, so a
+ * start menu group could not be declared at all: the shortcut always landed in the start menu
+ * root. These assert the two options reach the config, including `windows.menuGroup` acting as
+ * the default for the group, mirroring the MSI target (see ElectronBuilderMsiConfigTest).
+ */
+class ElectronBuilderNsisConfigTest {
+    private fun distributions(): JvmApplicationDistributions =
+        ProjectBuilder.builder().build().objects.newInstance(JvmApplicationDistributions::class.java)
+
+    private fun renderWindows(
+        distributions: JvmApplicationDistributions,
+        targetFormat: TargetFormat = TargetFormat.Nsis,
+    ): String {
+        val yaml = StringBuilder()
+        ElectronBuilderConfigGenerator().generateWindowsConfig(
+            yaml = yaml,
+            distributions = distributions,
+            targetFormat = targetFormat,
+            targetArch = Arch.X64,
+            windowsIconOverride = null,
+            executableName = "nucleusdemo",
+            nsisProtocolInclude = null,
+        )
+        return yaml.toString()
+    }
+
+    @Test
+    fun `nsis omits the options when nothing is configured`() {
+        val yaml = renderWindows(distributions())
+
+        assertTrue(yaml, yaml.contains("nsis:"))
+        assertFalse(yaml, yaml.contains("menuCategory"))
+        assertFalse(yaml, yaml.contains("shortcutName"))
+    }
+
+    @Test
+    fun `nsis settings are forwarded`() {
+        val distributions = distributions()
+        distributions.windows.nsis.menuCategory = "Acme Apps"
+        distributions.windows.nsis.shortcutName = "Acme"
+
+        val yaml = renderWindows(distributions)
+
+        assertTrue(yaml, yaml.contains("menuCategory: \"Acme Apps\""))
+        assertTrue(yaml, yaml.contains("shortcutName: \"Acme\""))
+    }
+
+    @Test
+    fun `windows menuGroup is used as the menu category`() {
+        val distributions = distributions()
+        distributions.windows.menuGroup = "Acme Apps"
+
+        val yaml = renderWindows(distributions)
+
+        assertTrue(yaml, yaml.contains("menuCategory: \"Acme Apps\""))
+    }
+
+    @Test
+    fun `explicit menu category wins over menuGroup`() {
+        val distributions = distributions()
+        distributions.windows.menuGroup = "From menuGroup"
+        distributions.windows.nsis.menuCategory = "From nsis"
+
+        val yaml = renderWindows(distributions)
+
+        assertTrue(yaml, yaml.contains("menuCategory: \"From nsis\""))
+        assertFalse(yaml, yaml.contains("From menuGroup"))
+    }
+
+    @Test
+    fun `nsis-web gets the same options`() {
+        val distributions = distributions()
+        distributions.windows.menuGroup = "Acme Apps"
+        distributions.windows.nsis.shortcutName = "Acme"
+
+        val yaml = renderWindows(distributions, TargetFormat.NsisWeb)
+
+        assertTrue(yaml, yaml.contains("nsisWeb:"))
+        assertTrue(yaml, yaml.contains("menuCategory: \"Acme Apps\""))
+        assertTrue(yaml, yaml.contains("shortcutName: \"Acme\""))
+    }
+}


### PR DESCRIPTION
Follow-up to #629, as offered there — and to your advice to prefer NSIS over MSI: this removes
the last blocker for migrating our MSI packaging to NSIS.

### Problem

The NSIS targets already expose most of electron-builder's installer settings
(`oneClick`, `runAfterFinish`, `createStartMenuShortcut`, …), but not `menuCategory` /
`shortcutName`. A start menu group therefore cannot be declared at all: the shortcut always
lands in the start menu root, while the jpackage-era packaging honored `windows.menuGroup`.

### Fix

Add the two remaining `CommonWindowsInstallerConfiguration` options to `NsisSettings` and emit
them for `nsis` and `nsis-web`:

```kotlin
windows {
  menuGroup = "MyApp"          // acts as the default for nsis.menuCategory, like on MSI
  nsis {
    menuCategory = "MyApp"     // explicit override, wins over menuGroup
    shortcutName = "My App"
  }
}
```

- Both options default to `null` (nothing emitted), so generated installers are unchanged unless
  a project opts in — with the same intended exception as the MSI target in #629:
  `windows.menuGroup`, the jpackage-era name for the same concept, acts as the default for
  `nsis.menuCategory`, so projects that declared a menu group get their start menu folder when
  they switch to NSIS.
- electron-builder side: both come from `CommonWindowsInstallerConfiguration` and are handled by
  the NSIS template (`menuCategory` creates the submenu, `shortcutName` overrides the shortcut
  label).

Verified end to end with the patched plugin published to Maven Local: rebuilt our app as an NSIS
installer with only `windows.menuGroup` declared, and a clean install produced
`Start Menu\Programs\ZonePane\ZonePane.lnk` (previously the shortcut landed in the root);
uninstall removes the shortcut, the folder and both registry keys.

### Tests

- `ElectronBuilderNsisConfigTest` (new, 5 cases): nothing emitted by default, both options
  forwarded, `windows.menuGroup` used as the menu category, explicit `nsis.menuCategory` wins,
  and `nsis-web` gets the same treatment.
- `ElectronBuilderMsiConfigTest`: the "nsis target is unaffected by the msi settings" case
  asserted that `menuCategory` never appears for NSIS; it now asserts the actual concern — that
  `msi {}` values do not leak into the `nsis` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
