### PR TITLE
fix(tao): skip VSync presents of clean frames on Windows (multi-window lag)

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -873,9 +873,20 @@ public class TaoWindow internal constructor(
         if (hwnd != 0L) NativeTaoWindowsDecoBridge.nativeSetStartupBackgroundEraseEnabled(hwnd, enabled)
     }
 
+    /**
+     * Invoked synchronously on every [show] call, before the native visibility
+     * flip. The Windows scene host uses it to force the next present: DWM does
+     * not reliably retain a pre-show swap once ShowWindow composites the
+     * window, so the redraw that follows a show must reach eglSwapBuffers even
+     * when the scene content itself is unchanged (clean frames skip the
+     * present otherwise — see TaoSceneBundle.visualDirty).
+     */
+    internal var showHook: (() -> Unit)? = null
+
     public fun show() {
         startupEraseActive = true
         setStartupBackgroundEraseEnabled(true)
+        showHook?.invoke()
         NativeTaoBridge.nativeSetVisible(handle, true)
         // Queued behind the show above (both ride the same event loop), so the
         // click-through state lands on the mapped window — see

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -319,6 +319,10 @@ internal class TaoComposeSceneHostWindows(
         hwnd = NativeTaoBridge.nativeHwndHandle(window.handle)
         require(hwnd != 0L) { "HWND unavailable; window not yet realised" }
 
+        // The swap after a show() must always happen, clean scene or not —
+        // see [forcePresentOnce].
+        window.showHook = { forcePresentOnce = true }
+
         // Install custom decoration (WndProc subclass + DwmExtendFrameIntoClientArea).
         // Title-bar height is set later — the value the TitleBar composable publishes
         // via SideEffect arrives after first composition.
@@ -1177,6 +1181,22 @@ internal class TaoComposeSceneHostWindows(
         }
     }
 
+    /**
+     * One-shot present override, armed by [TaoWindow.showHook]: the redraw
+     * following a show must swap even when the scene is clean, because DWM
+     * does not reliably retain a pre-show present once ShowWindow composites
+     * the window (see the matching re-request in event_loop.rs).
+     */
+    private var forcePresentOnce = true
+
+    /**
+     * The clear colour of the last presented frame. The resolved clear
+     * (backdrop tint / transparency / themed background) is read outside the
+     * composition, so a change never raises a scene invalidation — compare it
+     * here so a tint or transparency flip still reaches the screen.
+     */
+    private var lastPresentedClearArgb: Int? = null
+
     fun onRedrawRequested() {
         val ctx = directContext ?: return
         val bundle = sceneBundle ?: return
@@ -1200,6 +1220,7 @@ internal class TaoComposeSceneHostWindows(
         // present atomic — no exposed-strip black edge (the reason the old
         // onResized painted synchronously). resetGLAll after nativeResize is
         // unnecessary: the ES context/surface stay bound on this thread.
+        val resizeApplied = pendingResizeApply
         if (pendingResizeApply) {
             sc.size = IntSize(widthPx, heightPx)
             updateWindowInfoSize()
@@ -1265,6 +1286,13 @@ internal class TaoComposeSceneHostWindows(
                 return
             }
 
+        // Sampled before the render (and OR-ed with the post-render value
+        // below): an invalidation raised by this frame's own recompose/layout
+        // still counts as visual, while a recomposer-only tick — the global
+        // snapshot wake caused by a state write in ANOTHER window — leaves the
+        // flag untouched. See [TaoSceneBundle.visualDirty].
+        val dirtyBeforeRender = bundle.visualDirty.getAndSet(false)
+        val clearArgb = resolveClientClearArgb()
         try {
             // Clear to the resolved title-bar background (pushed by `TitleBar`
             // via [LocalRequestedClearColor]) so a Compose region without an
@@ -1277,7 +1305,7 @@ internal class TaoComposeSceneHostWindows(
             // Fully transparent without a backdrop: use the resolved clear
             // colour (alpha-0 by default, or a semi-transparent WindowBackground).
             // Opaque windows: themed clear as usual.
-            surface.canvas.clear(resolveClientClearArgb())
+            surface.canvas.clear(clearArgb)
             bundle.render(surface.canvas, now)
 
             // `flushAndSubmit` issues the glFlush that commits the frame to
@@ -1332,10 +1360,35 @@ internal class TaoComposeSceneHostWindows(
             hostContextDirtied = true
         }
 
-        // Present inline. nativePresent defensively re-binds the host's
-        // window surface first (a popup renderer may have left its pbuffer
-        // current) and eglSwapBuffers paces on the display refresh.
-        NativeTaoGlBridge.nativePresent(attachmentHandle)
+        // Present inline — but only when the frame carries visual changes.
+        // A clean frame (recomposer tick with no resulting layout/draw
+        // invalidation) skips eglSwapBuffers entirely: the swapchain already
+        // holds identical content, and the VSync-paced swap would park this
+        // shared event-loop thread until the next VBlank. With several
+        // visible windows, presenting those clean frames made every window
+        // re-present at the animating window's rate, serially blocking a
+        // VBlank each — the whole app then crawled (multi-window lag).
+        // Presents that must happen regardless of scene dirtiness:
+        //  - a size/scale apply (the parent HWND already changed geometry);
+        //  - the OS modal resize/move loop (every WM_SIZE must swap, #476);
+        //  - the first swap after show() (DWM drops pre-show presents);
+        //  - a resolved clear-colour change (read outside the composition,
+        //    so it never raises a scene invalidation).
+        // nativePresent defensively re-binds the host's window surface first
+        // (a popup renderer may have left its pbuffer current) and
+        // eglSwapBuffers paces on the display refresh.
+        val visualFrame = dirtyBeforeRender || bundle.visualDirty.get()
+        val mustPresent =
+            visualFrame ||
+                resizeApplied ||
+                resizeLoopActive ||
+                forcePresentOnce ||
+                lastPresentedClearArgb != clearArgb
+        if (mustPresent) {
+            forcePresentOnce = false
+            lastPresentedClearArgb = clearArgb
+            NativeTaoGlBridge.nativePresent(attachmentHandle)
+        }
 
         // Backstop for a continuation that landed after the post-record drain
         // (a worker slower than the record). Costs it the jitter threshold
@@ -1904,6 +1957,7 @@ internal class TaoComposeSceneHostWindows(
     }
 
     fun detach() {
+        window.showHook = null
         window.imePreedit = null
         window.imeCommit = null
         imeSession.onInputSession(null)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneBundle.kt
@@ -61,7 +61,27 @@ internal class TaoSceneBundle(
     private val exceptionRouter: TaoSceneExceptionRouter,
     /** The owner's coalescing frame scheduler; re-armed after a swallowed frame failure. */
     private val requestFrame: () -> Unit,
+    /** Shared with the scene's invalidation callbacks — see [visualDirty]. */
+    visualDirty: AtomicBoolean,
 ) : AutoCloseable {
+    /**
+     * Set by the scene's `invalidateLayout` / `invalidateDraw` callbacks — i.e.
+     * whenever the content actually needs a new layout/draw pass — and cleared
+     * by the host once the frame is presented.
+     *
+     * Exists to tell a *visual* frame apart from a recomposer-only tick: any
+     * snapshot write anywhere in the process (an animation in a sibling
+     * window, a ViewModel update) wakes every scene's [Recomposer] through the
+     * global apply observer, and the [FrameRecomposer]'s `invalidate` callback
+     * schedules a frame before knowing whether this scene is affected. Such a
+     * frame recomposes to nothing — no layout/draw invalidation fires — and a
+     * host can then skip the present. Presenting those empty frames is what
+     * made every visible window re-present at the animating window's rate,
+     * each present parking the shared event-loop thread on VSync (LapseCompose
+     * dashboard lag while the overlay window was visible).
+     */
+    val visualDirty: AtomicBoolean = visualDirty
+
     /**
      * Catches what user code throws in this scene: [render] covers layout and
      * draw, the [TaoSceneExceptionRouter] in the scene's coroutine context
@@ -170,6 +190,8 @@ internal fun canvasLayersSceneBundle(
     val frameRecomposer = FrameRecomposer(sceneContext) { requestFrame() }
     val guardScope = CoroutineScope(sceneContext + SupervisorJob())
     val edtGuard = RectManagerEdtGuard(guardScope, requestFrame)
+    // Starts true: the first frame must always present. See [TaoSceneBundle.visualDirty].
+    val visualDirty = AtomicBoolean(true)
     val scene =
         CanvasLayersComposeScene(
             frameRecomposer = frameRecomposer,
@@ -177,8 +199,14 @@ internal fun canvasLayersSceneBundle(
             layoutDirection = layoutDirection,
             size = size,
             platformContext = platformContext.withEdtGuard(edtGuard),
-            invalidateLayout = { renderingScope.onSceneInvalidation() },
-            invalidateDraw = { renderingScope.onSceneInvalidation() },
+            invalidateLayout = {
+                visualDirty.set(true)
+                renderingScope.onSceneInvalidation()
+            },
+            invalidateDraw = {
+                visualDirty.set(true)
+                renderingScope.onSceneInvalidation()
+            },
         )
     return TaoSceneBundle(
         scene,
@@ -189,6 +217,7 @@ internal fun canvasLayersSceneBundle(
         closed,
         exceptionRouter,
         requestFrame,
+        visualDirty,
     ).also { bundle -> exceptionRouter.sceneIsAlive = { bundle.isRecomposerAlive } }
 }
 
@@ -213,6 +242,8 @@ internal fun platformLayersSceneBundle(
     val frameRecomposer = FrameRecomposer(sceneContext) { requestFrame() }
     val guardScope = CoroutineScope(sceneContext + SupervisorJob())
     val edtGuard = RectManagerEdtGuard(guardScope, requestFrame)
+    // Starts true: the first frame must always present. See [TaoSceneBundle.visualDirty].
+    val visualDirty = AtomicBoolean(true)
     val scene =
         PlatformLayersComposeScene(
             frameRecomposer = frameRecomposer,
@@ -224,8 +255,14 @@ internal fun platformLayersSceneBundle(
                     override val platformContext: PlatformContext =
                         composeSceneContext.platformContext.withEdtGuard(edtGuard)
                 },
-            invalidateLayout = { renderingScope.onSceneInvalidation() },
-            invalidateDraw = { renderingScope.onSceneInvalidation() },
+            invalidateLayout = {
+                visualDirty.set(true)
+                renderingScope.onSceneInvalidation()
+            },
+            invalidateDraw = {
+                visualDirty.set(true)
+                renderingScope.onSceneInvalidation()
+            },
         )
     return TaoSceneBundle(
         scene,
@@ -236,6 +273,7 @@ internal fun platformLayersSceneBundle(
         closed,
         exceptionRouter,
         requestFrame,
+        visualDirty,
     ).also { bundle -> exceptionRouter.sceneIsAlive = { bundle.isRecomposerAlive } }
 }
 


### PR DESCRIPTION
## Summary
- Any snapshot state write anywhere in the process (an animation in one window) wakes **every** scene's `Recomposer` through the global apply observer, and the Windows Tao host rendered **and presented** the resulting clean frames unconditionally. Each `eglSwapBuffers` (interval 1) parks the shared event-loop thread until the next VBlank, so every visible window re-presented at the animating window's rate — with two windows open the VBlank waits serialize and input starves (reported as a laggy dashboard while a small always-on-top window is visible; closing it restored fluidity).
- `TaoSceneBundle` now tracks a `visualDirty` flag fed by the scene's `invalidateLayout`/`invalidateDraw` callbacks; `TaoComposeSceneHostWindows` skips `nativePresent` when the frame carried no visual change.
- Presents that must swap regardless of scene dirtiness are kept: a size/scale apply, the OS modal resize/move loop (#476), a resolved clear-colour change (backdrop tint/transparency, read outside the composition), and the first swap after `show()` — DWM does not reliably retain a pre-show present, so `TaoWindow.show()` arms a one-shot force via the new internal `showHook`.
- Measured on a two-window repro: a static 1 Hz overlay presented at ~90 fps while the sibling window animated (~10 ms VSync block charged per extra window per frame); with the fix it drops to 1-2 presents/s while the animating window keeps the full refresh rate.
- Clean frames still record/rasterize (only the present is skipped); skipping the draw phases too is a possible follow-up but needs care around the RectManager hand-driving pitfall documented in `TaoSceneBundle`. The Linux host presents inline the same way and likely wants the same skip.

## Test plan
- [x] `:decorated-window-tao:taoHeadfulTest` — 26 run, 0 failed (includes "render loop sustains the display refresh rate")
- [x] `:decorated-window-tao:check` (detekt, ktlint, apiCheck) and unit tests
- [x] Two-window repro: static overlay stops re-presenting; hide/show repaints correctly; resize/modal-loop behaviour unchanged