### PR TITLE
fix(tao): release Windows input locks before pumping calls (#644)

### DIFF
--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
@@ -54,7 +54,7 @@ use crate::{
   platform_impl::platform::{
     dark_mode::try_window_theme,
     dpi::{become_dpi_aware, dpi_to_scale_factor, enable_non_client_dpi_scaling},
-    ime::{is_msg_ime_related, ImeEvent},
+    ime::{is_msg_ime_related, peek_commit_queued, ImeEvent},
     keyboard::is_msg_keyboard_related,
     keyboard_layout::LAYOUT_CACHE,
     monitor::{self, MonitorHandle},
@@ -1033,11 +1033,20 @@ unsafe fn public_window_callback_inner<T: 'static>(
     if !is_ime_related {
       return;
     }
+    // Peek the queue BEFORE taking the window-state lock. `process_message`
+    // used to do this peek itself, with the lock held, which deadlocks the
+    // event-loop thread against itself: `PeekMessageW` delivers pending
+    // cross-thread sent messages inline (the kernel re-enters this window
+    // procedure through `KiUserCallbackDispatcher`), and nearly every arm
+    // below locks the window state. Same bug class as the keyboard one in
+    // #640, and a wider one — there only the keyboard arm took the lock,
+    // here almost everything does. Fixed upstream in tauri-apps/tao#1215.
+    let commit_queued = peek_commit_queued(window, msg);
     let events = {
       let mut window_state = subclass_input.window_state.lock();
       window_state
         .ime_handler
-        .process_message(window, msg, wparam, lparam, &mut result)
+        .process_message(window, msg, wparam, lparam, commit_queued, &mut result)
     };
     for ime_event in events {
       let event = match ime_event {
@@ -2347,8 +2356,14 @@ unsafe fn public_window_callback_inner<T: 'static>(
         update_theme(subclass_input, window, false);
         result = ProcResult::Value(LRESULT(0));
       } else if msg == *S_U_TASKBAR_RESTART {
-        let window_state = subclass_input.window_state.lock();
-        let _ = set_skip_taskbar(window, window_state.skip_taskbar);
+        // Read the flag out and release the lock before the COM call.
+        // `set_skip_taskbar` goes through `CoCreateInstance` +
+        // `ITaskbarList`, and an STA COM call pumps the message queue while
+        // it waits — so the window procedure is re-entered and any arm that
+        // locks the window state deadlocks. Fixed upstream in
+        // tauri-apps/tao#1264.
+        let skip_taskbar = subclass_input.window_state.lock().skip_taskbar;
+        let _ = set_skip_taskbar(window, skip_taskbar);
       }
     }
   };

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/ime.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/ime.rs
@@ -59,8 +59,13 @@ pub(crate) trait ImeSource {
 }
 
 /// Reads the live input context of `hwnd`.
+///
+/// `commit_queued` is passed in rather than peeked on demand: the peek must
+/// happen before the caller takes the window-state lock — see
+/// [`peek_commit_queued`].
 struct Imm32Source {
   hwnd: HWND,
+  commit_queued: bool,
 }
 
 impl ImeSource for Imm32Source {
@@ -75,22 +80,44 @@ impl ImeSource for Imm32Source {
   }
 
   fn commit_is_queued(&self) -> bool {
-    let mut msg = MaybeUninit::uninit();
-    let has_message = unsafe {
-      PeekMessageW(
-        msg.as_mut_ptr(),
-        Some(self.hwnd),
-        win32wm::WM_IME_COMPOSITION,
-        win32wm::WM_IME_COMPOSITION,
-        PM_NOREMOVE,
-      )
-    };
-    if !has_message.as_bool() {
-      return false;
-    }
-    let msg = unsafe { msg.assume_init() };
-    msg.lParam.0 as u32 & GCS_RESULTSTR.0 != 0
+    self.commit_queued
   }
+}
+
+/// Answers [`ImeSource::commit_is_queued`] for a real window, by peeking the
+/// message queue.
+///
+/// **Must be called before the window-state lock is taken.** `PeekMessageW`
+/// delivers pending cross-thread *sent* messages inline — the kernel re-enters
+/// the window procedure through `KiUserCallbackDispatcher` before the peek
+/// returns — and nearly every window-procedure arm locks the window state.
+/// Peeking while that lock is held therefore deadlocks the event-loop thread
+/// against itself: it parks in `WaitOnAddress` and never pumps a message
+/// again. Same bug class as the keyboard one in
+/// NucleusFramework/Nucleus#640, fixed upstream in tauri-apps/tao#1215.
+///
+/// Only `WM_IME_ENDCOMPOSITION` consults the queue (see the matching arm in
+/// [`ImeHandler::process_message_with`]), so every other message skips the
+/// syscall — and the inline message delivery it would trigger.
+pub(crate) fn peek_commit_queued(hwnd: HWND, msg_kind: u32) -> bool {
+  if msg_kind != win32wm::WM_IME_ENDCOMPOSITION {
+    return false;
+  }
+  let mut msg = MaybeUninit::uninit();
+  let has_message = unsafe {
+    PeekMessageW(
+      msg.as_mut_ptr(),
+      Some(hwnd),
+      win32wm::WM_IME_COMPOSITION,
+      win32wm::WM_IME_COMPOSITION,
+      PM_NOREMOVE,
+    )
+  };
+  if !has_message.as_bool() {
+    return false;
+  }
+  let msg = unsafe { msg.assume_init() };
+  msg.lParam.0 as u32 & GCS_RESULTSTR.0 != 0
 }
 
 pub fn is_msg_ime_related(msg_kind: u32) -> bool {
@@ -228,12 +255,15 @@ impl ImeHandler {
 }
 
 impl ImeHandler {
+  /// `commit_queued` must come from [`peek_commit_queued`], called *before*
+  /// the caller locked the window state.
   pub(crate) fn process_message(
     &mut self,
     hwnd: HWND,
     msg_kind: u32,
     wparam: WPARAM,
     lparam: LPARAM,
+    commit_queued: bool,
     result: &mut ProcResult,
   ) -> Vec<ImeEvent> {
     // `WM_IME_SETCONTEXT` is the one message whose handling *is* the Win32
@@ -248,7 +278,10 @@ impl ImeHandler {
       return Vec::new();
     }
 
-    let source = Imm32Source { hwnd };
+    let source = Imm32Source {
+      hwnd,
+      commit_queued,
+    };
     self.process_message_with(&source, msg_kind, wparam, lparam, result)
   }
 


### PR DESCRIPTION
Fixes #644.

Two more instances of the #640 bug class, both already fixed upstream and ported by hand (a `tao` bump is not viable — see #644 for why). Same shape in each case: a non-reentrant lock held across a call that pumps or synchronously sends messages, so a nested window-procedure dispatch re-locks it and the event-loop thread parks in `WaitOnAddress` for good.

## 1. IME — `window_state` held across a `PeekMessageW`

The window-state lock was held across `ImeHandler::process_message`, which peeks the queue on `WM_IME_ENDCOMPOSITION`. That peek exists for a good reason: the Korean IME sends `WM_IME_ENDCOMPOSITION` *before* the `WM_IME_COMPOSITION` carrying the committed string, so the queue decides whether to defer the end. But `PeekMessageW` delivers pending cross-thread sent messages inline, re-entering the window procedure.

**Wider blast radius than #640.** There, `KEY_EVENT_BUILDERS` was only taken by the keyboard arm, so the nested message had to be keyboard-related. `window_state` is locked by nearly every arm — mouse, focus, size, theme — so *any* nested message deadlocked. Trigger: end of an IME composition, i.e. CJK users.

The peek moved into a free function `ime::peek_commit_queued(hwnd, msg_kind)`, called before the lock, with the result passed into `process_message`. This mirrors upstream, whose summary reads *"IME character-pending detection happens before acquiring window state locks"*. It also skips the syscall entirely for every message other than `WM_IME_ENDCOMPOSITION`, which is the only arm that consults the queue.

Upstream: [tauri-apps/tao#1215](https://github.com/tauri-apps/tao/pull/1215) (tao 0.36.0) — the same PR that fixed the keyboard half we ported in #642.

## 2. `TaskbarCreated` — `window_state` held across STA COM calls

The lock was held across `set_skip_taskbar`, which does `com_initialized()` + `CoCreateInstance` + `ITaskbarList::AddTab`/`DeleteTab`. An STA COM call **pumps the message queue** while it waits, so the window procedure is re-entered and any arm locking `window_state` deadlocks. The flag is now read out and the guard released before the call.

Trigger: Explorer restarting — it broadcasts `TaskbarCreated` to every top-level window. Uncommon but real.

Upstream: [tauri-apps/tao#1264](https://github.com/tauri-apps/tao/pull/1264) (tao 0.36.0).

The sibling path `Window::set_skip_taskbar` was already safe (its guards are released before the COM call), so only the broadcast handler changed — matching upstream's fix exactly.

## Verification

These are hand-ports of upstream fixes that upstream validated, so they were not re-tested here beyond the build gate: `cargo check` is clean and `buildNativeWindows` produces the DLLs.

One thing I could not run: tao's own IME state-machine unit tests. The vendored crate is not a workspace member, so `cargo test -p tao` refuses ("requires dev-dependencies and is not a member of the workspace"). The change is compatible with them by construction — `ImeSource` is untouched and the tests drive `process_message_with` through their own stub; only `Imm32Source` (the production implementation) and `process_message`'s signature changed.

## Not ported

Two further upstream items from #644 are deliberately left out:

- **0.36.0** *"fix `Window` functions panics after the parent event loop dropped, they log the errors instead"* — worth having (a Rust panic crossing our JNI boundary is a process crash), but it touches many `Window` methods and would collide with our patches. Better as its own change.
- **0.37.0** *"skip `set_skip_taskbar` if `skip_taskbar` is false"* — pure optimization, and our `PATCH(nucleus)` in `set_skip_taskbar` deliberately mirrors both `SKIP_TASKBAR` and `ON_TASKBAR` into `WindowFlags` so the choice survives every `apply_diff`. Skipping the call risks changing that behaviour for no correctness gain.
