### PR TITLE
Tao: converge a v2 bounds request after a placement toggle storm

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NucleusWindowV2Bridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NucleusWindowV2Bridge.kt
@@ -147,9 +147,14 @@ internal fun BindNucleusWindowState(
     val latestV1 = v1
     val latestNativeWindow by rememberUpdatedState(nativeWindow)
     LaunchedEffect(v2, v1) {
+        // When the last placement was handed to v1. Both consumers below run on
+        // this effect's dispatcher (the Tao main thread), so a plain var is the
+        // whole synchronisation story.
+        var placementAppliedNs = Long.MIN_VALUE
         launch {
             for (placement in latestV2.placementRequests) {
                 latestV1.placement = placement
+                placementAppliedNs = System.nanoTime()
             }
         }
         launch {
@@ -168,6 +173,16 @@ internal fun BindNucleusWindowState(
                 val nativeStuck =
                     !v1LeavesPlacement && window != null && (window.isMaximized || window.isFullscreen)
                 val leftPlacement = v1LeavesPlacement || nativeStuck
+                // …and even the native flags are only a sample. AppKit clears
+                // `isZoomed` *before* it animates, so right after a toggle both
+                // the v1 bookkeeping and the flags can read Floating while the
+                // zoom that will re-assert the old frame has not landed yet —
+                // and then it lands on top of the bounds we are about to apply,
+                // with nobody watching, because `leftPlacement` said there was
+                // nothing to leave. A placement applied moments ago is therefore
+                // its own reason to confirm the result.
+                val placementInFlight =
+                    System.nanoTime() - placementAppliedNs < PLACEMENT_IN_FLIGHT_GRACE_NS
                 if (leftPlacement) {
                     // Bounds on a non-floating window make it floating (the v2
                     // contract) — but the restore is asynchronous, and on macOS
@@ -189,7 +204,9 @@ internal fun BindNucleusWindowState(
                 val resolved = resolveBounds(provider, latestV1, latestNativeWindow)
                 latestV1.size = resolved.size
                 latestV1.position = resolved.position
-                if (leftPlacement) latestNativeWindow?.let { confirmBounds(it, latestV1, resolved) }
+                if (leftPlacement || placementInFlight) {
+                    latestNativeWindow?.let { confirmBounds(it, latestV1, resolved) }
+                }
             }
         }
         launch {
@@ -702,11 +719,30 @@ private suspend fun confirmBounds(
                     kotlin.math.abs((outer.left - position.x).value) <= CONFIRM_TOLERANCE_DP &&
                         kotlin.math.abs((outer.top - position.y).value) <= CONFIRM_TOLERANCE_DP
                 )
-        if (sizeOk && positionOk) return
-        // A frame that went back to the zoomed size means the native placement
-        // reasserted itself; clear it before re-applying (on macOS by the
-        // re-apply itself — see restoreAndAwaitFloating).
-        if (window.isMaximized || window.isFullscreen) restoreAndAwaitFloating(window)
+        // A re-asserted placement is a failure to converge in its own right, and
+        // it has to be tested *before* the geometry: a maximized window ignores
+        // v1's size, so `decorationInsets` derives the insets from a target that
+        // never landed (2560 outer - 820 target = 1740 of "decoration"), and the
+        // subtraction above then reports `sizeOk` for any outer rectangle at all.
+        val placementClear = !window.isMaximized && !window.isFullscreen
+        if (placementClear && sizeOk && positionOk) return
+        if (!placementClear) {
+            // Clearing it is v1's job, not ours. `setMaximized(false)` is a
+            // `zoom:` toggle on macOS, and the window composable's placement
+            // effect issues exactly one when v1 goes Floating while its own
+            // `applied` bookkeeping still reads Maximized — which is precisely
+            // what a late zoom leaves behind, since the resize it triggers
+            // writes Maximized into both. Poking the native flag here instead
+            // would race that effect and re-zoom. Only when v1 already reads
+            // Floating (its effect stays idle) does the bridge clear the native
+            // state itself.
+            if (v1.placement != WindowPlacement.Floating) {
+                v1.placement = WindowPlacement.Floating
+                awaitFloating(window)
+            } else {
+                restoreAndAwaitFloating(window)
+            }
+        }
         v1.size = target.size
         v1.position = target.position
     }
@@ -744,6 +780,15 @@ private suspend fun awaitSettled(window: TaoWindow) {
         delay(PLACEMENT_RESTORE_RETRY_MS)
     }
 }
+
+/**
+ * How long after a placement was applied a bounds request still has to confirm
+ * its result. Covers a queued `zoom:` animation whose final frame lands after
+ * the bounds were applied; long enough for a burst of them to drain, short
+ * enough that ordinary geometry requests — a frame-paced move sends one per
+ * frame through the same channel — never pay for the confirmation.
+ */
+private const val PLACEMENT_IN_FLIGHT_GRACE_NS = 1_000_000_000L
 
 private const val PLACEMENT_RESTORE_RETRIES = 60
 private const val PLACEMENT_RESTORE_RETRY_MS = 50L

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/WindowApiV2HeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/WindowApiV2HeadfulCases.kt
@@ -344,7 +344,14 @@ internal object WindowApiV2HeadfulCases {
                     bottom = available.top + SCOPED_INSET + SCOPED_SIZE.height,
                 )
             state.requestBounds(rect)
-            awaitUntil("final bounds applied after the toggling storm", timeoutMillis = LONG_AWAIT_MS) {
+            awaitUntil(
+                "final bounds applied after the toggling storm",
+                timeoutMillis = LONG_AWAIT_MS,
+                detail = {
+                    "placement=${state.placement} outer=${outerDp()} wanted=$SCOPED_SIZE " +
+                        "maximized=${window.isMaximized} fullscreen=${window.isFullscreen}"
+                },
+            ) {
                 val outer = outerDp()
                 state.placement == WindowPlacement.Floating &&
                     closeEnough(SCOPED_SIZE.width.value, outer.width) &&


### PR DESCRIPTION
Fixes the `tao-headful` case `window v2 clone: rapid maximize/restore toggling then a bounds request converges`, which timed out at 30 s — 100% reproducible on one machine, intermittent on CI (it passed on `macos-latest` twice and failed once over the last two days).

Not a test problem: spamming `requestPlacement` faster than the OS animation and then asking for bounds leaves the window maximized on macOS and drops the bounds request on the floor. That is a legitimate use of the v2 API.

## Two defects, both required for the failure

**1. `leftPlacement` was a single sample.** The bridge decided whether it had a placement to leave from `v1.placement` plus the native flags, read once. AppKit clears `isZoomed` at the *start* of the un-zoom animation, so right after a toggle both read Floating while a queued `zoom:` has not landed. Instrumented:

```
[v2-probe] bounds req: v1.placement=Floating nativeMax=false nativeFs=false v1Leaves=false nativeStuck=false
[v2-probe] after restore: nativeMax=false outer=[180, 58, 2199, 958] resolved=(pos 60,90 size 820x560)
[v2-probe] done:         nativeMax=false outer=[180, 58, 2199, 958]
… window then re-zooms to 0,30 2560x1050 and stays there
```

So the bounds were applied to a window that was about to re-zoom, and `confirmBounds` — whose entire purpose is catching that — was skipped, because it is gated on the same flag. A placement applied within the last second is now its own reason to confirm.

**2. `confirmBounds` could not have recovered anyway.** It returned as soon as the geometry matched, never asking whether a placement had come back — and its size check cannot see one:

```
[cb] attempt outer=(0,30,2560,1080) insets=0x0       sizeOk=false posOk=false max=true v1.size=2560x1050
[cb] re-apply: v1.size=2560x1050 -> 820x560; max=true
[cb] attempt outer=(0,30,2560,1080) insets=1740x490  sizeOk=TRUE  posOk=false max=true v1.size=820x560
```

A maximized window ignores v1's size, so `decorationInsets(v1.size)` derives the insets from a target that never landed — 2560 outer − 820 target = 1740 dp of "decoration" — and `outer − insets − target` is then 0 for *any* outer rectangle. `sizeOk` is unfalsifiable after the first re-apply.

It now treats a re-asserted placement as a failure to converge in its own right, tested before the geometry, and clears it by handing `Floating` back to v1 so the window composable's placement effect issues the single `zoom:`. That is the same "who issues the restore matters" rule the bounds path already documents, and the reason poking the native flag here would race that effect and re-zoom.

## Test plan

- [x] the case: **PASS 3/3, 1.9 s** (was: FAIL 3/3, 30.6 s timeout)
- [x] whole `window v2 clone` suite: 11 run, 0 failed
- [x] full `taoHeadfulTest` on macOS: **205 run, 47 skipped, 0 failed**
- [x] `compileKotlin`, `detekt`, `ktlint` (main + test), `:decorated-window-tao:test`
- [ ] Windows / Linux headful in CI

Also adds a `detail` snapshot to that wait — a bare "timed out" is what made this expensive to diagnose.