### PR TITLE
feat: nucleusOptimization startup pack

### DIFF
--- a/examples/nucleus-demo/build.gradle.kts
+++ b/examples/nucleus-demo/build.gradle.kts
@@ -79,6 +79,7 @@ val nativePackageVersion = releaseVersion.substringBefore("-")
 
 nucleus.application {
     mainClass = "com.example.demo.MainKt"
+    nucleusOptimization = true
 
     buildTypes {
         release {

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/IdleGc.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/IdleGc.kt
@@ -1,0 +1,117 @@
+package dev.nucleusframework.application.internal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import dev.nucleusframework.application.NucleusWindow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.IdentityHashMap
+import java.util.logging.Logger
+
+/**
+ * Runtime side of `nucleus.application { nucleusOptimization = true }`.
+ * Keep the property name in sync with the plugin's `NUCLEUS_OPTIMIZATION_PROPERTY`.
+ */
+internal object NucleusOptimization {
+    const val PROPERTY: String = "nucleus.optimization"
+
+    val isEnabled: Boolean
+        get() = System.getProperty(PROPERTY) == "true"
+}
+
+/**
+ * Collects focus / minimized flows from every decorated window and dialog and
+ * runs [System.gc] according to [IdleGcController].
+ */
+internal object IdleGc {
+    private val logger = Logger.getLogger(IdleGc::class.java.name)
+    private val controller = IdleGcController()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val jobsLock = Any()
+    private val jobs = IdentityHashMap<NucleusWindow, Job>()
+    private val applyLock = Any()
+    private var debounceJob: Job? = null
+
+    fun attach(window: NucleusWindow) {
+        if (!NucleusOptimization.isEnabled) return
+        synchronized(jobsLock) {
+            if (window in jobs) return
+            controller.register(window, window.focusFlow.value, window.minimizedFlow.value)
+            jobs[window] =
+                scope.launch {
+                    launch { window.focusFlow.collect { handle(window) } }
+                    launch { window.minimizedFlow.collect { handle(window) } }
+                }
+        }
+    }
+
+    fun detach(window: NucleusWindow) {
+        val cmd =
+            synchronized(jobsLock) {
+                jobs.remove(window)?.cancel()
+                controller.unregister(window)
+            }
+        apply(cmd)
+    }
+
+    private fun handle(window: NucleusWindow) {
+        apply(controller.update(window, window.focusFlow.value, window.minimizedFlow.value))
+    }
+
+    private fun apply(cmd: IdleGcCommand) {
+        val runNow =
+            synchronized(applyLock) {
+                when (cmd) {
+                    IdleGcCommand.NoChange -> false
+                    IdleGcCommand.Cancel -> {
+                        cancelDebounce()
+                        false
+                    }
+                    IdleGcCommand.CollectNow -> {
+                        cancelDebounce()
+                        true
+                    }
+                    IdleGcCommand.Debounce -> {
+                        scheduleDebounce()
+                        false
+                    }
+                }
+            }
+        if (runNow) runGc()
+    }
+
+    private fun cancelDebounce() {
+        debounceJob?.cancel()
+        debounceJob = null
+    }
+
+    private fun scheduleDebounce() {
+        cancelDebounce()
+        debounceJob =
+            scope.launch {
+                delay(IdleGcController.UNFOCUS_DELAY_MS)
+                if (controller.shouldRunDeferredGc()) {
+                    runGc()
+                }
+            }
+    }
+
+    private fun runGc() {
+        logger.fine("Idle GC")
+        @Suppress("ExplicitGarbageCollectionCall")
+        System.gc()
+    }
+}
+
+@Composable
+internal fun ObserveIdleGc(window: NucleusWindow) {
+    if (!NucleusOptimization.isEnabled) return
+    DisposableEffect(window) {
+        IdleGc.attach(window)
+        onDispose { IdleGc.detach(window) }
+    }
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/IdleGc.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/IdleGc.kt
@@ -13,11 +13,11 @@ import java.util.IdentityHashMap
 import java.util.logging.Logger
 
 /**
- * Runtime side of `nucleus.application { nucleusOptimization = true }`.
- * Keep the property name in sync with the plugin's `NUCLEUS_OPTIMIZATION_PROPERTY`.
+ * Runtime side of the `nucleusOptimization { idleGc }` knob.
+ * Keep the property name in sync with the plugin's `NUCLEUS_IDLE_GC_PROPERTY`.
  */
 internal object NucleusOptimization {
-    const val PROPERTY: String = "nucleus.optimization"
+    const val PROPERTY: String = "nucleus.optimization.idleGc"
 
     val isEnabled: Boolean
         get() = System.getProperty(PROPERTY) == "true"

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/IdleGcController.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/IdleGcController.kt
@@ -1,0 +1,94 @@
+package dev.nucleusframework.application.internal
+
+/**
+ * Decides when idle GC should run for the `nucleusOptimization` pack.
+ *
+ * Serial is stop-the-world, so a collection is only requested when no tracked
+ * window is still focused and visible. A minimized window collects immediately;
+ * a mere focus loss waits [UNFOCUS_DELAY_MS] so alt-tab / click-away that
+ * comes back quickly does not hitch.
+ *
+ * The first snapshot for a window (registration) never triggers a collection,
+ * so a window that starts unfocused before its first paint cannot GC during
+ * startup.
+ */
+internal class IdleGcController {
+    private val lock = Any()
+    private val windows = LinkedHashMap<Any, WindowIdle>()
+    private var deferredArmed: Boolean = false
+
+    fun register(
+        id: Any,
+        focused: Boolean,
+        minimized: Boolean,
+    ) {
+        synchronized(lock) {
+            windows[id] = WindowIdle(focused, minimized)
+        }
+    }
+
+    fun unregister(id: Any): IdleGcCommand =
+        synchronized(lock) {
+            if (windows.remove(id) == null) IdleGcCommand.NoChange else commit(decide())
+        }
+
+    fun update(
+        id: Any,
+        focused: Boolean,
+        minimized: Boolean,
+    ): IdleGcCommand =
+        synchronized(lock) {
+            val next = WindowIdle(focused, minimized)
+            val prev = windows[id] ?: return@synchronized IdleGcCommand.NoChange
+            if (prev == next) return@synchronized IdleGcCommand.NoChange
+            windows[id] = next
+            commit(decide())
+        }
+
+    /**
+     * True when a deferred (unfocus) collection was armed and is still valid:
+     * every tracked window is unfocused and none is minimized. Minimize already
+     * collected immediately, so the delay must not fire a second time.
+     */
+    fun shouldRunDeferredGc(): Boolean =
+        synchronized(lock) {
+            deferredArmed && decide() == IdleGcCommand.Debounce
+        }
+
+    private fun decide(): IdleGcCommand {
+        if (windows.isEmpty() || windows.values.any { it.isInteracting }) {
+            return IdleGcCommand.Cancel
+        }
+        if (windows.values.any { it.minimized }) {
+            return IdleGcCommand.CollectNow
+        }
+        return IdleGcCommand.Debounce
+    }
+
+    private fun commit(cmd: IdleGcCommand): IdleGcCommand {
+        when (cmd) {
+            IdleGcCommand.Debounce -> deferredArmed = true
+            IdleGcCommand.Cancel, IdleGcCommand.CollectNow -> deferredArmed = false
+            IdleGcCommand.NoChange -> Unit
+        }
+        return cmd
+    }
+
+    private data class WindowIdle(
+        val focused: Boolean,
+        val minimized: Boolean,
+    ) {
+        val isInteracting: Boolean get() = focused && !minimized
+    }
+
+    companion object {
+        const val UNFOCUS_DELAY_MS: Long = 3_000
+    }
+}
+
+internal enum class IdleGcCommand {
+    NoChange,
+    Cancel,
+    Debounce,
+    CollectNow,
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedDialogAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedDialogAdapter.kt
@@ -158,6 +158,7 @@ private fun TaoDecoratedDialogScope.bindNucleusDialogContent(
         remember(taoScope, nucleusWindow) {
             TaoNucleusDecoratedDialogScope(taoScope, nucleusWindow)
         }
+    ObserveIdleGc(nucleusWindow)
     // Bridge the parent composition's locals (theme, density,
     // user-provided locals, …) into the dialog's own ComposeScene
     // via `ComposeScene.compositionLocalContext` rather than a

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -211,6 +211,7 @@ internal fun TaoDecoratedWindowScope.bindNucleusContent(
             TaoNucleusDecoratedWindowScope(taoScope, nucleusWindow)
         }
     ObserveSingleInstanceRestore(nucleusWindow)
+    ObserveIdleGc(nucleusWindow)
     // outerLocals were captured in the OUTER composition and cross the
     // scene boundary as this scene's own compositionLocalContext (the
     // parameter above for the first composition, the bridge below for

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/internal/IdleGcControllerTest.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/internal/IdleGcControllerTest.kt
@@ -1,0 +1,115 @@
+package dev.nucleusframework.application.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IdleGcControllerTest {
+    @Test
+    fun `registering an unfocused window does not schedule gc`() {
+        val c = IdleGcController()
+        c.register("w", focused = false, minimized = false)
+        assertEquals(IdleGcCommand.NoChange, c.update("w", focused = false, minimized = false))
+        assertFalse(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `unfocus schedules a deferred collection`() {
+        val c = IdleGcController()
+        c.register("w", focused = true, minimized = false)
+        assertEquals(IdleGcCommand.Debounce, c.update("w", focused = false, minimized = false))
+        assertTrue(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `refocus before the delay cancels deferred collection`() {
+        val c = IdleGcController()
+        c.register("w", focused = true, minimized = false)
+        assertEquals(IdleGcCommand.Debounce, c.update("w", focused = false, minimized = false))
+        assertEquals(IdleGcCommand.Cancel, c.update("w", focused = true, minimized = false))
+        assertFalse(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `minimize collects immediately`() {
+        val c = IdleGcController()
+        c.register("w", focused = true, minimized = false)
+        assertEquals(IdleGcCommand.CollectNow, c.update("w", focused = false, minimized = true))
+        assertFalse(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `minimize of a still-focused window collects immediately`() {
+        val c = IdleGcController()
+        c.register("w", focused = true, minimized = false)
+        assertEquals(IdleGcCommand.CollectNow, c.update("w", focused = true, minimized = true))
+        assertFalse(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `unfocus then minimize upgrades debounce to immediate`() {
+        val c = IdleGcController()
+        c.register("w", focused = true, minimized = false)
+        assertEquals(IdleGcCommand.Debounce, c.update("w", focused = false, minimized = false))
+        assertEquals(IdleGcCommand.CollectNow, c.update("w", focused = false, minimized = true))
+        assertFalse(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `second window still focused cancels idle gc`() {
+        val c = IdleGcController()
+        c.register("a", focused = true, minimized = false)
+        c.register("b", focused = false, minimized = false)
+        assertEquals(IdleGcCommand.Cancel, c.update("b", focused = true, minimized = false))
+        assertEquals(IdleGcCommand.Cancel, c.update("a", focused = false, minimized = false))
+        assertFalse(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `last focused window unfocusing schedules deferred collection`() {
+        val c = IdleGcController()
+        c.register("a", focused = true, minimized = false)
+        c.register("b", focused = false, minimized = false)
+        c.update("b", focused = true, minimized = false)
+        c.update("a", focused = false, minimized = false)
+        assertEquals(IdleGcCommand.Debounce, c.update("b", focused = false, minimized = false))
+        assertTrue(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `minimize is skipped while another window is interacting`() {
+        val c = IdleGcController()
+        c.register("a", focused = true, minimized = false)
+        c.register("b", focused = false, minimized = false)
+        assertEquals(IdleGcCommand.Cancel, c.update("b", focused = false, minimized = true))
+        assertFalse(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `dialog focus keeps the app interacting`() {
+        val c = IdleGcController()
+        c.register("window", focused = true, minimized = false)
+        c.register("dialog", focused = false, minimized = false)
+        c.update("window", focused = false, minimized = false)
+        assertEquals(IdleGcCommand.Cancel, c.update("dialog", focused = true, minimized = false))
+        assertFalse(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `unregistering the last window cancels pending collection`() {
+        val c = IdleGcController()
+        c.register("w", focused = true, minimized = false)
+        c.update("w", focused = false, minimized = false)
+        assertEquals(IdleGcCommand.Cancel, c.unregister("w"))
+        assertFalse(c.shouldRunDeferredGc())
+    }
+
+    @Test
+    fun `update after unregister is ignored`() {
+        val c = IdleGcController()
+        c.register("w", focused = true, minimized = false)
+        c.unregister("w")
+        assertEquals(IdleGcCommand.NoChange, c.update("w", focused = false, minimized = true))
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplication.kt
@@ -43,18 +43,31 @@ abstract class JvmApplication {
     abstract var garbageCollector: GarbageCollector?
 
     /**
-     * Opt-in desktop startup pack: Serial GC, `-Xms32m`, `-XX:MaxRAMPercentage=25`,
-     * a single JAR in the jpackage image, and idle GC (3s after the last window
-     * loses focus, immediately when a window is minimized).
+     * Master switch for the desktop startup pack: Serial GC, compact heap
+     * (`-Xms32m`, `-XX:MaxRAMPercentage=25`), a single JAR in the jpackage
+     * image, and idle GC (3s after last unfocus, immediately on minimize).
      *
-     * When ProGuard is enabled for a build type, that JAR is produced with
-     * [ProguardSettings.joinOutputJars]. Otherwise the runtime JARs are flattened
-     * with the existing uber-jar task. An explicit [garbageCollector] or `-Xms` /
+     * `true` turns on every knob still unset in the [nucleusOptimization]
+     * configure block. An explicit [garbageCollector] or `-Xms` /
      * `-XX:MaxRAMPercentage` in [jvmArgs] is left unchanged.
      *
-     * Does not enable AOT; set [JvmApplicationDistributions.enableAotCache] separately.
+     * Does not enable AOT; set [JvmApplicationDistributions.enableAotCache]
+     * separately.
      */
     abstract var nucleusOptimization: Boolean
+
+    /**
+     * Per-knob overrides for [nucleusOptimization]. `null` follows the master
+     * boolean; `true` / `false` force that piece on or off.
+     *
+     * ```
+     * nucleusOptimization = true
+     * nucleusOptimization { idleGc = false }
+     *
+     * nucleusOptimization { singleJar = true }
+     * ```
+     */
+    abstract fun nucleusOptimization(fn: Action<NucleusOptimizationSettings>)
 
     abstract val nativeDistributions: JvmApplicationDistributions
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplication.kt
@@ -42,6 +42,19 @@ abstract class JvmApplication {
      */
     abstract var garbageCollector: GarbageCollector?
 
+    /**
+     * Opt-in desktop startup pack: Serial GC, `-Xms32m`, `-XX:MaxRAMPercentage=25`,
+     * and a single JAR in the jpackage image.
+     *
+     * When ProGuard is enabled for a build type, that JAR is produced with
+     * [ProguardSettings.joinOutputJars]. Otherwise the runtime JARs are flattened
+     * with the existing uber-jar task. An explicit [garbageCollector] or `-Xms` /
+     * `-XX:MaxRAMPercentage` in [jvmArgs] is left unchanged.
+     *
+     * Does not enable AOT; set [JvmApplicationDistributions.enableAotCache] separately.
+     */
+    abstract var nucleusOptimization: Boolean
+
     abstract val nativeDistributions: JvmApplicationDistributions
 
     abstract fun nativeDistributions(fn: Action<JvmApplicationDistributions>)

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplication.kt
@@ -45,14 +45,16 @@ abstract class JvmApplication {
     /**
      * Master switch for the desktop startup pack: Serial GC, compact heap
      * (`-Xms32m`, `-XX:MaxRAMPercentage=25`), a single JAR in the jpackage
-     * image, and idle GC (3s after last unfocus, immediately on minimize).
+     * image, idle GC (3s after last unfocus, immediately on minimize), and
+     * the current OpenJDK as the jpackage / jlink / `run` JDK (auto-downloaded,
+     * like the GraalVM toolchain).
      *
      * `true` turns on every knob still unset in the [nucleusOptimization]
-     * configure block. An explicit [garbageCollector] or `-Xms` /
+     * configure block. An explicit [garbageCollector], [javaHome], or `-Xms` /
      * `-XX:MaxRAMPercentage` in [jvmArgs] is left unchanged.
      *
      * Does not enable AOT; set [JvmApplicationDistributions.enableAotCache]
-     * separately.
+     * separately. Does not change the Gradle compile JDK.
      */
     abstract var nucleusOptimization: Boolean
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplication.kt
@@ -44,7 +44,8 @@ abstract class JvmApplication {
 
     /**
      * Opt-in desktop startup pack: Serial GC, `-Xms32m`, `-XX:MaxRAMPercentage=25`,
-     * and a single JAR in the jpackage image.
+     * a single JAR in the jpackage image, and idle GC (3s after the last window
+     * loses focus, immediately when a window is minimized).
      *
      * When ProGuard is enabled for a build type, that JAR is produced with
      * [ProguardSettings.joinOutputJars]. Otherwise the runtime JARs are flattened

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/NucleusOptimizationSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/NucleusOptimizationSettings.kt
@@ -43,4 +43,12 @@ abstract class NucleusOptimizationSettings {
      * window is minimized.
      */
     var idleGc: Boolean? = null
+
+    /**
+     * Package and run the app with the current OpenJDK feature release,
+     * auto-downloaded and cached under `<gradle-user-home>/nucleus/jdk` like
+     * the GraalVM toolchain. An explicit [JvmApplication.javaHome] always
+     * wins. Does not change the Gradle compile JDK.
+     */
+    var lastJdk: Boolean? = null
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/NucleusOptimizationSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/NucleusOptimizationSettings.kt
@@ -1,0 +1,46 @@
+package dev.nucleusframework.desktop.application.dsl
+
+/**
+ * Per-knob overrides for [JvmApplication.nucleusOptimization].
+ *
+ * `null` (the default) follows the master boolean. `true` / `false` force that
+ * knob on or off, independently of the master and of the other knobs.
+ *
+ * Does not cover AOT ([JvmApplicationDistributions.enableAotCache]) or ProGuard.
+ *
+ * ```
+ * nucleus.application {
+ *     nucleusOptimization = true
+ *     nucleusOptimization { idleGc = false }
+ * }
+ *
+ * nucleus.application {
+ *     nucleusOptimization { singleJar = true }
+ * }
+ * ```
+ */
+abstract class NucleusOptimizationSettings {
+    /**
+     * Serial GC when [JvmApplication.garbageCollector] is unset.
+     * An explicit collector always wins.
+     */
+    var serialGc: Boolean? = null
+
+    /**
+     * `-Xms32m` and `-XX:MaxRAMPercentage=25`, unless already present in
+     * [JvmApplication.jvmArgs].
+     */
+    var compactHeap: Boolean? = null
+
+    /**
+     * Flatten runtime JARs (or [ProguardSettings.joinOutputJars] when ProGuard
+     * is on) so the jpackage image contains a single JAR.
+     */
+    var singleJar: Boolean? = null
+
+    /**
+     * Request a GC 3s after the last window loses focus, or immediately when a
+     * window is minimized.
+     */
+    var idleGc: Boolean? = null
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/ProguardSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/ProguardSettings.kt
@@ -12,7 +12,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import javax.inject.Inject
 
-private const val DEFAULT_PROGUARD_VERSION = "7.9.1"
+private const val DEFAULT_PROGUARD_VERSION = "7.10.0"
 
 abstract class ProguardSettings
     @Inject

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimization.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimization.kt
@@ -5,6 +5,10 @@ import dev.nucleusframework.desktop.application.dsl.GarbageCollector
 internal const val OPTIMIZED_XMS = "-Xms32m"
 internal const val OPTIMIZED_MAX_RAM_PERCENTAGE = "-XX:MaxRAMPercentage=25"
 
+/** Runtime flag read by `nucleus-application` to arm idle GC. Keep in sync with `NucleusOptimization`. */
+internal const val NUCLEUS_OPTIMIZATION_PROPERTY = "nucleus.optimization"
+internal const val OPTIMIZED_RUNTIME_FLAG = "-D$NUCLEUS_OPTIMIZATION_PROPERTY=true"
+
 /**
  * Applies [JvmApplicationData.nucleusOptimization] JVM flags without clobbering an
  * explicit collector or heap flags already on [app].
@@ -19,5 +23,8 @@ internal fun applyNucleusOptimization(app: JvmApplicationData) {
     }
     if (app.jvmArgs.none { it.startsWith("-XX:MaxRAMPercentage") }) {
         app.jvmArgs.add(OPTIMIZED_MAX_RAM_PERCENTAGE)
+    }
+    if (app.jvmArgs.none { it.startsWith("-D$NUCLEUS_OPTIMIZATION_PROPERTY=") }) {
+        app.jvmArgs.add(OPTIMIZED_RUNTIME_FLAG)
     }
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimization.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimization.kt
@@ -1,0 +1,23 @@
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.desktop.application.dsl.GarbageCollector
+
+internal const val OPTIMIZED_XMS = "-Xms32m"
+internal const val OPTIMIZED_MAX_RAM_PERCENTAGE = "-XX:MaxRAMPercentage=25"
+
+/**
+ * Applies [JvmApplicationData.nucleusOptimization] JVM flags without clobbering an
+ * explicit collector or heap flags already on [app].
+ */
+internal fun applyNucleusOptimization(app: JvmApplicationData) {
+    if (!app.nucleusOptimization) return
+    if (app.garbageCollector == null) {
+        app.garbageCollector = GarbageCollector.SERIAL
+    }
+    if (app.jvmArgs.none { it.startsWith("-Xms") }) {
+        app.jvmArgs.add(OPTIMIZED_XMS)
+    }
+    if (app.jvmArgs.none { it.startsWith("-XX:MaxRAMPercentage") }) {
+        app.jvmArgs.add(OPTIMIZED_MAX_RAM_PERCENTAGE)
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimization.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimization.kt
@@ -1,6 +1,7 @@
 package dev.nucleusframework.desktop.application.internal
 
 import dev.nucleusframework.desktop.application.dsl.GarbageCollector
+import org.gradle.api.Project
 
 internal const val OPTIMIZED_XMS = "-Xms32m"
 internal const val OPTIMIZED_MAX_RAM_PERCENTAGE = "-XX:MaxRAMPercentage=25"
@@ -21,6 +22,9 @@ internal val JvmApplicationData.optSingleJar: Boolean
 internal val JvmApplicationData.optIdleGc: Boolean
     get() = nucleusOptimizationSettings.idleGc ?: nucleusOptimization
 
+internal val JvmApplicationData.optLastJdk: Boolean
+    get() = nucleusOptimizationSettings.lastJdk ?: nucleusOptimization
+
 /**
  * Applies [JvmApplicationData.nucleusOptimization] JVM flags without clobbering an
  * explicit collector or heap flags already on [app].
@@ -40,4 +44,23 @@ internal fun applyNucleusOptimization(app: JvmApplicationData) {
     if (app.optIdleGc && app.jvmArgs.none { it.startsWith("-D$NUCLEUS_IDLE_GC_PROPERTY=") }) {
         app.jvmArgs.add(OPTIMIZED_IDLE_GC_FLAG)
     }
+}
+
+/**
+ * Points packaging / `run` at an auto-downloaded current OpenJDK when
+ * [JvmApplicationData.optLastJdk] is on. An explicit `javaHome` wins. The
+ * [org.gradle.api.provider.ValueSource] stays lazy — listing tasks does not
+ * download the JDK.
+ */
+internal fun applyNucleusOptimizationJdk(
+    project: Project,
+    app: JvmApplicationData,
+) {
+    if (!app.optLastJdk || app.hasCustomJavaHome || app.javaHomeOverride != null) return
+    app.javaHomeOverride =
+        project.providers.of(NucleusJdkToolchainValueSource::class.java) { spec ->
+            spec.parameters.installBaseDir.set(
+                project.gradle.gradleUserHomeDir.resolve("nucleus/jdk").absolutePath,
+            )
+        }
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimization.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimization.kt
@@ -6,25 +6,38 @@ internal const val OPTIMIZED_XMS = "-Xms32m"
 internal const val OPTIMIZED_MAX_RAM_PERCENTAGE = "-XX:MaxRAMPercentage=25"
 
 /** Runtime flag read by `nucleus-application` to arm idle GC. Keep in sync with `NucleusOptimization`. */
-internal const val NUCLEUS_OPTIMIZATION_PROPERTY = "nucleus.optimization"
-internal const val OPTIMIZED_RUNTIME_FLAG = "-D$NUCLEUS_OPTIMIZATION_PROPERTY=true"
+internal const val NUCLEUS_IDLE_GC_PROPERTY = "nucleus.optimization.idleGc"
+internal const val OPTIMIZED_IDLE_GC_FLAG = "-D$NUCLEUS_IDLE_GC_PROPERTY=true"
+
+internal val JvmApplicationData.optSerialGc: Boolean
+    get() = nucleusOptimizationSettings.serialGc ?: nucleusOptimization
+
+internal val JvmApplicationData.optCompactHeap: Boolean
+    get() = nucleusOptimizationSettings.compactHeap ?: nucleusOptimization
+
+internal val JvmApplicationData.optSingleJar: Boolean
+    get() = nucleusOptimizationSettings.singleJar ?: nucleusOptimization
+
+internal val JvmApplicationData.optIdleGc: Boolean
+    get() = nucleusOptimizationSettings.idleGc ?: nucleusOptimization
 
 /**
  * Applies [JvmApplicationData.nucleusOptimization] JVM flags without clobbering an
  * explicit collector or heap flags already on [app].
  */
 internal fun applyNucleusOptimization(app: JvmApplicationData) {
-    if (!app.nucleusOptimization) return
-    if (app.garbageCollector == null) {
+    if (app.optSerialGc && app.garbageCollector == null) {
         app.garbageCollector = GarbageCollector.SERIAL
     }
-    if (app.jvmArgs.none { it.startsWith("-Xms") }) {
-        app.jvmArgs.add(OPTIMIZED_XMS)
+    if (app.optCompactHeap) {
+        if (app.jvmArgs.none { it.startsWith("-Xms") }) {
+            app.jvmArgs.add(OPTIMIZED_XMS)
+        }
+        if (app.jvmArgs.none { it.startsWith("-XX:MaxRAMPercentage") }) {
+            app.jvmArgs.add(OPTIMIZED_MAX_RAM_PERCENTAGE)
+        }
     }
-    if (app.jvmArgs.none { it.startsWith("-XX:MaxRAMPercentage") }) {
-        app.jvmArgs.add(OPTIMIZED_MAX_RAM_PERCENTAGE)
-    }
-    if (app.jvmArgs.none { it.startsWith("-D$NUCLEUS_OPTIMIZATION_PROPERTY=") }) {
-        app.jvmArgs.add(OPTIMIZED_RUNTIME_FLAG)
+    if (app.optIdleGc && app.jvmArgs.none { it.startsWith("-D$NUCLEUS_IDLE_GC_PROPERTY=") }) {
+        app.jvmArgs.add(OPTIMIZED_IDLE_GC_FLAG)
     }
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationContext.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationContext.kt
@@ -12,6 +12,7 @@ import dev.nucleusframework.internal.javaSourceSets
 import dev.nucleusframework.internal.mppExt
 import dev.nucleusframework.internal.utils.OS
 import dev.nucleusframework.internal.utils.Target
+import dev.nucleusframework.internal.utils.currentArch
 import dev.nucleusframework.internal.utils.currentOS
 import dev.nucleusframework.internal.utils.jdkArch
 import dev.nucleusframework.internal.utils.joinDashLowercaseNonEmpty
@@ -50,8 +51,19 @@ internal data class JvmApplicationContext(
         runtimeFiles.configureUsageBy(this, fn)
     }
 
-    /** Architecture of the configured JDK (may differ from the Gradle daemon's arch when cross-building). */
-    val targetArch by lazy { jdkArch(java.io.File(app.javaHome)) }
+    /**
+     * Architecture of the configured JDK (may differ from the Gradle daemon's
+     * arch when cross-building). The auto-downloaded OpenJDK 27 matches the
+     * host, so we must not realize [JvmApplicationData.javaHomeOverride] here
+     * — that would download the JDK at configuration time.
+     */
+    val targetArch by lazy {
+        if (app.javaHomeOverride != null) {
+            currentArch
+        } else {
+            jdkArch(java.io.File(app.javaHome))
+        }
+    }
 
     /** Target combining the current OS with the configured JDK's architecture. */
     val targetTarget by lazy { Target(currentOS, targetArch) }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationData.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationData.kt
@@ -39,8 +39,19 @@ internal open class JvmApplicationData
             set(value) {
                 customJavaHome = value
             }
+
+        internal val hasCustomJavaHome: Boolean
+            get() = customJavaHome != null
+
+        /**
+         * Lazy JDK home used by packaging / `run`. When [optLastJdk] is on
+         * this is a [NucleusJdkToolchainValueSource]; otherwise it reads
+         * [javaHome].
+         */
+        internal var javaHomeOverride: Provider<String>? = null
+
         val javaHomeProvider: Provider<String>
-            get() = providers.provider { javaHome }
+            get() = javaHomeOverride ?: providers.provider { javaHome }
         val args: MutableList<String> = ArrayList()
         val jvmArgs: MutableList<String> = ArrayList()
         var garbageCollector: GarbageCollector? = null

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationData.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationData.kt
@@ -6,8 +6,8 @@
 package dev.nucleusframework.desktop.application.internal
 
 import dev.nucleusframework.desktop.application.dsl.GarbageCollector
-
 import dev.nucleusframework.desktop.application.dsl.GraalvmSettings
+import dev.nucleusframework.desktop.application.dsl.NucleusOptimizationSettings
 import dev.nucleusframework.desktop.application.dsl.JvmApplicationBuildTypes
 import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
 import dev.nucleusframework.internal.utils.new
@@ -45,6 +45,7 @@ internal open class JvmApplicationData
         val jvmArgs: MutableList<String> = ArrayList()
         var garbageCollector: GarbageCollector? = null
         var nucleusOptimization: Boolean = false
+        val nucleusOptimizationSettings: NucleusOptimizationSettings = objects.new()
         val nativeDistributions: JvmApplicationDistributions = objects.new()
         val buildTypes: JvmApplicationBuildTypes = objects.new()
         val graalvm: GraalvmSettings = objects.new()

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationData.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationData.kt
@@ -6,6 +6,7 @@
 package dev.nucleusframework.desktop.application.internal
 
 import dev.nucleusframework.desktop.application.dsl.GarbageCollector
+
 import dev.nucleusframework.desktop.application.dsl.GraalvmSettings
 import dev.nucleusframework.desktop.application.dsl.JvmApplicationBuildTypes
 import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
@@ -43,6 +44,7 @@ internal open class JvmApplicationData
         val args: MutableList<String> = ArrayList()
         val jvmArgs: MutableList<String> = ArrayList()
         var garbageCollector: GarbageCollector? = null
+        var nucleusOptimization: Boolean = false
         val nativeDistributions: JvmApplicationDistributions = objects.new()
         val buildTypes: JvmApplicationBuildTypes = objects.new()
         val graalvm: GraalvmSettings = objects.new()

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationInternal.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationInternal.kt
@@ -6,6 +6,7 @@
 package dev.nucleusframework.desktop.application.internal
 
 import dev.nucleusframework.desktop.application.dsl.GarbageCollector
+
 import dev.nucleusframework.desktop.application.dsl.GraalvmSettings
 import dev.nucleusframework.desktop.application.dsl.JvmApplication
 import dev.nucleusframework.desktop.application.dsl.JvmApplicationBuildTypes
@@ -75,6 +76,8 @@ internal open class JvmApplicationInternal
         }
 
         final override var garbageCollector: GarbageCollector? by data::garbageCollector
+
+        final override var nucleusOptimization: Boolean by data::nucleusOptimization
 
         final override val nativeDistributions: JvmApplicationDistributions by data::nativeDistributions
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationInternal.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/JvmApplicationInternal.kt
@@ -10,6 +10,7 @@ import dev.nucleusframework.desktop.application.dsl.GarbageCollector
 import dev.nucleusframework.desktop.application.dsl.GraalvmSettings
 import dev.nucleusframework.desktop.application.dsl.JvmApplication
 import dev.nucleusframework.desktop.application.dsl.JvmApplicationBuildTypes
+import dev.nucleusframework.desktop.application.dsl.NucleusOptimizationSettings
 import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
 import dev.nucleusframework.internal.utils.new
 import dev.nucleusframework.desktop.application.dsl.AdditionalLauncher
@@ -78,6 +79,10 @@ internal open class JvmApplicationInternal
         final override var garbageCollector: GarbageCollector? by data::garbageCollector
 
         final override var nucleusOptimization: Boolean by data::nucleusOptimization
+
+        final override fun nucleusOptimization(fn: Action<NucleusOptimizationSettings>) {
+            fn.execute(data.nucleusOptimizationSettings)
+        }
 
         final override val nativeDistributions: JvmApplicationDistributions by data::nativeDistributions
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NucleusJdkToolchainProvisioner.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NucleusJdkToolchainProvisioner.kt
@@ -1,0 +1,343 @@
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.internal.utils.Arch
+import dev.nucleusframework.internal.utils.OS
+import dev.nucleusframework.internal.utils.currentArch
+import dev.nucleusframework.internal.utils.currentOS
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import java.net.HttpURLConnection
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+import javax.inject.Inject
+
+/**
+ * Current OpenJDK used as the jpackage / jlink / `run` JDK when
+ * [dev.nucleusframework.desktop.application.dsl.NucleusOptimizationSettings.lastJdk]
+ * is on.
+ */
+// TODO: switch OpenJDK 27 from RC build 35 to GA (2026-09-15). Update
+// OPENJDK_27_HASH / OPENJDK_27_BUILD from https://jdk.java.net/27/ and rename
+// OPENJDK_27_INSTALL_ID to openjdk-27 so existing caches re-provision.
+internal const val OPENJDK_27_FEATURE = 27
+internal const val OPENJDK_27_BUILD = 35
+internal const val OPENJDK_27_HASH = "55ce5470a6294008af0057ff4626d0e5"
+internal const val OPENJDK_27_INSTALL_ID = "openjdk-27-rc-b35"
+
+private const val OPENJDK_27_DOWNLOAD_BASE =
+    "https://download.java.net/java/GA/jdk27/$OPENJDK_27_HASH/$OPENJDK_27_BUILD/GPL"
+
+internal data class NucleusJdkToolchainRequest(
+    val os: OS,
+    val arch: Arch,
+    val installBaseDir: File,
+)
+
+/**
+ * Configuration-cache-safe entry point to [NucleusJdkToolchainProvisioner].
+ * Stays lazy so `gradlew tasks` / an IDE sync never downloads the JDK.
+ */
+internal abstract class NucleusJdkToolchainValueSource :
+    ValueSource<String, NucleusJdkToolchainValueSource.Params> {
+    interface Params : ValueSourceParameters {
+        val installBaseDir: Property<String>
+    }
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    override fun obtain(): String {
+        val request =
+            NucleusJdkToolchainRequest(
+                os = currentOS,
+                arch = currentArch,
+                installBaseDir = File(parameters.installBaseDir.get()),
+            )
+        return NucleusJdkToolchainProvisioner
+            .provision(
+                request,
+                execOperations,
+                Logging.getLogger(NucleusJdkToolchainProvisioner::class.java),
+            ).absolutePath
+    }
+}
+
+/**
+ * Downloads and caches OpenJDK 27 for the JVM packaging toolchain, mirroring
+ * [GraalvmToolchainProvisioner] for native-image.
+ *
+ * `NUCLEUS_JDK_HOME` pointing at a valid JDK 27 installation bypasses the
+ * download. macOS Intel and Windows aarch64 are not published by OpenJDK 27
+ * — set [dev.nucleusframework.desktop.application.dsl.JvmApplication.javaHome]
+ * to a local JDK 27 instead.
+ */
+@Suppress("TooManyFunctions")
+internal object NucleusJdkToolchainProvisioner {
+    private const val MARKER_FILE = ".nucleus-provisioned"
+    private const val CONNECT_TIMEOUT_MS = 30_000
+    private const val READ_TIMEOUT_MS = 60_000
+    private const val MAX_REDIRECTS = 5
+    private const val DOWNLOAD_BUFFER_SIZE = 1 shl 16
+    private const val HTTP_FIRST_REDIRECT = 300
+    private const val HTTP_FIRST_ERROR = 400
+    private const val ENV_JDK_HOME = "NUCLEUS_JDK_HOME"
+
+    fun provision(
+        request: NucleusJdkToolchainRequest,
+        execOperations: ExecOperations,
+        logger: Logger,
+    ): File {
+        environmentOverride(logger)?.let { return it }
+
+        val id = installationId(request)
+        val installDir = File(request.installBaseDir, id)
+        readMarker(installDir)?.let { return it }
+
+        request.installBaseDir.mkdirs()
+        RandomAccessFile(File(request.installBaseDir, "$id.lock"), "rw").use { lockFile ->
+            lockFile.channel.lock().use {
+                readMarker(installDir)?.let { return it }
+                return downloadAndInstall(request, id, installDir, execOperations, logger)
+            }
+        }
+    }
+
+    internal fun downloadUrl(
+        os: OS,
+        arch: Arch,
+    ): String = "$OPENJDK_27_DOWNLOAD_BASE/${artifactName(os, arch)}"
+
+    internal fun installationId(request: NucleusJdkToolchainRequest): String =
+        "$OPENJDK_27_INSTALL_ID-${request.os.id}-${archToken(request.arch)}"
+
+    internal fun archToken(arch: Arch): String =
+        when (arch) {
+            Arch.X64 -> "x64"
+            Arch.Arm64 -> "aarch64"
+        }
+
+    internal fun checkSupported(
+        os: OS,
+        arch: Arch,
+    ) {
+        val unsupported =
+            (os == OS.MacOS && arch == Arch.X64) ||
+                (os == OS.Windows && arch == Arch.Arm64)
+        check(!unsupported) {
+            "OpenJDK $OPENJDK_27_FEATURE has no ${os.id}-${archToken(arch)} build. " +
+                "Set nucleus.application { javaHome = \"...\" } to a local JDK $OPENJDK_27_FEATURE, " +
+                "or set $ENV_JDK_HOME."
+        }
+    }
+
+    private fun artifactName(
+        os: OS,
+        arch: Arch,
+    ): String {
+        checkSupported(os, arch)
+        val ext = if (os == OS.Windows) "zip" else "tar.gz"
+        return "openjdk-${OPENJDK_27_FEATURE}_${os.id}-${archToken(arch)}_bin.$ext"
+    }
+
+    private fun environmentOverride(logger: Logger): File? {
+        val env = System.getenv(ENV_JDK_HOME)?.takeIf { it.isNotBlank() } ?: return null
+        val root = File(env)
+        val home = root.resolve("Contents/Home").takeIf { it.isDirectory } ?: root
+        if (javaBinary(home) == null) {
+            logger.warn(
+                "[nucleusOptimization] $ENV_JDK_HOME is set to $env but contains no bin/java — ignoring it",
+            )
+            return null
+        }
+        val feature = javaFeatureVersion(home)
+        if (feature != OPENJDK_27_FEATURE) {
+            logger.warn(
+                "[nucleusOptimization] $ENV_JDK_HOME ($home) is JDK $feature, expected " +
+                    "$OPENJDK_27_FEATURE — ignoring it and downloading OpenJDK $OPENJDK_27_FEATURE",
+            )
+            return null
+        }
+        logger.lifecycle("[nucleusOptimization] Using $ENV_JDK_HOME toolchain: $home")
+        return home
+    }
+
+    private fun javaFeatureVersion(javaHome: File): Int? {
+        val release = javaHome.resolve("release")
+        if (!release.isFile) return null
+        val raw =
+            release
+                .readLines()
+                .firstOrNull { it.startsWith("JAVA_VERSION=") }
+                ?.substringAfter("JAVA_VERSION=")
+                ?.trim('"')
+                ?: return null
+        return raw.takeWhile { it.isDigit() }.toIntOrNull()
+    }
+
+    private fun readMarker(installDir: File): File? {
+        val marker = File(installDir, MARKER_FILE)
+        if (!marker.isFile) return null
+        val home = File(installDir, marker.readText().trim())
+        return home.takeIf { it.isDirectory && javaBinary(it) != null }
+    }
+
+    private fun downloadAndInstall(
+        request: NucleusJdkToolchainRequest,
+        id: String,
+        installDir: File,
+        execOperations: ExecOperations,
+        logger: Logger,
+    ): File {
+        val url = downloadUrl(request.os, request.arch)
+        val description =
+            "OpenJDK $OPENJDK_27_FEATURE-rc+$OPENJDK_27_BUILD " +
+                "(${request.os.id}-${archToken(request.arch)})"
+        logger.lifecycle("[nucleusOptimization] Downloading $description from $url")
+        val archive = File(request.installBaseDir, "$id.download")
+        val extractDir = File(request.installBaseDir, "$id.extract")
+        try {
+            download(url, archive)
+            verifyChecksum(archive, "$url.sha256", logger)
+
+            extractDir.deleteRecursively()
+            extract(archive, extractDir, execOperations)
+
+            val topDir =
+                extractDir.listFiles()?.singleOrNull { it.isDirectory }
+                    ?: error("Unexpected archive layout for $url: expected a single top-level directory")
+            val homeRelative =
+                if (topDir.resolve("Contents/Home").isDirectory) {
+                    "${topDir.name}/Contents/Home"
+                } else {
+                    topDir.name
+                }
+            checkNotNull(javaBinary(File(extractDir, homeRelative))) {
+                "Downloaded toolchain $description contains no bin/java ($topDir)"
+            }
+
+            installDir.deleteRecursively()
+            installDir.mkdirs()
+            Files.move(
+                topDir.toPath(),
+                installDir.toPath().resolve(topDir.name),
+                StandardCopyOption.ATOMIC_MOVE,
+            )
+            File(installDir, MARKER_FILE).writeText(homeRelative)
+
+            val home = File(installDir, homeRelative)
+            logger.lifecycle("[nucleusOptimization] $description installed to $home")
+            return home
+        } finally {
+            archive.delete()
+            extractDir.deleteRecursively()
+        }
+    }
+
+    private fun javaBinary(home: File): File? =
+        listOf("java", "java.exe")
+            .map { home.resolve("bin/$it") }
+            .firstOrNull { it.isFile }
+
+    private fun verifyChecksum(
+        archive: File,
+        sha256Url: String,
+        logger: Logger,
+    ) {
+        val text =
+            runCatching { fetchText(sha256Url) }.getOrElse {
+                logger.warn(
+                    "[nucleusOptimization] Could not fetch checksum $sha256Url (${it.message}) — " +
+                        "skipping verification",
+                )
+                return
+            }
+        val expected = text.trim().substringBefore(' ')
+        val actual = archive.digest("SHA-256")
+        check(actual.equals(expected, ignoreCase = true)) {
+            "Checksum mismatch for $sha256Url: expected $expected, got $actual"
+        }
+    }
+
+    private fun File.digest(algorithm: String): String {
+        val digest = MessageDigest.getInstance(algorithm)
+        inputStream().use { input ->
+            val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun download(
+        url: String,
+        dest: File,
+    ) {
+        try {
+            openConnection(url).inputStream.use { input ->
+                dest.outputStream().use { output -> input.copyTo(output, DOWNLOAD_BUFFER_SIZE) }
+            }
+        } catch (e: IOException) {
+            throw IOException(
+                "Failed to download OpenJDK $OPENJDK_27_FEATURE from $url: ${e.message}",
+                e,
+            )
+        }
+    }
+
+    private fun fetchText(url: String): String =
+        openConnection(url).inputStream.use { it.readBytes().decodeToString() }
+
+    @Suppress("ThrowsCount")
+    private fun openConnection(url: String): HttpURLConnection {
+        var current = url
+        repeat(MAX_REDIRECTS) {
+            val connection = URI(current).toURL().openConnection() as HttpURLConnection
+            connection.connectTimeout = CONNECT_TIMEOUT_MS
+            connection.readTimeout = READ_TIMEOUT_MS
+            connection.instanceFollowRedirects = true
+            val code = connection.responseCode
+            when {
+                code in HTTP_FIRST_REDIRECT until HTTP_FIRST_ERROR -> {
+                    val location =
+                        connection.getHeaderField("Location")
+                            ?: throw IOException("Redirect without Location header from $current")
+                    connection.disconnect()
+                    current = location
+                }
+                code >= HTTP_FIRST_ERROR -> throw IOException("HTTP $code from $current")
+                else -> return connection
+            }
+        }
+        throw IOException("Too many redirects for $url")
+    }
+
+    private fun extract(
+        archive: File,
+        destDir: File,
+        execOperations: ExecOperations,
+    ) {
+        destDir.mkdirs()
+        val output = ByteArrayOutputStream()
+        val result =
+            execOperations.exec { spec ->
+                spec.commandLine("tar", "-xf", archive.absolutePath, "-C", destDir.absolutePath)
+                spec.standardOutput = output
+                spec.errorOutput = output
+                spec.isIgnoreExitValue = true
+            }
+        check(result.exitValue == 0) { "tar failed extracting ${archive.name}: $output" }
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
@@ -79,6 +79,8 @@ internal const val NUCLEUS_TASK_GROUP = "nucleus"
 // todo: file associations
 // todo: use workers
 internal fun JvmApplicationContext.configureJvmApplication() {
+    applyNucleusOptimization(app)
+
     if (app.isDefaultConfigurationEnabled) {
         configureDefaultApp()
     }
@@ -380,6 +382,14 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
         }
     }
 
+    val flattenJars =
+        tasks.register<AbstractJarsFlattenTask>(
+            taskNameAction = "flatten",
+            taskNameObject = "Jars",
+        ) {
+            configureFlattenJars(this, runProguard)
+        }
+
     // === Non-sandboxed pipeline (direct distribution formats: DMG, ZIP, NSIS, etc.) ===
 
     val createDistributable =
@@ -395,6 +405,7 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
                 checkRuntime = commonTasks.checkRuntime,
                 unpackDefaultResources = commonTasks.unpackDefaultResources,
                 runProguard = runProguard,
+                flattenJars = flattenJars,
                 patchCaCertificates = commonTasks.patchCaCertificates,
                 sandboxed = false,
             )
@@ -479,6 +490,7 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
                         checkRuntime = commonTasks.checkRuntime,
                         unpackDefaultResources = commonTasks.unpackDefaultResources,
                         runProguard = runProguard,
+                        flattenJars = flattenJars,
                         stripNativeLibs = stripNativeLibsFromJars,
                         patchCaCertificates = commonTasks.patchCaCertificates,
                         sandboxed = true,
@@ -595,14 +607,6 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
             }
         }
     }
-
-    val flattenJars =
-        tasks.register<AbstractJarsFlattenTask>(
-            taskNameAction = "flatten",
-            taskNameObject = "Jars",
-        ) {
-            configureFlattenJars(this, runProguard)
-        }
 
     val packageUberJarForCurrentOS =
         tasks.register<Jar>(
@@ -757,7 +761,11 @@ private fun JvmApplicationContext.configureProguardTask(
         dontobfuscate.set(settings.obfuscate.map { !it })
         dontoptimize.set(settings.optimize.map { !it })
 
-        joinOutputJars.set(settings.joinOutputJars)
+        joinOutputJars.set(
+            settings.joinOutputJars.map { enabled ->
+                enabled || app.nucleusOptimization
+            },
+        )
 
         dependsOn(unpackDefaultResources)
         defaultComposeRulesFile.set(unpackDefaultResources.flatMap { it.resources.defaultComposeProguardRules })
@@ -798,6 +806,7 @@ private fun JvmApplicationContext.configurePackageTask(
     checkRuntime: TaskProvider<AbstractCheckNativeDistributionRuntime>? = null,
     unpackDefaultResources: TaskProvider<AbstractUnpackDefaultApplicationResourcesTask>,
     runProguard: Provider<AbstractProguardTask>? = null,
+    flattenJars: TaskProvider<AbstractJarsFlattenTask>? = null,
     stripNativeLibs: TaskProvider<AbstractStripNativeLibsFromJarsTask>? = null,
     patchCaCertificates: TaskProvider<AbstractPatchCaCertificatesTask>? = null,
     sandboxed: Boolean = false,
@@ -886,6 +895,14 @@ private fun JvmApplicationContext.configurePackageTask(
             packageTask.launcherMainJar.set(runProguard.flatMap { it.mainJarInDestinationDir })
             packageTask.mangleJarFilesNames.set(false)
             packageTask.packageFromUberJar.set(runProguard.flatMap { it.joinOutputJars })
+        }
+        app.nucleusOptimization && flattenJars != null -> {
+            packageTask.dependsOn(flattenJars)
+            val flattened = flattenJars.flatMap { it.flattenedJar }
+            packageTask.files.from(flattened)
+            packageTask.launcherMainJar.set(flattened)
+            packageTask.mangleJarFilesNames.set(false)
+            packageTask.packageFromUberJar.set(true)
         }
         else -> {
             packageTask.useAppRuntimeFiles { (runtimeJars, mainJar) ->

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
@@ -80,6 +80,7 @@ internal const val NUCLEUS_TASK_GROUP = "nucleus"
 // todo: use workers
 internal fun JvmApplicationContext.configureJvmApplication() {
     applyNucleusOptimization(app)
+    applyNucleusOptimizationJdk(project, app)
 
     if (app.isDefaultConfigurationEnabled) {
         configureDefaultApp()
@@ -662,7 +663,7 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
     val patchMacJvmTask: TaskProvider<AbstractPatchMacJvmTask>? =
         if (currentOS == OS.MacOS && app.nativeDistributions.macOS.macOsSdkVersion != null) {
             registerPatchMacJvmTask(
-                javaHome = app.javaHome,
+                javaHome = app.javaHomeProvider,
                 minVersion = app.nativeDistributions.macOS.minimumSystemVersion ?: "10.13",
                 sdkVersion = app.nativeDistributions.macOS.macOsSdkVersion!!,
             )
@@ -1135,11 +1136,9 @@ private fun JvmApplicationContext.configureRunTask(
     exec.dependsOn(prepareAppResources)
 
     exec.mainClass.set(app.mainClass)
-    exec.executable(javaExecutable(app.javaHome))
     if (currentOS == OS.MacOS) {
         val sdkVersion = app.nativeDistributions.macOS.macOsSdkVersion
         if (sdkVersion != null && patchMacJvmTask != null) {
-            val javaHome = app.javaHome
             exec.dependsOn(patchMacJvmTask)
             // Route the fork through a vtool-patched copy of the JDK so AppKit
             // gates Liquid Glass on. `javaLauncher` is finalized before
@@ -1158,12 +1157,14 @@ private fun JvmApplicationContext.configureRunTask(
                 .asFile
             val patchedJavaHomeFile = patchedBinFile.parentFile.parentFile
             exec.javaLauncher.set(
-                ExternalJavaLauncher(
-                    javaBinary = patchedBinFile,
-                    javaHome = patchedJavaHomeFile,
-                    objects = project.objects,
-                    metadataJavaHome = java.io.File(javaHome),
-                ),
+                app.javaHomeProvider.map { home ->
+                    ExternalJavaLauncher(
+                        javaBinary = patchedBinFile,
+                        javaHome = patchedJavaHomeFile,
+                        objects = project.objects,
+                        metadataJavaHome = java.io.File(home),
+                    )
+                },
             )
             // `executable` isn't Provider-aware in Gradle 9, but it isn't
             // finalized before `doFirst` either — align it with the launcher
@@ -1171,7 +1172,11 @@ private fun JvmApplicationContext.configureRunTask(
             exec.doFirst {
                 (it as JavaExec).executable(patchedBinFile.absolutePath)
             }
+        } else {
+            configureRunJavaHome(exec)
         }
+    } else {
+        configureRunJavaHome(exec)
     }
     exec.jvmArgs =
         arrayListOf<String>().apply {
@@ -1308,8 +1313,24 @@ private fun sandboxingJvmArgs(resourcesPath: String): List<String> =
  * tasks of all build types since inputs (javaHome, SDK/min version) are
  * identical at the project level.
  */
+private fun JvmApplicationContext.configureRunJavaHome(exec: JavaExec) {
+    if (app.javaHomeOverride != null) {
+        exec.javaLauncher.set(
+            app.javaHomeProvider.map { home ->
+                ExternalJavaLauncher(
+                    javaBinary = java.io.File(javaExecutable(home)),
+                    javaHome = java.io.File(home),
+                    objects = project.objects,
+                )
+            },
+        )
+    } else {
+        exec.executable(javaExecutable(app.javaHome))
+    }
+}
+
 private fun JvmApplicationContext.registerPatchMacJvmTask(
-    javaHome: String,
+    javaHome: Provider<String>,
     minVersion: String,
     sdkVersion: String,
 ): TaskProvider<AbstractPatchMacJvmTask> {

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
@@ -763,7 +763,7 @@ private fun JvmApplicationContext.configureProguardTask(
 
         joinOutputJars.set(
             settings.joinOutputJars.map { enabled ->
-                enabled || app.nucleusOptimization
+                enabled || app.optSingleJar
             },
         )
 
@@ -896,7 +896,7 @@ private fun JvmApplicationContext.configurePackageTask(
             packageTask.mangleJarFilesNames.set(false)
             packageTask.packageFromUberJar.set(runProguard.flatMap { it.joinOutputJars })
         }
-        app.nucleusOptimization && flattenJars != null -> {
+        app.optSingleJar && flattenJars != null -> {
             packageTask.dependsOn(flattenJars)
             val flattened = flattenJars.flatMap { it.flattenedJar }
             packageTask.files.from(flattened)

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimizationTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimizationTest.kt
@@ -3,6 +3,7 @@ package dev.nucleusframework.desktop.application.internal
 import dev.nucleusframework.desktop.application.dsl.GarbageCollector
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -23,7 +24,7 @@ class ApplyNucleusOptimizationTest {
         applyNucleusOptimization(app)
         assertEquals(GarbageCollector.SERIAL, app.garbageCollector)
         assertEquals(
-            listOf(OPTIMIZED_XMS, OPTIMIZED_MAX_RAM_PERCENTAGE, OPTIMIZED_RUNTIME_FLAG),
+            listOf(OPTIMIZED_XMS, OPTIMIZED_MAX_RAM_PERCENTAGE, OPTIMIZED_IDLE_GC_FLAG),
             app.jvmArgs.toList(),
         )
     }
@@ -38,7 +39,7 @@ class ApplyNucleusOptimizationTest {
         applyNucleusOptimization(app)
         assertEquals(GarbageCollector.G1, app.garbageCollector)
         assertEquals(
-            listOf("-Xms64m", "-XX:MaxRAMPercentage=40", OPTIMIZED_RUNTIME_FLAG),
+            listOf("-Xms64m", "-XX:MaxRAMPercentage=40", OPTIMIZED_IDLE_GC_FLAG),
             app.jvmArgs.toList(),
         )
     }
@@ -47,10 +48,76 @@ class ApplyNucleusOptimizationTest {
     fun `enabled does not duplicate an existing runtime flag`() {
         val app = applicationData()
         app.nucleusOptimization = true
-        app.jvmArgs.add("-Dnucleus.optimization=false")
+        app.jvmArgs.add("-Dnucleus.optimization.idleGc=false")
         applyNucleusOptimization(app)
-        assertEquals(1, app.jvmArgs.count { it.startsWith("-Dnucleus.optimization=") })
-        assertTrue(app.jvmArgs.contains("-Dnucleus.optimization=false"))
+        assertEquals(1, app.jvmArgs.count { it.startsWith("-Dnucleus.optimization.idleGc=") })
+        assertTrue(app.jvmArgs.contains("-Dnucleus.optimization.idleGc=false"))
+    }
+
+    @Test
+    fun `master on idleGc off omits the runtime flag`() {
+        val app = applicationData()
+        app.nucleusOptimization = true
+        app.nucleusOptimizationSettings.idleGc = false
+        applyNucleusOptimization(app)
+        assertEquals(GarbageCollector.SERIAL, app.garbageCollector)
+        assertEquals(listOf(OPTIMIZED_XMS, OPTIMIZED_MAX_RAM_PERCENTAGE), app.jvmArgs.toList())
+        assertFalse(app.optIdleGc)
+        assertTrue(app.optSingleJar)
+    }
+
+    @Test
+    fun `master on serialGc off leaves collector unset`() {
+        val app = applicationData()
+        app.nucleusOptimization = true
+        app.nucleusOptimizationSettings.serialGc = false
+        applyNucleusOptimization(app)
+        assertNull(app.garbageCollector)
+        assertTrue(app.optCompactHeap)
+        assertTrue(app.optIdleGc)
+        assertFalse(app.optSerialGc)
+    }
+
+    @Test
+    fun `only idleGc sets the runtime flag`() {
+        val app = applicationData()
+        app.nucleusOptimizationSettings.idleGc = true
+        applyNucleusOptimization(app)
+        assertNull(app.garbageCollector)
+        assertEquals(listOf(OPTIMIZED_IDLE_GC_FLAG), app.jvmArgs.toList())
+        assertFalse(app.optSerialGc)
+        assertFalse(app.optCompactHeap)
+        assertFalse(app.optSingleJar)
+    }
+
+    @Test
+    fun `only serialGc sets the collector`() {
+        val app = applicationData()
+        app.nucleusOptimizationSettings.serialGc = true
+        applyNucleusOptimization(app)
+        assertEquals(GarbageCollector.SERIAL, app.garbageCollector)
+        assertTrue(app.jvmArgs.isEmpty())
+    }
+
+    @Test
+    fun `only compactHeap sets heap flags`() {
+        val app = applicationData()
+        app.nucleusOptimizationSettings.compactHeap = true
+        applyNucleusOptimization(app)
+        assertNull(app.garbageCollector)
+        assertEquals(listOf(OPTIMIZED_XMS, OPTIMIZED_MAX_RAM_PERCENTAGE), app.jvmArgs.toList())
+        assertFalse(app.optIdleGc)
+    }
+
+    @Test
+    fun `only singleJar does not touch jvm flags`() {
+        val app = applicationData()
+        app.nucleusOptimizationSettings.singleJar = true
+        applyNucleusOptimization(app)
+        assertNull(app.garbageCollector)
+        assertTrue(app.jvmArgs.isEmpty())
+        assertTrue(app.optSingleJar)
+        assertFalse(app.optIdleGc)
     }
 
     private fun applicationData(): JvmApplicationData {

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimizationTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimizationTest.kt
@@ -1,0 +1,44 @@
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.desktop.application.dsl.GarbageCollector
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApplyNucleusOptimizationTest {
+    @Test
+    fun `disabled does not touch collector or heap flags`() {
+        val app = applicationData()
+        applyNucleusOptimization(app)
+        assertNull(app.garbageCollector)
+        assertTrue(app.jvmArgs.isEmpty())
+    }
+
+    @Test
+    fun `enabled sets serial and heap when unset`() {
+        val app = applicationData()
+        app.nucleusOptimization = true
+        applyNucleusOptimization(app)
+        assertEquals(GarbageCollector.SERIAL, app.garbageCollector)
+        assertEquals(listOf(OPTIMIZED_XMS, OPTIMIZED_MAX_RAM_PERCENTAGE), app.jvmArgs.toList())
+    }
+
+    @Test
+    fun `enabled keeps an explicit collector and existing heap flags`() {
+        val app = applicationData()
+        app.nucleusOptimization = true
+        app.garbageCollector = GarbageCollector.G1
+        app.jvmArgs.add("-Xms64m")
+        app.jvmArgs.add("-XX:MaxRAMPercentage=40")
+        applyNucleusOptimization(app)
+        assertEquals(GarbageCollector.G1, app.garbageCollector)
+        assertEquals(listOf("-Xms64m", "-XX:MaxRAMPercentage=40"), app.jvmArgs.toList())
+    }
+
+    private fun applicationData(): JvmApplicationData {
+        val project = ProjectBuilder.builder().build()
+        return project.objects.newInstance(JvmApplicationData::class.java)
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimizationTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimizationTest.kt
@@ -1,9 +1,11 @@
 package dev.nucleusframework.desktop.application.internal
 
 import dev.nucleusframework.desktop.application.dsl.GarbageCollector
+import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -120,8 +122,59 @@ class ApplyNucleusOptimizationTest {
         assertFalse(app.optIdleGc)
     }
 
-    private fun applicationData(): JvmApplicationData {
+    @Test
+    fun `disabled does not provision a JDK`() {
         val project = ProjectBuilder.builder().build()
-        return project.objects.newInstance(JvmApplicationData::class.java)
+        val app = applicationData(project)
+        applyNucleusOptimizationJdk(project, app)
+        assertNull(app.javaHomeOverride)
+        assertFalse(app.optLastJdk)
     }
+
+    @Test
+    fun `master on provisions a lazy JDK home`() {
+        val project = ProjectBuilder.builder().build()
+        val app = applicationData(project)
+        app.nucleusOptimization = true
+        applyNucleusOptimizationJdk(project, app)
+        assertTrue(app.optLastJdk)
+        assertNotNull(app.javaHomeOverride)
+    }
+
+    @Test
+    fun `explicit javaHome wins over JDK provisioning`() {
+        val project = ProjectBuilder.builder().build()
+        val app = applicationData(project)
+        app.nucleusOptimization = true
+        app.javaHome = "/custom/jdk"
+        applyNucleusOptimizationJdk(project, app)
+        assertNull(app.javaHomeOverride)
+        assertEquals("/custom/jdk", app.javaHome)
+    }
+
+    @Test
+    fun `master on lastJdk off does not provision`() {
+        val project = ProjectBuilder.builder().build()
+        val app = applicationData(project)
+        app.nucleusOptimization = true
+        app.nucleusOptimizationSettings.lastJdk = false
+        applyNucleusOptimizationJdk(project, app)
+        assertFalse(app.optLastJdk)
+        assertNull(app.javaHomeOverride)
+    }
+
+    @Test
+    fun `only lastJdk provisions without touching JVM flags`() {
+        val project = ProjectBuilder.builder().build()
+        val app = applicationData(project)
+        app.nucleusOptimizationSettings.lastJdk = true
+        applyNucleusOptimization(app)
+        applyNucleusOptimizationJdk(project, app)
+        assertNull(app.garbageCollector)
+        assertTrue(app.jvmArgs.isEmpty())
+        assertNotNull(app.javaHomeOverride)
+    }
+
+    private fun applicationData(project: Project = ProjectBuilder.builder().build()): JvmApplicationData =
+        project.objects.newInstance(JvmApplicationData::class.java)
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimizationTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/ApplyNucleusOptimizationTest.kt
@@ -22,7 +22,10 @@ class ApplyNucleusOptimizationTest {
         app.nucleusOptimization = true
         applyNucleusOptimization(app)
         assertEquals(GarbageCollector.SERIAL, app.garbageCollector)
-        assertEquals(listOf(OPTIMIZED_XMS, OPTIMIZED_MAX_RAM_PERCENTAGE), app.jvmArgs.toList())
+        assertEquals(
+            listOf(OPTIMIZED_XMS, OPTIMIZED_MAX_RAM_PERCENTAGE, OPTIMIZED_RUNTIME_FLAG),
+            app.jvmArgs.toList(),
+        )
     }
 
     @Test
@@ -34,7 +37,20 @@ class ApplyNucleusOptimizationTest {
         app.jvmArgs.add("-XX:MaxRAMPercentage=40")
         applyNucleusOptimization(app)
         assertEquals(GarbageCollector.G1, app.garbageCollector)
-        assertEquals(listOf("-Xms64m", "-XX:MaxRAMPercentage=40"), app.jvmArgs.toList())
+        assertEquals(
+            listOf("-Xms64m", "-XX:MaxRAMPercentage=40", OPTIMIZED_RUNTIME_FLAG),
+            app.jvmArgs.toList(),
+        )
+    }
+
+    @Test
+    fun `enabled does not duplicate an existing runtime flag`() {
+        val app = applicationData()
+        app.nucleusOptimization = true
+        app.jvmArgs.add("-Dnucleus.optimization=false")
+        applyNucleusOptimization(app)
+        assertEquals(1, app.jvmArgs.count { it.startsWith("-Dnucleus.optimization=") })
+        assertTrue(app.jvmArgs.contains("-Dnucleus.optimization=false"))
     }
 
     private fun applicationData(): JvmApplicationData {

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/NucleusJdkToolchainProvisionerTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/NucleusJdkToolchainProvisionerTest.kt
@@ -1,0 +1,56 @@
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.internal.utils.Arch
+import dev.nucleusframework.internal.utils.OS
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NucleusJdkToolchainProvisionerTest {
+    @Test
+    fun `download URL is the pinned OpenJDK 27 RC`() {
+        val url = NucleusJdkToolchainProvisioner.downloadUrl(OS.Windows, Arch.X64)
+        assertEquals(
+            "https://download.java.net/java/GA/jdk27/" +
+                "$OPENJDK_27_HASH/$OPENJDK_27_BUILD/GPL/" +
+                "openjdk-27_windows-x64_bin.zip",
+            url,
+        )
+        assertTrue(url.contains("openjdk-27_"))
+    }
+
+    @Test
+    fun `linux aarch64 uses the aarch64 token and tar gz`() {
+        val url = NucleusJdkToolchainProvisioner.downloadUrl(OS.Linux, Arch.Arm64)
+        assertTrue(url.endsWith("openjdk-27_linux-aarch64_bin.tar.gz"))
+    }
+
+    @Test
+    fun `macos aarch64 is published`() {
+        val url = NucleusJdkToolchainProvisioner.downloadUrl(OS.MacOS, Arch.Arm64)
+        assertTrue(url.endsWith("openjdk-27_macos-aarch64_bin.tar.gz"))
+    }
+
+    @Test
+    fun `install id embeds the RC pin so GA re-provisions`() {
+        val id =
+            NucleusJdkToolchainProvisioner.installationId(
+                NucleusJdkToolchainRequest(
+                    os = OS.Windows,
+                    arch = Arch.X64,
+                    installBaseDir = java.io.File("."),
+                ),
+            )
+        assertEquals("openjdk-27-rc-b35-windows-x64", id)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `macos x64 is not published`() {
+        NucleusJdkToolchainProvisioner.downloadUrl(OS.MacOS, Arch.X64)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `windows aarch64 is not published`() {
+        NucleusJdkToolchainProvisioner.downloadUrl(OS.Windows, Arch.Arm64)
+    }
+}


### PR DESCRIPTION
## Summary

Adds `nucleusOptimization`, a one-switch startup/runtime performance pack, rebased on `nucleus-2.6`.

- **`nucleusOptimization` startup pack** (plugin) — bundles the launcher JVM options that pay off for a desktop app's startup.
- **Per-knob DSL** — every knob in the pack can be toggled individually instead of all-or-nothing.
- **Idle GC** (`nucleus-application`) — when the pack is on, windows and dialogs observe activity and trigger a GC once the app goes idle, so a backgrounded app gives memory back. Wired through the shared `bindNucleusContent` / `bindNucleusDialogContent` helpers introduced by the satellite/tab work, so decorated windows, dialogs, tabs and satellites all get it.
- **`lastJdk`** — packaging can auto-download the current OpenJDK instead of pinning a toolchain by hand.

## Test plan

- `IdleGcControllerTest`, `ApplyNucleusOptimizationTest`, `NucleusJdkToolchainProvisionerTest`
- `:nucleus-application:compileKotlin` clean after the rebase