### PR TITLE
fix(tao): port the Windows re-entrancy deadlock fixes to 2.6 (#640, #644)

### DIFF
--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
@@ -54,7 +54,7 @@ use crate::{
   platform_impl::platform::{
     dark_mode::try_window_theme,
     dpi::{become_dpi_aware, dpi_to_scale_factor, enable_non_client_dpi_scaling},
-    ime::{is_msg_ime_related, ImeEvent},
+    ime::{is_msg_ime_related, peek_commit_queued, ImeEvent},
     keyboard::is_msg_keyboard_related,
     keyboard_layout::LAYOUT_CACHE,
     monitor::{self, MonitorHandle},
@@ -1033,11 +1033,20 @@ unsafe fn public_window_callback_inner<T: 'static>(
     if !is_ime_related {
       return;
     }
+    // Peek the queue BEFORE taking the window-state lock. `process_message`
+    // used to do this peek itself, with the lock held, which deadlocks the
+    // event-loop thread against itself: `PeekMessageW` delivers pending
+    // cross-thread sent messages inline (the kernel re-enters this window
+    // procedure through `KiUserCallbackDispatcher`), and nearly every arm
+    // below locks the window state. Same bug class as the keyboard one in
+    // #640, and a wider one — there only the keyboard arm took the lock,
+    // here almost everything does. Fixed upstream in tauri-apps/tao#1215.
+    let commit_queued = peek_commit_queued(window, msg);
     let events = {
       let mut window_state = subclass_input.window_state.lock();
       window_state
         .ime_handler
-        .process_message(window, msg, wparam, lparam, &mut result)
+        .process_message(window, msg, wparam, lparam, commit_queued, &mut result)
     };
     for ime_event in events {
       let event = match ime_event {
@@ -2347,8 +2356,14 @@ unsafe fn public_window_callback_inner<T: 'static>(
         update_theme(subclass_input, window, false);
         result = ProcResult::Value(LRESULT(0));
       } else if msg == *S_U_TASKBAR_RESTART {
-        let window_state = subclass_input.window_state.lock();
-        let _ = set_skip_taskbar(window, window_state.skip_taskbar);
+        // Read the flag out and release the lock before the COM call.
+        // `set_skip_taskbar` goes through `CoCreateInstance` +
+        // `ITaskbarList`, and an STA COM call pumps the message queue while
+        // it waits — so the window procedure is re-entered and any arm that
+        // locks the window state deadlocks. Fixed upstream in
+        // tauri-apps/tao#1264.
+        let skip_taskbar = subclass_input.window_state.lock().skip_taskbar;
+        let _ = set_skip_taskbar(window, skip_taskbar);
       }
     }
   };

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
@@ -972,12 +972,43 @@ unsafe fn public_window_callback_inner<T: 'static>(
       return;
     }
     let events = {
-      let mut key_event_builders =
-        crate::platform_impl::platform::keyboard::KEY_EVENT_BUILDERS.lock();
-      if let Some(key_event_builder) = key_event_builders.get_mut(&WindowId(window.0 as _)) {
-        key_event_builder.process_message(window, msg, wparam, lparam, &mut result)
-      } else {
-        Vec::new()
+      use crate::platform_impl::platform::keyboard::KEY_EVENT_BUILDERS;
+      let window_id = WindowId(window.0 as _);
+
+      // Take the builder OUT of the map for the duration of
+      // `process_message` rather than holding the map lock across it.
+      // `process_message` calls `PeekMessageW`, and PeekMessage delivers
+      // pending cross-thread *sent* messages inline — the kernel re-enters
+      // this very window procedure through `KiUserCallbackDispatcher`.
+      // Holding the non-reentrant `KEY_EVENT_BUILDERS` mutex across that
+      // re-entry deadlocks the event-loop thread against itself: it parks in
+      // `WaitOnAddress` and never pumps a message again, so the window goes
+      // "Not Responding" for good (NucleusFramework/Nucleus#640, hit while
+      // moving a window between Windows 11 virtual desktops — that path is
+      // keyboard-triggered and makes the shell send messages to the window
+      // mid-peek).
+      //
+      // While the builder is taken, a nested key message finds an empty slot
+      // and is dropped. That is the right trade-off: only injected or sent
+      // key messages can nest here, since real keyboard input is posted to
+      // the queue rather than sent, and `process_message` peeks with
+      // PM_NOREMOVE so it never dispatches queued messages itself.
+      let taken = KEY_EVENT_BUILDERS
+        .lock()
+        .get_mut(&window_id)
+        .and_then(Option::take);
+
+      match taken {
+        Some(mut key_event_builder) => {
+          let events = key_event_builder.process_message(window, msg, wparam, lparam, &mut result);
+          // Put it back only if the slot still exists: the window may have
+          // been dropped (which removes its slot) while we were processing.
+          if let Some(slot) = KEY_EVENT_BUILDERS.lock().get_mut(&window_id) {
+            *slot = Some(key_event_builder);
+          }
+          events
+        }
+        None => Vec::new(),
       }
     };
     for event in events {

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/ime.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/ime.rs
@@ -59,8 +59,13 @@ pub(crate) trait ImeSource {
 }
 
 /// Reads the live input context of `hwnd`.
+///
+/// `commit_queued` is passed in rather than peeked on demand: the peek must
+/// happen before the caller takes the window-state lock — see
+/// [`peek_commit_queued`].
 struct Imm32Source {
   hwnd: HWND,
+  commit_queued: bool,
 }
 
 impl ImeSource for Imm32Source {
@@ -75,22 +80,44 @@ impl ImeSource for Imm32Source {
   }
 
   fn commit_is_queued(&self) -> bool {
-    let mut msg = MaybeUninit::uninit();
-    let has_message = unsafe {
-      PeekMessageW(
-        msg.as_mut_ptr(),
-        Some(self.hwnd),
-        win32wm::WM_IME_COMPOSITION,
-        win32wm::WM_IME_COMPOSITION,
-        PM_NOREMOVE,
-      )
-    };
-    if !has_message.as_bool() {
-      return false;
-    }
-    let msg = unsafe { msg.assume_init() };
-    msg.lParam.0 as u32 & GCS_RESULTSTR.0 != 0
+    self.commit_queued
   }
+}
+
+/// Answers [`ImeSource::commit_is_queued`] for a real window, by peeking the
+/// message queue.
+///
+/// **Must be called before the window-state lock is taken.** `PeekMessageW`
+/// delivers pending cross-thread *sent* messages inline — the kernel re-enters
+/// the window procedure through `KiUserCallbackDispatcher` before the peek
+/// returns — and nearly every window-procedure arm locks the window state.
+/// Peeking while that lock is held therefore deadlocks the event-loop thread
+/// against itself: it parks in `WaitOnAddress` and never pumps a message
+/// again. Same bug class as the keyboard one in
+/// NucleusFramework/Nucleus#640, fixed upstream in tauri-apps/tao#1215.
+///
+/// Only `WM_IME_ENDCOMPOSITION` consults the queue (see the matching arm in
+/// [`ImeHandler::process_message_with`]), so every other message skips the
+/// syscall — and the inline message delivery it would trigger.
+pub(crate) fn peek_commit_queued(hwnd: HWND, msg_kind: u32) -> bool {
+  if msg_kind != win32wm::WM_IME_ENDCOMPOSITION {
+    return false;
+  }
+  let mut msg = MaybeUninit::uninit();
+  let has_message = unsafe {
+    PeekMessageW(
+      msg.as_mut_ptr(),
+      Some(hwnd),
+      win32wm::WM_IME_COMPOSITION,
+      win32wm::WM_IME_COMPOSITION,
+      PM_NOREMOVE,
+    )
+  };
+  if !has_message.as_bool() {
+    return false;
+  }
+  let msg = unsafe { msg.assume_init() };
+  msg.lParam.0 as u32 & GCS_RESULTSTR.0 != 0
 }
 
 pub fn is_msg_ime_related(msg_kind: u32) -> bool {
@@ -228,12 +255,15 @@ impl ImeHandler {
 }
 
 impl ImeHandler {
+  /// `commit_queued` must come from [`peek_commit_queued`], called *before*
+  /// the caller locked the window state.
   pub(crate) fn process_message(
     &mut self,
     hwnd: HWND,
     msg_kind: u32,
     wparam: WPARAM,
     lparam: LPARAM,
+    commit_queued: bool,
     result: &mut ProcResult,
   ) -> Vec<ImeEvent> {
     // `WM_IME_SETCONTEXT` is the one message whose handling *is* the Win32
@@ -248,7 +278,10 @@ impl ImeHandler {
       return Vec::new();
     }
 
-    let source = Imm32Source { hwnd };
+    let source = Imm32Source {
+      hwnd,
+      commit_queued,
+    };
     self.process_message_with(&source, msg_kind, wparam, lparam, result)
   }
 

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/keyboard.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/keyboard.rs
@@ -59,7 +59,14 @@ pub struct MessageAsKeyEvent {
   pub is_synthetic: bool,
 }
 
-pub(crate) static KEY_EVENT_BUILDERS: Lazy<Mutex<HashMap<WindowId, KeyEventBuilder>>> =
+/// Per-window key event builders.
+///
+/// The value is an `Option` slot so a message handler can *take* the builder
+/// out for the duration of `KeyEventBuilder::process_message` instead of
+/// holding this mutex across it — see the take/put-back in
+/// `event_loop::public_window_callback` and issue
+/// NucleusFramework/Nucleus#640.
+pub(crate) static KEY_EVENT_BUILDERS: Lazy<Mutex<HashMap<WindowId, Option<KeyEventBuilder>>>> =
   Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Stores information required to make `KeyEvent`s.
@@ -133,9 +140,21 @@ impl KeyEventBuilder {
           *result = ProcResult::Value(LRESULT(0));
         }
 
-        let mut layouts = LAYOUT_CACHE.lock();
-        let event_info =
-          PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Pressed, &mut layouts);
+        // The LAYOUT_CACHE guard is deliberately scoped to end before the
+        // `PeekMessageW` below and re-acquired after it. `PeekMessageW`
+        // delivers pending cross-thread `SendMessage`s inline (the kernel
+        // re-enters this window procedure through
+        // `KiUserCallbackDispatcher`), and every other arm of this function
+        // locks LAYOUT_CACHE too. Holding a non-reentrant `parking_lot::Mutex`
+        // across the peek therefore deadlocks the whole event loop against
+        // itself — the thread parks in `WaitOnAddress` and never pumps again
+        // (NucleusFramework/Nucleus#640: reproducible while switching Windows
+        // 11 virtual desktops, which is keyboard-triggered and makes the shell
+        // send messages to the window mid-peek).
+        let event_info = {
+          let mut layouts = LAYOUT_CACHE.lock();
+          PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Pressed, &mut layouts)
+        };
 
         let mut next_msg = MaybeUninit::uninit();
         let peek_retval = unsafe {
@@ -150,6 +169,7 @@ impl KeyEventBuilder {
         let has_next_key_message = peek_retval.as_bool();
         self.event_info = None;
         let mut finished_event_info = Some(event_info);
+        let mut layouts = LAYOUT_CACHE.lock();
         if has_next_key_message {
           let next_msg = unsafe { next_msg.assume_init() };
           let next_msg_kind = next_msg.message;
@@ -298,9 +318,12 @@ impl KeyEventBuilder {
           return vec![];
         }
 
-        let mut layouts = LAYOUT_CACHE.lock();
-        let event_info =
-          PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Released, &mut layouts);
+        // Same reentrancy hazard as the key-press arm above: never hold
+        // LAYOUT_CACHE across `PeekMessageW`.
+        let event_info = {
+          let mut layouts = LAYOUT_CACHE.lock();
+          PartialKeyEventInfo::from_message(wparam, lparam, ElementState::Released, &mut layouts)
+        };
         let mut next_msg = MaybeUninit::uninit();
         let peek_retval = unsafe {
           PeekMessageW(
@@ -313,6 +336,7 @@ impl KeyEventBuilder {
         };
         let has_next_key_message = peek_retval.as_bool();
         let mut valid_event_info = Some(event_info);
+        let mut layouts = LAYOUT_CACHE.lock();
         if has_next_key_message {
           let next_msg = unsafe { next_msg.assume_init() };
           let (_, layout) = layouts.get_current_layout();

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/window.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/window.rs
@@ -1357,7 +1357,7 @@ unsafe fn init<T: 'static>(
 
   KEY_EVENT_BUILDERS
     .lock()
-    .insert(win.id(), KeyEventBuilder::default());
+    .insert(win.id(), Some(KeyEventBuilder::default()));
 
   let _ = win.set_skip_taskbar(pl_attribs.skip_taskbar);
   win.set_window_icon(attributes.window_icon);


### PR DESCRIPTION
Ports the three Windows re-entrancy deadlocks fixed on `main` to the 2.6 line. Clean cherry-pick of `c20018a5` (#642, fixes #640) and `3c105d2d` (#645, fixes #644) — the affected files were byte-identical between the two branches, so there were no conflicts, and `cargo check` is clean here.

All three are the same bug class: a non-reentrant lock held across a call that pumps or synchronously sends messages, so a nested window-procedure dispatch re-locks it and the event-loop thread parks in `WaitOnAddress` for good — the window goes `(Not Responding)` and never recovers.

| Lock | Held across | Trigger | Upstream |
|---|---|---|---|
| `KEY_EVENT_BUILDERS` (global map) | `KeyEventBuilder::process_message` → `PeekMessageW` | any key message + a pending cross-thread sent message | [tao#1215](https://github.com/tauri-apps/tao/pull/1215) |
| `LAYOUT_CACHE` (global) | `PeekMessageW` in the key-press / key-release arms | same, via a nested mouse or focus message | [tao#1215](https://github.com/tauri-apps/tao/pull/1215) |
| `window_state` | IME end-of-composition peek | end of an IME composition (CJK users) | [tao#1215](https://github.com/tauri-apps/tao/pull/1215) |
| `window_state` | `set_skip_taskbar` → STA COM calls, which pump | Explorer restarting (`TaskbarCreated` broadcast) | [tao#1264](https://github.com/tauri-apps/tao/pull/1264) |

These are `tao` defects, not Nucleus ones, and all were fixed upstream in tao 0.36.0. We vendor 0.35.0 and cannot bump — [tao#1231](https://github.com/tauri-apps/tao/pull/1231) removed Windows window subclassing, restructuring the code our `PATCH(nucleus)` set lives in — so they are hand-ported.

Reported by a user as a permanent freeze when moving a window to another virtual desktop on Windows 11 (#640). The same upstream defect had already surfaced through two other triggers: Alt+Tab during startup ([tauri#12531](https://github.com/tauri-apps/tauri/issues/12531)) and RDP disconnection (tao#1215).

Shipped on the 2.5 line as `v2.5.13`.
