### PR TITLE
fix(application): keep window content on the UI applier (#636) [2.6]

### DIFF
--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -52,6 +52,13 @@ kotlin {
     }
 }
 
+// #636 regression guard: the Compose applier-mismatch diagnostic is a warning,
+// so ComposableTargetIsolationFixture would silently rot. Escalate it to an
+// error for the test compilation, where that fixture lives.
+tasks.named<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileTestKotlin") {
+    compilerOptions.freeCompilerArgs.add("-Xwarning-level=COMPOSE_APPLIER_CALL_MISMATCH:error")
+}
+
 // ── Native build ────────────────────────────────────────────────────────────
 // Tao + jni crate + per-platform helpers (Metal on macOS, WGL + WndProc deco
 // on Windows). Native binaries ship in src/main/resources/nucleus/native/.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedDialog.kt
@@ -1,15 +1,22 @@
-@file:Suppress("MagicNumber")
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("MagicNumber", "ktlint:standard:annotation")
 
 package dev.nucleusframework.window.tao
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.dp
@@ -45,6 +52,7 @@ import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDecoBridge
  */
 @Suppress("LongParameterList", "FunctionNaming", "LongMethod")
 @Composable
+@ComposableOpenTarget(-1)
 public fun ApplicationScope.DecoratedDialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -61,7 +69,7 @@ public fun ApplicationScope.DecoratedDialog(
     // dialog content sees the parent window's theme/user locals without
     // hijacking popup routing. See [LocalTaoCompositionLocalContextBridge].
     compositionLocalContext: CompositionLocalContext? = null,
-    content: @Composable TaoDecoratedDialogScope.() -> Unit,
+    content: @Composable @UiComposable TaoDecoratedDialogScope.() -> Unit,
 ) {
     // Captured in the parent's composition: `LocalTaoWindow.current` here is
     // the enclosing DecoratedWindow's TaoWindow, not the dialog's own window

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -1,8 +1,14 @@
-@file:Suppress("MagicNumber")
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("MagicNumber", "ktlint:standard:annotation")
 
 package dev.nucleusframework.window.tao
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -11,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.key.KeyEvent
@@ -57,6 +64,7 @@ import kotlin.math.roundToInt
 @Suppress("LongParameterList", "FunctionNaming", "LongMethod", "CyclomaticComplexMethod")
 @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
+@ComposableOpenTarget(-1)
 public fun ApplicationScope.DecoratedWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -184,7 +192,7 @@ public fun ApplicationScope.DecoratedWindow(
      * does *not* give you (it is not `_NET_WM_WINDOW_TYPE_DESKTOP`).
      */
     alwaysOnBottom: Boolean = false,
-    content: @Composable TaoDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable TaoDecoratedWindowScope.() -> Unit,
 ) {
     val latestOnClose by rememberUpdatedState(onCloseRequest)
     val latestPreview by rememberUpdatedState(onPreviewKeyEvent)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/Satellite.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/Satellite.kt
@@ -1,3 +1,10 @@
+// #636: the window openers below are `@ComposableOpenTarget(-1)` with
+// `@UiComposable` content lambdas — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.window.tao
 
 import androidx.compose.foundation.Canvas
@@ -16,6 +23,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
@@ -27,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -147,6 +156,7 @@ internal class SatelliteScopeImpl(
  */
 @Suppress("LongParameterList", "FunctionNaming")
 @Composable
+@ComposableOpenTarget(-1)
 public fun ApplicationScope.Satellite(
     workspace: SatelliteWorkspace,
     id: String,
@@ -156,9 +166,11 @@ public fun ApplicationScope.Satellite(
     resizable: Boolean = true,
     hideWhileOwnerFullscreenOrMaximized: Boolean = true,
     compositionLocalContext: CompositionLocalContext? = null,
-    floatingContentWrapper: @Composable TaoDecoratedWindowScope.(content: @Composable () -> Unit) -> Unit = { it() },
-    header: @Composable SatelliteScope.() -> Unit = { DefaultSatelliteHeader() },
-    content: @Composable SatelliteScope.() -> Unit,
+    floatingContentWrapper:
+        @Composable @UiComposable TaoDecoratedWindowScope.(content: @Composable @UiComposable () -> Unit) -> Unit =
+        { it() },
+    header: @Composable @UiComposable SatelliteScope.() -> Unit = { DefaultSatelliteHeader() },
+    content: @Composable @UiComposable SatelliteScope.() -> Unit,
 ) {
     val entry = remember(workspace, id) { workspace.register(id, title, initialPlacement, initiallyOpen) }
     val scope = remember(entry) { SatelliteScopeImpl(workspace, entry, isDocked = false) }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/SatelliteWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/SatelliteWindow.kt
@@ -1,8 +1,14 @@
-@file:Suppress("MagicNumber")
+// #636: the window openers below are `@ComposableOpenTarget(-1)` with
+// `@UiComposable` content lambdas — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation", "MagicNumber")
 
 package dev.nucleusframework.window.tao
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -12,6 +18,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -110,6 +117,7 @@ import kotlinx.coroutines.delay
  */
 @Suppress("LongParameterList", "FunctionNaming", "LongMethod")
 @Composable
+@ComposableOpenTarget(-1)
 public fun ApplicationScope.SatelliteWindow(
     onCloseRequest: () -> Unit,
     parent: TaoWindow? = LocalTaoWindow.current,
@@ -125,7 +133,7 @@ public fun ApplicationScope.SatelliteWindow(
     // Parent composition locals bridged into the satellite's own ComposeScene
     // from its first composition, exactly like [DecoratedDialog].
     compositionLocalContext: CompositionLocalContext? = null,
-    content: @Composable TaoDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable TaoDecoratedWindowScope.() -> Unit,
 ) {
     val latestContent by rememberUpdatedState(content)
     val latestOnClose by rememberUpdatedState(onCloseRequest)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TabWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TabWindows.kt
@@ -1,3 +1,10 @@
+// #636: the window openers below are `@ComposableOpenTarget(-1)` with
+// `@UiComposable` content lambdas — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.window.tao
 
 import androidx.compose.foundation.layout.Box
@@ -5,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -17,6 +25,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
@@ -80,12 +89,13 @@ internal class TabScopeImpl(
  */
 @Suppress("FunctionNaming")
 @Composable
+@ComposableOpenTarget(-1)
 public fun ApplicationScope.Tab(
     workspace: TabWorkspace,
     id: String,
     title: String,
     group: String? = null,
-    content: @Composable TabScope.() -> Unit,
+    content: @Composable @UiComposable TabScope.() -> Unit,
 ) {
     val entry = remember(workspace, id) { workspace.register(id, title, group) }
     // Published as snapshot state so the window hosting the tab picks up a new

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
@@ -1,6 +1,14 @@
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.window.tao
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -8,6 +16,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
@@ -65,6 +74,7 @@ public fun isTaoStandalonePopupAvailable(): Boolean =
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun TaoStandalonePopup(
     visible: Boolean,
     position: WindowPosition.Absolute,
@@ -73,7 +83,7 @@ public fun TaoStandalonePopup(
     onOutsideClick: (() -> Unit)? = null,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null,
     onKeyEvent: ((KeyEvent) -> Boolean)? = null,
-    content: @Composable () -> Unit,
+    content: @Composable @UiComposable () -> Unit,
 ) {
     if (Platform.Current != Platform.Windows &&
         Platform.Current != Platform.MacOS &&

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/ComposableTargetIsolationFixture.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/ComposableTargetIsolationFixture.kt
@@ -1,0 +1,65 @@
+package dev.nucleusframework.window.tao
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableTarget
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPosition
+import dev.nucleusframework.window.tao.v2.rememberWindowState
+
+/**
+ * Compile-time regression fixture for #636 — Tao counterpart of the one in
+ * `nucleus-application`.
+ *
+ * Every opener below hosts its content in a fresh `ComposeScene`, so each is
+ * `@ComposableOpenTarget(-1)` with `@UiComposable` content lambdas — callable
+ * from any applier, always composing UI. `compileTestKotlin` escalates
+ * `COMPOSE_APPLIER_CALL_MISMATCH` to an error (see build.gradle.kts), so the
+ * calls below fail the build if that isolation regresses.
+ */
+@Composable
+@ComposableTarget(applier = "org.example.FakeApplier")
+private fun rememberNonUiTargetedState(): Any = remember { Any() }
+
+@Suppress("UnusedPrivateMember")
+private fun windowsStayUiRegardlessOfTheScopeApplier() {
+    taoApplication {
+        // Binds the application scope's applier to a non-UI one.
+        rememberNonUiTargetedState()
+
+        DecoratedWindow(onCloseRequest = ::exitApplication) { Box(Modifier) }
+        DecoratedDialog(onCloseRequest = ::exitApplication) { Box(Modifier) }
+        DecoratedWindow(
+            onCloseRequest = ::exitApplication,
+            state = rememberWindowState(),
+        ) { Box(Modifier) }
+        SatelliteWindow(onCloseRequest = ::exitApplication) { Box(Modifier) }
+        TaoStandalonePopup(
+            visible = false,
+            position = WindowPosition.Absolute(0.dp, 0.dp),
+            size = DpSize(1.dp, 1.dp),
+        ) { Box(Modifier) }
+
+        // Every composable lambda of an opener, not just `content`: an
+        // unannotated one drags the caller's applier back in.
+        val satellites = rememberSatelliteWorkspace()
+        Satellite(
+            workspace = satellites,
+            id = "inspector",
+            title = "Inspector",
+            floatingContentWrapper = { body -> Box(Modifier) { body() } },
+            header = { Box(Modifier) },
+        ) { Box(Modifier) }
+
+        val tabs = rememberTabWorkspace()
+        TabWindows(
+            workspace = tabs,
+            strip = { Box(Modifier) },
+            windowContentWrapper = { body -> Box(Modifier) { body() } },
+        )
+        Tab(workspace = tabs, id = "first", title = "First") { Box(Modifier) }
+    }
+}

--- a/nucleus-application/build.gradle.kts
+++ b/nucleus-application/build.gradle.kts
@@ -55,6 +55,13 @@ kotlin {
     }
 }
 
+// #636 regression guard: the Compose applier-mismatch diagnostic is a warning,
+// so ComposableTargetIsolationFixture would silently rot. Escalate it to an
+// error for the test compilation, where that fixture lives.
+tasks.named<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileTestKotlin") {
+    compilerOptions.freeCompilerArgs.add("-Xwarning-level=COMPOSE_APPLIER_CALL_MISMATCH:error")
+}
+
 /**
  * Live process E2E for the system-theme bridge (needs a display / D-Bus on Linux).
  * Not part of `check` — run explicitly: `./gradlew :nucleus-application:systemThemeE2E`

--- a/nucleus-application/detekt-baseline.xml
+++ b/nucleus-application/detekt-baseline.xml
@@ -13,7 +13,5 @@
     <ID>UndocumentedPublicFunction:NucleusWindow.kt:NucleusWindow$public fun setMinimumSize</ID>
     <ID>UndocumentedPublicFunction:NucleusWindow.kt:NucleusWindow$public fun show</ID>
     <ID>UndocumentedPublicFunction:NucleusWindow.kt:NucleusWindow$public fun toFront</ID>
-    <ID>UndocumentedPublicFunction:NucleusWindowHost.kt:NucleusDialogHost$@Composable public fun Dialog</ID>
-    <ID>UndocumentedPublicFunction:NucleusWindowHost.kt:NucleusWindowHost$@Composable public fun Window</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedDialog.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedDialog.kt
@@ -1,9 +1,17 @@
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
 @file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+@file:Suppress("ktlint:standard:annotation")
 
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.DpSize
@@ -18,6 +26,7 @@ import dev.nucleusframework.window.tao.v2.DialogState as NucleusDialogState
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun NucleusApplicationScope.DecoratedDialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -29,7 +38,7 @@ public fun NucleusApplicationScope.DecoratedDialog(
     focusable: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
-    content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
 ) {
     when (this) {
         is TaoNucleusApplicationScope ->
@@ -58,6 +67,7 @@ public fun NucleusApplicationScope.DecoratedDialog(
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun DecoratedDialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -69,7 +79,7 @@ public fun DecoratedDialog(
     focusable: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
-    content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
 ) {
     LocalNucleusApplicationScope.current.DecoratedDialog(
         onCloseRequest = onCloseRequest,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -1,9 +1,17 @@
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
 @file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+@file:Suppress("ktlint:standard:annotation")
 
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.DpSize
@@ -19,6 +27,7 @@ import dev.nucleusframework.window.tao.v2.WindowState as NucleusWindowState
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun NucleusApplicationScope.DecoratedWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -87,7 +96,7 @@ public fun NucleusApplicationScope.DecoratedWindow(
     // desktop widgets. Mutually exclusive with [alwaysOnTop] — last one set
     // wins. Reactive.
     alwaysOnBottom: Boolean = false,
-    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
 ) {
     when (this) {
         is TaoNucleusApplicationScope ->
@@ -132,6 +141,7 @@ public fun NucleusApplicationScope.DecoratedWindow(
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun DecoratedWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -155,7 +165,7 @@ public fun DecoratedWindow(
     visibleOnAllWorkspaces: Boolean = false,
     forceX11: Boolean = false,
     alwaysOnBottom: Boolean = false,
-    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
 ) {
     LocalNucleusApplicationScope.current.DecoratedWindow(
         onCloseRequest = onCloseRequest,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindowHost.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindowHost.kt
@@ -1,11 +1,19 @@
+// #636: the window/dialog openers below are `@ComposableOpenTarget(-1)` with a
+// `@UiComposable` content lambda — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
 @file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+@file:Suppress("ktlint:standard:annotation")
 
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.DpSize
@@ -57,7 +65,13 @@ import dev.nucleusframework.window.tao.v2.WindowState as NucleusWindowState
  * `visibleOnAllWorkspaces`, `forceX11`) are not routed through the host.
  */
 public fun interface NucleusWindowHost {
+    /**
+     * Opens a window hosting [content] on the active backend. Callable from
+     * any applier — [content] is always composed as UI, in the new window's
+     * own composition.
+     */
     @Composable
+    @ComposableOpenTarget(-1)
     public fun Window(
         onCloseRequest: () -> Unit,
         state: WindowState,
@@ -77,7 +91,7 @@ public fun interface NucleusWindowHost {
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
         alwaysOnBottom: Boolean,
-        content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+        content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
     )
 
     /**
@@ -151,7 +165,12 @@ public fun interface NucleusWindowHost {
  * Parameter surface matches [DecoratedDialog].
  */
 public fun interface NucleusDialogHost {
+    /**
+     * Opens a dialog hosting [content] on the active backend. Same applier
+     * contract as [NucleusWindowHost.Window].
+     */
     @Composable
+    @ComposableOpenTarget(-1)
     public fun Dialog(
         onCloseRequest: () -> Unit,
         state: DialogState,
@@ -163,7 +182,7 @@ public fun interface NucleusDialogHost {
         focusable: Boolean,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
-        content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+        content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
     )
 
     /**
@@ -244,6 +263,7 @@ public val LocalNucleusDialogHost: ProvidableCompositionLocal<NucleusDialogHost>
  */
 public object DefaultNucleusWindowHost : NucleusWindowHost {
     @Composable
+    @ComposableOpenTarget(-1)
     override fun Window(
         onCloseRequest: () -> Unit,
         state: WindowState,
@@ -263,7 +283,7 @@ public object DefaultNucleusWindowHost : NucleusWindowHost {
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
         alwaysOnBottom: Boolean,
-        content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+        content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
     ) {
         DecoratedWindow(
             onCloseRequest = onCloseRequest,
@@ -347,6 +367,7 @@ public object DefaultNucleusWindowHost : NucleusWindowHost {
  */
 public object DefaultNucleusDialogHost : NucleusDialogHost {
     @Composable
+    @ComposableOpenTarget(-1)
     override fun Dialog(
         onCloseRequest: () -> Unit,
         state: DialogState,
@@ -358,7 +379,7 @@ public object DefaultNucleusDialogHost : NucleusDialogHost {
         focusable: Boolean,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
-        content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+        content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
     ) {
         DecoratedDialog(
             onCloseRequest = onCloseRequest,
@@ -421,6 +442,7 @@ public object DefaultNucleusDialogHost : NucleusDialogHost {
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun HostedWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -440,7 +462,7 @@ public fun HostedWindow(
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     alwaysOnBottom: Boolean = false,
-    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
 ) {
     LocalNucleusWindowHost.current.Window(
         onCloseRequest = onCloseRequest,
@@ -475,6 +497,7 @@ public fun HostedWindow(
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun HostedDialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -486,7 +509,7 @@ public fun HostedDialog(
     focusable: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
-    content: @Composable NucleusDecoratedDialogScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedDialogScope.() -> Unit,
 ) {
     LocalNucleusDialogHost.current.Dialog(
         onCloseRequest = onCloseRequest,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/Satellite.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/Satellite.kt
@@ -1,6 +1,15 @@
+// #636: the window openers below are `@ComposableOpenTarget(-1)` with
+// `@UiComposable` content lambdas — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
+import androidx.compose.ui.UiComposable
 import dev.nucleusframework.application.internal.TaoSatelliteWorkspaceAdapter
 import dev.nucleusframework.window.tao.DefaultSatelliteHeader
 import dev.nucleusframework.window.tao.SatellitePlacement
@@ -42,6 +51,7 @@ import dev.nucleusframework.window.tao.SatelliteWorkspace
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun NucleusApplicationScope.Satellite(
     workspace: SatelliteWorkspace,
     id: String,
@@ -51,8 +61,8 @@ public fun NucleusApplicationScope.Satellite(
     resizable: Boolean = true,
     hideWhileOwnerFullscreenOrMaximized: Boolean = true,
     nativeContextMenu: Boolean = true,
-    header: @Composable SatelliteScope.() -> Unit = { DefaultSatelliteHeader() },
-    content: @Composable SatelliteScope.() -> Unit,
+    header: @Composable @UiComposable SatelliteScope.() -> Unit = { DefaultSatelliteHeader() },
+    content: @Composable @UiComposable SatelliteScope.() -> Unit,
 ) {
     when (this) {
         is TaoNucleusApplicationScope ->
@@ -78,6 +88,7 @@ public fun NucleusApplicationScope.Satellite(
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun Satellite(
     workspace: SatelliteWorkspace,
     id: String,
@@ -87,8 +98,8 @@ public fun Satellite(
     resizable: Boolean = true,
     hideWhileOwnerFullscreenOrMaximized: Boolean = true,
     nativeContextMenu: Boolean = true,
-    header: @Composable SatelliteScope.() -> Unit = { DefaultSatelliteHeader() },
-    content: @Composable SatelliteScope.() -> Unit,
+    header: @Composable @UiComposable SatelliteScope.() -> Unit = { DefaultSatelliteHeader() },
+    content: @Composable @UiComposable SatelliteScope.() -> Unit,
 ) {
     LocalNucleusApplicationScope.current.Satellite(
         workspace = workspace,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/SatelliteWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/SatelliteWindow.kt
@@ -1,6 +1,15 @@
+// #636: the window openers below are `@ComposableOpenTarget(-1)` with
+// `@UiComposable` content lambdas — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import dev.nucleusframework.application.internal.TaoSatelliteWindowAdapter
@@ -51,6 +60,7 @@ import dev.nucleusframework.window.tao.rememberSatelliteWindowState
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun NucleusApplicationScope.SatelliteWindow(
     onCloseRequest: () -> Unit,
     parent: NucleusWindow? = null,
@@ -64,7 +74,7 @@ public fun NucleusApplicationScope.SatelliteWindow(
     nativeContextMenu: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
-    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
 ) {
     when (this) {
         is TaoNucleusApplicationScope ->
@@ -95,6 +105,7 @@ public fun NucleusApplicationScope.SatelliteWindow(
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
+@ComposableOpenTarget(-1)
 public fun SatelliteWindow(
     onCloseRequest: () -> Unit,
     parent: NucleusWindow? = null,
@@ -108,7 +119,7 @@ public fun SatelliteWindow(
     nativeContextMenu: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
-    content: @Composable NucleusDecoratedWindowScope.() -> Unit,
+    content: @Composable @UiComposable NucleusDecoratedWindowScope.() -> Unit,
 ) {
     LocalNucleusApplicationScope.current.SatelliteWindow(
         onCloseRequest = onCloseRequest,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/Tab.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/Tab.kt
@@ -1,6 +1,15 @@
+// #636: the window openers below are `@ComposableOpenTarget(-1)` with
+// `@UiComposable` content lambdas — callable from any applier, always composing
+// UI — so a non-UI composable called in the caller's scope cannot reclassify
+// the window content. ktlint's `annotation` and `function-type-modifier-spacing`
+// rules contradict each other on the resulting two-annotation parameter type.
+@file:Suppress("ktlint:standard:annotation")
+
 package dev.nucleusframework.application
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
+import androidx.compose.ui.UiComposable
 import dev.nucleusframework.application.internal.TaoTabWorkspaceAdapter
 import dev.nucleusframework.window.tao.TabScope
 import dev.nucleusframework.window.tao.TabStrip
@@ -103,12 +112,13 @@ public fun TabWindows(
  */
 @Suppress("FunctionNaming")
 @Composable
+@ComposableOpenTarget(-1)
 public fun NucleusApplicationScope.Tab(
     workspace: TabWorkspace,
     id: String,
     title: String,
     group: String? = null,
-    content: @Composable TabScope.() -> Unit,
+    content: @Composable @UiComposable TabScope.() -> Unit,
 ) {
     when (this) {
         is TaoNucleusApplicationScope ->
@@ -129,12 +139,13 @@ public fun NucleusApplicationScope.Tab(
  */
 @Suppress("FunctionNaming")
 @Composable
+@ComposableOpenTarget(-1)
 public fun Tab(
     workspace: TabWorkspace,
     id: String,
     title: String,
     group: String? = null,
-    content: @Composable TabScope.() -> Unit,
+    content: @Composable @UiComposable TabScope.() -> Unit,
 ) {
     LocalNucleusApplicationScope.current.Tab(
         workspace = workspace,

--- a/nucleus-application/src/test/kotlin/dev/nucleusframework/application/ComposableTargetIsolationFixture.kt
+++ b/nucleus-application/src/test/kotlin/dev/nucleusframework/application/ComposableTargetIsolationFixture.kt
@@ -1,0 +1,51 @@
+package dev.nucleusframework.application
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableTarget
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+/**
+ * Compile-time regression fixture for #636.
+ *
+ * Every window / dialog opener is declared `@ComposableOpenTarget(-1)` with a
+ * `@UiComposable` content lambda, so the applier a caller happens to be bound
+ * to never reaches the window content — and opening a window never binds the
+ * caller's applier either. Without that, one non-UI composable called in the
+ * `nucleusApplication` scope reclassified the whole scope (and every nested
+ * window) to that applier, and each `@UiComposable` call inside it warned —
+ * fatal under `-Werror`.
+ *
+ * `compileTestKotlin` escalates `COMPOSE_APPLIER_CALL_MISMATCH` to an error
+ * (see build.gradle.kts), so a regression fails the build here instead of in a
+ * consumer's app.
+ */
+@Composable
+@ComposableTarget(applier = "org.example.FakeApplier")
+private fun rememberNonUiTargetedState(): Any = remember { Any() }
+
+/**
+ * Unmarked wrapper, exactly like an app's own theme composable: the Compose
+ * compiler infers `[0[0]]` for it, so it forwards whatever applier the
+ * application scope was bound to.
+ */
+@Composable
+private fun InferredWrapper(content: @Composable () -> Unit) {
+    content()
+}
+
+@Suppress("UnusedPrivateMember")
+private fun windowsStayUiRegardlessOfTheScopeApplier() {
+    nucleusApplication(enableSingleInstance = false) {
+        // Binds the application scope's applier to a non-UI one.
+        rememberNonUiTargetedState()
+
+        InferredWrapper {
+            DecoratedWindow(onCloseRequest = ::exitApplication) { Box(Modifier) }
+            DecoratedDialog(onCloseRequest = ::exitApplication) { Box(Modifier) }
+            HostedWindow(onCloseRequest = ::exitApplication) { Box(Modifier) }
+            HostedDialog(onCloseRequest = ::exitApplication) { Box(Modifier) }
+        }
+    }
+}


### PR DESCRIPTION
Port de #648 (commit `41266637`) sur `nucleus-2.6`, étendu aux ouvreurs de fenêtres propres à cette branche.

## Rappel du bug (#636)

Les ouvreurs de fenêtres/dialogues laissaient le compilateur **inférer** leur cible de composition (`[0[0]]`) : un seul jeton liait l'applier de l'appelant à celui du contenu. Un composable non-UI appelé dans le scope `nucleusApplication` — le compilateur colle `@ComposableTarget` sur toute factory non annotée qui transmet un lambda de contenu marqué, cf. `rememberMapState` de MapLibre Compose — reclassait tout le scope, fenêtres imbriquées incluses, et chaque appel `@UiComposable` déclenchait un warning (fatal avec `-Werror`).

## Correctif

Chaque ouvreur est `@ComposableOpenTarget(-1)` avec des lambdas de contenu `@UiComposable` : appelable depuis n'importe quel applier, et contenu toujours composé en UI dans la composition propre de la fenêtre.

Couvert : `DecoratedWindow`/`DecoratedDialog`, les interfaces `NucleusWindowHost`/`NucleusDialogHost` + implémentations par défaut, `HostedWindow`/`HostedDialog`, **`SatelliteWindow`, `Satellite`, `Tab`** (nouveaux en 2.6), et les équivalents Tao + `TaoStandalonePopup`.

Déjà corrects par inférence, laissés tels quels (vérifié dans le bytecode) : `TabWindows`, les `DecoratedWindow`/`DecoratedDialog` v2, `DragGhostWindow`, et les wrappers Material 2/3 / Jewel — tous en `[_[androidx.compose.ui.UiComposable]]`.

## Point non évident

Dès qu'une déclaration porte une cible explicite, l'inférence s'arrête pour **toute** la déclaration : chaque paramètre lambda composable doit être annoté, pas seulement `content`. `floatingContentWrapper` de `Satellite` était le cas concret — le laisser nu continuait de faire entrer l'applier de l'appelant dans le contenu du satellite. La fixture passe désormais explicitement `floatingContentWrapper`, `header`, `strip` et `windowContentWrapper` pour couvrir ça.

## Garde anti-régression

`COMPOSE_APPLIER_CALL_MISMATCH` n'est qu'un warning : `compileTestKotlin` l'escalade en erreur (`-Xwarning-level`) dans les deux modules, et une `ComposableTargetIsolationFixture` par module compile la forme rapportée (factory non-UI dans le scope application, contenu UI dans chaque fenêtre).

## Vérifications

Conflits du cherry-pick (en-têtes de fichier + imports des 3 fichiers de `nucleus-application`) résolus à la main. `apiCheck`, `detekt`, `ktlintCheck` et `testClasses` passent ; aucun changement à l'exécution (annotations de compilation uniquement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)