### PR TITLE
fix(tao): keep alwaysOnTop sticky on Windows

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/WindowsBackdrop.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/WindowsBackdrop.kt
@@ -193,6 +193,10 @@ internal object WindowsBackdropMode {
 
         val holder = Holder(style, tint, tier, composeTint = 0, WindowsBackdropAppliedTier.None)
         val applied = applyNative(hwnd, holder)
+        // The backdrop apply rewrites the window's DWM/frame state and can
+        // drop WS_EX_TOPMOST on the way (#631); reassert the requested
+        // z-order after it.
+        window.reassertAlwaysOnTop()
         // A style the OS declined is not stacked at all: transparency over a
         // backdrop that was never drawn renders as black, and an unstacked
         // holder's release can never underflow a survivor's slot.
@@ -230,6 +234,8 @@ internal object WindowsBackdropMode {
                     WindowsBackdropTier.Auto.nativeValue,
                 )
             }
+            // See acquire: backdrop teardown is a style rewrite too (#631).
+            window.reassertAlwaysOnTop()
             return
         }
         if (wasTop) {
@@ -240,6 +246,7 @@ internal object WindowsBackdropMode {
             if (hwnd != 0L) top.appliedTier = applyNative(hwnd, top)
             entry.transparencyState?.value = top.appliedTier != WindowsBackdropAppliedTier.None
             entry.composeTintState?.value = top.composeTint
+            window.reassertAlwaysOnTop()
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -251,7 +251,13 @@ public fun ApplicationScope.DecoratedWindow(
                     resizable = resizable,
                     enabled = enabled,
                     focusable = focusable,
-                    alwaysOnTop = false,
+                    // The real initial value, not a hardcoded false (#631): the
+                    // reactive LaunchedEffect below only runs once the event
+                    // loop resumes, so an overlay created with the flag set
+                    // would otherwise show non-topmost first — and on Windows
+                    // the late async flag flip can lose the race against the
+                    // creation-time style rewrites (acrylic, skip-taskbar).
+                    alwaysOnTop = alwaysOnTop,
                     // Apply Maximized at builder time. Fullscreen still needs
                     // a post-creation toggle because tao's `WindowBuilder` does
                     // not expose `with_fullscreen` in the same way (it takes a

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -657,6 +657,31 @@ public class TaoWindow internal constructor(
         }
         alwaysOnTopRequested = alwaysOnTop
         NativeTaoBridge.nativeSetAlwaysOnTop(handle, alwaysOnTop)
+        // Windows: also apply the z-order directly and synchronously. The tao
+        // path above only updates its WindowFlags cache and posts an async
+        // SetWindowPos on a cache diff, which can lose the race against style
+        // rewrites (#631) — and once the cache and reality disagree, the tao
+        // path never repairs it.
+        applyTopmostDirect(alwaysOnTop)
+    }
+
+    /**
+     * Re-applies the requested topmost z-order when it is set — the repair
+     * half of issue #631. Windows style rewrites (a DWM backdrop switch, the
+     * fullscreen toggle's `HWND_NOTOPMOST`, a size apply racing tao's async
+     * z-order `SetWindowPos`) can silently drop `WS_EX_TOPMOST` while both
+     * tao's flag cache and [alwaysOnTopRequested] still say `true`, so the
+     * regular [setAlwaysOnTop] dedup never repairs it. Idempotent and cheap
+     * when the z-order already matches; no-op off Windows.
+     */
+    internal fun reassertAlwaysOnTop() {
+        if (alwaysOnTopRequested) applyTopmostDirect(true)
+    }
+
+    private fun applyTopmostDirect(topmost: Boolean) {
+        if (Platform.Current != Platform.Windows || !NativeTaoWindowsDecoBridge.isLoaded) return
+        val hwnd = NativeTaoBridge.nativeHwndHandle(handle)
+        if (hwnd != 0L) NativeTaoWindowsDecoBridge.nativeApplyTopmost(hwnd, topmost)
     }
 
     /**
@@ -1119,6 +1144,10 @@ public class TaoWindow internal constructor(
                 // Win32 emits WM_SIZE/SIZE_MINIMIZED as 0x0. Keep resize
                 // listeners on the last real content size while minimized.
                 if (a <= 0 || b <= 0) return
+                // A size apply can drop WS_EX_TOPMOST (#631) — repair it
+                // before app code observes the resize. Idempotent no-op when
+                // the z-order is already correct or the flag is off.
+                reassertAlwaysOnTop()
                 resizedListeners.forEach { it.invoke(a, b) }
             }
             TaoEventCode.MOVED -> movedListeners.forEach { it.invoke(a, b) }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDecoBridge.kt
@@ -140,6 +140,30 @@ internal object NativeTaoWindowsDecoBridge {
     )
 
     /**
+     * Applies the requested topmost z-order directly and synchronously,
+     * bypassing tao's `WindowFlags` cache (issue #631). tao only issues the
+     * z-order `SetWindowPos` on a flag *diff* — and then asynchronously — so
+     * a `WS_EX_TOPMOST` membership lost to an external rewrite (fullscreen
+     * toggle, DWM backdrop switch, size apply) is never repaired through the
+     * regular `setAlwaysOnTop` path. Idempotent when the z-order already
+     * matches.
+     */
+    @JvmStatic
+    external fun nativeApplyTopmost(
+        hwnd: Long,
+        topmost: Boolean,
+    )
+
+    /**
+     * E2E probe: whether [hwnd] is currently a member of the topmost band
+     * (`WS_EX_TOPMOST`). Mirrors [nativeIsBackdropActive]'s role — lets the
+     * headful suite assert the real z-order bit instead of Kotlin caches
+     * (issue #631 regression coverage).
+     */
+    @JvmStatic
+    external fun nativeIsTopmost(hwnd: Long): Boolean
+
+    /**
      * Toggles borderless fullscreen. The geometry change runs inline and
      * its `WM_WINDOWPOSCHANGED` re-enters the JVM synchronously via
      * [onFullscreenSizeChanged], so the new-size frame is rendered and

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -1938,3 +1938,36 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeSetWin
         SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 }
 
+
+/* Issue #631: apply the requested topmost z-order directly and synchronously.
+ * tao caches its WindowFlags and only issues the z-order SetWindowPos when a
+ * flag *diff* appears (and then with SWP_ASYNCWINDOWPOS), so a WS_EX_TOPMOST
+ * band membership lost to an external rewrite — the fullscreen toggle's
+ * HWND_NOTOPMOST, a DWM backdrop switch, a size apply racing the async
+ * z-order change — is never repaired through that path: the cache still says
+ * ALWAYS_ON_TOP and the diff stays empty. This bypasses the cache entirely
+ * and is idempotent when the z-order already matches. */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeApplyTopmost(
+    JNIEnv *env, jclass clazz, jlong hwndLong, jboolean topmost)
+{
+    (void)env; (void)clazz;
+    HWND hwnd = (HWND)(uintptr_t)hwndLong;
+    if (!hwnd || !IsWindow(hwnd)) return;
+    SetWindowPos(hwnd, topmost ? HWND_TOPMOST : HWND_NOTOPMOST,
+        0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+}
+
+/* E2E probe (issue #631 headful regression): whether the HWND is currently a
+ * member of the topmost band. Mirrors nativeIsBackdropActive's role — lets
+ * the headful suite assert the real z-order bit instead of Kotlin caches. */
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDecoBridge_nativeIsTopmost(
+    JNIEnv *env, jclass clazz, jlong hwndLong)
+{
+    (void)env; (void)clazz;
+    HWND hwnd = (HWND)(uintptr_t)hwndLong;
+    if (!hwnd || !IsWindow(hwnd)) return JNI_FALSE;
+    LONG_PTR ex = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    return (ex & WS_EX_TOPMOST) ? JNI_TRUE : JNI_FALSE;
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AlwaysOnTopHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/AlwaysOnTopHeadfulCases.kt
@@ -1,0 +1,94 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
+import dev.nucleusframework.core.runtime.Platform
+import dev.nucleusframework.window.WindowsBackdrop
+import dev.nucleusframework.window.WindowsBackdropStyle
+import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
+
+/**
+ * #631 — `alwaysOnTop` must keep the HWND in the topmost band for the life of
+ * the window: through the acrylic backdrop apply/teardown, through size
+ * applies, and through explicit toggles. Probes the real `WS_EX_TOPMOST` bit
+ * via [NativeTaoWindowsDecoBridge.nativeIsTopmost] instead of Kotlin caches
+ * (which is exactly what went stale in the issue).
+ */
+internal object AlwaysOnTopHeadfulCases {
+    private val isWindows: Boolean = Platform.Current == Platform.Windows
+
+    fun all(): List<TaoWindowTestCase> = listOf(alwaysOnTopSticksThroughStyleRewrites())
+
+    @Suppress("LongMethod")
+    private fun alwaysOnTopSticksThroughStyleRewrites(): TaoWindowTestCase {
+        val acrylic = mutableStateOf(false)
+        val windowState =
+            WindowState(
+                position = WindowPosition.Aligned(Alignment.Center),
+                size = DpSize(WINDOW_W_DP.dp, WINDOW_H_DP.dp),
+            )
+        return TaoWindowTestCase(
+            name = "#631 alwaysOnTop sticks through acrylic and size rewrites",
+            skip = { if (!isWindows) "Windows-only z-order probe" else null },
+            windowState = windowState,
+            size = DpSize(WINDOW_W_DP.dp, WINDOW_H_DP.dp),
+            content = {
+                if (acrylic.value) WindowsBackdrop(WindowsBackdropStyle.Acrylic)
+                Box(Modifier.fillMaxSize().background(Color(0x33000000)))
+            },
+            driver = {
+                awaitUntil("window mapped") { bounds() != null }
+                val hwnd = NativeTaoBridge.nativeHwndHandle(window.handle)
+                check(hwnd != 0L) { "no HWND" }
+
+                fun topmost() = NativeTaoWindowsDecoBridge.nativeIsTopmost(hwnd)
+
+                window.setAlwaysOnTop(true)
+                awaitUntil("WS_EX_TOPMOST after setAlwaysOnTop(true)") { topmost() }
+
+                // Acrylic apply rewrites the DWM/frame state (#631 clobber #1).
+                acrylic.value = true
+                awaitUntil("backdrop active") {
+                    NativeTaoWindowsDecoBridge.nativeIsBackdropActive(hwnd)
+                }
+                settle(SETTLE_AFTER_REWRITE_MILLIS)
+                check(topmost()) { "WS_EX_TOPMOST dropped by the acrylic apply (#631)" }
+
+                // Size apply goes through tao's SetWindowPos path (#631 clobber #2).
+                windowState.size = DpSize(RESIZED_W_DP.dp, RESIZED_H_DP.dp)
+                settle(SETTLE_AFTER_REWRITE_MILLIS)
+                check(topmost()) { "WS_EX_TOPMOST dropped by the size apply (#631)" }
+
+                // Explicit toggles must be effective both ways (issue steps 2-3).
+                window.setAlwaysOnTop(false)
+                awaitUntil("WS_EX_TOPMOST cleared after setAlwaysOnTop(false)") { !topmost() }
+                window.setAlwaysOnTop(true)
+                awaitUntil("WS_EX_TOPMOST restored after re-enable") { topmost() }
+
+                // Backdrop teardown is a style rewrite too.
+                acrylic.value = false
+                awaitUntil("backdrop gone") {
+                    !NativeTaoWindowsDecoBridge.nativeIsBackdropActive(hwnd)
+                }
+                settle(SETTLE_AFTER_REWRITE_MILLIS)
+                check(topmost()) { "WS_EX_TOPMOST dropped by the backdrop teardown (#631)" }
+            },
+        )
+    }
+
+    private const val WINDOW_W_DP = 320
+    private const val WINDOW_H_DP = 200
+    private const val RESIZED_W_DP = 260
+    private const val RESIZED_H_DP = 120
+    private const val SETTLE_AFTER_REWRITE_MILLIS = 300L
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -366,6 +366,7 @@ public object TaoHeadfulTestSuiteMain {
             PopupScaleHeadfulCases.all() +
             ClipboardHeadfulCases.all() +
             AnimatedWindowSizeHeadfulCases.all() +
+            AlwaysOnTopHeadfulCases.all() +
             ImeHeadfulCases.all()
 
     private val cases: List<TaoWindowTestCase> =


### PR DESCRIPTION
Fixes #631.

## Summary
- **Creation**: `DecoratedWindowComposable` no longer hardcodes `alwaysOnTop = false` at `openDecoratedWindow` time — the real initial value is applied before the first show, instead of racing the creation-time style rewrites (acrylic, skip-taskbar) from a later `LaunchedEffect`.
- **Synchronous direct apply**: tao only issues the z-order `SetWindowPos` on a `WindowFlags` cache diff — and then with `SWP_ASYNCWINDOWPOS` — so once an external rewrite drops `WS_EX_TOPMOST` while the cache still says `ALWAYS_ON_TOP`, no path ever repairs it. `TaoWindow.setAlwaysOnTop` now additionally applies the z-order directly and synchronously through the new deco-bridge `nativeApplyTopmost` (plain `SetWindowPos`, no async flag), while still forwarding to tao so its cache stays coherent for its own future rewrites.
- **Repair after clobbers**: new internal `TaoWindow.reassertAlwaysOnTop()` re-applies the requested band after the known clobber sites — every `RESIZED` event and the `WindowsBackdrop` apply / teardown / survivor-restore paths. Idempotent no-op when the z-order already matches or the flag is off; no-op off Windows.
- **Probe + regression test**: `nativeIsTopmost` reads the real `GWL_EXSTYLE` bit (mirroring `nativeIsBackdropActive`), and a new headful case drives the issue's exact scenario — enable topmost, apply Acrylic, resize, toggle the flag both ways, tear the backdrop down — asserting `WS_EX_TOPMOST` at each step.

## Test plan
- [x] `taoHeadfulTest` — 27 run, 0 failed, including the new "#631 alwaysOnTop sticks through acrylic and size rewrites"
- [x] `:decorated-window-tao:check` (detekt, ktlint, apiCheck, unit tests)