### PR TITLE
fix(application): keep window content on the UI applier (#636)

### DIFF
--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -52,6 +52,13 @@ kotlin {
     }
 }
 
+// #636 regression guard: the Compose applier-mismatch diagnostic is a warning,
+// so ComposableTargetIsolationFixture would silently rot. Escalate it to an
+// error for the test compilation, where that fixture lives.
+tasks.named<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileTestKotlin") {
+    compilerOptions.freeCompilerArgs.add("-Xwarning-level=COMPOSE_APPLIER_CALL_MISMATCH:error")
+}
+
 // ── Native build ────────────────────────────────────────────────────────────
 // Tao + jni crate + per-platform helpers (Metal on macOS, WGL + WndProc deco
 // on Windows). Native binaries ship in src/main/resources/nucleus/native/.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
@@ -1,15 +1,22 @@
-@file:Suppress("MagicNumber")
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("MagicNumber", "ktlint:standard:annotation")
 
 package dev.nucleusframework.window.tao
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.dp
@@ -45,6 +52,7 @@ import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
  */
 @Suppress("LongParameterList", "FunctionNaming", "LongMethod")
 @Composable
+@ComposableOpenTarget(-1)
 public fun ApplicationScope.DecoratedDialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -61,7 +69,7 @@ public fun ApplicationScope.DecoratedDialog(
     // dialog content sees the parent window's theme/user locals without
     // hijacking popup routing. See [LocalTaoCompositionLocalContextBridge].
     compositionLocalContext: CompositionLocalContext? = null,
-    content: @Composable TaoDecoratedDialogScope.() -> Unit,
+    content: @Composable @UiComposable TaoDecoratedDialogScope.() -> Unit,
 ) {
     // Captured in the parent's composition: `LocalTaoWindow.current` here is
     // the enclosing DecoratedWindow's TaoWindow, not the dialog's own window

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -1,8 +1,14 @@
-@file:Suppress("MagicNumber")
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("MagicNumber", "ktlint:standard:annotation")
 
 package dev.nucleusframework.window.tao
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -11,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.key.KeyEvent
@@ -57,6 +64,7 @@ import kotlin.math.roundToInt
 @Suppress("LongParameterList", "FunctionNaming", "LongMethod", "CyclomaticComplexMethod")
 @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
+@ComposableOpenTarget(-1)
 public fun ApplicationScope.DecoratedWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -184,7 +192,7 @@ public fun ApplicationScope.DecoratedWindow(
      * does *not* give you (it is not `_NET_WM_WINDOW_TYPE_DESKTOP`).
      */
     alwaysOnBottom: Boolean = false,
-    content: @Composable TaoDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable TaoDecoratedWindowScope.() -> Unit,
 ) {
     val latestOnClose by rememberUpdatedState(onCloseRequest)
     val latestPreview by rememberUpdatedState(onPreviewKeyEvent)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
@@ -1,6 +1,14 @@
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.window.tao
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -8,6 +16,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
@@ -65,6 +74,7 @@ public fun isTaoStandalonePopupAvailable(): Boolean =
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun TaoStandalonePopup(
     visible: Boolean,
     position: WindowPosition.Absolute,
@@ -73,7 +83,7 @@ public fun TaoStandalonePopup(
     onOutsideClick: (() -> Unit)? = null,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null,
     onKeyEvent: ((KeyEvent) -> Boolean)? = null,
-    content: @Composable () -> Unit,
+    content: @Composable @UiComposable () -> Unit,
 ) {
     if (Platform.Current != Platform.Windows &&
         Platform.Current != Platform.MacOS &&

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/ComposableTargetIsolationFixture.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/ComposableTargetIsolationFixture.kt
@@ -1,0 +1,40 @@
+package dev.nucleusframework.window.tao
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableTarget
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPosition
+
+/**
+ * Compile-time regression fixture for #636 — Tao counterpart of the one in
+ * `nucleus-application`.
+ *
+ * [DecoratedWindow], [DecoratedDialog] and [TaoStandalonePopup] each host their
+ * content in a fresh `ComposeScene`, so they are declared
+ * `@ComposableOpenTarget(-1)` with a `@UiComposable` content lambda: callable
+ * from any applier, always composing UI content. `compileTestKotlin` escalates
+ * `COMPOSE_APPLIER_CALL_MISMATCH` to an error (see build.gradle.kts).
+ */
+@Composable
+@ComposableTarget(applier = "org.example.FakeApplier")
+private fun rememberNonUiTargetedState(): Any = remember { Any() }
+
+@Suppress("UnusedPrivateMember")
+private fun windowsStayUiRegardlessOfTheScopeApplier() {
+    taoApplication {
+        // Binds the application scope's applier to a non-UI one.
+        rememberNonUiTargetedState()
+
+        DecoratedWindow(onCloseRequest = ::exitApplication) { Box(Modifier) }
+        DecoratedDialog(onCloseRequest = ::exitApplication) { Box(Modifier) }
+        TaoStandalonePopup(
+            visible = false,
+            position = WindowPosition.Absolute(0.dp, 0.dp),
+            size = DpSize(1.dp, 1.dp),
+        ) { Box(Modifier) }
+    }
+}

--- a/nucleus-application/build.gradle.kts
+++ b/nucleus-application/build.gradle.kts
@@ -58,6 +58,13 @@ kotlin {
     }
 }
 
+// #636 regression guard: the Compose applier-mismatch diagnostic is a warning,
+// so ComposableTargetIsolationFixture would silently rot. Escalate it to an
+// error for the test compilation, where that fixture lives.
+tasks.named<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileTestKotlin") {
+    compilerOptions.freeCompilerArgs.add("-Xwarning-level=COMPOSE_APPLIER_CALL_MISMATCH:error")
+}
+
 /**
  * Live process E2E for the system-theme bridge (needs a display / D-Bus on Linux).
  * Not part of `check` — run explicitly: `./gradlew :nucleus-application:systemThemeE2E`

--- a/nucleus-application/detekt-baseline.xml
+++ b/nucleus-application/detekt-baseline.xml
@@ -13,7 +13,5 @@
     <ID>UndocumentedPublicFunction:NucleusWindow.kt:NucleusWindow$public fun setMinimumSize</ID>
     <ID>UndocumentedPublicFunction:NucleusWindow.kt:NucleusWindow$public fun show</ID>
     <ID>UndocumentedPublicFunction:NucleusWindow.kt:NucleusWindow$public fun toFront</ID>
-    <ID>UndocumentedPublicFunction:NucleusWindowHost.kt:NucleusDialogHost$@Composable public fun Dialog</ID>
-    <ID>UndocumentedPublicFunction:NucleusWindowHost.kt:NucleusWindowHost$@Composable public fun Window</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedDialog.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedDialog.kt
@@ -1,8 +1,17 @@
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.window.DialogState
@@ -18,6 +27,7 @@ import dev.nucleusframework.window.DecoratedDialog as AwtDecoratedDialog
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun NucleusApplicationScope.DecoratedDialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -29,7 +39,7 @@ public fun NucleusApplicationScope.DecoratedDialog(
     focusable: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
-    content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
 ) {
     when (this) {
         is AwtNucleusApplicationScope ->
@@ -88,6 +98,7 @@ public fun NucleusApplicationScope.DecoratedDialog(
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun DecoratedDialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -99,7 +110,7 @@ public fun DecoratedDialog(
     focusable: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
-    content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
 ) {
     LocalNucleusApplicationScope.current.DecoratedDialog(
         onCloseRequest = onCloseRequest,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -1,8 +1,17 @@
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.DpSize
@@ -20,6 +29,7 @@ import dev.nucleusframework.window.DecoratedWindow as AwtDecoratedWindow
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun NucleusApplicationScope.DecoratedWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -94,7 +104,7 @@ public fun NucleusApplicationScope.DecoratedWindow(
     // desktop widgets. Mutually exclusive with [alwaysOnTop] — last one set
     // wins. Reactive. Honoured by the Tao backend; the AWT backend ignores it.
     alwaysOnBottom: Boolean = false,
-    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
 ) {
     when (this) {
         is AwtNucleusApplicationScope ->
@@ -172,6 +182,7 @@ public fun NucleusApplicationScope.DecoratedWindow(
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun DecoratedWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -195,7 +206,7 @@ public fun DecoratedWindow(
     visibleOnAllWorkspaces: Boolean = false,
     forceX11: Boolean = false,
     alwaysOnBottom: Boolean = false,
-    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
 ) {
     LocalNucleusApplicationScope.current.DecoratedWindow(
         onCloseRequest = onCloseRequest,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindowHost.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindowHost.kt
@@ -1,8 +1,17 @@
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.DpSize
@@ -49,7 +58,13 @@ import androidx.compose.ui.window.rememberWindowState
  * `visibleOnAllWorkspaces`, `forceX11`) are not routed through the host.
  */
 public fun interface NucleusWindowHost {
+    /**
+     * Opens a window hosting [content] on the active backend. Callable from
+     * any applier — [content] is always composed as UI, in the new window's
+     * own composition.
+     */
     @Composable
+    @ComposableOpenTarget(-1)
     public fun Window(
         onCloseRequest: () -> Unit,
         state: WindowState,
@@ -69,7 +84,7 @@ public fun interface NucleusWindowHost {
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
         alwaysOnBottom: Boolean,
-        content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+        content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
     )
 }
 
@@ -83,7 +98,12 @@ public fun interface NucleusWindowHost {
  * Parameter surface matches [DecoratedDialog].
  */
 public fun interface NucleusDialogHost {
+    /**
+     * Opens a dialog hosting [content] on the active backend. Same applier
+     * contract as [NucleusWindowHost.Window].
+     */
     @Composable
+    @ComposableOpenTarget(-1)
     public fun Dialog(
         onCloseRequest: () -> Unit,
         state: DialogState,
@@ -95,7 +115,7 @@ public fun interface NucleusDialogHost {
         focusable: Boolean,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
-        content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+        content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
     )
 }
 
@@ -135,6 +155,7 @@ public val LocalNucleusDialogHost: ProvidableCompositionLocal<NucleusDialogHost>
  */
 public object DefaultNucleusWindowHost : NucleusWindowHost {
     @Composable
+    @ComposableOpenTarget(-1)
     override fun Window(
         onCloseRequest: () -> Unit,
         state: WindowState,
@@ -154,7 +175,7 @@ public object DefaultNucleusWindowHost : NucleusWindowHost {
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
         alwaysOnBottom: Boolean,
-        content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+        content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
     ) {
         DecoratedWindow(
             onCloseRequest = onCloseRequest,
@@ -186,6 +207,7 @@ public object DefaultNucleusWindowHost : NucleusWindowHost {
  */
 public object DefaultNucleusDialogHost : NucleusDialogHost {
     @Composable
+    @ComposableOpenTarget(-1)
     override fun Dialog(
         onCloseRequest: () -> Unit,
         state: DialogState,
@@ -197,7 +219,7 @@ public object DefaultNucleusDialogHost : NucleusDialogHost {
         focusable: Boolean,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
-        content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+        content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
     ) {
         DecoratedDialog(
             onCloseRequest = onCloseRequest,
@@ -226,6 +248,7 @@ public object DefaultNucleusDialogHost : NucleusDialogHost {
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun HostedWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -245,7 +268,7 @@ public fun HostedWindow(
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     alwaysOnBottom: Boolean = false,
-    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
 ) {
     LocalNucleusWindowHost.current.Window(
         onCloseRequest = onCloseRequest,
@@ -280,6 +303,7 @@ public fun HostedWindow(
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun HostedDialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -291,7 +315,7 @@ public fun HostedDialog(
     focusable: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
-    content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
 ) {
     LocalNucleusDialogHost.current.Dialog(
         onCloseRequest = onCloseRequest,

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/ComposableTargetIsolationFixture.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/ComposableTargetIsolationFixture.kt
@@ -1,0 +1,51 @@
+package dev.nucleusframework.application
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableTarget
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+/**
+ * Compile-time regression fixture for #636.
+ *
+ * Every window / dialog opener is declared `@ComposableOpenTarget(-1)` with a
+ * `@UiComposable` content lambda, so the applier a caller happens to be bound
+ * to never reaches the window content — and opening a window never binds the
+ * caller's applier either. Without that, one non-UI composable called in the
+ * `nucleusApplication` scope reclassified the whole scope (and every nested
+ * window) to that applier, and each `@UiComposable` call inside it warned —
+ * fatal under `-Werror`.
+ *
+ * `compileTestKotlin` escalates `COMPOSE_APPLIER_CALL_MISMATCH` to an error
+ * (see build.gradle.kts), so a regression fails the build here instead of in a
+ * consumer's app.
+ */
+@Composable
+@ComposableTarget(applier = "org.example.FakeApplier")
+private fun rememberNonUiTargetedState(): Any = remember { Any() }
+
+/**
+ * Unmarked wrapper, exactly like an app's own theme composable: the Compose
+ * compiler infers `[0[0]]` for it, so it forwards whatever applier the
+ * application scope was bound to.
+ */
+@Composable
+private fun InferredWrapper(content: @Composable () -> Unit) {
+    content()
+}
+
+@Suppress("UnusedPrivateMember")
+private fun windowsStayUiRegardlessOfTheScopeApplier() {
+    nucleusApplication(enableSingleInstance = false) {
+        // Binds the application scope's applier to a non-UI one.
+        rememberNonUiTargetedState()
+
+        InferredWrapper {
+            DecoratedWindow(onCloseRequest = ::exitApplication) { Box(Modifier) }
+            DecoratedDialog(onCloseRequest = ::exitApplication) { Box(Modifier) }
+            HostedWindow(onCloseRequest = ::exitApplication) { Box(Modifier) }
+            HostedDialog(onCloseRequest = ::exitApplication) { Box(Modifier) }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #636.

## Problem

The window/dialog openers had their Compose composition target **inferred**, and the inferred token correlated the caller's applier with the window content's. One non-UI-targeted composable in the `nucleusApplication` scope — the compiler bakes `@ComposableTarget(applier = …)` onto any unmarked state factory that forwards a target-marked content lambda, e.g. MapLibre Compose's `rememberMapState` — reclassified the whole scope, nested windows included, and every `@UiComposable` call inside warned. Warnings only, but fatal under `-Werror`.

## Fix

Declare each opener `@ComposableOpenTarget(-1)` with a `@UiComposable` content lambda — the shape Compose Desktop's own `Window`/`Dialog` use (`@ComposableOpenTarget(-1)`), plus the explicit UI content that Compose Desktop leaves inferred:

* callable from **any** applier → opening a window no longer binds the caller's scope;
* content is always **UI** → the caller's applier no longer reaches the window content.

Covered: `DecoratedWindow` / `DecoratedDialog` (both overloads each), the `NucleusWindowHost` / `NucleusDialogHost` interfaces + `DefaultNucleus*Host`, `HostedWindow` / `HostedDialog`, and Tao's `DecoratedWindow`, `DecoratedDialog`, `TaoStandalonePopup`. The Material 2/3 and Jewel wrappers pick the same scheme up through inference — verified in the bytecode, they all now read `[_[androidx.compose.ui.UiComposable]]`.

`nucleusApplication` itself keeps its inferred `[0[0]]` scheme, matching `androidx.compose.ui.window.application`.

## Regression guard

`COMPOSE_APPLIER_CALL_MISMATCH` is a warning, so `compileTestKotlin` in both modules escalates it to an error via `-Xwarning-level`, and a `ComposableTargetIsolationFixture` per module compiles the reported shape (non-UI-targeted factory in the application scope, UI content in every window). Removing any of the new annotations fails the build — verified.

## Verification

* Reproduced the original warnings with a fixture standing in for the MapLibre factory, and confirmed `androidx`'s `application` + `Window` produced the identical warning before the fix.
* `apiCheck`, `detekt`, `ktlintCheck` and `testClasses` pass project-wide (the pre-existing `:ktlintKotlinScriptCheck` and `examples:{rect-stress,widget}-demo:apiCheck` failures on `main` are untouched).
* No runtime change: both annotations are compile-time metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)