### PR TITLE
fix(tao): never hold key-event locks across PeekMessageW on Windows (#640)

### DIFF
--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
@@ -972,12 +972,43 @@ unsafe fn public_window_callback_inner<T: 'static>(
       return;
     }
     let events = {
-      let mut key_event_builders =
-        crate::platform_impl::platform::keyboard::KEY_EVENT_BUILDERS.lock();
-      if let Some(key_event_builder) = key_event_builders.get_mut(&WindowId(window.0 as _)) {
-        key_event_builder.process_message(window, msg, wparam, lparam, &mut result)
-      } else {
-        Vec::new()
+      use crate::platform_impl::platform::keyboard::KEY_EVENT_BUILDERS;
+      let window_id = WindowId(window.0 as _);
+
+      // Take the builder OUT of the map for the duration of
+      // `process_message` rather than holding the map lock across it.
+      // `process_message` calls `PeekMessageW`, and PeekMessage delivers
+      // pending cross-thread *sent* messages inline — the kernel re-enters
+      // this very window procedure through `KiUserCallbackDispatcher`.
+      // Holding the non-reentrant `KEY_EVENT_BUILDERS` mutex across that
+      // re-entry deadlocks the event-loop thread against itself: it parks in
+      // `WaitOnAddress` and never pumps a message again, so the window goes
+      // "Not Responding" for good (NucleusFramework/Nucleus#640, hit while
+      // moving a window between Windows 11 virtual desktops — that path is
+      // keyboard-triggered and makes the shell send messages to the window
+      // mid-peek).
+      //
+      // While the builder is taken, a nested key message finds an empty slot
+      // and is dropped. That is the right trade-off: only injected or sent
+      // key messages can nest here, since real keyboard input is posted to
+      // the queue rather than sent, and `process_message` peeks with
+      // PM_NOREMOVE so it never dispatches queued messages itself.
+      let taken = KEY_EVENT_BUILDERS
+        .lock()
+        .get_mut(&window_id)
+        .and_then(Option::take);
+
+      match taken {
+        Some(mut key_event_builder) => {
+          let events = key_event_builder.process_message(window, msg, wparam, lparam, &mut result);
+          // Put it back only if the slot still exists: the window may have
+          // been dropped (which removes its slot) while we were processing.
+          if let Some(slot) = KEY_EVENT_BUILDERS.lock().get_mut(&window_id) {
+            *slot = Some(key_event_builder);
+          }
+          events
+        }
+        None => Vec::new(),
       }
     };
     for event in events {

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/keyboard.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/keyboard.rs
@@ -59,7 +59,14 @@ pub struct MessageAsKeyEvent {
   pub is_synthetic: bool,
 }
 
-pub(crate) static KEY_EVENT_BUILDERS: Lazy<Mutex<HashMap<WindowId, KeyEventBuilder>>> =
+/// Per-window key event builders.
+///
+/// The value is an `Option` slot so a message handler can *take* the builder
+/// out for the duration of `KeyEventBuilder::process_message` instead of
+/// holding this mutex across it — see the take/put-back in
+/// `event_loop::public_window_callback` and issue
+/// NucleusFramework/Nucleus#640.
+pub(crate) static KEY_EVENT_BUILDERS: Lazy<Mutex<HashMap<WindowId, Option<KeyEventBuilder>>>> =
   Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Stores information required to make `KeyEvent`s.
@@ -133,9 +140,21 @@ impl KeyEventBuilder {
           *result = ProcResult::Value(LRESULT(0));
         }
 
-        let mut layouts = LAYOUT_CACHE.lock();
-        let event_info =
-          PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Pressed, &mut layouts);
+        // The LAYOUT_CACHE guard is deliberately scoped to end before the
+        // `PeekMessageW` below and re-acquired after it. `PeekMessageW`
+        // delivers pending cross-thread `SendMessage`s inline (the kernel
+        // re-enters this window procedure through
+        // `KiUserCallbackDispatcher`), and every other arm of this function
+        // locks LAYOUT_CACHE too. Holding a non-reentrant `parking_lot::Mutex`
+        // across the peek therefore deadlocks the whole event loop against
+        // itself — the thread parks in `WaitOnAddress` and never pumps again
+        // (NucleusFramework/Nucleus#640: reproducible while switching Windows
+        // 11 virtual desktops, which is keyboard-triggered and makes the shell
+        // send messages to the window mid-peek).
+        let event_info = {
+          let mut layouts = LAYOUT_CACHE.lock();
+          PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Pressed, &mut layouts)
+        };
 
         let mut next_msg = MaybeUninit::uninit();
         let peek_retval = unsafe {
@@ -150,6 +169,7 @@ impl KeyEventBuilder {
         let has_next_key_message = peek_retval.as_bool();
         self.event_info = None;
         let mut finished_event_info = Some(event_info);
+        let mut layouts = LAYOUT_CACHE.lock();
         if has_next_key_message {
           let next_msg = unsafe { next_msg.assume_init() };
           let next_msg_kind = next_msg.message;
@@ -298,9 +318,12 @@ impl KeyEventBuilder {
           return vec![];
         }
 
-        let mut layouts = LAYOUT_CACHE.lock();
-        let event_info =
-          PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Released, &mut layouts);
+        // Same reentrancy hazard as the key-press arm above: never hold
+        // LAYOUT_CACHE across `PeekMessageW`.
+        let event_info = {
+          let mut layouts = LAYOUT_CACHE.lock();
+          PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Released, &mut layouts)
+        };
         let mut next_msg = MaybeUninit::uninit();
         let peek_retval = unsafe {
           PeekMessageW(
@@ -313,6 +336,7 @@ impl KeyEventBuilder {
         };
         let has_next_key_message = peek_retval.as_bool();
         let mut valid_event_info = Some(event_info);
+        let mut layouts = LAYOUT_CACHE.lock();
         if has_next_key_message {
           let next_msg = unsafe { next_msg.assume_init() };
           let (_, layout) = layouts.get_current_layout();

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/window.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/window.rs
@@ -1357,7 +1357,7 @@ unsafe fn init<T: 'static>(
 
   KEY_EVENT_BUILDERS
     .lock()
-    .insert(win.id(), KeyEventBuilder::default());
+    .insert(win.id(), Some(KeyEventBuilder::default()));
 
   let _ = win.set_skip_taskbar(pl_attribs.skip_taskbar);
   win.set_window_icon(attributes.window_icon);


### PR DESCRIPTION
Fixes #640.

## The bug

`PeekMessageW` delivers pending cross-thread **sent** messages inline: the kernel re-enters the window procedure through `KiUserCallbackDispatcher` before the peek returns. Two non-reentrant `parking_lot::Mutex`es were held across such a peek, so the nested dispatch deadlocked the event-loop thread against itself — it parked in `WaitOnAddress` and never pumped a message again, leaving the window permanently `(Not Responding)`.

The reporter's native stack shows it directly (read bottom-up): `DispatchMessage` → wndproc chain → `PeekMessageW` → `NtUserPeekMessage` → `KiUserCallbackDispatcher` → **the same wndproc chain again** → `WaitOnAddress`. The `main` thread burned exactly 0 ms of CPU across three dumps 5 s apart, and Windows itself ghosted the window (Alt+F4 offered the "End task / Wait" dialog; the window was neither draggable nor focusable).

## The fix

- **`event_loop.rs`** — the keyboard callback held the global `KEY_EVENT_BUILDERS` map across `KeyEventBuilder::process_message`, which peeks. The builder is now taken out of the map for the duration and put back afterwards, only if the slot still exists (so a window dropped re-entrantly is not resurrected). The map value became an `Option` slot to make that take/put-back possible.
- **`keyboard.rs`** — the key-press and key-release arms held `LAYOUT_CACHE` across their peek, while every other arm *and* `update_modifiers` (reached from any mouse or focus message) lock it too. The guard is now scoped to end before the peek and re-acquired after it.

Both are needed: without the first, a nested key message blocks on the map; with only the first, a nested mouse message blocks on `LAYOUT_CACHE`.

Only injected or sent key messages can nest here — real keyboard input is posted to the queue rather than sent, and the peeks use `PM_NOREMOVE` so they never dispatch queued messages themselves. A nested key message therefore now finds an empty builder slot and is dropped instead of hanging the process.

## Verification

- Both deadlock sites are provable by inspection, and the reporter's stack matches their shape exactly.
- Keyboard input verified end-to-end on the patched native: `Tab`×4 + `Space` in the Jewel sample moves the focus ring and activates the theme button (focus traversal, `WM_KEYDOWN` → `WM_CHAR`, and activation all still work).
- **Not** verified by an automated before/after repro. I could only trigger the hang once in eight local attempts: cross-process `SendMessage` hammering alone does not nest (Windows will not re-enter a sent-message handler with another send), and I could not recreate what the shell does during a virtual-desktop move. The reporter reproduces it 100% of the time, so this PR's Windows x64 package (`test-packages-Windows-amd64`, contains the portable `.exe`) is going to them for confirmation.

## Upstream: this is a `tao` defect, already fixed upstream

The faulty code is upstream `tao` verbatim — none of our 51 `PATCH(nucleus)` markers is anywhere near it. Upstream fixed both hazards in [tauri-apps/tao#1215](https://github.com/tauri-apps/tao/pull/1215), *"fix(windows): avoid reentrant input lock deadlocks"* (merged 10 June 2026, shipped in **tao 0.36.0**), and their fix does the same thing this PR does: move the `PeekMessage` calls out of the locked sections and narrow the layout-cache lock scope. `keyboard.rs` upstream even carries the comment `// We MUST release the layout lock before calling next_kbd_msg, otherwise it may deadlock`.

We vendor **0.35.0**, which predates it. Notable: upstream's reporter hit the same deadlock through **RDP disconnections** rather than virtual desktops — different trigger, identical mechanism.

So this is independent corroboration of the diagnosis, not a guess. It also means no current Tauri app is exposed. Our exposure was higher than a Tauri app's even on 0.35, because WebView2 owns its own child HWND and handles keyboard input there, whereas Compose gets every keystroke through this tao path.

### Why this is a hand-applied fix and not a bump

[tao#1231](https://github.com/tauri-apps/tao/pull/1231) removed Windows window subclassing, restructuring `SubclassInput<T>` into userdata `WindowData<T>` — exactly the code our Windows patches live in (8 markers in `windows/event_loop.rs`, 5 in `window_state.rs`, 4 in `windows/window.rs`). Those patches would have to be re-authored, not rebased, so a bump is a rewrite. We own this fork, and upstream fixes have to be harvested by hand.

#644 tracks the two other upstream deadlock fixes we are still missing: the IME half of #1215, and the `TaskbarCreated` one from [tao#1264](https://github.com/tauri-apps/tao/pull/1264).
