### PR TITLE
fix(tao): give the GraalVM test image the classes it was compiled against

### DIFF
--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -103,9 +103,16 @@ val taoTestClassesJar by tasks.registering(Jar::class) {
     from(sourceSets.test.get().output)
 }
 
+// Consumers get the compiled test classes *and* what those classes need at run
+// time. Without the `extendsFrom`, every dependency of the test source set has
+// to be repeated in each consumer, and one that is not simply throws
+// NoClassDefFoundError the first time the suite reaches the code that uses it —
+// which is how `examples/tao-native-test` lost Material 3 and took the whole
+// GraalVM job down with the Tao main thread.
 val taoTestArtifacts: Configuration by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false
+    extendsFrom(configurations.testImplementation.get())
 }
 
 artifacts {

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/DialogAppearanceHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/DialogAppearanceHeadfulCases.kt
@@ -364,6 +364,7 @@ internal object DialogAppearanceHeadfulCases {
                     "${if (native) "native popup layer" else "in-scene layer"}",
             skip = ::skipReason,
             nativePopupLayers = native,
+            paintDefaultBackground = false,
             content = { if (material) MaterialContent() else Content() },
         ) {
             awaitUntil("window mapped") { window.hasRealFramePx() }
@@ -386,30 +387,53 @@ internal object DialogAppearanceHeadfulCases {
             val capturing =
                 java.util.concurrent.atomic
                     .AtomicBoolean(true)
-            val grabber =
-                kotlin.concurrent.thread(name = "dialog-appearance-capture") {
-                    while (capturing.get() && frames.size < MAX_FRAMES) {
-                        frames += System.nanoTime() to robot.createScreenCapture(region)
-                    }
-                }
             // Warm-up: the first composition of a dialog loads fonts and theme
-            // tokens; that would be filmed as a slow appearance.
+            // tokens; that would be filmed as a slow appearance. It runs BEFORE
+            // the grabber starts — the film is a fixed budget of frames, and a
+            // host that captures faster than the warm-up lasts would spend the
+            // whole budget on it and leave the curve with nothing after
+            // `shownNs`, which reads as "the dialog never showed up on screen".
             dialogShown.value = true
             settle(SETTLE_BEFORE_MILLIS)
             dialogShown.value = false
             settle(SETTLE_BEFORE_MILLIS)
             settle(WARMUP_MILLIS)
+            // One capture session per half, each with its own frame budget. A
+            // single session would spend the whole budget on the appearance —
+            // grabbing is much faster than the film lasts — and leave the
+            // disappearance with no frames, which reads as "the dialog never
+            // went away" in the comparison.
+            var grabber: Thread? = null
+
+            fun startFilm() {
+                capturing.set(true)
+                val from = frames.size
+                grabber =
+                    kotlin.concurrent.thread(name = "dialog-appearance-capture") {
+                        while (capturing.get() && frames.size - from < MAX_FRAMES_PER_HALF) {
+                            frames += System.nanoTime() to robot.createScreenCapture(region)
+                        }
+                    }
+            }
+
+            fun stopFilm() {
+                capturing.set(false)
+                grabber?.join()
+                grabber = null
+            }
+            startFilm()
             val shownNs = System.nanoTime()
             dialogShown.value = true
             var hiddenNs = Long.MAX_VALUE
             try {
                 settle(FILM_MILLIS)
+                stopFilm()
                 hiddenNs = System.nanoTime()
                 dialogShown.value = false
+                startFilm()
                 settle(HIDE_FILM_MILLIS)
             } finally {
-                capturing.set(false)
-                grabber.join()
+                stopFilm()
                 dialogShown.value = false
             }
             settle(SETTLE_BEFORE_MILLIS)
@@ -583,6 +607,10 @@ internal object DialogAppearanceHeadfulCases {
     private const val STALL_TOLERANCE = 3
     private const val HEIGHT_RATIO_TOLERANCE = 0.15f
     private const val MAX_FRAMES = 200
+
+    /** Per-half budget; the two halves together stay within [MAX_FRAMES]. */
+    private const val MAX_FRAMES_PER_HALF = MAX_FRAMES / 2
+
     private const val DUMP_UNTIL_MS = 1_300L
     private const val SETTLE_PX = 1
     private const val SETTLE_COLOR = 6

--- a/examples/tao-native-test/build.gradle.kts
+++ b/examples/tao-native-test/build.gradle.kts
@@ -16,13 +16,14 @@ plugins {
 dependencies {
     implementation(project(":decorated-window-tao"))
     // The suites live in decorated-window-tao's test source set; consumed as a
-    // classes jar through the module's taoTestArtifacts configuration.
+    // classes jar through the module's taoTestArtifacts configuration, which
+    // also carries what those classes need at run time (kotlin.test, Compose
+    // Desktop, Material 3) — so a dependency added to that test source set
+    // reaches this image without being repeated here.
     implementation(project(path = ":decorated-window-tao", configuration = "taoTestArtifacts"))
     implementation(project(":core-runtime"))
     implementation(project(":graalvm-runtime"))
     implementation(compose.desktop.currentOs)
-    // Runtime deps of the compiled test classes (kotlin.test assertions).
-    implementation(kotlin("test"))
     // Regression fixture for issue #443: an SLF4J 2.x backend that must initialize at
     // RUN time. If anything on the classpath restores `--initialize-at-build-time=org.slf4j`,
     // the native-image build fails on LogbackMDCAdapter in the image heap.


### PR DESCRIPTION
## Summary

`test-graalvm` fails on all three platforms with `NoClassDefFoundError: androidx/compose/material3/MaterialThemeKt`, thrown **on the Tao main thread**, which closes the event loop and takes the whole job down. `examples/tao-native-test` compiles `decorated-window-tao`'s test suites into a native image, but `taoTestArtifacts` published only the compiled classes — every dependency of that test source set had to be repeated in the consumer, and Material 3 was not. The configuration now extends `testImplementation`, so a dependency added to the suites reaches the image without being repeated.

Reproduced and verified on the JVM (`:examples:tao-native-test:run --args=headful`), which shares that classpath — two minutes instead of a 24-minute native build.

With the film cases finally reaching their own code, three things they had never been green on:

- **Zero-height content.** They compose into a `ColumnScope` next to the harness's default `fillMaxSize` background, so the forty rows of text that exist to make the owner's per-frame present cost something rendered nowhere. `paintDefaultBackground = false`.
- **The grabber started before the warm-up** and spent its whole frame budget on it, leaving the curve with nothing after the timestamp it measures from — reported as "the dialog never showed up on screen".
- **One capture session covered both halves**, so the appearance consumed the budget and the disappearance got no frames, which is what the two `matches the in-scene layer` cases were failing on. Each half films in its own session now, within the same total budget.

## Test plan

- [x] `:examples:tao-native-test:run --args=headful` — the `NoClassDefFoundError` is gone and the suite runs past the Material 3 cases
- [x] `taoHeadfulTest -Dnucleus.tao.headful.filter=appearance` under Xvfb + openbox: 6 failures → 0, two consecutive runs
- [x] `:decorated-window-tao:test`, `ktlintCheck`, `detekt`, `apiCheck`; `:examples:tao-native-test:compileKotlin`
- [ ] `test-graalvm` on all three platforms in CI

### Known, not addressed here

`graphicsLayer translation filmed — native popup layer` hangs on Linux, which is what makes that leg reach the 900 s watchdog. It draws a `GraphicsLayer` created from the *owner window's* `GraphicsContext` inside the popup's own GL context, with alpha forcing the saveLayer path; the in-scene variant of the same case passes. Pre-existing, and its own investigation.

The `native popup layer matches the in-scene layer` comparison is borderline under Xvfb (slide-in measured 15 px vs 10 px against a 4 px tolerance) — a 6 ms sample period is coarse for a 10 dp slide. Tolerances left as calibrated.