### PR TITLE
Tao: NativeView/TextureView headful monkeys and the embed bugs they caught

### DIFF
--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -177,6 +177,10 @@ val taoHeadfulTest by tasks.registering(JavaExec::class) {
     System.getProperty("nucleus.tao.headful.monkeySeed")?.let {
         systemProperty("nucleus.tao.headful.monkeySeed", it)
     }
+    // Replays a journal instead of a random walk (comma-separated action names).
+    System.getProperty("nucleus.tao.headful.monkeyScript")?.let {
+        systemProperty("nucleus.tao.headful.monkeyScript", it)
+    }
     System.getProperties().stringPropertyNames().filter { it.startsWith("nucleus.dialog.appearance.") }.forEach {
         systemProperty(it, System.getProperty(it))
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeView.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeView.kt
@@ -69,9 +69,10 @@ public fun NativeView(
     val view = remember { factory() }
     val latestUpdate by rememberUpdatedState(update)
 
-    DisposableEffect(view) {
-        onDispose { view.dispose() }
-    }
+    // `view.dispose()` is owned by [EmbeddedNativeView], sequenced *after* the
+    // host detach: `dispose()` promises the handle is never touched again, and
+    // a separate effect here ran first on unmount — the detach then walked a
+    // widget the app had already destroyed (SIGSEGV in `nativeDetach`).
     SideEffect { latestUpdate(view) }
 
     when (view) {
@@ -128,14 +129,24 @@ private fun EmbeddedNativeView(
     val host = LocalTaoNativeViewHost.current
     val latestContent by rememberUpdatedState(content)
     if (!enabled || host == null) {
+        DisposableEffect(view) {
+            onDispose { view.dispose() }
+        }
         Box(modifier)
         return
     }
 
     val regionToken = remember { Any() }
+    // One effect for attach, detach and dispose, so the order is fixed by
+    // construction: the host lets go of the handle, then the app frees it.
+    // The keys never change for a live embedding (the host is the window's,
+    // the token is remembered), so this only fires on unmount.
     DisposableEffect(host, regionToken) {
         host.attach(handle, regionToken)
-        onDispose { host.detach(handle, regionToken) }
+        onDispose {
+            host.detach(handle, regionToken)
+            view.dispose()
+        }
     }
 
     val density = LocalDensity.current

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NucleusPlatformView.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NucleusPlatformView.kt
@@ -102,7 +102,13 @@ public sealed interface NucleusPlatformView {
      * punched rect shows the desktop instead of the widget.
      */
     public interface GtkWidget : NucleusPlatformView {
-        /** Pointer to the user-supplied `GtkWidget*` (cast to Long). */
+        /**
+         * Pointer to the user-supplied `GtkWidget*` (cast to Long). The app
+         * owns a reference to it (`g_object_ref_sink`) for as long as the
+         * handle is in use and releases it from [dispose]: the container's
+         * unparent on detach drops the container's own reference, and a
+         * widget nobody else holds is finalised right there.
+         */
         public val gtkWidgetHandle: Long
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureView.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureView.kt
@@ -88,12 +88,16 @@ internal data class D3D11SharedTextureSource(
  * finish their writes (`commit` + `waitUntilCompleted`, or double buffering)
  * *before* calling [TextureViewController.markFrameAvailable]; a producer
  * still writing while the compositor copies can tear, never crash.
+ *
+ * The returned source retains [ioSurface] for as long as it is reachable, so
+ * a producer that releases its own hold (the "close under a live view"
+ * case) cannot free the surface out from under a later remount.
  */
 public fun nucleusIOSurfaceTextureSource(
     ioSurface: Long,
     widthPx: Int,
     heightPx: Int,
-): TextureViewSource = IOSurfaceTextureSource(ioSurface, widthPx, heightPx)
+): TextureViewSource = IOSurfaceTextureSource(ioSurface, widthPx, heightPx).also(::retainIoSurfaceForSource)
 
 internal data class IOSurfaceTextureSource(
     val ioSurface: Long,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureViewMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureViewMac.kt
@@ -15,6 +15,7 @@ import dev.nucleusframework.window.tao.scene.TaoMetalTextureHost
 import org.jetbrains.skia.BackendRenderTarget
 import org.jetbrains.skia.ColorSpace
 import org.jetbrains.skia.ContentChangeMode
+import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.Image
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.Surface
@@ -169,6 +170,9 @@ private val metalTextureImports =
         importTexture = ::importTexture,
         closeImport = { it.close() },
     )
+
+/** Whether any `TextureView` import is currently alive on [context] — the headful suite's leak probe. */
+internal fun hasMetalTextureImports(context: DirectContext): Boolean = metalTextureImports.hasImportsFor(context)
 
 private fun importTexture(
     host: TaoMetalTextureHost,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureViewMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TextureViewMac.kt
@@ -21,6 +21,7 @@ import org.jetbrains.skia.Rect
 import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceColorFormat
 import org.jetbrains.skia.SurfaceOrigin
+import java.lang.ref.Cleaner
 
 /**
  * macOS implementation of [TextureView]. The producer's `IOSurface` (or
@@ -242,5 +243,31 @@ private fun importTexture(
             return@runOnRenderThread null
         }
         MacImportedTexture(handle, host, renderTarget, surface, widthPx, heightPx)
+    }
+}
+
+/**
+ * Keeps [IOSurfaceTextureSource.ioSurface] alive for the source's lifetime:
+ * the producer may `CFRelease` on close while a `TextureView` still holds
+ * the source (and may remount it). The matching release runs when the
+ * source is collected. No-op when the Metal bridge is not loaded.
+ */
+internal fun retainIoSurfaceForSource(source: IOSurfaceTextureSource) {
+    val ptr = source.ioSurface
+    if (ptr == 0L || !NativeTaoMacOsTextureBridge.isLoaded) return
+    if (!NativeTaoMacOsTextureBridge.nativeRetainIOSurface(ptr)) return
+    ioSurfaceCleaner.register(source, IoSurfaceRelease(ptr))
+}
+
+private val ioSurfaceCleaner: Cleaner = Cleaner.create()
+
+/** Must not capture the source, or the Cleaner would never run. */
+private class IoSurfaceRelease(
+    private val ptr: Long,
+) : Runnable {
+    override fun run() {
+        if (NativeTaoMacOsTextureBridge.isLoaded) {
+            NativeTaoMacOsTextureBridge.nativeReleaseIOSurface(ptr)
+        }
     }
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/ResizeFrameDecoration.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/ResizeFrameDecoration.kt
@@ -131,7 +131,7 @@ internal class ResizeFrameDecoration(
      */
     fun onMove(direction: Direction?): Boolean {
         if (direction != null) {
-            NativeTaoBridge.nativeSetCursorIcon(windowHandle, direction.cursorIcon)
+            NativeTaoBridge.setCursorIcon(windowHandle, direction.cursorIcon)
             inBand = true
             return true
         }
@@ -139,7 +139,7 @@ internal class ResizeFrameDecoration(
             inBand = false
             // Restore the default cursor immediately; Compose will overwrite
             // it on the next motion if a `PointerIcon` modifier is in scope.
-            NativeTaoBridge.nativeSetCursorIcon(windowHandle, TaoCursorIcon.DEFAULT)
+            NativeTaoBridge.setCursorIcon(windowHandle, TaoCursorIcon.DEFAULT)
         }
         return false
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/TaoLinuxOverlayController.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/TaoLinuxOverlayController.kt
@@ -77,6 +77,24 @@ internal class TaoLinuxOverlayControllerImpl(
     /** key → GtkEventBox pointer (0 if creation failed). */
     private val boxes: MutableMap<Any, Long> = LinkedHashMap()
 
+    private val focusSinkKey: Any = object {}
+
+    /**
+     * Puts an invisible, focusable EventBox first in the overlay's focus
+     * chain, before any embed is added. GTK hands a newly focused window
+     * with no focus widget to its *first* focusable child — which used to be
+     * the embed, so a `WebKitWebView` or a `GtkEntry` held GTK focus (and a
+     * caret) from the moment the window mapped, next to Compose's own. The
+     * sink takes that default focus instead; being one of our boxes, keys
+     * then route to Tao's toplevel handler and on to Compose. Parked at
+     * (-1, -1) 1×1, it never catches a click. Idempotent; call before the
+     * first attach.
+     */
+    fun ensureFocusSink() {
+        if (focusSinkKey in boxes) return
+        registerRegion(focusSinkKey, -1, -1, 1, 1)
+    }
+
     /**
      * Translates the EventBox's logical pixel reports back into
      * Compose's physical pixel space (matching what Tao's

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoBridge.kt
@@ -733,12 +733,34 @@ internal object NativeTaoBridge {
         fullscreen: Boolean,
     )
 
-    /** Sets the OS cursor for the window. [code] follows [TaoCursorIcon]. */
+    /**
+     * Sets the OS cursor for the window. [code] follows [TaoCursorIcon].
+     * Callers go through [setCursorIcon], which records the request first.
+     */
     @JvmStatic
     external fun nativeSetCursorIcon(
         handle: Long,
         code: Int,
     )
+
+    /**
+     * The last cursor code requested per window handle, exactly as it was
+     * handed to [nativeSetCursorIcon]. The platform cursor itself cannot be
+     * read back portably (and never under Xvfb), so this is what the headful
+     * suite asserts against: a `BasicTextField` under a still pointer must
+     * have left a `TEXT` here, and a native view under it must not have
+     * flipped it back.
+     */
+    val lastCursorIcon: java.util.concurrent.ConcurrentHashMap<Long, Int> = java.util.concurrent.ConcurrentHashMap()
+
+    /** Records the request in [lastCursorIcon] and applies it. */
+    fun setCursorIcon(
+        handle: Long,
+        code: Int,
+    ) {
+        lastCursorIcon[handle] = code
+        nativeSetCursorIcon(handle, code)
+    }
 
     /**
      * Anchors the platform IME UI at the given window-local rect in *physical

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
@@ -119,7 +119,7 @@ internal object NativeTaoEglBridge {
         handle: Long,
         xLogical: Int,
         yLogical: Int,
-    )
+    ): Boolean
 
     /**
      * Wayland only: declares which part of the content surface is fully opaque,
@@ -209,4 +209,16 @@ internal object NativeTaoEglBridge {
      */
     @JvmStatic
     external fun nativeGetProcAddrFunctionPointer(): Long
+
+    /**
+     * Wayland only: puts the content sub-surface in `set_sync` (buffers apply
+     * with GTK's toplevel commit, atomically with the positions of embedded
+     * native views) or back in `set_desync` (buffers apply on their own).
+     * No-op on X11.
+     */
+    @JvmStatic
+    external fun nativeSetSubsurfaceSync(
+        handle: Long,
+        sync: Boolean,
+    )
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxWidgetBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxWidgetBridge.kt
@@ -189,4 +189,57 @@ internal object NativeTaoLinuxWidgetBridge {
         dx: Float,
         dy: Float,
     )
+
+    /**
+     * Gives the keyboard back to Compose after a press Compose kept: clears
+     * the GTK focus widget when it is an embed (not one of the suite's own
+     * input boxes), so keys route to Tao's toplevel handler again. `true`
+     * when it did.
+     */
+    @JvmStatic
+    external fun nativeClaimKeyboardForCompose(gtkWindowPtr: Long): Boolean
+
+    /**
+     * GDK's live pointer button mask (`GDK_BUTTON1_MASK = 1 shl 8`,
+     * `GDK_BUTTON3_MASK = 1 shl 10`, …), or -1 when unavailable.
+     */
+    @JvmStatic
+    external fun nativeQueryPointerButtons(gtkWindowPtr: Long): Int
+
+    // ── Diagnostics for the headful suite ─────────────────────────────
+
+    /**
+     * A fresh, unparented `GtkEntry` for a headful case to embed through
+     * `NativeView` — the test module cannot fabricate a `GtkWidget*` on
+     * its own. 0 when GTK is unavailable. Destroy with
+     * [nativeDiagDestroyWidget].
+     */
+    @JvmStatic
+    external fun nativeDiagCreateEntry(): Long
+
+    /** Detaches and destroys a widget from [nativeDiagCreateEntry]. */
+    @JvmStatic
+    external fun nativeDiagDestroyWidget(widgetPtr: Long)
+
+    /** The widget [gtkWindowPtr] routes keys to (`gtk_window_get_focus`), or 0. */
+    @JvmStatic
+    external fun nativeDiagFocusWidget(gtkWindowPtr: Long): Long
+
+    /** Whether [widgetPtr] itself holds GTK focus. */
+    @JvmStatic
+    external fun nativeDiagWidgetHasFocus(widgetPtr: Long): Boolean
+
+    /** The text of an entry from [nativeDiagCreateEntry], or null. */
+    @JvmStatic
+    external fun nativeDiagEntryText(widgetPtr: Long): String?
+
+    /**
+     * Where a widget sits, in Tao's content-box coordinates and logical px,
+     * as `[x, y, w, h]` — null while it is not mapped.
+     */
+    @JvmStatic
+    external fun nativeDiagWidgetFrame(
+        gtkWindowPtr: Long,
+        widgetPtr: Long,
+    ): IntArray?
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxWidgetBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxWidgetBridge.kt
@@ -206,6 +206,10 @@ internal object NativeTaoLinuxWidgetBridge {
     @JvmStatic
     external fun nativeQueryPointerButtons(gtkWindowPtr: Long): Int
 
+    /** `gtk_widget_queue_draw` on the toplevel: GTK paints and commits it on its next frame. */
+    @JvmStatic
+    external fun nativeQueueToplevelDraw(gtkWindowPtr: Long)
+
     // ── Diagnostics for the headful suite ─────────────────────────────
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoMacOsNativeViewBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoMacOsNativeViewBridge.kt
@@ -198,4 +198,37 @@ internal object NativeTaoMacOsNativeViewBridge {
      */
     @JvmStatic
     external fun nativeIsFirstResponder(overlayNsView: Long): Boolean
+
+    // ── Diagnostics for the headful suite ─────────────────────────────
+
+    /**
+     * A retained, unparented `NSTextField` for a headful case to embed
+     * through `NativeView`. 0 on failure. Release with [nativeDiagReleaseView].
+     */
+    @JvmStatic
+    external fun nativeDiagCreateTextField(): Long
+
+    /** Removes a view from [nativeDiagCreateTextField] from its superview and releases it. */
+    @JvmStatic
+    external fun nativeDiagReleaseView(nsView: Long)
+
+    /**
+     * Whether [nsView] is editing: its window's first responder is the view
+     * or the field editor working on its behalf — the AppKit shape of
+     * "keystrokes go to the embed".
+     */
+    @JvmStatic
+    external fun nativeDiagViewIsEditing(nsView: Long): Boolean
+
+    /** Whether [contentNsView] itself is its window's first responder — keystrokes go to Compose. */
+    @JvmStatic
+    external fun nativeDiagViewIsFirstResponder(contentNsView: Long): Boolean
+
+    /** The string value of a field from [nativeDiagCreateTextField], or null. */
+    @JvmStatic
+    external fun nativeDiagTextFieldString(nsView: Long): String?
+
+    /** A subview's frame in physical px with a top-left origin, as `[x, y, w, h]`, or null. */
+    @JvmStatic
+    external fun nativeDiagViewFrame(nsView: Long): IntArray?
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoMacOsNativeViewBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoMacOsNativeViewBridge.kt
@@ -98,6 +98,24 @@ internal object NativeTaoMacOsNativeViewBridge {
     @JvmStatic
     external fun nativeMakeContentViewFirstResponder(contentNsView: Long)
 
+    /**
+     * Delivers a Tao key event to the window's first responder when that
+     * responder is an embedded native view (or its field editor), not the
+     * Tao content view. Synthetic keys never enter AppKit's responder chain,
+     * so an `NSTextField` that holds first responder would otherwise never
+     * see a letter typed through the in-process driver.
+     *
+     * [type] is a `TaoEventCode` (`KEY_DOWN` / `KEY_UP` / `KEY_TYPED`).
+     * Returns `true` when the embed took the event.
+     */
+    @JvmStatic
+    external fun nativeDispatchKeyToFirstResponder(
+        contentNsView: Long,
+        type: Int,
+        vkCode: Int,
+        codePoint: Int,
+    ): Boolean
+
     // ── Sibling overlay NSView ────────────────────────────────────────
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoMacOsTextureBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoMacOsTextureBridge.kt
@@ -81,6 +81,19 @@ internal object NativeTaoMacOsTextureBridge {
     @JvmStatic
     external fun nativeDestroy(handle: Long)
 
+    /**
+     * `CFRetain` on a live `IOSurfaceRef`. Used by
+     * [dev.nucleusframework.window.tao.nucleusIOSurfaceTextureSource] so a
+     * producer close cannot free the surface while the source is still
+     * reachable. False when [ioSurfacePtr] is 0 or not an IOSurface.
+     */
+    @JvmStatic
+    external fun nativeRetainIOSurface(ioSurfacePtr: Long): Boolean
+
+    /** `CFRelease` matching a successful [nativeRetainIOSurface]. */
+    @JvmStatic
+    external fun nativeReleaseIOSurface(ioSurfacePtr: Long)
+
     // ---- Metal test producer (demos / smoke tests) --------------------
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsNativeViewBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsNativeViewBridge.kt
@@ -14,6 +14,7 @@ private const val LIBRARY_NAME = "nucleus_tao_windows_native_view"
  * HWNDs instead of NSViews. All entry points must run on the Tao
  * main UI thread (= the thread that owns the parent HWND).
  */
+@Suppress("TooManyFunctions")
 internal object NativeTaoWindowsNativeViewBridge {
     val isLoaded: Boolean = NativeLibraryLoader.load(LIBRARY_NAME, NativeTaoWindowsNativeViewBridge::class.java)
 
@@ -87,4 +88,31 @@ internal object NativeTaoWindowsNativeViewBridge {
         dx: Float,
         dy: Float,
     )
+
+    // ── Diagnostics for the headful suite ─────────────────────────────
+
+    /**
+     * A single-line `EDIT` control created as a hidden top-level window,
+     * for a headful case to embed through `NativeView` (whose attach
+     * turns it into a child of the Tao HWND). 0 on failure. Destroy with
+     * [nativeDiagDestroyWindow].
+     */
+    @JvmStatic
+    external fun nativeDiagCreateEdit(): Long
+
+    /** `DestroyWindow` on a control from [nativeDiagCreateEdit]. */
+    @JvmStatic
+    external fun nativeDiagDestroyWindow(hwnd: Long)
+
+    /** The HWND holding Win32 keyboard focus on this thread's queue (`GetFocus`), or 0. */
+    @JvmStatic
+    external fun nativeDiagFocusedHwnd(): Long
+
+    /** The text of a control from [nativeDiagCreateEdit], or null. */
+    @JvmStatic
+    external fun nativeDiagWindowText(hwnd: Long): String?
+
+    /** A child's rect in its parent's client px, top-left origin, as `[x, y, w, h]`, or null. */
+    @JvmStatic
+    external fun nativeDiagWindowFrame(hwnd: Long): IntArray?
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsNativeViewBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsNativeViewBridge.kt
@@ -89,6 +89,31 @@ internal object NativeTaoWindowsNativeViewBridge {
         dy: Float,
     )
 
+    /**
+     * Hands Win32 keyboard focus back to [parentHwnd] when a descendant (an
+     * embedded child) holds it, and returns whether it did. Called after a
+     * press Compose kept, so the keyboard follows the click.
+     */
+    @JvmStatic
+    external fun nativeClaimKeyboardForCompose(parentHwnd: Long): Boolean
+
+    /**
+     * The mouse buttons this thread's queue holds down, as a mask: bit 0
+     * left, bit 1 right, bit 2 middle. The truth behind a release a child
+     * HWND captured and Compose never saw.
+     */
+    @JvmStatic
+    external fun nativeQueryPointerButtons(): Int
+
+    /**
+     * Takes the mouse capture back from an embedded child of [parentHwnd],
+     * and returns whether it had one. A child that captures on a forwarded
+     * press would otherwise keep every later mouse message, leaving the whole
+     * Compose window unable to see the pointer.
+     */
+    @JvmStatic
+    external fun nativeReleaseChildCapture(parentHwnd: Long): Boolean
+
     // ── Diagnostics for the headful suite ─────────────────────────────
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsNativeViewBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsNativeViewBridge.kt
@@ -114,6 +114,15 @@ internal object NativeTaoWindowsNativeViewBridge {
     @JvmStatic
     external fun nativeReleaseChildCapture(parentHwnd: Long): Boolean
 
+    /**
+     * The pointer's position in [parentHwnd]'s client pixels, packed as
+     * `(x shl 32) or (y and 0xffffffff)`, or [Long.MIN_VALUE] when it cannot
+     * be read. Tao reports a button without one, and the move that would
+     * have carried it may never have reached the window.
+     */
+    @JvmStatic
+    external fun nativeCursorPosInClient(parentHwnd: Long): Long
+
     // ── Diagnostics for the headful suite ─────────────────────────────
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHost.kt
@@ -130,6 +130,16 @@ internal interface TaoPopupHost {
     fun unregisterRenderer(token: Any)
 
     /**
+     * A layer this host handed out has closed and must leave the host's live
+     * set. Compose closes a native popup layer only when the layer's own
+     * disappearance animation finishes; an owner window torn down before
+     * that would otherwise leave the layer's window mapped for good, so the
+     * host tracks its layers and closes the survivors on detach.
+     */
+    @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+    fun onLayerClosed(layer: androidx.compose.ui.scene.ComposeSceneLayer) {}
+
+    /**
      * Runs [block] on the host's dedicated Metal render thread and blocks until
      * it returns. Overlay/popup surfaces must create, use, and close their Skia
      * `DirectContext` here so Skia's Metal context thread-affinity is respected

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostLinux.kt
@@ -111,6 +111,16 @@ internal interface TaoPopupHostLinux {
     fun unregisterRenderer(token: Any)
 
     /**
+     * A layer this host handed out has closed and must leave the host's live
+     * set. Compose closes a native popup layer only when the layer's own
+     * disappearance animation finishes; an owner window torn down before
+     * that would otherwise leave the layer's window mapped for good, so the
+     * host tracks its layers and closes the survivors on detach.
+     */
+    @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+    fun onLayerClosed(layer: androidx.compose.ui.scene.ComposeSceneLayer) {}
+
+    /**
      * Registers a key handler consulted by the host's `onKeyEvent` before
      * the main scene's dispatch. Popup windows never own keyboard focus on
      * Linux (override-redirect windows on X11, subsurfaces on Wayland), so

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupHostWindows.kt
@@ -149,6 +149,16 @@ internal interface TaoPopupHostWindows {
     fun unregisterRenderer(token: Any)
 
     /**
+     * A layer this host handed out has closed and must leave the host's live
+     * set. Compose closes a native popup layer only when the layer's own
+     * disappearance animation finishes; an owner window torn down before
+     * that would otherwise leave the layer's window mapped for good, so the
+     * host tracks its layers and closes the survivors on detach.
+     */
+    @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+    fun onLayerClosed(layer: androidx.compose.ui.scene.ComposeSceneLayer) {}
+
+    /**
      * Notify the host that a popup [TaoPopupSceneLayerWindows] is about
      * to close. Lets parent scenes (e.g., the [NativeView] overlay) clear
      * any focus state that the popup left in a stuck "Captured" state in

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
@@ -548,6 +548,7 @@ internal class TaoPopupSceneLayer(
 
     override fun close() {
         host.unregisterRenderer(rendererToken)
+        host.onLayerClosed(this)
         host.popupScrims.unregister(rendererToken)
         // Mark disposed before any teardown so a surface already recorded this
         // frame is skipped at replay time (TaoRecordedSurface.isAlive).

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayer.kt
@@ -547,6 +547,11 @@ internal class TaoPopupSceneLayer(
     }
 
     override fun close() {
+        // Idempotent: an owner torn down mid-animation closes its surviving
+        // layers itself (see the host's detach sweep), and Compose then
+        // disposes the same layer as the composition unwinds. A second pass
+        // would release the native panel twice.
+        if (disposed) return
         host.unregisterRenderer(rendererToken)
         host.onLayerClosed(this)
         host.popupScrims.unregister(rendererToken)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerLinux.kt
@@ -258,7 +258,7 @@ internal class TaoPopupSceneLayerLinux(
 
                     override fun setPointerIcon(pointerIcon: PointerIcon) {
                         if (released) return
-                        NativeTaoBridge.nativeSetCursorIcon(
+                        NativeTaoBridge.setCursorIcon(
                             popupWindow.handle,
                             pointerIcon.toTaoCursorIconCode(),
                         )
@@ -453,6 +453,7 @@ internal class TaoPopupSceneLayerLinux(
         released = true
         trace { "close" }
         host.unregisterRenderer(rendererToken)
+        host.onLayerClosed(this)
         host.popupScrims.unregister(rendererToken)
         host.unregisterKeyHandler(keyHandlerToken)
         host.unregisterOwnerMoveListener(moveListenerToken)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -427,6 +427,7 @@ internal class TaoPopupSceneLayerWindows(
         released = true
         host.notifyPopupClosing()
         host.unregisterRenderer(rendererToken)
+        host.onLayerClosed(this)
         host.popupScrims.unregister(rendererToken)
         host.unregisterOwnerMoveListener(moveListenerToken)
         PopupNativeBridgeWindows.nativeUninstallOutsideClickMonitor(panelHandle)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/popup/TaoPopupSceneLayerWindows.kt
@@ -424,6 +424,11 @@ internal class TaoPopupSceneLayerWindows(
     override var consumePointerInputOutside: Boolean = initialConsumePointerInputOutside
 
     override fun close() {
+        // Idempotent: an owner torn down mid-animation closes its surviving
+        // layers itself (see the host's detach sweep), and Compose then
+        // disposes the same layer as the composition unwinds. A second pass
+        // would release the native panel twice.
+        if (released) return
         released = true
         host.notifyPopupClosing()
         host.unregisterRenderer(rendererToken)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -866,7 +866,17 @@ internal class TaoComposeSceneHost(
     // consumes the event before the main scene sees it.
     private val popupKeyHandlers: MutableMap<Any, (KeyEvent) -> Boolean> = LinkedHashMap()
 
-    fun nativeViewHost(): TaoNativeViewHost? {
+    /**
+     * One host instance per scene. The composition local built from it keys
+     * `NativeView`'s attach effect: a fresh object on every recomposition of
+     * the window root would detach and re-attach every embed each time.
+     */
+    private var nativeViewHostInstance: dev.nucleusframework.window.tao.TaoNativeViewHost? = null
+
+    fun nativeViewHost(): dev.nucleusframework.window.tao.TaoNativeViewHost? =
+        nativeViewHostInstance ?: createNativeViewHost()?.also { nativeViewHostInstance = it }
+
+    private fun createNativeViewHost(): TaoNativeViewHost? {
         if (nsViewHandle == 0L) return null
         if (!NativeTaoMacOsNativeViewBridge.isLoaded) return null
         val outer = this
@@ -1003,12 +1013,17 @@ internal class TaoComposeSceneHost(
         )
     }
 
+    /** Native popup layers handed out by [nativePopupLayerFactory] and not yet closed — swept by [detach]. */
+    @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+    private val liveNativePopupLayers = linkedSetOf<androidx.compose.ui.scene.ComposeSceneLayer>()
+
     /**
      * Builds this window's native popup layers ([TaoPopupSceneLayer]). The
      * factory behind [nativePopupLayers], and the one `NativePopupLayers { }`
      * hands to a subtree that wants native surfaces while the window's own
      * popups stay in-scene. `null` before the NSView is attached.
      */
+
     fun nativePopupLayerFactory(): TaoPopupLayerFactory? {
         val popupHost = popupHost() ?: return null
         return { density, layoutDirection, focusable, consumeOutside ->
@@ -1018,7 +1033,7 @@ internal class TaoComposeSceneHost(
                 initialLayoutDirection = layoutDirection,
                 initialFocusable = focusable,
                 initialConsumePointerInputOutside = consumeOutside,
-            )
+            ).also { liveNativePopupLayers += it }
         }
     }
 
@@ -1062,6 +1077,11 @@ internal class TaoComposeSceneHost(
                 popupRenderers.remove(token)
             }
 
+            @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+            override fun onLayerClosed(layer: androidx.compose.ui.scene.ComposeSceneLayer) {
+                liveNativePopupLayers.remove(layer)
+            }
+
             override fun <T> runOnRenderThread(block: () -> T): T = outer.runOnRenderThread(block)
 
             override fun registerKeyHandler(
@@ -1076,7 +1096,7 @@ internal class TaoComposeSceneHost(
             }
 
             override fun setCursor(iconCode: Int) {
-                NativeTaoBridge.nativeSetCursorIcon(outer.window.handle, iconCode)
+                NativeTaoBridge.setCursorIcon(outer.window.handle, iconCode)
             }
         }
     }
@@ -1702,6 +1722,12 @@ internal class TaoComposeSceneHost(
     }
 
     fun detach() {
+        // Layers whose dismiss animation was still running: Compose closes a
+        // native popup layer only when its own disappearance finishes, so an
+        // owner destroyed mid-animation left the layer's popup window mapped
+        // for good — an invisible rectangle eating every click under it.
+        for (layer in liveNativePopupLayers.toList()) layer.close()
+        liveNativePopupLayers.clear()
         window.inboundDragAndDropNode = null
         window.imeReplaceCommit = null
         window.imePreedit = null
@@ -1832,7 +1858,7 @@ private class TaoPlatformContext(
         }
 
     override fun setPointerIcon(pointerIcon: androidx.compose.ui.input.pointer.PointerIcon) {
-        NativeTaoBridge.nativeSetCursorIcon(windowHandle, mapPointerIcon(pointerIcon))
+        NativeTaoBridge.setCursorIcon(windowHandle, mapPointerIcon(pointerIcon))
     }
 
     /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -248,6 +248,23 @@ internal class TaoComposeSceneHost(
     /** Set by NativeView pointer-interop when a Press was forwarded to AppKit. */
     private var nativePointerDispatchedThisEvent: Boolean = false
 
+    /**
+     * Handles whose [TaoNativeViewHost.detach] has already run. A layout pass
+     * can still report the slot of an embed in the frame that removes it, and
+     * [scheduleInteropAction] may drain a `setFrame` after dispose — both
+     * must no-op. Only *detached* handles are refused: the first `setFrame`
+     * routinely lands before the attach effect.
+     */
+    private val detachedNativeViews: MutableSet<Long> = mutableSetOf()
+
+    /**
+     * Captured at the first composition via [setContent]. Exposes
+     * `FocusManager.clearFocus(force = true)` so a press handed to an embed
+     * can drop a Compose `BasicTextField`'s caret — the Linux/Windows hosts
+     * do the same.
+     */
+    private var capturedFocusManager: androidx.compose.ui.focus.FocusManager? = null
+
     /** Renderer's view of whether interop is currently active — lags the
      *  transaction's flag by one frame on the OFF transition so the
      *  final sync flush still goes through `presentsWithTransaction`. */
@@ -649,6 +666,8 @@ internal class TaoComposeSceneHost(
     fun setContent(content: @Composable () -> Unit) =
         exceptionHandler.catchExceptions {
             scene?.setContent {
+                val fm = androidx.compose.ui.platform.LocalFocusManager.current
+                androidx.compose.runtime.SideEffect { capturedFocusManager = fm }
                 TaoTextToolbarHost(textToolbar) {
                     val onSel = onTextSelectionForA11y
                     // Expose the publisher so themed wrappers (nucleus-application) can
@@ -898,6 +917,7 @@ internal class TaoComposeSceneHost(
                     WindowTransparencyMode.acquire(outer.window, outer.glassBackgroundState)
                 }
                 outer.interopAttachCount++
+                outer.detachedNativeViews.remove(childHandle)
                 NativeTaoMacOsNativeViewBridge.nativeAddSubview(outer.nsViewHandle, childHandle)
             }
 
@@ -905,6 +925,7 @@ internal class TaoComposeSceneHost(
                 childHandle: Long,
                 regionToken: Any,
             ) {
+                outer.detachedNativeViews += childHandle
                 NativeTaoMacOsNativeViewBridge.nativeRemoveSubview(childHandle)
                 outer.interopAttachCount--
                 if (outer.interopAttachCount == 0) {
@@ -921,7 +942,9 @@ internal class TaoComposeSceneHost(
                 heightPx: Int,
                 regionToken: Any,
             ) {
+                if (handle in outer.detachedNativeViews) return
                 outer.scheduleInteropAction {
+                    if (handle in outer.detachedNativeViews) return@scheduleInteropAction
                     NativeTaoMacOsNativeViewBridge
                         .nativeSetSubviewFrame(outer.nsViewHandle, handle, xPx, yPx, widthPx, heightPx)
                 }
@@ -931,7 +954,9 @@ internal class TaoComposeSceneHost(
                 handle: Long,
                 radiusPx: Float,
             ) {
+                if (handle in outer.detachedNativeViews) return
                 outer.scheduleInteropAction {
+                    if (handle in outer.detachedNativeViews) return@scheduleInteropAction
                     NativeTaoMacOsNativeViewBridge
                         .nativeSetSubviewCornerRadius(outer.nsViewHandle, handle, radiusPx)
                 }
@@ -946,6 +971,16 @@ internal class TaoComposeSceneHost(
                 pressed: Boolean,
             ) {
                 if (outer.nsViewHandle == 0L || handle == 0L) return
+                if (handle in outer.detachedNativeViews) return
+                if (type == NATIVE_POINTER_PRESS) {
+                    // The embed takes the keyboard with this press
+                    // (`makeFirstResponder` in the bridge): a Compose text
+                    // field must not keep showing a caret beside the embed's.
+                    // Deferred — this runs inside the Press dispatch.
+                    outer.flushingDispatcher.enqueue(
+                        Runnable { outer.capturedFocusManager?.clearFocus(force = true) },
+                    )
+                }
                 NativeTaoMacOsNativeViewBridge.nativeDispatchPointer(
                     outer.nsViewHandle,
                     handle,
@@ -965,6 +1000,7 @@ internal class TaoComposeSceneHost(
                 dy: Float,
             ) {
                 if (outer.nsViewHandle == 0L || handle == 0L) return
+                if (handle in outer.detachedNativeViews) return
                 NativeTaoMacOsNativeViewBridge.nativeDispatchScroll(
                     outer.nsViewHandle,
                     handle,
@@ -1446,6 +1482,21 @@ internal class TaoComposeSceneHost(
                 val handler = popupKeyHandlers[token] ?: continue
                 if (handler(composeEvent)) return true
             }
+        }
+        // An embed that holds first responder owns the keyboard. Synthetic
+        // keys never enter AppKit's responder chain, so deliver them here
+        // before Compose — otherwise a focused NSTextField never sees them
+        // and a still-focused BasicTextField would eat the letter too.
+        if (nsViewHandle != 0L &&
+            NativeTaoMacOsNativeViewBridge.isLoaded &&
+            NativeTaoMacOsNativeViewBridge.nativeDispatchKeyToFirstResponder(
+                nsViewHandle,
+                type,
+                vkCode,
+                codePoint,
+            )
+        ) {
+            return true
         }
         if (sc.sendKeyEvent(composeEvent)) return true
         return keyHandler?.invoke(composeEvent) == true
@@ -1958,3 +2009,6 @@ private class TaoPlatformContext(
  * which AppKit only ever asks near the caret.
  */
 private const val IME_DOCUMENT_WINDOW_UTF16 = 128
+
+/** `TaoNativeViewHost.dispatchPointerToNative` type code for a Press. */
+private const val NATIVE_POINTER_PRESS = 1

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -54,6 +54,7 @@ import dev.nucleusframework.window.tao.event.toTaoCursorIconCode
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoEglBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxTouchBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxWidgetBridge
 import dev.nucleusframework.window.tao.hasGlTextureImports
 import dev.nucleusframework.window.tao.installContentMeasurer
 import dev.nucleusframework.window.tao.popup.PopupScreenGeometry
@@ -320,6 +321,13 @@ internal class TaoComposeSceneHostLinux(
      * opaque region. Tracked by handle so duplicate attach/detach is safe.
      */
     private val attachedNativeViews: MutableSet<Long> = linkedSetOf()
+
+    /**
+     * Handles whose detach has run and that have not been attached again —
+     * a late `setFrame` for one of these must not touch the widget.
+     * Cleared on attach: a new widget can be allocated at an old address.
+     */
+    private val detachedNativeViews: MutableSet<Long> = hashSetOf()
     private val nativeViewRects: MutableMap<Long, IntArray> = LinkedHashMap()
 
     /**
@@ -464,6 +472,24 @@ internal class TaoComposeSceneHostLinux(
      * resize hit-test; re-adding a code already in the set is a no-op.
      */
     private val pressedButtons = mutableSetOf<Int>()
+
+    /**
+     * Tao codes of the buttons whose press Compose handed to an embedded
+     * native widget ([TaoNativeViewHost.dispatchPointerToNative]) and whose
+     * release has not come back yet.
+     *
+     * Such a release routinely never comes: the embed's own context menu, or a
+     * drag it starts, takes a grab and the release goes there. Compose is then
+     * left holding a button forever, and — since a click needs a down
+     * *transition* — every later click on Compose is dead, and hover no longer
+     * updates the cursor. [healStaleNativePresses] asks GDK which buttons are
+     * really down on the next motion and releases the phantoms; the next press
+     * releases them regardless, the way the macOS host does.
+     */
+    private val forwardedNativeButtons = mutableSetOf<Int>()
+
+    /** Whether the press being dispatched was handed to a native view — reset at every press. */
+    private var nativePointerDispatchedThisEvent = false
 
     /**
      * Captured at the first composition via [setContent]. Exposes the
@@ -724,13 +750,26 @@ internal class TaoComposeSceneHostLinux(
         directContext = ctx
         // Publish the TextureView handle for the fresh EGL context / Skia
         // context pair (see glTextureHostState).
+        val ownAttachment = attachmentHandle
         glTextureHostState.value =
             object : TaoGlTextureHost {
                 override val directContext: DirectContext = ctx
 
-                // Read live: 0 once the window detached, so a late disposal
-                // can't bind (nor dereference) a freed attachment.
-                override fun <T> withContextCurrent(block: () -> T): T? = withEglContextCurrent(attachmentHandle, block)
+                // Bound only while this pair is the live one. A Wayland
+                // hide/show rebuilds the EGL context *and* the DirectContext:
+                // reading the outer attachment live would bind the *new* EGL
+                // context for a consumer still holding this object's closed
+                // `ctx` — a `flushAndSubmit` on it is a SIGSEGV in Skia. Once
+                // the outer handle moved on (or went to 0 on detach) this
+                // pair is gone, and the caller's null means "context gone".
+                override fun <T> withContextCurrent(block: () -> T): T? =
+                    if (attachmentHandle != ownAttachment ||
+                        directContext !== this@TaoComposeSceneHostLinux.directContext
+                    ) {
+                        null
+                    } else {
+                        withEglContextCurrent(ownAttachment, block)
+                    }
             }
 
         // The native attach binds the EGL context to *this* thread (the GTK
@@ -1976,6 +2015,7 @@ internal class TaoComposeSceneHostLinux(
         val yPx = bFixed / 1024f
         lastPointerX = xPx
         lastPointerY = yPx
+        if (forwardedNativeButtons.isNotEmpty()) healStaleNativePresses()
         // Real pointer motion resuming means the compositor released any
         // resize/move grab — that's our grab-ended signal (the compositor
         // withholds motion for the whole grab), so drop the focus mask here
@@ -2079,6 +2119,14 @@ internal class TaoComposeSceneHostLinux(
         // Any other real press means no compositor grab is in flight.
         if (pressed) {
             compositorDragActive = false
+            nativePointerDispatchedThisEvent = false
+            // A button an embed swallowed the release of must not still be
+            // "down" when this press is hit-tested — see [forwardedNativeButtons].
+            for (stale in forwardedNativeButtons.toList()) {
+                if (stale != buttonCode && stale in pressedButtons) onPointerButton(stale, pressed = false)
+            }
+        } else {
+            forwardedNativeButtons.remove(buttonCode)
         }
         if (pressed) pressedButtons.add(buttonCode) else pressedButtons.remove(buttonCode)
 
@@ -2095,6 +2143,42 @@ internal class TaoComposeSceneHostLinux(
             keyboardModifiers = currentKeyboardModifiers,
             button = mapButton(buttonCode),
         )
+        if (pressed && !nativePointerDispatchedThisEvent && attachedNativeViews.isNotEmpty()) {
+            // Compose kept the press, so the keyboard is Compose's: an embed
+            // the user clicked into earlier would otherwise keep GTK focus
+            // and every keystroke, while Compose shows a focused text field.
+            // The macOS host does the same with `makeFirstResponder`.
+            val gtkWindow = NativeTaoBridge.nativeLinuxGtkWindow(window.handle)
+            if (gtkWindow != 0L && NativeTaoLinuxWidgetBridge.isLoaded) {
+                NativeTaoLinuxWidgetBridge.nativeClaimKeyboardForCompose(gtkWindow)
+            }
+        }
+    }
+
+    /**
+     * Releases every [forwardedNativeButtons] entry GDK reports as up. Only
+     * called while there is one, so a window without embeds never pays the
+     * device query.
+     */
+    private fun healStaleNativePresses() {
+        if (!NativeTaoLinuxWidgetBridge.isLoaded) return
+        val gtkWindow = NativeTaoBridge.nativeLinuxGtkWindow(window.handle)
+        if (gtkWindow == 0L) return
+        val mask = NativeTaoLinuxWidgetBridge.nativeQueryPointerButtons(gtkWindow)
+        if (mask < 0) return
+        for (button in forwardedNativeButtons.toList()) {
+            val bit =
+                when (button) {
+                    dev.nucleusframework.window.tao.TaoMouseButton.LEFT -> GDK_BUTTON1_MASK
+                    dev.nucleusframework.window.tao.TaoMouseButton.MIDDLE -> GDK_BUTTON2_MASK
+                    dev.nucleusframework.window.tao.TaoMouseButton.RIGHT -> GDK_BUTTON3_MASK
+                    else -> 0
+                }
+            if (mask and bit == 0) {
+                forwardedNativeButtons.remove(button)
+                if (button in pressedButtons) onPointerButton(button, pressed = false)
+            }
+        }
     }
 
     /**
@@ -2263,6 +2347,10 @@ internal class TaoComposeSceneHostLinux(
         return keyHandler?.invoke(composeEvent) == true
     }
 
+    /** Native popup layers handed out by [nativePopupLayerFactory] and not yet closed — swept by [detach]. */
+    @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+    private val liveNativePopupLayers = linkedSetOf<androidx.compose.ui.scene.ComposeSceneLayer>()
+
     /**
      * Builds this window's native popup layers ([TaoPopupSceneLayerLinux]).
      * The factory behind [nativePopupLayers], and the one `NativePopupLayers { }`
@@ -2271,6 +2359,7 @@ internal class TaoComposeSceneHostLinux(
      * was: a Wayland hide/show rebuilds the EGL pair and the host reads the
      * live one.
      */
+
     fun nativePopupLayerFactory(): TaoPopupLayerFactory =
         { density, layoutDirection, focusable, consumeOutside ->
             TaoPopupSceneLayerLinux(
@@ -2279,7 +2368,7 @@ internal class TaoComposeSceneHostLinux(
                 initialLayoutDirection = layoutDirection,
                 initialFocusable = focusable,
                 initialConsumePointerInputOutside = consumeOutside,
-            )
+            ).also { liveNativePopupLayers += it }
         }
 
     /**
@@ -2359,6 +2448,11 @@ internal class TaoComposeSceneHostLinux(
                 outer.popupRenderers.remove(token)
             }
 
+            @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+            override fun onLayerClosed(layer: androidx.compose.ui.scene.ComposeSceneLayer) {
+                outer.liveNativePopupLayers.remove(layer)
+            }
+
             override fun registerKeyHandler(
                 token: Any,
                 handler: (KeyEvent) -> Boolean,
@@ -2423,6 +2517,16 @@ internal class TaoComposeSceneHostLinux(
     }
 
     /**
+     * One host instance per scene. The composition local built from it keys
+     * `NativeView`'s attach effect: a fresh object on every recomposition of
+     * the window root would detach and re-attach every embed each time.
+     */
+    private var nativeViewHostInstance: dev.nucleusframework.window.tao.TaoNativeViewHost? = null
+
+    fun nativeViewHost(): dev.nucleusframework.window.tao.TaoNativeViewHost? =
+        nativeViewHostInstance ?: createNativeViewHost()?.also { nativeViewHostInstance = it }
+
+    /**
      * Plumbing for the `GtkWidget` variant of `NucleusPlatformView`.
      * Resolves Tao's `GtkApplicationWindow*` once (it doesn't change
      * for the lifetime of the window), routes attach/detach/setFrame
@@ -2433,7 +2537,7 @@ internal class TaoComposeSceneHostLinux(
      * library is available (missing on non-Linux builds and on Linux
      * builds that didn't ship the .so).
      */
-    fun nativeViewHost(): dev.nucleusframework.window.tao.TaoNativeViewHost? {
+    private fun createNativeViewHost(): dev.nucleusframework.window.tao.TaoNativeViewHost? {
         if (window.handle == 0L) return null
         if (!dev.nucleusframework.window.tao.ffi.NativeTaoLinuxWidgetBridge.isLoaded) return null
         val gtkWindow =
@@ -2446,9 +2550,13 @@ internal class TaoComposeSceneHostLinux(
                 childHandle: Long,
                 regionToken: Any,
             ) {
+                // The sink must be the first focusable child of the overlay,
+                // ahead of the embed — see [TaoLinuxOverlayControllerImpl.ensureFocusSink].
+                outer.overlayController.ensureFocusSink()
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxWidgetBridge
                     .nativeAttach(gtkWindow, childHandle)
                 outer.foreignGlInterop = true
+                outer.detachedNativeViews.remove(childHandle)
                 if (childHandle != 0L && outer.attachedNativeViews.add(childHandle)) {
                     // Force a re-push: lastOpaqueRegion may still hold the full
                     // opaque key from before the embed existed.
@@ -2463,6 +2571,7 @@ internal class TaoComposeSceneHostLinux(
             ) {
                 outer.nativeViewRects.remove(childHandle)
                 outer.overlayController.unregisterRegion(regionToken)
+                outer.detachedNativeViews += childHandle
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxWidgetBridge
                     .nativeDetach(childHandle)
                 if (childHandle != 0L && outer.attachedNativeViews.remove(childHandle)) {
@@ -2479,6 +2588,13 @@ internal class TaoComposeSceneHostLinux(
                 heightPx: Int,
                 regionToken: Any,
             ) {
+                // A layout pass can still report the slot of an embed whose
+                // detach already ran (the node is placed once more in the
+                // frame that removes it); the widget may be gone by then. Only
+                // *detached* handles are refused: the first setFrame routinely
+                // lands before the attach effect, and it is what mounts the
+                // widget (the C side defers the mount to the first real rect).
+                if (handle in outer.detachedNativeViews) return
                 // Compose feeds physical pixels; GTK 3 lays out in
                 // logical pixels (the compositor applies the device
                 // scale on its own).
@@ -2520,8 +2636,28 @@ internal class TaoComposeSceneHostLinux(
                 val rect = outer.nativeViewRects[handle]
                 val xLogical = ((xPx - (rect?.get(0)?.toFloat() ?: 0f)) / s).toInt()
                 val yLogical = ((yPx - (rect?.get(1)?.toFloat() ?: 0f)) / s).toInt()
+                if (type == NATIVE_POINTER_PRESS) {
+                    // NativeView numbers buttons 1 = primary, 2 = secondary.
+                    outer.forwardedNativeButtons +=
+                        if (button == NATIVE_SECONDARY_BUTTON) {
+                            dev.nucleusframework.window.tao.TaoMouseButton.RIGHT
+                        } else {
+                            dev.nucleusframework.window.tao.TaoMouseButton.LEFT
+                        }
+                    // The embed takes the keyboard with this press (the bridge
+                    // grabs GTK focus for it before forwarding): a Compose text
+                    // field must not keep showing a caret beside the embed's.
+                    // Deferred — this runs inside the Press dispatch.
+                    outer.flushingDispatcher.enqueue(
+                        Runnable { outer.capturedFocusManager?.clearFocus(force = true) },
+                    )
+                }
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxWidgetBridge
                     .nativeDispatchPointer(handle, type, xLogical, yLogical, button, pressed)
+            }
+
+            override fun noteNativePointerDispatch() {
+                outer.nativePointerDispatchedThisEvent = true
             }
 
             override fun dispatchScrollToNative(
@@ -2635,6 +2771,12 @@ internal class TaoComposeSceneHostLinux(
 
     fun detach() {
         liveHosts -= this
+        // Layers whose dismiss animation was still running: Compose closes a
+        // native popup layer only when its own disappearance finishes, so an
+        // owner destroyed mid-animation left the layer's popup window mapped
+        // for good — an invisible rectangle eating every click under it.
+        for (layer in liveNativePopupLayers.toList()) layer.close()
+        liveNativePopupLayers.clear()
         window.contentSnapshot = null
         window.inboundDragAndDropNode = null
         window.imePreedit = null
@@ -2997,10 +3139,19 @@ private class LinuxTaoPlatformContext(
         // through `gdk_window_set_device_cursor` for every master pointer of
         // the seat — required because GTK 3 manages cursors via XInput 2's
         // per-device table, which masks legacy `XDefineCursor`.
-        NativeTaoBridge.nativeSetCursorIcon(windowHandle, mapPointerIcon(pointerIcon))
+        NativeTaoBridge.setCursorIcon(windowHandle, mapPointerIcon(pointerIcon))
     }
 
     private fun mapPointerIcon(icon: androidx.compose.ui.input.pointer.PointerIcon): Int = icon.toTaoCursorIconCode()
 }
 
 private val linuxHostLogger: Logger = Logger.getLogger("dev.nucleusframework.window.tao.scene")
+
+/** `TaoNativeViewHost.dispatchPointerToNative` type codes and button numbers, as `NativeView` sends them. */
+private const val NATIVE_POINTER_PRESS = 1
+private const val NATIVE_SECONDARY_BUTTON = 2
+
+/** GDK button bits in a modifier mask. */
+private const val GDK_BUTTON1_MASK = 1 shl 8
+private const val GDK_BUTTON2_MASK = 1 shl 9
+private const val GDK_BUTTON3_MASK = 1 shl 10

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -426,6 +426,15 @@ internal class TaoComposeSceneHostLinux(
      */
     private var lastResizeEventNs: Long = 0L
     private var resizeBurstActive: Boolean = false
+
+    /**
+     * Whether the content sub-surface is in `set_sync` mode — entered with the
+     * resize burst while an embed is attached, left when the burst ends. In
+     * that mode a Compose buffer only shows with GTK's toplevel commit, which
+     * is what makes it land atomically with the embed's new position; see
+     * `NativeTaoEglBridge.nativeSetSubsurfaceSync`.
+     */
+    private var subsurfaceSynced: Boolean = false
     private var appliedSwapInterval: Int = 1
     private var pendingSwapInterval: Int? = null
 
@@ -827,6 +836,8 @@ internal class TaoComposeSceneHostLinux(
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         NativeTaoEglBridge.nativeDetach(attachmentHandle)
         attachmentHandle = 0L
+        // The sub-surface went with the attachment; a fresh one starts desync.
+        subsurfaceSynced = false
     }
 
     /**
@@ -1444,6 +1455,10 @@ internal class TaoComposeSceneHostLinux(
                 resizeBurstActive = true
                 pendingSwapInterval = 0
             }
+            if (!subsurfaceSynced && attachedNativeViews.isNotEmpty() && attachmentHandle != 0L) {
+                subsurfaceSynced = true
+                NativeTaoEglBridge.nativeSetSubsurfaceSync(attachmentHandle, true)
+            }
             // Two catch-up frames: (1) swap that allocates the new buffer,
             // (2) paint into it. Refreshed on every motion so a continuous
             // drag always has headroom after the last pixel.
@@ -1483,12 +1498,16 @@ internal class TaoComposeSceneHostLinux(
      */
     private fun updateResizeBurstSwapInterval() {
         if (attachmentHandle == 0L || attachedKind != 2 || window.isPopup) return
-        if (resizeBurstActive &&
-            lastResizeEventNs > 0L &&
-            System.nanoTime() - lastResizeEventNs >= RESIZE_BURST_HOLD_NS
-        ) {
+        val burstOver = lastResizeEventNs > 0L && System.nanoTime() - lastResizeEventNs >= RESIZE_BURST_HOLD_NS
+        if (resizeBurstActive && burstOver) {
             resizeBurstActive = false
             pendingSwapInterval = 1
+        }
+        if (subsurfaceSynced && burstOver) {
+            subsurfaceSynced = false
+            // `set_desync` applies whatever the compositor still caches, so
+            // the last frame of the burst is never stranded.
+            NativeTaoEglBridge.nativeSetSubsurfaceSync(attachmentHandle, false)
         }
         val want = pendingSwapInterval ?: return
         pendingSwapInterval = null
@@ -1512,7 +1531,16 @@ internal class TaoComposeSceneHostLinux(
         val packed = NativeTaoBridge.nativeLinuxContentOrigin(window.handle)
         val xLogical = (packed shr 32).toInt()
         val yLogical = packed.toInt()
-        NativeTaoEglBridge.nativeSetContentOffset(attachmentHandle, xLogical, yLogical)
+        if (NativeTaoEglBridge.nativeSetContentOffset(attachmentHandle, xLogical, yLogical)) {
+            // The new position is pending parent state: GTK's next commit
+            // applies it, and after a maximize/restore GTK is idle — ask it
+            // to paint. (Committing the parent ourselves is not safe; see the
+            // native side.)
+            val gtkWindow = NativeTaoBridge.nativeLinuxGtkWindow(window.handle)
+            if (gtkWindow != 0L && NativeTaoLinuxWidgetBridge.isLoaded) {
+                NativeTaoLinuxWidgetBridge.nativeQueueToplevelDraw(gtkWindow)
+            }
+        }
     }
 
     /**
@@ -1851,6 +1879,14 @@ internal class TaoComposeSceneHostLinux(
         surface.flushAndSubmit(syncCpu = false)
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
+        if (subsurfaceSynced) {
+            // In sync mode this frame only shows with GTK's next commit; make
+            // sure there is one, also once the pointer has stopped moving.
+            val gtkWindow = NativeTaoBridge.nativeLinuxGtkWindow(window.handle)
+            if (gtkWindow != 0L && NativeTaoLinuxWidgetBridge.isLoaded) {
+                NativeTaoLinuxWidgetBridge.nativeQueueToplevelDraw(gtkWindow)
+            }
+        }
 
         // Re-align the content subsurface with GTK's content area AFTER the
         // swap was requested, so the repositioning (which the native side
@@ -2842,6 +2878,8 @@ internal class TaoComposeSceneHostLinux(
             NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
             NativeTaoEglBridge.nativeDetach(attachmentHandle)
             attachmentHandle = 0L
+            // The sub-surface went with the attachment; a fresh one starts desync.
+            subsurfaceSynced = false
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -1629,12 +1629,17 @@ internal class TaoComposeSceneHostWindows(
         )
     }
 
+    /** Native popup layers handed out by [nativePopupLayerFactory] and not yet closed — swept by [detach]. */
+    @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+    private val liveNativePopupLayers = linkedSetOf<androidx.compose.ui.scene.ComposeSceneLayer>()
+
     /**
      * Builds this window's native popup layers ([TaoPopupSceneLayerWindows]).
      * The factory behind [nativePopupLayers], and the one `NativePopupLayers { }`
      * hands to a subtree that wants native surfaces while the window's own
      * popups stay in-scene. `null` until the HWND and its Skia context exist.
      */
+
     fun nativePopupLayerFactory(): TaoPopupLayerFactory? {
         val popupHost = popupHost() ?: return null
         return { density, layoutDirection, focusable, consumeOutside ->
@@ -1644,7 +1649,7 @@ internal class TaoComposeSceneHostWindows(
                 initialLayoutDirection = layoutDirection,
                 initialFocusable = focusable,
                 initialConsumePointerInputOutside = consumeOutside,
-            )
+            ).also { liveNativePopupLayers += it }
         }
     }
 
@@ -1697,6 +1702,11 @@ internal class TaoComposeSceneHostWindows(
             override fun unregisterRenderer(token: Any) {
                 outer.popupRenderers.remove(token)
                 outer.hostContextDirtied = true
+            }
+
+            @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+            override fun onLayerClosed(layer: androidx.compose.ui.scene.ComposeSceneLayer) {
+                outer.liveNativePopupLayers.remove(layer)
             }
 
             override fun registerKeyHandler(
@@ -1767,7 +1777,17 @@ internal class TaoComposeSceneHostWindows(
         for (cb in ownerMoveListeners.values.toList()) cb()
     }
 
-    fun nativeViewHost(): dev.nucleusframework.window.tao.TaoNativeViewHost? {
+    /**
+     * One host instance per scene. The composition local built from it keys
+     * `NativeView`'s attach effect: a fresh object on every recomposition of
+     * the window root would detach and re-attach every embed each time.
+     */
+    private var nativeViewHostInstance: dev.nucleusframework.window.tao.TaoNativeViewHost? = null
+
+    fun nativeViewHost(): dev.nucleusframework.window.tao.TaoNativeViewHost? =
+        nativeViewHostInstance ?: createNativeViewHost()?.also { nativeViewHostInstance = it }
+
+    private fun createNativeViewHost(): dev.nucleusframework.window.tao.TaoNativeViewHost? {
         if (hwnd == 0L) return null
         if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge.isLoaded) return null
         val parent = hwnd
@@ -2053,6 +2073,12 @@ internal class TaoComposeSceneHostWindows(
     }
 
     fun detach() {
+        // Layers whose dismiss animation was still running: Compose closes a
+        // native popup layer only when its own disappearance finishes, so an
+        // owner destroyed mid-animation left the layer's popup window mapped
+        // for good — an invisible rectangle eating every click under it.
+        for (layer in liveNativePopupLayers.toList()) layer.close()
+        liveNativePopupLayers.clear()
         window.showHook = null
         window.inboundDragAndDropNode = null
         window.imePreedit = null
@@ -2249,7 +2275,7 @@ private class WindowsTaoPlatformContext(
     }
 
     override fun setPointerIcon(pointerIcon: androidx.compose.ui.input.pointer.PointerIcon) {
-        NativeTaoBridge.nativeSetCursorIcon(
+        NativeTaoBridge.setCursorIcon(
             windowHandle,
             mapPointerIcon(pointerIcon),
         )

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -1239,7 +1239,22 @@ internal class TaoComposeSceneHostWindows(
     }
 
     fun onFocusChanged(focused: Boolean) {
-        windowInfo.isWindowFocused = focused
+        // Win32 focus moving to an embedded child (a `NativeView`, WebView2)
+        // reaches Tao as the main HWND losing it, but the window is still the
+        // one the user is working in. Telling the scene otherwise puts its
+        // focus system to sleep: carets stop, `clearFocus` stops taking, and
+        // anything reading `LocalWindowInfo.isWindowFocused` goes inactive
+        // under the user's hands. `DecoratedWindow` keeps its chrome active
+        // through the same question.
+        windowInfo.isWindowFocused = focused || isFocusInsideWindowTree()
+    }
+
+    /** Whether Win32 keyboard focus is on this window or on something it contains. */
+    private fun isFocusInsideWindowTree(): Boolean {
+        if (hwnd == 0L) return false
+        if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge.isLoaded) return false
+        return dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
+            .nativeIsFocusInTree(hwnd)
     }
 
     private fun updateWindowInfoSize() {
@@ -1477,6 +1492,8 @@ internal class TaoComposeSceneHostWindows(
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
         healStaleNativePresses()
+        // Tao saw this move, so its own idea of the position is current again.
+        pointerPositionSetByOverlay = false
         if (!pointerDeadband.shouldDispatchMove(xPx, yPx, scale)) return
         scene?.sendPointerEvent(
             eventType = PointerEventType.Move,
@@ -1509,6 +1526,7 @@ internal class TaoComposeSceneHostWindows(
         pressed: Boolean,
     ) {
         if (nativePointerRedispatchInFlight) return
+        syncPointerPositionFromWin32()
         if (consumeOverlayEcho(mapButton(buttonCode), pressed)) return
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
@@ -1559,6 +1577,50 @@ internal class TaoComposeSceneHostWindows(
         if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge.isLoaded) return
         dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
             .nativeClaimKeyboardForCompose(hwnd)
+    }
+
+    /**
+     * Whether the scene's pointer position came from the blending overlay,
+     * which Tao knows nothing about — see [syncPointerPositionFromWin32].
+     */
+    private var pointerPositionSetByOverlay: Boolean = false
+
+    /**
+     * Puts the scene's pointer back where Win32 says it is, moving it there
+     * first when it has drifted.
+     *
+     * Tao reports a button press without a position, so the scene places it
+     * where the last move left the pointer — and Tao drops a `WM_MOUSEMOVE`
+     * whose coordinate equals the last one *it* saw. Every move over a
+     * `NativeView` is delivered to the blending overlay instead, which never
+     * reaches Tao, so its idea of the position goes stale: a pointer that
+     * leaves the embed and comes back to a point Tao saw before gets no move
+     * at all, and the click that follows is dispatched onto the embed the
+     * user just left. It is dead, and so is every click after it.
+     */
+    private fun syncPointerPositionFromWin32() {
+        if (!pointerPositionSetByOverlay) return
+        pointerPositionSetByOverlay = false
+        if (hwnd == 0L) return
+        if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge.isLoaded) return
+        val packed =
+            dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
+                .nativeCursorPosInClient(hwnd)
+        if (packed == Long.MIN_VALUE) return
+        val xPx = (packed shr 32).toInt().toFloat()
+        val yPx = packed.toInt().toFloat()
+        if (kotlin.math.abs(xPx - pointerDeadband.x) < 1f && kotlin.math.abs(yPx - pointerDeadband.y) < 1f) return
+        lastPointerX = xPx
+        lastPointerY = yPx
+        pointerDeadband.shouldDispatchMove(xPx, yPx, scale)
+        // The scene has to *travel* there: a press on a node the pointer was
+        // never seen entering leaves hover and cursor state on the old one.
+        scene?.sendPointerEvent(
+            eventType = PointerEventType.Move,
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
+            type = PointerType.Mouse,
+            keyboardModifiers = currentKeyboardModifiers,
+        )
     }
 
     /**
@@ -2029,10 +2091,17 @@ internal class TaoComposeSceneHostWindows(
                     // The embed takes the keyboard with this press (the bridge
                     // SetFocuses it before forwarding): a Compose text field
                     // must not keep showing a caret beside the embed's.
-                    // Deferred — this runs inside the Press dispatch.
-                    outer.flushingDispatcher.enqueue(
-                        Runnable { outer.capturedFocusManager?.clearFocus(force = true) },
-                    )
+                    //
+                    // Deferred, because this runs inside the Press dispatch —
+                    // but on the main dispatcher, not the frame queue: the
+                    // press may be the one that opens the embed's own context
+                    // menu, whose modal loop stops the window painting, and a
+                    // focus clear waiting for a frame would never run while
+                    // the menu the user is looking at is up.
+                    dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+                        .dispatch(kotlin.coroutines.EmptyCoroutineContext) {
+                            outer.capturedFocusManager?.clearFocus(force = true)
+                        }
                 }
                 outer.nativePointerRedispatchInFlight = true
                 try {
@@ -2040,6 +2109,7 @@ internal class TaoComposeSceneHostWindows(
                         .nativeDispatchPointer(parent, handle, type, xPx, yPx, button, pressed)
                 } finally {
                     outer.nativePointerRedispatchInFlight = false
+                    outer.window.resetRedrawLatch()
                 }
             }
 
@@ -2061,6 +2131,12 @@ internal class TaoComposeSceneHostWindows(
                         .nativeDispatchScroll(parent, handle, xPx, yPx, dx, dy)
                 } finally {
                     outer.nativePointerRedispatchInFlight = false
+                    // Handing an event to a child HWND runs its handler on this
+                    // thread, and anything it pumps swallows the redraw this
+                    // window had pending — the coalescing latch then suppresses
+                    // every later request and the window silently stops
+                    // painting. See TaoWindow.resetRedrawLatch.
+                    outer.window.resetRedrawLatch()
                 }
             }
         }
@@ -2160,6 +2236,7 @@ internal class TaoComposeSceneHostWindows(
         ) {
             lastPointerX = x
             lastPointerY = y
+            pointerPositionSetByOverlay = true
             currentKeyboardModifiers = taoKeyboardModifiers(modifiers)
             windowInfo.keyboardModifiers = currentKeyboardModifiers
             val pointerButton =
@@ -2217,10 +2294,10 @@ internal class TaoComposeSceneHostWindows(
     }
 
     // Hop the debounced semantics walk onto the render thread (it touches
-    // Compose state) and request a redraw. See AbstractTaoComposeSceneHost.
+    // Compose state); the enqueue asks for the frame that drains it. See
+    // AbstractTaoComposeSceneHost.
     override fun dispatchA11yWalk(block: () -> Unit) {
         flushingDispatcher.enqueue(Runnable { block() })
-        window.requestRedraw()
     }
 
     /**
@@ -2392,8 +2469,15 @@ internal class TaoComposeSceneHostWindows(
             window.requestRedraw()
         }
 
+        /**
+         * Queues [block] for the next drain. The drains all sit in the frame
+         * path, so this asks for a frame too — a window with nothing else to
+         * redraw would otherwise hold the block forever (a focus clear that
+         * never runs leaves two carets on screen).
+         */
         fun enqueue(block: Runnable) {
             queue.add(block)
+            window.requestRedraw()
         }
 
         fun drain() {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -343,6 +343,33 @@ internal class TaoComposeSceneHostWindows(
      */
     private var nativePointerRedispatchInFlight: Boolean = false
 
+    /** Whether the press being dispatched was handed to a native view — reset at every press. */
+    private var nativePointerDispatchedThisEvent: Boolean = false
+
+    /**
+     * Buttons whose press was forwarded to an embedded child HWND and whose
+     * release Compose has not seen. A child that `SetCapture`s on the press
+     * (every EDIT does, so does WebView2) gets the release alone; Compose
+     * would keep the button down and every later click would have no down
+     * transition. Healed from Win32's own button state on the next move and
+     * released before a new press — see [healStaleNativePresses].
+     */
+    private val forwardedNativeButtons = mutableSetOf<PointerButton>()
+
+    /** Buttons the scene currently holds down, so a release Compose never saw the press of is dropped. */
+    private val pressedButtons = mutableSetOf<PointerButton>()
+
+    /** Live `NativeView` embeds; the keyboard reclaim only runs while there is one. */
+    private var attachedNativeViewCount: Int = 0
+
+    /**
+     * Captured at the first composition via [setContent]. Exposes the
+     * standard `FocusManager.clearFocus(force = true)` the scene-level
+     * focus manager doesn't, so a press that hands the keyboard to an embed
+     * also drops the Compose text field's caret.
+     */
+    private var capturedFocusManager: androidx.compose.ui.focus.FocusManager? = null
+
     // Frame pacing is delegated to VSync — `eglSwapInterval(1)` makes
     // eglSwapBuffers pace off the display refresh, which keeps Compose
     // animations (smooth scroll, etc.) aligned on the display cadence at the
@@ -975,6 +1002,8 @@ internal class TaoComposeSceneHostWindows(
     fun setContent(content: @Composable () -> Unit) =
         exceptionHandler.catchExceptions {
             scene?.setContent {
+                val fm = androidx.compose.ui.platform.LocalFocusManager.current
+                androidx.compose.runtime.SideEffect { capturedFocusManager = fm }
                 // Stock Compose Desktop Windows wheel behavior; only the
                 // lines-per-notch factor is reapplied (see TaoWindowsScrollConfig).
                 ProvideTaoWindowsScrollConfig {
@@ -1447,6 +1476,7 @@ internal class TaoComposeSceneHostWindows(
         lastPointerY = yPx
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
+        healStaleNativePresses()
         if (!pointerDeadband.shouldDispatchMove(xPx, yPx, scale)) return
         scene?.sendPointerEvent(
             eventType = PointerEventType.Move,
@@ -1479,14 +1509,157 @@ internal class TaoComposeSceneHostWindows(
         pressed: Boolean,
     ) {
         if (nativePointerRedispatchInFlight) return
+        if (consumeOverlayEcho(mapButton(buttonCode), pressed)) return
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
+        sendButtonToScene(mapButton(buttonCode), pressed)
+    }
+
+    /**
+     * The one button path of the scene, for the HWND's own messages and the
+     * blending overlay's alike. Around the dispatch it keeps Compose's idea
+     * of the buttons honest against the embeds (see [forwardedNativeButtons])
+     * and gives the keyboard to whichever side the press went to.
+     */
+    private fun sendButtonToScene(
+        button: PointerButton,
+        pressed: Boolean,
+    ) {
+        if (pressed) {
+            // A button an embed swallowed the release of must not still be
+            // "down" when this press is hit-tested: Compose would see no
+            // down transition and the click would be dead.
+            for (stale in forwardedNativeButtons.toList()) releaseStaleNativePress(stale)
+            nativePointerDispatchedThisEvent = false
+            pressedButtons.add(button)
+        } else {
+            if (forwardedNativeButtons.remove(button)) releaseChildCapture()
+            // A release whose press the scene never saw (it went to an
+            // embed, a popup layer, or the frame) means nothing to it.
+            if (!pressedButtons.remove(button)) return
+        }
         scene?.sendPointerEvent(
             eventType = if (pressed) PointerEventType.Press else PointerEventType.Release,
             position = Offset(pointerDeadband.x, pointerDeadband.y),
             type = PointerType.Mouse,
             keyboardModifiers = currentKeyboardModifiers,
-            button = mapButton(buttonCode),
+            button = button,
+        )
+        if (pressed && !nativePointerDispatchedThisEvent) claimKeyboardForCompose()
+    }
+
+    /**
+     * Takes Win32 keyboard focus back from an embed after a press Compose
+     * kept. Without it an embed clicked into earlier keeps the keyboard while
+     * Compose shows a focused text field — the macOS host does the same with
+     * `makeFirstResponder`.
+     */
+    private fun claimKeyboardForCompose() {
+        if (attachedNativeViewCount == 0 || hwnd == 0L) return
+        if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge.isLoaded) return
+        dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
+            .nativeClaimKeyboardForCompose(hwnd)
+    }
+
+    /**
+     * The last button event the blending overlay fed to the scene, kept until
+     * the main HWND replays it — see [consumeOverlayEcho].
+     */
+    private var echoButton: PointerButton? = null
+    private var echoPressed: Boolean = false
+    private var echoXPx: Float = 0f
+    private var echoYPx: Float = 0f
+    private var echoAtNanos: Long = 0L
+
+    private fun noteOverlayButton(
+        button: PointerButton,
+        pressed: Boolean,
+        xPx: Float,
+        yPx: Float,
+    ) {
+        echoButton = button
+        echoPressed = pressed
+        echoXPx = xPx
+        echoYPx = yPx
+        echoAtNanos = System.nanoTime()
+    }
+
+    /**
+     * Whether this main-HWND button event is Windows replaying one the
+     * blending overlay already gave the scene, and must be dropped.
+     *
+     * Pixels a `NativeView` owns are the overlay's: it is the window under
+     * them and hit-tests them first. Forwarding the press it reports to the
+     * embedded child moves Win32 focus, and the queue then replays the very
+     * same message to the owner HWND. Dispatched a second time it leaves
+     * Compose holding a press with no release, and every later click on the
+     * window is dead. Matched on button, position and recency, and consumed
+     * once, so a genuine second click — a double click on the embed, or a
+     * programmatic dispatch straight into the window — still gets through.
+     */
+    private fun consumeOverlayEcho(
+        button: PointerButton,
+        pressed: Boolean,
+    ): Boolean {
+        val pending = echoButton ?: return false
+        if (pending != button || echoPressed != pressed) return false
+        if (System.nanoTime() - echoAtNanos > OVERLAY_ECHO_WINDOW_NANOS) return false
+        if (kotlin.math.abs(lastPointerX - echoXPx) > OVERLAY_ECHO_SLACK_PX ||
+            kotlin.math.abs(lastPointerY - echoYPx) > OVERLAY_ECHO_SLACK_PX
+        ) {
+            return false
+        }
+        echoButton = null
+        return true
+    }
+
+    /**
+     * Hands the mouse capture back when an embed took it on a forwarded
+     * press. Without this the child HWND keeps every later mouse message and
+     * the Compose window — its own HWND and the blending overlay alike —
+     * never sees the pointer again.
+     */
+    private fun releaseChildCapture() {
+        if (hwnd == 0L) return
+        if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge.isLoaded) return
+        dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
+            .nativeReleaseChildCapture(hwnd)
+    }
+
+    /**
+     * Releases every [forwardedNativeButtons] entry Win32 reports as up. Only
+     * pays the query while there is one, so a window without embeds never
+     * does.
+     */
+    private fun healStaleNativePresses() {
+        if (forwardedNativeButtons.isEmpty()) return
+        if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge.isLoaded) return
+        val mask =
+            dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
+                .nativeQueryPointerButtons()
+        for (button in forwardedNativeButtons.toList()) {
+            val bit =
+                when (button) {
+                    PointerButton.Primary -> WIN32_LBUTTON_BIT
+                    PointerButton.Secondary -> WIN32_RBUTTON_BIT
+                    PointerButton.Tertiary -> WIN32_MBUTTON_BIT
+                    else -> 0
+                }
+            if (mask and bit == 0) releaseStaleNativePress(button)
+        }
+    }
+
+    /** The release the embed kept, synthesized where the scene last saw the pointer. */
+    private fun releaseStaleNativePress(button: PointerButton) {
+        forwardedNativeButtons.remove(button)
+        releaseChildCapture()
+        if (!pressedButtons.remove(button)) return
+        scene?.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            position = Offset(pointerDeadband.x, pointerDeadband.y),
+            type = PointerType.Mouse,
+            keyboardModifiers = currentKeyboardModifiers,
+            button = button,
         )
     }
 
@@ -1800,6 +1973,7 @@ internal class TaoComposeSceneHostWindows(
                 dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
                     .nativeAttach(parent, childHandle)
                 outer.nativeViewBlending.retain()
+                outer.attachedNativeViewCount++
             }
 
             override fun detach(
@@ -1810,6 +1984,7 @@ internal class TaoComposeSceneHostWindows(
                 dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
                     .nativeDetach(childHandle)
                 outer.nativeViewBlending.release()
+                outer.attachedNativeViewCount = (outer.attachedNativeViewCount - 1).coerceAtLeast(0)
             }
 
             override fun setFrame(
@@ -1842,6 +2017,23 @@ internal class TaoComposeSceneHostWindows(
                 pressed: Boolean,
             ) {
                 if (parent == 0L) return
+                if (type == NATIVE_POINTER_PRESS) {
+                    // The child SetCaptures on this press and keeps the
+                    // release; Compose hears of it through the heal.
+                    outer.forwardedNativeButtons +=
+                        when (button) {
+                            NATIVE_SECONDARY_BUTTON -> PointerButton.Secondary
+                            NATIVE_MIDDLE_BUTTON -> PointerButton.Tertiary
+                            else -> PointerButton.Primary
+                        }
+                    // The embed takes the keyboard with this press (the bridge
+                    // SetFocuses it before forwarding): a Compose text field
+                    // must not keep showing a caret beside the embed's.
+                    // Deferred — this runs inside the Press dispatch.
+                    outer.flushingDispatcher.enqueue(
+                        Runnable { outer.capturedFocusManager?.clearFocus(force = true) },
+                    )
+                }
                 outer.nativePointerRedispatchInFlight = true
                 try {
                     dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
@@ -1849,6 +2041,10 @@ internal class TaoComposeSceneHostWindows(
                 } finally {
                     outer.nativePointerRedispatchInFlight = false
                 }
+            }
+
+            override fun noteNativePointerDispatch() {
+                outer.nativePointerDispatchedThisEvent = true
             }
 
             override fun dispatchScrollToNative(
@@ -1979,18 +2175,21 @@ internal class TaoComposeSceneHostWindows(
                     2 -> PointerEventType.Release
                     else -> PointerEventType.Move
                 }
-            // Same sub-pixel deadband as the main stream (#615) — the
-            // overlay WndProc shares the scene's single mouse pointer.
-            if (eventType == PointerEventType.Move &&
-                !pointerDeadband.shouldDispatchMove(x, y, scale)
-            ) {
+            if (eventType != PointerEventType.Move) {
+                noteOverlayButton(pointerButton ?: PointerButton.Primary, eventType == PointerEventType.Press, x, y)
+                // The overlay reports in owner-client px, like the HWND.
+                pointerDeadband.shouldDispatchMove(x, y, scale)
+                sendButtonToScene(pointerButton ?: PointerButton.Primary, eventType == PointerEventType.Press)
                 return
             }
+            healStaleNativePresses()
+            // Same sub-pixel deadband as the main stream (#615) — the
+            // overlay WndProc shares the scene's single mouse pointer.
+            if (!pointerDeadband.shouldDispatchMove(x, y, scale)) return
             scene?.sendPointerEvent(
                 eventType = eventType,
                 position = Offset(pointerDeadband.x, pointerDeadband.y),
                 type = PointerType.Mouse,
-                button = pointerButton,
                 keyboardModifiers = currentKeyboardModifiers,
             )
         }
@@ -2283,3 +2482,19 @@ private class WindowsTaoPlatformContext(
 
     private fun mapPointerIcon(icon: androidx.compose.ui.input.pointer.PointerIcon): Int = icon.toTaoCursorIconCode()
 }
+
+/** `NativeView` pointer type / button codes (see `TaoNativeViewHost.dispatchPointerToNative`). */
+private const val NATIVE_POINTER_PRESS = 1
+private const val NATIVE_SECONDARY_BUTTON = 2
+private const val NATIVE_MIDDLE_BUTTON = 3
+
+/** Bits of `NativeTaoWindowsNativeViewBridge.nativeQueryPointerButtons`. */
+private const val WIN32_LBUTTON_BIT = 1
+private const val WIN32_RBUTTON_BIT = 2
+private const val WIN32_MBUTTON_BIT = 4
+
+/** How long after an overlay button event its main-HWND replay may arrive. */
+private const val OVERLAY_ECHO_WINDOW_NANOS = 500_000_000L
+
+/** How far the replayed position may sit from the overlay's, in px. */
+private const val OVERLAY_ECHO_SLACK_PX = 2f

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
@@ -290,6 +290,7 @@ typedef int             (*PFN_wl_display_flush)(wl_display *);
 #define WL_SUBCOMPOSITOR_GET_SUBSURFACE    1
 #define WL_SUBSURFACE_DESTROY              0
 #define WL_SUBSURFACE_SET_POSITION         1
+#define WL_SUBSURFACE_SET_SYNC             4
 #define WL_SUBSURFACE_SET_DESYNC           5
 #define WL_SURFACE_DESTROY                 0
 #define WL_SURFACE_ATTACH                  1
@@ -1521,14 +1522,14 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeResize(
  * draws. Cheap no-op when the offset is unchanged; no-op on X11 (the CSD is
  * never latched there).
  */
-JNIEXPORT void JNICALL
+JNIEXPORT jboolean JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetContentOffset(
     JNIEnv *env, jclass clazz, jlong handle, jint xLogical, jint yLogical)
 {
     (void) env; (void) clazz;
     EglAttachment *att = (EglAttachment *) (uintptr_t) handle;
-    if (!att || !att->wl_subsurface || !p_wl_proxy_marshal_flags) return;
-    if (att->content_off_x == xLogical && att->content_off_y == yLogical) return;
+    if (!att || !att->wl_subsurface || !p_wl_proxy_marshal_flags) return JNI_FALSE;
+    if (att->content_off_x == xLogical && att->content_off_y == yLogical) return JNI_FALSE;
     att->content_off_x = xLogical;
     att->content_off_y = yLogical;
     p_wl_proxy_marshal_flags(att->wl_subsurface, WL_SUBSURFACE_SET_POSITION,
@@ -1538,14 +1539,44 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetContentOffs
      * GTK's next commit, and after a maximize/restore GTK has already
      * committed its reallocation by the time this runs and then goes idle,
      * which would leave the old offset applied forever (content shifted
-     * bottom-right by the former shadow margins). Issue an empty commit on
-     * GTK's toplevel surface ourselves: it applies pending state only, and
-     * this call always runs on the GTK main thread (the render loop), so
-     * GTK is never mid-way through its own attach/damage/commit sequence. */
-    if (att->wl_parent_surface) {
-        p_wl_proxy_marshal_flags(att->wl_parent_surface, WL_SURFACE_COMMIT,
-            NULL, p_wl_proxy_get_version(att->wl_parent_surface), 0);
-    }
+     * bottom-right by the former shadow margins). This used to issue an
+     * empty commit on GTK's toplevel surface here. That is not safe: GDK
+     * attaches its SHM buffer in `end_paint` and commits it in
+     * `after_paint`, and a commit of ours between the two hands the
+     * compositor a buffer GDK still counts as staged — the release then
+     * fails GDK's `buffer_release_callback` check and cairo aborts the
+     * process (seen after a minimize/restore storm). The caller asks GTK to
+     * repaint the toplevel instead, and GTK's own commit applies the
+     * position. Returns whether the offset changed, so the caller knows to. */
+    if (p_wl_display_flush && att->wl_display_conn) p_wl_display_flush(att->wl_display_conn);
+    return JNI_TRUE;
+}
+
+/**
+ * Switches the content sub-surface between `set_sync` and `set_desync`.
+ *
+ * Normally desync: Compose's buffers land on their own, independently of
+ * GTK's cairo paint cycle (see the file header). Through an interactive
+ * resize that independence is the problem: an embedded native view
+ * (`NativeView`, e.g. WebKit's accelerated sub-surface) is positioned by GTK
+ * on its allocation, and a sub-surface position is parent state that only
+ * takes effect on GTK's toplevel commit — one GTK paint after Compose laid
+ * the new hole out and swapped. The embed peels off the hole by a frame on
+ * every configure. In sync mode our buffer is cached by the compositor and
+ * applied atomically with that same GTK commit, hole and embed together.
+ * Per the protocol, `set_desync` applies any cached state at once, so
+ * leaving sync mode never strands a frame.
+ */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetSubsurfaceSync(
+    JNIEnv *env, jclass clazz, jlong handle, jboolean sync)
+{
+    (void) env; (void) clazz;
+    EglAttachment *att = (EglAttachment *) (uintptr_t) handle;
+    if (!att || !att->wl_subsurface || !p_wl_proxy_marshal_flags) return;
+    p_wl_proxy_marshal_flags(att->wl_subsurface,
+        sync ? WL_SUBSURFACE_SET_SYNC : WL_SUBSURFACE_SET_DESYNC,
+        NULL, p_wl_proxy_get_version(att->wl_subsurface), 0);
     if (p_wl_display_flush && att->wl_display_conn) p_wl_display_flush(att->wl_display_conn);
 }
 

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_widget.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_widget.c
@@ -125,6 +125,7 @@ typedef void       (*PFN_g_object_unref)(void *obj);
 typedef void       (*PFN_g_list_free)(GList *list);
 typedef GtkWidget *(*PFN_gtk_window_get_focus)(GtkWindow *window);
 typedef void       (*PFN_gtk_container_check_resize)(GtkContainer *container);
+typedef void       (*PFN_gtk_widget_queue_draw)(GtkWidget *widget);
 typedef void      *(*PFN_gdk_window_get_display)(void *window);
 typedef void      *(*PFN_gdk_display_get_default_seat)(void *display);
 typedef void      *(*PFN_gdk_seat_get_pointer)(void *seat);
@@ -178,6 +179,7 @@ static struct {
     /* Optional: keyboard-owner bookkeeping and the live button state. */
     PFN_gtk_window_get_focus      gtk_window_get_focus;
     PFN_gtk_container_check_resize gtk_container_check_resize;
+    PFN_gtk_widget_queue_draw     gtk_widget_queue_draw;
     PFN_gdk_window_get_display    gdk_window_get_display;
     PFN_gdk_display_get_default_seat gdk_display_get_default_seat;
     PFN_gdk_seat_get_pointer      gdk_seat_get_pointer;
@@ -257,6 +259,7 @@ static int ensure_gtk_loaded(void) {
     }
     g.gtk_window_get_focus        = (PFN_gtk_window_get_focus)        dlsym(libgtk, "gtk_window_get_focus");
     g.gtk_container_check_resize  = (PFN_gtk_container_check_resize)  dlsym(libgtk, "gtk_container_check_resize");
+    g.gtk_widget_queue_draw       = (PFN_gtk_widget_queue_draw)       dlsym(libgtk, "gtk_widget_queue_draw");
     g.g_object_ref                = (PFN_g_object_ref)                dlsym(libgobj, "g_object_ref");
     g.g_object_unref              = (PFN_g_object_unref)              dlsym(libgobj, "g_object_unref");
     if (libglib != NULL) {
@@ -803,6 +806,20 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeQueryP
     unsigned int mask = 0;
     g.gdk_window_get_device_position(gdk_window, pointer, NULL, NULL, &mask);
     return (jint) mask;
+}
+
+/* Asks GTK to paint — and so commit — its toplevel on its next frame. While
+ * the content sub-surface is in sync mode (resize burst with an embed), a
+ * Compose buffer is only shown by GTK's commit; GTK commits on every
+ * configure while the pointer moves, and this covers the frames in between
+ * and the last one after the pointer stops. */
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeQueueToplevelDraw(
+    JNIEnv *env, jclass clazz, jlong gtk_window_ptr)
+{
+    (void) env; (void) clazz;
+    if (!ensure_gtk_loaded() || g.gtk_widget_queue_draw == NULL || gtk_window_ptr == 0) return;
+    g.gtk_widget_queue_draw((GtkWidget *) (uintptr_t) gtk_window_ptr);
 }
 
 /* ── Input-box overlay: hit capture for NativeView blending ──

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_widget.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_widget.c
@@ -123,6 +123,13 @@ typedef void       (*PFN_gdk_event_free)(void *event);
 typedef void      *(*PFN_g_object_ref)(void *obj);
 typedef void       (*PFN_g_object_unref)(void *obj);
 typedef void       (*PFN_g_list_free)(GList *list);
+typedef GtkWidget *(*PFN_gtk_window_get_focus)(GtkWindow *window);
+typedef void       (*PFN_gtk_container_check_resize)(GtkContainer *container);
+typedef void      *(*PFN_gdk_window_get_display)(void *window);
+typedef void      *(*PFN_gdk_display_get_default_seat)(void *display);
+typedef void      *(*PFN_gdk_seat_get_pointer)(void *seat);
+typedef void      *(*PFN_gdk_window_get_device_position)(
+    void *window, void *device, int *x, int *y, unsigned int *mask);
 
 /* GtkAlign enum — `GTK_ALIGN_FILL` = 0 (GTK 3), `GTK_ALIGN_START` = 1.
  * We use START on the dummy main child so it doesn't request expansion. */
@@ -168,6 +175,13 @@ static struct {
     PFN_g_object_ref              g_object_ref;
     PFN_g_object_unref            g_object_unref;
     PFN_g_list_free               g_list_free;
+    /* Optional: keyboard-owner bookkeeping and the live button state. */
+    PFN_gtk_window_get_focus      gtk_window_get_focus;
+    PFN_gtk_container_check_resize gtk_container_check_resize;
+    PFN_gdk_window_get_display    gdk_window_get_display;
+    PFN_gdk_display_get_default_seat gdk_display_get_default_seat;
+    PFN_gdk_seat_get_pointer      gdk_seat_get_pointer;
+    PFN_gdk_window_get_device_position gdk_window_get_device_position;
 } g;
 
 static void *load_first(const char *const *names) {
@@ -236,7 +250,13 @@ static int ensure_gtk_loaded(void) {
     if (libgdk != NULL) {
         g.gdk_event_copy          = (PFN_gdk_event_copy)              dlsym(libgdk, "gdk_event_copy");
         g.gdk_event_free          = (PFN_gdk_event_free)              dlsym(libgdk, "gdk_event_free");
+        g.gdk_window_get_display  = (PFN_gdk_window_get_display)      dlsym(libgdk, "gdk_window_get_display");
+        g.gdk_display_get_default_seat = (PFN_gdk_display_get_default_seat) dlsym(libgdk, "gdk_display_get_default_seat");
+        g.gdk_seat_get_pointer    = (PFN_gdk_seat_get_pointer)        dlsym(libgdk, "gdk_seat_get_pointer");
+        g.gdk_window_get_device_position = (PFN_gdk_window_get_device_position) dlsym(libgdk, "gdk_window_get_device_position");
     }
+    g.gtk_window_get_focus        = (PFN_gtk_window_get_focus)        dlsym(libgtk, "gtk_window_get_focus");
+    g.gtk_container_check_resize  = (PFN_gtk_container_check_resize)  dlsym(libgtk, "gtk_container_check_resize");
     g.g_object_ref                = (PFN_g_object_ref)                dlsym(libgobj, "g_object_ref");
     g.g_object_unref              = (PFN_g_object_unref)              dlsym(libgobj, "g_object_unref");
     if (libglib != NULL) {
@@ -348,6 +368,24 @@ typedef struct {
     gint x, y, w, h;
     gint valid;
 } widget_rect_t;
+
+/* Whether [widget] is one of the EventBoxes this file creates — the input
+ * boxes and the focus sink. GTK focus on one of them means Compose owns the
+ * keyboard (Tao's toplevel handler feeds it); focus on anything else means
+ * an embed does. Tao reads the same marker (`nucleus_tao_input_box`) to
+ * decide whether a key press is Compose's or the embed's. */
+static int is_nucleus_input_box(GtkWidget *widget) {
+    return widget != NULL && g.g_object_get_data(widget, NUCLEUS_INPUT_BOX_KEY) != NULL;
+}
+
+/* The GTK focus widget of the toplevel [widget] lives in, or NULL. */
+static GtkWidget *focus_widget_of(GtkWidget *widget) {
+    if (g.gtk_window_get_focus == NULL) return NULL;
+    GtkWidget *toplevel = g.gtk_widget_get_toplevel(widget);
+    if (toplevel == NULL) return NULL;
+    return g.gtk_window_get_focus((GtkWindow *) toplevel);
+}
+
 
 /* `get-child-position` signal handler. Reads the cached rect from the
  * child's GObject data and writes it into [allocation]. ALWAYS returns
@@ -529,6 +567,25 @@ static void egl_restore(const egl_snapshot_t *s) {
  * widget never realises at the offscreen 1×1 parking allocation
  * (WebKit's GPU compositor sizes its glyph atlas at first paint and
  * never recovers from a 1×1 start: page text stays blank). */
+/* Re-runs `get-child-position` for the overlay's children with the rects
+ * just cached — synchronously. `gtk_widget_queue_resize` alone parks the
+ * allocation until GTK's next frame-clock layout phase, one compositor
+ * frame after Compose laid the slot out: through a resize the embed then
+ * trails the window by a frame at best, and by several when the frame
+ * clock is paced slower than the Compose layouts feeding it. Processing
+ * the queued resize right here lands the embed in the same frame as the
+ * Compose content around it. The overlay reports min = 0, so the pass
+ * never reaches the GtkApplicationWindow. The embed's own size_allocate
+ * may touch its GL (WebKit's accelerated surface): guard the thread's EGL
+ * context like every other GTK call that can. */
+static void relayout_overlay_now(GtkWidget *overlay) {
+    g.gtk_widget_queue_resize(overlay);
+    if (g.gtk_container_check_resize == NULL) return;
+    egl_snapshot_t saved = egl_save();
+    g.gtk_container_check_resize((GtkContainer *) overlay);
+    egl_restore(&saved);
+}
+
 static void mount_on_overlay(GtkWidget *overlay, GtkWidget *widget) {
     GtkWidget *parent = g.gtk_widget_get_parent(widget);
     if (parent == overlay) return;
@@ -669,12 +726,10 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeSetFra
         return;
     }
 
-    /* Trigger a re-layout pass on the overlay so
-     * `get-child-position` runs with the new rect. The overlay
-     * itself reports min = 0 (we pinned it via set_size_request),
-     * so this does NOT propagate up to the GtkApplicationWindow —
-     * shrinking the window stays cheap. */
-    g.gtk_widget_queue_resize(parent);
+    /* Re-layout the overlay so `get-child-position` runs with the new
+     * rect — now, not at the next frame-clock tick (see
+     * relayout_overlay_now). */
+    relayout_overlay_now(parent);
 }
 
 /* Clears the GTK window's focused widget. The Compose overlay slot
@@ -700,6 +755,54 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeReques
     if (gtk_window_ptr == 0) return;
     GtkWindow *win = (GtkWindow *) (uintptr_t) gtk_window_ptr;
     g.gtk_window_set_focus(win, NULL);
+}
+
+/* Gives the keyboard back to Compose after a press Compose kept: when an
+ * embed holds GTK focus (the user clicked into it earlier), a click on
+ * Compose ground outside every input box would otherwise leave the keys
+ * with the embed while Compose shows a focused text field. Clearing the
+ * focus widget routes keys to the toplevel handler again — Tao picks them
+ * up for Compose — and the next focus-in lands on the focus sink, never
+ * on the embed. Returns whether anything changed. */
+EXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeClaimKeyboardForCompose(
+    JNIEnv *env, jclass clazz, jlong gtk_window_ptr)
+{
+    (void) env; (void) clazz;
+    if (!ensure_gtk_loaded() || g.gtk_window_get_focus == NULL) return JNI_FALSE;
+    if (gtk_window_ptr == 0) return JNI_FALSE;
+    GtkWindow *win = (GtkWindow *) (uintptr_t) gtk_window_ptr;
+    GtkWidget *focus = g.gtk_window_get_focus(win);
+    if (focus == NULL || is_nucleus_input_box(focus)) return JNI_FALSE;
+    g.gtk_window_set_focus(win, NULL);
+    return JNI_TRUE;
+}
+
+/* The pointer's button state as GDK sees it right now (GDK_BUTTON1_MASK =
+ * 1 << 8, BUTTON2 = 1 << 9, BUTTON3 = 1 << 10), or -1 when it cannot be
+ * read. A press forwarded to an embed can lose its release to a grab the
+ * embed takes — its context menu, a drag it starts — so the host asks GDK
+ * which buttons are really down instead of trusting the last event. */
+EXPORT jint JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeQueryPointerButtons(
+    JNIEnv *env, jclass clazz, jlong gtk_window_ptr)
+{
+    (void) env; (void) clazz;
+    if (!ensure_gtk_loaded() || gtk_window_ptr == 0) return -1;
+    if (g.gtk_widget_get_window == NULL || g.gdk_window_get_display == NULL ||
+        g.gdk_display_get_default_seat == NULL || g.gdk_seat_get_pointer == NULL ||
+        g.gdk_window_get_device_position == NULL) {
+        return -1;
+    }
+    void *gdk_window = g.gtk_widget_get_window((GtkWidget *) (uintptr_t) gtk_window_ptr);
+    if (gdk_window == NULL) return -1;
+    void *display = g.gdk_window_get_display(gdk_window);
+    void *seat = display != NULL ? g.gdk_display_get_default_seat(display) : NULL;
+    void *pointer = seat != NULL ? g.gdk_seat_get_pointer(seat) : NULL;
+    if (pointer == NULL) return -1;
+    unsigned int mask = 0;
+    g.gdk_window_get_device_position(gdk_window, pointer, NULL, NULL, &mask);
+    return (jint) mask;
 }
 
 /* ── Input-box overlay: hit capture for NativeView blending ──
@@ -886,8 +989,13 @@ static gboolean on_input_box_button_press(GtkWidget *widget, void *event_ptr,
     s_live_event = NULL;
     /* Focus the box only when Compose kept the press; if it was
      * forwarded to the embed, the embed grabbed focus and stealing it
-     * back would send the next keystrokes to Compose instead. */
-    if (!s_live_event_forwarded && g.gtk_widget_grab_focus != NULL) {
+     * back would send the next keystrokes to Compose instead. And only
+     * when the keyboard is not already Compose's: moving focus from one
+     * of our boxes to another fires a focus-out that the Kotlin side
+     * turns into "clear the Compose focus" — a click on a Compose button
+     * over an embed would deselect the text field beside it. */
+    if (!s_live_event_forwarded && g.gtk_widget_grab_focus != NULL &&
+        !is_nucleus_input_box(focus_widget_of(widget))) {
         g.gtk_widget_grab_focus(widget);
     }
     /* TRUE = consume the event. We have already dispatched it to
@@ -1100,7 +1208,7 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeMoveIn
     rect->valid = 1;
 
     GtkWidget *overlay = g.gtk_widget_get_parent(box);
-    if (overlay != NULL) g.gtk_widget_queue_resize(overlay);
+    if (overlay != NULL) relayout_overlay_now(overlay);
 }
 
 EXPORT void JNICALL
@@ -1194,4 +1302,158 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeDispat
     GtkWidget *widget = (GtkWidget *) (uintptr_t) widget_ptr;
     if (!g.g_type_check_instance_is_a(widget, g.gtk_widget_get_type())) return;
     forward_live_event(widget, (double) x_logical, (double) y_logical);
+}
+
+/* ── Diagnostics for the headful suite ──────────────────────────────────
+ *
+ * The test module has no way to fabricate a `GtkWidget*` of its own, and
+ * a NativeView case needs a real, focusable one: a widget that takes GTK
+ * keyboard focus on click and shows an I-beam is what the focus and
+ * cursor races between Compose and an embed happen against. These entry
+ * points hand out a plain `GtkEntry`, say which widget the GTK window
+ * currently focuses, and read the entry back — nothing here is used by
+ * `NativeView` itself. Resolved lazily and optionally, so a GTK without
+ * one of these symbols still mounts embeds. */
+
+typedef GtkWidget  *(*PFN_gtk_entry_new)(void);
+typedef const char *(*PFN_gtk_entry_get_text)(GtkWidget *entry);
+typedef GtkWidget  *(*PFN_gtk_window_get_focus)(GtkWindow *window);
+typedef gboolean    (*PFN_gtk_widget_has_focus)(GtkWidget *widget);
+typedef void       *(*PFN_g_object_ref_sink)(void *object);
+typedef void        (*PFN_gtk_widget_get_allocation)(GtkWidget *widget, GdkRectangle *allocation);
+typedef gboolean    (*PFN_gtk_widget_get_mapped)(GtkWidget *widget);
+
+static struct {
+    int resolved;
+    PFN_gtk_entry_new        gtk_entry_new;
+    PFN_gtk_entry_get_text   gtk_entry_get_text;
+    PFN_gtk_window_get_focus gtk_window_get_focus;
+    PFN_gtk_widget_has_focus gtk_widget_has_focus;
+    PFN_g_object_ref_sink    g_object_ref_sink;
+    PFN_gtk_widget_get_allocation gtk_widget_get_allocation;
+    PFN_gtk_widget_get_mapped gtk_widget_get_mapped;
+} diag;
+
+static int ensure_diag_loaded(void) {
+    if (!ensure_gtk_loaded()) return 0;
+    if (diag.resolved) return diag.gtk_entry_new != NULL;
+    diag.resolved = 1;
+    const char *gtk_libs[] = { "libgtk-3.so.0", "libgtk-3.so", NULL };
+    void *libgtk = load_first(gtk_libs);
+    if (libgtk == NULL) return 0;
+    diag.gtk_entry_new        = (PFN_gtk_entry_new)        dlsym(libgtk, "gtk_entry_new");
+    diag.gtk_entry_get_text   = (PFN_gtk_entry_get_text)   dlsym(libgtk, "gtk_entry_get_text");
+    diag.gtk_window_get_focus = (PFN_gtk_window_get_focus) dlsym(libgtk, "gtk_window_get_focus");
+    diag.gtk_widget_has_focus = (PFN_gtk_widget_has_focus) dlsym(libgtk, "gtk_widget_has_focus");
+    diag.gtk_widget_get_allocation = (PFN_gtk_widget_get_allocation) dlsym(libgtk, "gtk_widget_get_allocation");
+    diag.gtk_widget_get_mapped = (PFN_gtk_widget_get_mapped) dlsym(libgtk, "gtk_widget_get_mapped");
+    const char *gobj_libs[] = { "libgobject-2.0.so.0", "libgobject-2.0.so", NULL };
+    void *libgobj = load_first(gobj_libs);
+    if (libgobj != NULL) diag.g_object_ref_sink = (PFN_g_object_ref_sink) dlsym(libgobj, "g_object_ref_sink");
+    return diag.gtk_entry_new != NULL && diag.g_object_ref_sink != NULL;
+}
+
+/* A fresh, unparented `GtkEntry` — the caller owns it until
+ * nativeDiagDestroyWidget. Owned the way a well-behaved embedder owns a
+ * widget it hands to NativeView: `g_object_ref_sink` here, so the
+ * container's unparent on detach does not finalise it under the app, and
+ * `g_object_unref` after the destroy. Shown here so the deferred mount in
+ * nativeSetFrame maps it as soon as it is realised. */
+EXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeDiagCreateEntry(
+    JNIEnv *env, jclass clazz)
+{
+    (void) env; (void) clazz;
+    if (!ensure_diag_loaded()) return 0;
+    GtkWidget *entry = diag.gtk_entry_new();
+    if (entry == NULL) return 0;
+    diag.g_object_ref_sink(entry);
+    g.gtk_widget_set_can_focus(entry, GTK_TRUE);
+    g.gtk_widget_show(entry);
+    return (jlong) (uintptr_t) entry;
+}
+
+/* Destroys a widget made by nativeDiagCreateEntry. Detaches it first so
+ * GtkOverlay's child window bookkeeping runs before GTK finalises it. */
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeDiagDestroyWidget(
+    JNIEnv *env, jclass clazz, jlong widget_ptr)
+{
+    (void) env; (void) clazz;
+    if (!ensure_gtk_loaded() || widget_ptr == 0) return;
+    GtkWidget *widget = (GtkWidget *) (uintptr_t) widget_ptr;
+    if (!g.g_type_check_instance_is_a(widget, g.gtk_widget_get_type())) return;
+    GtkWidget *parent = g.gtk_widget_get_parent(widget);
+    if (parent != NULL) g.gtk_container_remove((GtkContainer *) parent, widget);
+    g.gtk_widget_destroy(widget);
+    g.g_object_unref(widget);
+}
+
+/* The widget the GTK window routes key events to, as a pointer, or 0
+ * when nothing in the window has focus. A NativeView case compares it
+ * against its entry and against nothing — after a click on Compose the
+ * focus must sit on an input box (or nowhere), never on the embed. */
+EXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeDiagFocusWidget(
+    JNIEnv *env, jclass clazz, jlong gtk_window_ptr)
+{
+    (void) env; (void) clazz;
+    if (!ensure_diag_loaded() || diag.gtk_window_get_focus == NULL) return 0;
+    if (gtk_window_ptr == 0) return 0;
+    GtkWidget *focus = diag.gtk_window_get_focus((GtkWindow *) (uintptr_t) gtk_window_ptr);
+    return (jlong) (uintptr_t) focus;
+}
+
+/* Whether [widget_ptr] itself has GTK focus (its toplevel need not be active). */
+EXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeDiagWidgetHasFocus(
+    JNIEnv *env, jclass clazz, jlong widget_ptr)
+{
+    (void) env; (void) clazz;
+    if (!ensure_diag_loaded() || diag.gtk_widget_has_focus == NULL) return JNI_FALSE;
+    if (widget_ptr == 0) return JNI_FALSE;
+    return diag.gtk_widget_has_focus((GtkWidget *) (uintptr_t) widget_ptr) ? JNI_TRUE : JNI_FALSE;
+}
+
+/* The text typed into an entry made by nativeDiagCreateEntry — proves
+ * that keystrokes reached the embed (or did not) after a focus change. */
+EXPORT jstring JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeDiagEntryText(
+    JNIEnv *env, jclass clazz, jlong widget_ptr)
+{
+    (void) clazz;
+    if (!ensure_diag_loaded() || diag.gtk_entry_get_text == NULL) return NULL;
+    if (widget_ptr == 0) return NULL;
+    const char *text = diag.gtk_entry_get_text((GtkWidget *) (uintptr_t) widget_ptr);
+    return text != NULL ? (*env)->NewStringUTF(env, text) : NULL;
+}
+
+/* Where the probe actually sits: its allocation translated into the
+ * coordinates of Tao's content box (the widget Compose's origin maps to),
+ * in logical pixels, as `[x, y, w, h]` — or null while it is not mapped.
+ * A resize case compares this against the Compose slot to measure how far
+ * the embed trails the layout. */
+EXPORT jintArray JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxWidgetBridge_nativeDiagWidgetFrame(
+    JNIEnv *env, jclass clazz, jlong gtk_window_ptr, jlong widget_ptr)
+{
+    (void) clazz;
+    if (!ensure_diag_loaded() || diag.gtk_widget_get_allocation == NULL || diag.gtk_widget_get_mapped == NULL) {
+        return NULL;
+    }
+    if (gtk_window_ptr == 0 || widget_ptr == 0) return NULL;
+    GtkWidget *widget = (GtkWidget *) (uintptr_t) widget_ptr;
+    if (!g.g_type_check_instance_is_a(widget, g.gtk_widget_get_type())) return NULL;
+    if (!diag.gtk_widget_get_mapped(widget)) return NULL;
+    GtkWidget *content = g.gtk_bin_get_child((GtkWidget *) (uintptr_t) gtk_window_ptr);
+    if (content == NULL) return NULL;
+    GdkRectangle allocation;
+    diag.gtk_widget_get_allocation(widget, &allocation);
+    int x = 0, y = 0;
+    if (!g.gtk_widget_translate_coordinates(widget, content, 0, 0, &x, &y)) return NULL;
+    jint out[4] = { x, y, allocation.width, allocation.height };
+    jintArray result = (*env)->NewIntArray(env, 4);
+    if (result == NULL) return NULL;
+    (*env)->SetIntArrayRegion(env, result, 0, 4, out);
+    return result;
 }

--- a/decorated-window-tao/src/main/native/macos/native_view.m
+++ b/decorated-window-tao/src/main/native/macos/native_view.m
@@ -680,3 +680,101 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeRe
     }
     [overlay removeFromSuperview];
 }
+
+// ── Diagnostics for the headful suite ──────────────────────────────────
+//
+// A NativeView case needs a real, focusable AppKit view — one that takes
+// first responder on click and shows an I-beam — to race against Compose.
+// The test module cannot allocate one itself, so these hand out a plain
+// NSTextField and read the responder chain and the text back. Nothing here
+// is used by NativeView proper.
+
+JNIEXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeDiagCreateTextField(
+    JNIEnv *env, jclass clazz)
+{
+    (void)env; (void)clazz;
+    NSTextField *field = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 64, 24)];
+    field.editable = YES;
+    field.selectable = YES;
+    field.bezeled = YES;
+    field.wantsLayer = YES;
+    return (jlong)(uintptr_t)(__bridge_retained void *)field;
+}
+
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeDiagReleaseView(
+    JNIEnv *env, jclass clazz, jlong viewPtr)
+{
+    (void)env; (void)clazz;
+    if (viewPtr == 0) return;
+    NSView *view = (__bridge_transfer NSView *)(void *)(uintptr_t)viewPtr;
+    [view removeFromSuperview];
+}
+
+/* An NSTextField never is the first responder itself while edited: the
+ * window's shared field editor (an NSTextView whose delegate is the
+ * field) is. Both shapes mean "keystrokes go to the embed". */
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeDiagViewIsEditing(
+    JNIEnv *env, jclass clazz, jlong viewPtr)
+{
+    (void)env; (void)clazz;
+    NSView *view = view_from_long(viewPtr);
+    if (view == nil || view.window == nil) return JNI_FALSE;
+    NSResponder *first = view.window.firstResponder;
+    if (first == view) return JNI_TRUE;
+    if ([first isKindOfClass:[NSTextView class]]) {
+        NSTextView *editor = (NSTextView *)first;
+        if (editor.isFieldEditor && editor.delegate == (id<NSTextViewDelegate>)view) return JNI_TRUE;
+    }
+    return JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeDiagViewIsFirstResponder(
+    JNIEnv *env, jclass clazz, jlong viewPtr)
+{
+    (void)env; (void)clazz;
+    NSView *view = view_from_long(viewPtr);
+    if (view == nil || view.window == nil) return JNI_FALSE;
+    return view.window.firstResponder == view ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jstring JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeDiagTextFieldString(
+    JNIEnv *env, jclass clazz, jlong viewPtr)
+{
+    (void)clazz;
+    NSView *view = view_from_long(viewPtr);
+    if (![view isKindOfClass:[NSTextField class]]) return NULL;
+    NSString *value = ((NSTextField *)view).stringValue ?: @"";
+    return (*env)->NewStringUTF(env, value.UTF8String);
+}
+
+/* The view's frame in its superview, converted to Compose's convention:
+ * physical pixels, top-left origin, as `[x, y, w, h]`. Null without a
+ * superview or a window. */
+JNIEXPORT jintArray JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeDiagViewFrame(
+    JNIEnv *env, jclass clazz, jlong viewPtr)
+{
+    (void)clazz;
+    NSView *view = view_from_long(viewPtr);
+    if (view == nil || view.superview == nil || view.window == nil) return NULL;
+    CGFloat scale = view.window.backingScaleFactor;
+    if (scale <= 0) scale = 1.0;
+    NSRect frame = view.frame;
+    CGFloat parentHeight = view.superview.bounds.size.height;
+    CGFloat topLeftY = view.superview.isFlipped ? frame.origin.y : parentHeight - frame.origin.y - frame.size.height;
+    jint out[4] = {
+        (jint)lround(frame.origin.x * scale),
+        (jint)lround(topLeftY * scale),
+        (jint)lround(frame.size.width * scale),
+        (jint)lround(frame.size.height * scale),
+    };
+    jintArray result = (*env)->NewIntArray(env, 4);
+    if (result == NULL) return NULL;
+    (*env)->SetIntArrayRegion(env, result, 0, 4, out);
+    return result;
+}

--- a/decorated-window-tao/src/main/native/macos/native_view.m
+++ b/decorated-window-tao/src/main/native/macos/native_view.m
@@ -412,6 +412,18 @@ static NSEvent *mouse_event_at(NSView *view, NSEventType type, NSPoint windowPoi
                               pressure:1.0];
 }
 
+/* NSControl.mouseDown: and NSTextView.mouseDown: run
+ * trackMouse:untilMouseUp: (or a selection loop) and do not return
+ * until an AppKit mouse-up is dequeued. Compose pointer dispatch is
+ * on the Tao main thread; the matching up is the *next* event we have
+ * not delivered yet. Calling those selectors from here stalls the loop
+ * forever on a synthetic press, and on a live one steals the up
+ * Compose still needs to see. A right-click handler may also pop an
+ * NSMenu, which is the same kind of nested modal loop. */
+static BOOL view_runs_mouse_tracking(NSView *hit) {
+    return [hit isKindOfClass:[NSControl class]] || [hit isKindOfClass:[NSTextView class]];
+}
+
 /* [type] 1 = down, 2 = up, 3 = move. [button] 0 none, 1 primary, 2 secondary.
  * [pressed] is the Compose pointer-down state (move + pressed → dragged). */
 JNIEXPORT void JNICALL
@@ -426,7 +438,12 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeDi
     if (content == nil || child == nil) return;
     NSPoint windowPoint = window_point_from_compose_px(content, xPx, yPx);
     NSView *hit = hit_native_child(child, windowPoint);
-    if (hit == nil) return;
+    if (hit == nil) {
+        // Press on the slot before the child has a hit-testable frame:
+        // first-responder is still enough for typing.
+        if (type == 1) [child.window makeFirstResponder:child];
+        return;
+    }
 
     NSEventType nsType;
     if (type == 1) {
@@ -438,20 +455,24 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeDi
     } else {
         nsType = NSEventTypeMouseMoved;
     }
+    if (type == 1) {
+        [hit.window makeFirstResponder:hit];
+        if (view_runs_mouse_tracking(hit) || nsType == NSEventTypeRightMouseDown) return;
+    } else if (view_runs_mouse_tracking(hit) ||
+               nsType == NSEventTypeRightMouseUp ||
+               nsType == NSEventTypeRightMouseDragged) {
+        return;
+    }
     NSEvent *current = NSApp.currentEvent;
     NSEvent *event = (current != nil && current.type == nsType)
         ? current
         : mouse_event_at(hit, nsType, windowPoint, type == 1 ? 1 : 0);
     if (type == 1) {
-        [hit.window makeFirstResponder:hit];
-        if (nsType == NSEventTypeRightMouseDown) [hit rightMouseDown:event];
-        else [hit mouseDown:event];
+        [hit mouseDown:event];
     } else if (type == 2) {
-        if (nsType == NSEventTypeRightMouseUp) [hit rightMouseUp:event];
-        else [hit mouseUp:event];
+        [hit mouseUp:event];
     } else if (pressed == JNI_TRUE) {
-        if (nsType == NSEventTypeRightMouseDragged) [hit rightMouseDragged:event];
-        else [hit mouseDragged:event];
+        [hit mouseDragged:event];
     } else {
         [hit mouseMoved:event];
     }
@@ -515,6 +536,103 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeMa
     NSView *content = view_from_long(contentPtr);
     if (content == nil) return;
     [content.window makeFirstResponder:content];
+}
+
+/* Whether [first] is some view other than the Tao content view — an
+ * embed, or the field editor working on one. Keys then belong to AppKit,
+ * not Compose. */
+static BOOL first_responder_is_embed(NSView *content) {
+    if (content == nil || content.window == nil) return NO;
+    NSResponder *first = content.window.firstResponder;
+    if (first == nil || first == content) return NO;
+    if ([first isKindOfClass:[NSTextView class]]) {
+        NSTextView *editor = (NSTextView *)first;
+        if (editor.isFieldEditor) return YES;
+    }
+    return [first isKindOfClass:[NSView class]] && ((NSView *)first).window == content.window;
+}
+
+/* Carbon HIToolbox virtual key codes (Events.h). Used only to synthesise
+ * a caret-key NSEvent onto the first responder; we do not link Carbon. */
+#define NUCLEUS_VK_LEFT_ARROW  0x7B
+#define NUCLEUS_VK_RIGHT_ARROW 0x7C
+#define NUCLEUS_VK_DOWN_ARROW  0x7D
+#define NUCLEUS_VK_UP_ARROW    0x7E
+#define NUCLEUS_VK_DELETE      0x33
+#define NUCLEUS_VK_RETURN      0x24
+#define NUCLEUS_VK_FORWARD_DEL 0x75
+#define NUCLEUS_VK_TAB         0x30
+#define NUCLEUS_VK_ESCAPE      0x35
+
+/* AWT VK_* → Carbon kVK_* for the caret / editing keys the host forwards
+ * when Compose did not consume them and an embed holds first responder. */
+static unsigned short carbon_key_code_for_awt(jint vkCode) {
+    switch (vkCode) {
+        case 37:  return NUCLEUS_VK_LEFT_ARROW;   /* VK_LEFT */
+        case 39:  return NUCLEUS_VK_RIGHT_ARROW;  /* VK_RIGHT */
+        case 40:  return NUCLEUS_VK_DOWN_ARROW;   /* VK_DOWN */
+        case 38:  return NUCLEUS_VK_UP_ARROW;     /* VK_UP */
+        case 8:   return NUCLEUS_VK_DELETE;       /* VK_BACK_SPACE */
+        case 10:  return NUCLEUS_VK_RETURN;       /* VK_ENTER */
+        case 127: return NUCLEUS_VK_FORWARD_DEL;  /* VK_DELETE */
+        case 9:   return NUCLEUS_VK_TAB;          /* VK_TAB */
+        case 27:  return NUCLEUS_VK_ESCAPE;       /* VK_ESCAPE */
+        default:  return 0xFFFF;
+    }
+}
+
+/* Tao KEY_DOWN / KEY_UP / KEY_TYPED onto the current first responder when
+ * that responder is an embed. Synthetic Compose keys never enter AppKit's
+ * responder chain (they are posted into the Tao window), so without this
+ * an NSTextField that holds first responder never sees a letter typed
+ * through the in-process driver. Returns JNI_TRUE when the embed took it. */
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsNativeViewBridge_nativeDispatchKeyToFirstResponder(
+    JNIEnv *env, jclass clazz,
+    jlong contentPtr, jint type, jint vkCode, jint codePoint)
+{
+    (void)env; (void)clazz;
+    NSView *content = view_from_long(contentPtr);
+    if (!first_responder_is_embed(content)) return JNI_FALSE;
+    NSResponder *first = content.window.firstResponder;
+    const jint kTaoKeyDown = 14;
+    const jint kTaoKeyUp = 15;
+    const jint kTaoKeyTyped = 19;
+    if (type == kTaoKeyTyped) {
+        if (codePoint <= 0) return JNI_FALSE;
+        unichar ch = (unichar)codePoint;
+        NSString *text = [NSString stringWithCharacters:&ch length:1];
+        if ([first conformsToProtocol:@protocol(NSTextInputClient)]) {
+            [(id<NSTextInputClient>)first insertText:text
+                                    replacementRange:NSMakeRange(NSNotFound, 0)];
+            return JNI_TRUE;
+        }
+        if ([first isKindOfClass:[NSTextField class]]) {
+            NSTextField *field = (NSTextField *)first;
+            NSString *current = field.stringValue ?: @"";
+            field.stringValue = [current stringByAppendingString:text];
+            return JNI_TRUE;
+        }
+        return JNI_FALSE;
+    }
+    if (type != kTaoKeyDown && type != kTaoKeyUp) return JNI_FALSE;
+    unsigned short keyCode = carbon_key_code_for_awt(vkCode);
+    if (keyCode == 0xFFFF) return JNI_FALSE;
+    NSEventType nsType = (type == kTaoKeyDown) ? NSEventTypeKeyDown : NSEventTypeKeyUp;
+    NSEvent *event = [NSEvent keyEventWithType:nsType
+                                      location:NSZeroPoint
+                                 modifierFlags:0
+                                     timestamp:[NSProcessInfo processInfo].systemUptime
+                                  windowNumber:content.window.windowNumber
+                                       context:nil
+                                    characters:@""
+                   charactersIgnoringModifiers:@""
+                                     isARepeat:NO
+                                       keyCode:keyCode];
+    if (event == nil) return JNI_FALSE;
+    if (type == kTaoKeyDown) [first keyDown:event];
+    else [first keyUp:event];
+    return JNI_TRUE;
 }
 
 /* ================================================================== */

--- a/decorated-window-tao/src/main/native/macos/texture.m
+++ b/decorated-window-tao/src/main/native/macos/texture.m
@@ -256,6 +256,30 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsTextureBridge_nativeDestr
     free(t);
 }
 
+/* Extra retain on an IOSurface held by a TextureViewSource, so a producer
+ * close (its own CFRelease) cannot free the surface while the source is
+ * still reachable. Remounting TextureView after CloseProducerUnderView
+ * would otherwise call IOSurfaceGetPixelFormat on a dangling pointer.
+ * The matching release is the source's Cleaner. */
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsTextureBridge_nativeRetainIOSurface(
+        JNIEnv *env, jclass clazz, jlong ioSurfacePtr) {
+    (void)env; (void)clazz;
+    if (ioSurfacePtr == 0) return JNI_FALSE;
+    CFTypeRef ref = (CFTypeRef)(uintptr_t)ioSurfacePtr;
+    if (CFGetTypeID(ref) != IOSurfaceGetTypeID()) return JNI_FALSE;
+    CFRetain(ref);
+    return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsTextureBridge_nativeReleaseIOSurface(
+        JNIEnv *env, jclass clazz, jlong ioSurfacePtr) {
+    (void)env; (void)clazz;
+    if (ioSurfacePtr == 0) return;
+    CFRelease((CFTypeRef)(uintptr_t)ioSurfacePtr);
+}
+
 /* ================================================================== */
 /*  Metal test producer (demos / smoke tests)                          */
 /* ================================================================== */

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -241,10 +241,22 @@ pub(crate) fn run_event_loop_blocking() {
             }
             Event::UserEvent(user) => match user {
                 UserEvent::Wake => {
-                    // No-op: the side-effect we want is the loop returning from
-                    // its `Wait` to dispatch this event, which guarantees a
-                    // following `MainEventsCleared` tick that drains
+                    // The side-effect we want is the loop returning from its
+                    // `Wait` to dispatch this event, which normally guarantees
+                    // a following `MainEventsCleared` tick that drains
                     // `TaoMainDispatcher`.
+                    //
+                    // Windows: not inside a nested modal message loop. Tao
+                    // derives `MainEventsCleared` from an internal WM_PAINT on
+                    // its thread-message window, and a modal loop running on
+                    // this thread — an embedded EDIT's context menu, a
+                    // `DoDragDrop` — never generates it, while it does deliver
+                    // the posted wake. Drain the dispatcher here, so the app's
+                    // coroutines keep running for as long as the menu is up.
+                    // Outside a modal loop the tick that follows finds an
+                    // empty queue.
+                    #[cfg(target_os = "windows")]
+                    dispatch(0, EVENT_MAIN_EVENTS_CLEARED, 0, 0);
                 }
                 UserEvent::CreateWindow {
                     handle,

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -146,6 +146,28 @@ fn x11_display() -> Option<gtk::gdk::Display> {
     })
 }
 
+/// Serves the redraws asked for during this batch (Windows only — see
+/// `UserEvent::RequestRedraw`), after the dispatcher drain that precedes every
+/// call site so a frame sees the work that produced it. A window destroyed
+/// meanwhile is skipped; one that asks again while being painted lands in the
+/// next batch, which the request itself wakes the loop for.
+#[cfg(target_os = "windows")]
+fn serve_pending_redraws(pending: &mut Vec<u64>) {
+    if pending.is_empty() {
+        return;
+    }
+    let serving: Vec<u64> = pending.drain(..).collect();
+    for handle in serving {
+        let alive = {
+            let guard = WINDOWS.lock().unwrap();
+            guard.as_ref().is_some_and(|map| map.contains_key(&handle))
+        };
+        if alive {
+            dispatch(handle, EVENT_REDRAW_REQUESTED, 0, 0);
+        }
+    }
+}
+
 pub(crate) fn run_event_loop_blocking() {
     // GTK backend selection. Default: let GDK auto-pick (= native Wayland on
     // a Wayland session, X11 elsewhere). The Wayland-native path goes through
@@ -251,12 +273,15 @@ pub(crate) fn run_event_loop_blocking() {
                     // its thread-message window, and a modal loop running on
                     // this thread — an embedded EDIT's context menu, a
                     // `DoDragDrop` — never generates it, while it does deliver
-                    // the posted wake. Drain the dispatcher here, so the app's
-                    // coroutines keep running for as long as the menu is up.
-                    // Outside a modal loop the tick that follows finds an
-                    // empty queue.
+                    // the posted wake. Drain the dispatcher here, and serve the
+                    // frames that work asks for, so the app keeps running *and*
+                    // painting for as long as the menu is up. Outside a modal
+                    // loop the tick that follows finds both queues empty.
                     #[cfg(target_os = "windows")]
-                    dispatch(0, EVENT_MAIN_EVENTS_CLEARED, 0, 0);
+                    {
+                        dispatch(0, EVENT_MAIN_EVENTS_CLEARED, 0, 0);
+                        serve_pending_redraws(&mut pending_redraws);
+                    }
                 }
                 UserEvent::CreateWindow {
                     handle,
@@ -1085,18 +1110,7 @@ pub(crate) fn run_event_loop_blocking() {
                 // being painted lands in the next batch, which the request
                 // itself wakes the loop for.
                 #[cfg(target_os = "windows")]
-                if !pending_redraws.is_empty() {
-                    let serving: Vec<u64> = pending_redraws.drain(..).collect();
-                    for handle in serving {
-                        let alive = {
-                            let guard = WINDOWS.lock().unwrap();
-                            guard.as_ref().is_some_and(|map| map.contains_key(&handle))
-                        };
-                        if alive {
-                            dispatch(handle, EVENT_REDRAW_REQUESTED, 0, 0);
-                        }
-                    }
-                }
+                serve_pending_redraws(&mut pending_redraws);
             }
             // macOS deep links: AppKit installs its own `kAEGetURL` handler
             // during `finishLaunching` (routing to `application:openURLs:`).

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
@@ -53,6 +53,23 @@ use super::{
 
 use taskbar::TaskbarIndicator;
 
+/// Whether GTK focus sits on a widget Nucleus did not create — an embedded
+/// native view (`NativeView`), which the widget bridge never marks with
+/// `nucleus_tao_input_box` the way it marks its own capture boxes. Keys then
+/// belong to the embed: no IME filtering on its behalf, no delivery to
+/// Compose, plain GTK propagation to the focus widget. Without this the
+/// toplevel's `GtkIMContext` consumed every printable key and the handler
+/// stopped propagation, so a `WebKitWebView` or a `GtkEntry` the user had
+/// clicked into never received a single character.
+fn embed_owns_keyboard(window: &gtk::Window) -> bool {
+  let Some(focus) = window.focused_widget() else {
+    return false;
+  };
+  // SAFETY: only the presence of the key is read; the pointer stored under it
+  // (a non-null marker set by the widget bridge) is never dereferenced.
+  unsafe { glib::prelude::ObjectExt::data::<()>(&focus, "nucleus_tao_input_box").is_none() }
+}
+
 #[derive(Clone)]
 pub struct EventLoopWindowTarget<T> {
   /// Gdk display
@@ -1142,7 +1159,10 @@ impl<T: 'static> EventLoop<T> {
             let handler = keyboard_handler.clone();
             let ime_ = ime.clone();
             let ime_state_press = ime_state.clone();
-            window.connect_key_press_event(move |_, event_key| {
+            window.connect_key_press_event(move |window, event_key| {
+              if embed_owns_keyboard(window) {
+                return glib::Propagation::Proceed;
+              }
               // The IME gets first refusal, and a key it consumed must not also
               // reach Compose — otherwise the Enter that confirms a conversion
               // also inserts a newline, and the BackSpace that edits the
@@ -1157,12 +1177,19 @@ impl<T: 'static> EventLoop<T> {
               }
               handler(event_key.to_owned(), ElementState::Pressed);
 
-              glib::Propagation::Proceed
+              // Compose owns the keyboard and has the key: stop here so GtkWindow's
+              // own bindings do not run on it too — an arrow or a Tab would
+              // otherwise `move-focus` into an embedded native view, which then
+              // steals every following keystroke from the Compose text field.
+              glib::Propagation::Stop
             });
 
             let handler = keyboard_handler.clone();
             let ime_state_release = ime_state;
-            window.connect_key_release_event(move |_, event_key| {
+            window.connect_key_release_event(move |window, event_key| {
+              if embed_owns_keyboard(window) {
+                return glib::Propagation::Proceed;
+              }
               let filtered = ime.filter_keypress(event_key);
               if !ime_state_release
                 .borrow_mut()
@@ -1171,7 +1198,7 @@ impl<T: 'static> EventLoop<T> {
                 return glib::Propagation::Stop;
               }
               handler(event_key.to_owned(), ElementState::Released);
-              glib::Propagation::Proceed
+              glib::Propagation::Stop
             });
 
             let tx_clone = event_tx.clone();

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_native_view.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_native_view.c
@@ -227,3 +227,72 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_native
     short delta = (short)(msg == WM_MOUSEHWHEEL ? (-dx * 120.0f) : (-dy * 120.0f));
     SendMessageW(target, msg, MAKEWPARAM(0, delta), MAKELPARAM((short)pt.x, (short)pt.y));
 }
+
+/* ── Diagnostics for the headful suite ──────────────────────────────────
+ *
+ * A NativeView case needs a real, focusable child HWND — one that takes
+ * Win32 keyboard focus on click and shows an I-beam — to race against
+ * Compose. The test module cannot create one itself, so these hand out a
+ * plain single-line EDIT control and read the focus and the text back.
+ * Nothing here is used by NativeView proper. */
+
+JNIEXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeDiagCreateEdit(
+    JNIEnv *env, jclass clazz) {
+    (void)env; (void)clazz;
+    /* Hidden top-level: nativeAttach flips it to WS_CHILD and reparents,
+     * exactly the path a user-created control takes. */
+    HWND edit = CreateWindowExW(
+        0, L"EDIT", L"",
+        WS_POPUP | ES_LEFT | ES_AUTOHSCROLL,
+        0, 0, 64, 24,
+        NULL, NULL, GetModuleHandleW(NULL), NULL);
+    return (jlong)(uintptr_t)edit;
+}
+
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeDiagDestroyWindow(
+    JNIEnv *env, jclass clazz, jlong hwnd) {
+    (void)env; (void)clazz;
+    HWND h = hwnd_from_jlong(hwnd);
+    if (IsWindow(h)) DestroyWindow(h);
+}
+
+JNIEXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeDiagFocusedHwnd(
+    JNIEnv *env, jclass clazz) {
+    (void)env; (void)clazz;
+    return (jlong)(uintptr_t)GetFocus();
+}
+
+JNIEXPORT jstring JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeDiagWindowText(
+    JNIEnv *env, jclass clazz, jlong hwnd) {
+    (void)clazz;
+    HWND h = hwnd_from_jlong(hwnd);
+    if (!IsWindow(h)) return NULL;
+    WCHAR buf[512];
+    int len = GetWindowTextW(h, buf, 512);
+    if (len < 0) len = 0;
+    return (*env)->NewString(env, (const jchar *)buf, (jsize)len);
+}
+
+/* The control's rectangle in its parent's client coordinates (physical
+ * px, top-left origin) as `[x, y, w, h]`, or null when not a window. */
+JNIEXPORT jintArray JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeDiagWindowFrame(
+    JNIEnv *env, jclass clazz, jlong hwnd) {
+    (void)clazz;
+    HWND h = hwnd_from_jlong(hwnd);
+    if (!IsWindow(h)) return NULL;
+    HWND parent = GetParent(h);
+    RECT rect;
+    if (!GetWindowRect(h, &rect)) return NULL;
+    POINT corners[2] = { { rect.left, rect.top }, { rect.right, rect.bottom } };
+    if (parent) MapWindowPoints(NULL, parent, corners, 2);
+    jint out[4] = { corners[0].x, corners[0].y, corners[1].x - corners[0].x, corners[1].y - corners[0].y };
+    jintArray result = (*env)->NewIntArray(env, 4);
+    if (result == NULL) return NULL;
+    (*env)->SetIntArrayRegion(env, result, 0, 4, out);
+    return result;
+}

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_native_view.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_native_view.c
@@ -168,8 +168,17 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_native
 
 /* Compose physical pixels (top-left, parent-client) → a mouse message
  * on the embedded child. When [childHwnd] is not a window (WebView2
- * CompositionController, hwnd=0) the message is posted to [parentHwnd]
- * so a parent subclass (sample_webview.cpp SendMouseInput) still sees it. */
+ * CompositionController, hwnd=0) the message is sent to [parentHwnd]
+ * so a parent subclass (sample_webview.cpp SendMouseInput) still sees it.
+ *
+ * A real child gets the message *posted*: its handler may run a modal
+ * loop — an EDIT opens its context menu from WM_RBUTTONUP and does not
+ * return until the menu is dismissed — and that loop must not nest inside
+ * the Compose pointer dispatch this call is made from. Posted messages
+ * keep their order and run before the next input message, so a forwarded
+ * press still reaches the child before the release Win32 delivers to it
+ * directly once it has captured the mouse. The parent keeps SendMessage:
+ * the host guards the synchronous echo through Tao's WndProc. */
 JNIEXPORT void JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeDispatchPointer(
     JNIEnv *env, jclass clazz,
@@ -182,11 +191,13 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_native
     if (!IsWindow(parent)) return;
     HWND target = IsWindow(child) ? child : parent;
     if (type == 1 && IsWindow(child)) SetFocus(child);
-    if (nucleus_tao_replay_last_native_input(target)) return;
-    POINT pt = { (LONG)xPx, (LONG)yPx };
-    if (target != parent) {
-        MapWindowPoints(parent, target, &pt, 1);
-    }
+    /* A press goes out synchronously so the capture the child takes on it can
+     * be handed straight back (below); everything else is posted, because a
+     * child's handler may run a modal loop — an EDIT opens its context menu
+     * from WM_RBUTTONUP and does not return until it is dismissed — which
+     * must not nest inside the Compose pointer dispatch we are called from.
+     * The parent is always sent to: the host guards that synchronous echo. */
+    BOOL post = (target != parent) && (type != 1);
     UINT msg;
     if (type == 1) {
         msg = (button == 2) ? WM_RBUTTONDOWN :
@@ -197,6 +208,11 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_native
     } else {
         msg = WM_MOUSEMOVE;
     }
+    if (nucleus_tao_replay_last_native_input(target, msg, post)) return;
+    POINT pt = { (LONG)xPx, (LONG)yPx };
+    if (target != parent) {
+        MapWindowPoints(parent, target, &pt, 1);
+    }
     WPARAM mk = 0;
     if (button == 2 || (pressed == JNI_TRUE && button == 2)) mk |= MK_RBUTTON;
     else if (button == 3 || (pressed == JNI_TRUE && button == 3)) mk |= MK_MBUTTON;
@@ -204,7 +220,19 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_native
     if (GetKeyState(VK_SHIFT) & 0x8000) mk |= MK_SHIFT;
     if (GetKeyState(VK_CONTROL) & 0x8000) mk |= MK_CONTROL;
     LPARAM lp = MAKELPARAM((short)pt.x, (short)pt.y);
-    SendMessageW(target, msg, mk, lp);
+    if (post) {
+        PostMessageW(target, msg, mk, lp);
+    } else {
+        SendMessageW(target, msg, mk, lp);
+    }
+    /* Compose routes this pointer, not the embed: a child that captured the
+     * mouse on the press would take every later message off the window —
+     * neither the Compose scene nor its blending overlay would see the
+     * pointer again, and the whole UI reads as dead. */
+    if (type == 1) {
+        HWND capture = GetCapture();
+        if (capture && capture != parent && IsChild(parent, capture)) ReleaseCapture();
+    }
 }
 
 JNIEXPORT void JNICALL
@@ -218,14 +246,70 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_native
     HWND child = hwnd_from_jlong(childHwnd);
     if (!IsWindow(parent)) return;
     HWND target = IsWindow(child) ? child : parent;
-    if (nucleus_tao_replay_last_native_input(target)) return;
-    POINT pt = { (LONG)xPx, (LONG)yPx };
-    ClientToScreen(parent, &pt);
+    BOOL post = (target != parent);
     UINT msg = (dx != 0.0f && (dy == 0.0f || (dx > dy || dx < -dy)))
         ? WM_MOUSEHWHEEL : WM_MOUSEWHEEL;
+    if (nucleus_tao_replay_last_native_input(target, msg, post)) return;
+    POINT pt = { (LONG)xPx, (LONG)yPx };
+    ClientToScreen(parent, &pt);
     /* Compose/AWT deltas are already negated vs Win32. */
     short delta = (short)(msg == WM_MOUSEHWHEEL ? (-dx * 120.0f) : (-dy * 120.0f));
-    SendMessageW(target, msg, MAKEWPARAM(0, delta), MAKELPARAM((short)pt.x, (short)pt.y));
+    if (post) {
+        PostMessageW(target, msg, MAKEWPARAM(0, delta), MAKELPARAM((short)pt.x, (short)pt.y));
+    } else {
+        SendMessageW(target, msg, MAKEWPARAM(0, delta), MAKELPARAM((short)pt.x, (short)pt.y));
+    }
+}
+
+/* Compose kept a press, so the keyboard is Compose's: hands Win32 focus
+ * back to the Tao HWND when an embedded child (an EDIT, WebView2) holds it.
+ * Win32 never moves focus on a click into a plain client area by itself, so
+ * a child clicked into earlier would keep every keystroke while Compose
+ * shows a focused text field. */
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeClaimKeyboardForCompose(
+    JNIEnv *env, jclass clazz, jlong parentHwnd) {
+    (void)env; (void)clazz;
+    HWND parent = hwnd_from_jlong(parentHwnd);
+    if (!IsWindow(parent)) return JNI_FALSE;
+    HWND focused = GetFocus();
+    if (!focused || focused == parent || !IsChild(parent, focused)) return JNI_FALSE;
+    SetFocus(parent);
+    return JNI_TRUE;
+}
+
+/* The mouse buttons down as this thread's message queue knows them: bit 0
+ * left, bit 1 right, bit 2 middle. A press forwarded to a child HWND makes
+ * the child SetCapture, so the release goes to the child alone and Compose
+ * never hears of it — the host asks Win32 which buttons are really down
+ * instead of trusting the last event it saw. */
+JNIEXPORT jint JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeQueryPointerButtons(
+    JNIEnv *env, jclass clazz) {
+    (void)env; (void)clazz;
+    jint mask = 0;
+    if (GetKeyState(VK_LBUTTON) & 0x8000) mask |= 1;
+    if (GetKeyState(VK_RBUTTON) & 0x8000) mask |= 2;
+    if (GetKeyState(VK_MBUTTON) & 0x8000) mask |= 4;
+    return mask;
+}
+
+/* A child HWND that captured the mouse on a forwarded press (an EDIT does,
+ * so does WebView2) keeps every later mouse message on itself — the Tao
+ * window and its blending overlay stop hearing from the pointer entirely and
+ * the whole Compose UI reads as dead. Compose owns the pointer, so the host
+ * hands the capture back as soon as the gesture the child was given ends.
+ * Returns whether a capture was taken away. */
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeReleaseChildCapture(
+    JNIEnv *env, jclass clazz, jlong parentHwnd) {
+    (void)env; (void)clazz;
+    HWND parent = hwnd_from_jlong(parentHwnd);
+    if (!IsWindow(parent)) return JNI_FALSE;
+    HWND capture = GetCapture();
+    if (!capture || capture == parent || !IsChild(parent, capture)) return JNI_FALSE;
+    ReleaseCapture();
+    return JNI_TRUE;
 }
 
 /* ── Diagnostics for the headful suite ──────────────────────────────────

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_native_view.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_native_view.c
@@ -312,6 +312,27 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_native
     return JNI_TRUE;
 }
 
+/* The pointer's position in [parentHwnd]'s client pixels, packed as
+ * `(x << 32) | (y & 0xffffffff)`, or LLONG_MIN when it cannot be read.
+ *
+ * Tao reports a button without a position, so the scene places it where the
+ * last `CursorMoved` left the pointer — and Tao drops a `WM_MOUSEMOVE` whose
+ * coordinate equals the last one *it* saw. Every move over a `NativeView`
+ * goes to the blending overlay instead, so Tao's idea of the position goes
+ * stale and a click that comes back to a point it saw before is placed where
+ * the pointer no longer is. The host asks Win32 instead. */
+JNIEXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsNativeViewBridge_nativeCursorPosInClient(
+    JNIEnv *env, jclass clazz, jlong parentHwnd) {
+    (void)env; (void)clazz;
+    HWND parent = hwnd_from_jlong(parentHwnd);
+    if (!IsWindow(parent)) return MININT64;
+    POINT pt;
+    if (!GetCursorPos(&pt)) return MININT64;
+    if (!ScreenToClient(parent, &pt)) return MININT64;
+    return ((jlong)pt.x << 32) | ((jlong)pt.y & 0xffffffffLL);
+}
+
 /* ── Diagnostics for the headful suite ──────────────────────────────────
  *
  * A NativeView case needs a real, focusable child HWND — one that takes

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay.c
@@ -211,8 +211,13 @@ void nucleus_tao_remember_native_input(HWND hwnd, UINT msg, WPARAM w, LPARAM l) 
     gHasLastInput = TRUE;
 }
 
-BOOL nucleus_tao_replay_last_native_input(HWND target) {
+BOOL nucleus_tao_replay_last_native_input(HWND target, UINT expectedMsg, BOOL post) {
     if (!gHasLastInput || !IsWindow(target)) return FALSE;
+    /* Only the event being forwarded is worth replaying verbatim. A press
+     * dispatched in-process (no overlay message behind it) or a move that
+     * reached the scene through the owner HWND's capture would otherwise
+     * replay whatever the overlay saw last — a stale press, say. */
+    if (gLastInputMsg != expectedMsg) return FALSE;
     LPARAM lp = gLastInputL;
     if (gLastInputMsg != WM_MOUSEWHEEL && gLastInputMsg != WM_MOUSEHWHEEL &&
         target != gLastInputHwnd && IsWindow(gLastInputHwnd)) {
@@ -220,7 +225,11 @@ BOOL nucleus_tao_replay_last_native_input(HWND target) {
         MapWindowPoints(gLastInputHwnd, target, &pt, 1);
         lp = MAKELPARAM((short)pt.x, (short)pt.y);
     }
-    SendMessageW(target, gLastInputMsg, gLastInputW, lp);
+    if (post) {
+        PostMessageW(target, gLastInputMsg, gLastInputW, lp);
+    } else {
+        SendMessageW(target, gLastInputMsg, gLastInputW, lp);
+    }
     return TRUE;
 }
 

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay_internal.h
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay_internal.h
@@ -74,7 +74,13 @@ void nucleus_tao_remember_native_input(HWND hwnd, UINT msg, WPARAM w, LPARAM l);
 
 /** Replay the stashed message onto [target]. Wheel LPARAMs stay
  *  screen-space; mouse LPARAMs are mapped from the source HWND. */
-BOOL nucleus_tao_replay_last_native_input(HWND target);
+/* Replays the remembered message onto [target] when it is of kind
+ * [expectedMsg] (the message the caller would otherwise synthesise); returns
+ * FALSE when nothing matching is remembered. [post] queues it with
+ * PostMessageW instead of SendMessageW — for a child HWND, whose handler may
+ * open a modal loop (an EDIT's context menu on WM_RBUTTONUP) that must not
+ * run inside the Compose pointer dispatch that is forwarding the event. */
+BOOL nucleus_tao_replay_last_native_input(HWND target, UINT expectedMsg, BOOL post);
 
 #ifdef __cplusplus
 }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MonkeySupport.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/MonkeySupport.kt
@@ -1,0 +1,223 @@
+package dev.nucleusframework.window.tao.headful
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.thread
+import kotlin.math.max
+
+// What every monkey case shares: the seed, the journal that makes a random
+// failure readable, and the watchdog that measures `Dispatchers.Main` from
+// a thread that is not on it.
+//
+// A monkey does not assert that "the right thing happened" — for a random
+// sequence there is none. It asserts that nothing wedges and nothing is left
+// behind, and it has to be *diagnosable* when it fails: the seed replays the
+// action sequence, the journal names the last actions, and the watchdog dumps
+// every stack the moment the loop stops answering — which the driver cannot
+// do for itself, because it runs on the very dispatcher that is stuck.
+
+/** System property that replays a red run's action sequence. */
+internal const val MONKEY_SEED_PROPERTY = "nucleus.tao.headful.monkeySeed"
+
+/** Fixed so a green run stays green; override the property to explore. */
+internal const val MONKEY_DEFAULT_SEED = 20_260_903L
+
+/** The seed of a monkey run; overridable so a red run replays exactly. */
+internal fun monkeySeed(): Long = System.getProperty(MONKEY_SEED_PROPERTY)?.toLongOrNull() ?: MONKEY_DEFAULT_SEED
+
+/**
+ * System property that replaces the random walk with a fixed action list —
+ * the journal of a red run pasted back, comma-separated, to turn a sequence
+ * into a repro and then bisect it by deleting entries.
+ */
+internal const val MONKEY_SCRIPT_PROPERTY = "nucleus.tao.headful.monkeyScript"
+
+/** The scripted actions, by enum name, or null for a random walk. */
+internal fun monkeyScript(): List<String>? =
+    System
+        .getProperty(MONKEY_SCRIPT_PROPERTY)
+        ?.split(',')
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?.takeIf { it.isNotEmpty() }
+
+/**
+ * The last [depth] actions of a run plus what it reached, newest last.
+ *
+ * Concurrent because [MainLoopWatchdog] prints it from its own thread,
+ * precisely when the main thread is not answering. [reached] counts what the
+ * run actually did: a monkey whose every guard refuses early still passes
+ * every invariant, so a green run has to say what it exercised.
+ */
+internal class MonkeyJournal(
+    private val tag: String,
+    val seed: Long,
+    private val depth: Int = JOURNAL_DEPTH,
+) {
+    private val entries = ConcurrentLinkedDeque<String>()
+    private val reached = mutableMapOf<String, Int>()
+
+    /** Index of the action being applied, for reports. */
+    @Volatile
+    var step: Int = 0
+
+    /**
+     * Also echoed to stderr as it happens: a native abort (a Rust panic, a
+     * SIGSEGV in a bridge) leaves no Kotlin frame to print the journal from,
+     * and the last echoed line is then the only record of what was running.
+     */
+    fun record(action: Any) {
+        if (entries.size >= depth) entries.pollFirst()
+        entries.addLast("$step $action")
+        System.err.println("[$tag] $step $action")
+    }
+
+    fun reach(what: String) {
+        reached[what] = (reached[what] ?: 0) + 1
+    }
+
+    fun reachedCount(what: String): Int = reached[what] ?: 0
+
+    fun reachedSummary(): String = reached.toSortedMap().toString()
+
+    /** Only the journal, the seed and the step: safe to read from another thread. */
+    fun report(): String =
+        buildString {
+            appendLine("  $tag seed $seed, at step $step, last ${entries.size} actions:")
+            for (entry in entries) appendLine("    $entry")
+        }
+
+    fun failure(
+        reason: String,
+        state: String,
+    ): String =
+        buildString {
+            appendLine("$tag failed at step $step: $reason")
+            appendLine("  seed: $seed (replay with -D$MONKEY_SEED_PROPERTY=$seed)")
+            appendLine("  state: $state")
+            append(report())
+        }
+
+    private companion object {
+        const val JOURNAL_DEPTH = 40
+    }
+}
+
+/**
+ * Runs [block] under the short per-action budget. An action is a handful of
+ * calls and a settle, so [budgetMillis] is orders of magnitude of slack —
+ * anything that exceeds it is stuck, not slow, and saying *which* action
+ * wedged is worth far more than the case's own deadline firing later.
+ */
+internal suspend fun <T> monkeyAction(
+    describe: () -> String,
+    budgetMillis: Long = MONKEY_ACTION_BUDGET_MILLIS,
+    block: suspend () -> T,
+): T =
+    try {
+        withTimeout(budgetMillis) { block() }
+    } catch (timeout: TimeoutCancellationException) {
+        throw IllegalStateException("${describe()} never returned (budget ${budgetMillis}ms)", timeout)
+    }
+
+internal const val MONKEY_ACTION_BUDGET_MILLIS = 5_000L
+
+/**
+ * Measures `Dispatchers.Main` from a thread that is not on it.
+ *
+ * Every mutation, every frame and the driver itself run on the Tao event-loop
+ * thread, which is also the main dispatcher. That makes the one failure a
+ * monkey is hunting invisible from the inside: if the loop and the dispatcher
+ * ever wait on each other, the driver is not running either, so it cannot fail
+ * its own case — the suite would just hit its deadline with no clue why.
+ *
+ * So the heartbeat is posted from outside. A round trip unanswered for
+ * [MONKEY_STALL_DUMP_MILLIS] dumps every thread's stack next to the journal,
+ * which names both halves of the deadlock; one that comes back late is
+ * reported as the worst stall and fails the case at the end. If it never comes
+ * back the suite's own watchdog halts the process — with the dump already on
+ * stderr.
+ */
+internal class MainLoopWatchdog(
+    private val name: String,
+    private val journal: () -> String,
+) {
+    private val worst = AtomicLong(0)
+    private val stopped = AtomicBoolean(false)
+    private val dumped = AtomicBoolean(false)
+    private val main = CoroutineScope(Dispatchers.Main)
+    private var watcher: Thread? = null
+
+    fun start(): MainLoopWatchdog {
+        watcher = thread(isDaemon = true, name = "$name-watchdog") { watch() }
+        return this
+    }
+
+    /** Stops watching and answers the worst round trip it measured, in ms. */
+    fun stop(): Long {
+        stopped.set(true)
+        watcher?.interrupt()
+        main.cancel()
+        return worst.get()
+    }
+
+    private fun watch() {
+        try {
+            while (!stopped.get()) {
+                val posted = System.nanoTime()
+                val beat = CountDownLatch(1)
+                main.launch { beat.countDown() }
+                if (!beat.await(MONKEY_STALL_DUMP_MILLIS, TimeUnit.MILLISECONDS)) {
+                    dumpEveryThread()
+                    // Gone for good: the suite watchdog owns the process from
+                    // here, and the dump above is what it will be diagnosed on.
+                    if (!beat.await(STALL_GIVE_UP_MILLIS, TimeUnit.MILLISECONDS)) return
+                }
+                val roundTrip = (System.nanoTime() - posted) / NANOS_PER_MILLI
+                worst.accumulateAndGet(roundTrip) { a, b -> max(a, b) }
+                Thread.sleep(BEAT_INTERVAL_MILLIS)
+            }
+        } catch (_: InterruptedException) {
+            // stop() interrupted the wait; nothing left to measure.
+        }
+    }
+
+    private fun dumpEveryThread() {
+        if (!dumped.compareAndSet(false, true)) return
+        val dump =
+            buildString {
+                appendLine(
+                    "[$name] Dispatchers.Main has not answered in ${MONKEY_STALL_DUMP_MILLIS}ms — " +
+                        "the Tao loop and the dispatcher may be deadlocked",
+                )
+                append(journal())
+                for ((thread, frames) in Thread.getAllStackTraces()) {
+                    appendLine("  \"${thread.name}\" ${thread.state}")
+                    for (frame in frames) appendLine("      at $frame")
+                }
+            }
+        System.err.println(dump)
+        System.err.flush()
+    }
+
+    private companion object {
+        const val BEAT_INTERVAL_MILLIS = 250L
+        const val STALL_GIVE_UP_MILLIS = 30_000L
+        const val NANOS_PER_MILLI = 1_000_000L
+    }
+}
+
+/** A heartbeat unanswered this long is a stall worth every thread's stack. */
+internal const val MONKEY_STALL_DUMP_MILLIS = 8_000L
+
+/** Same threshold: a stall that recovered still fails the case, with the dump already printed. */
+internal const val MONKEY_MAX_STALL_MILLIS = MONKEY_STALL_DUMP_MILLIS

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/NativeProbe.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/NativeProbe.kt
@@ -1,0 +1,203 @@
+package dev.nucleusframework.window.tao.headful
+
+import dev.nucleusframework.core.runtime.Platform
+import dev.nucleusframework.window.tao.NucleusPlatformView
+import dev.nucleusframework.window.tao.TaoWindow
+import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxWidgetBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoMacOsNativeViewBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsNativeViewBridge
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A real, focusable native text widget for a headful case to embed through
+ * `NativeView`: a `GtkEntry`, an `NSTextField` or an `EDIT` control.
+ *
+ * The focus and cursor races between Compose and an embed only happen
+ * against a widget that *takes* keyboard focus on click and *shows* an
+ * I-beam — an empty overlay view has neither, so it cannot lose a keystroke
+ * or leave a stale cursor behind. The bridges hand these out for the suite
+ * (`nativeDiag*`); nothing in `NativeView` itself uses them.
+ *
+ * [platformView] is what `NativeView`'s factory returns. Its `dispose()` — the
+ * one `NativeView` calls when it leaves composition — destroys the widget and
+ * marks the probe [isDisposed], so a fixture can count probes created against
+ * probes disposed and know whether an unmount leaked one.
+ */
+internal class NativeProbe private constructor(
+    /** The widget as a handle, for reports. */
+    val handle: Long,
+    private val focusQuery: () -> Boolean,
+    private val textQuery: () -> String?,
+    private val frameQuery: () -> IntArray?,
+    private val destroy: () -> Unit,
+) {
+    @Volatile
+    var isDisposed: Boolean = false
+        private set
+
+    /** Whether the OS routes keystrokes to the widget right now. */
+    fun hasNativeFocus(): Boolean = !isDisposed && focusQuery()
+
+    /** What has been typed into the widget so far. */
+    fun text(): String = if (isDisposed) "" else textQuery().orEmpty()
+
+    /**
+     * Where the platform actually put the widget, in the window's content
+     * space and physical px as `[x, y, w, h]` — null while it is not mapped.
+     * Compared against the Compose slot to see how far the embed trails the
+     * layout through a resize.
+     */
+    fun framePx(): IntArray? = if (isDisposed) null else frameQuery()
+
+    val platformView: NucleusPlatformView =
+        when (Platform.Current) {
+            Platform.Linux ->
+                object : NucleusPlatformView.GtkWidget {
+                    override val gtkWidgetHandle: Long get() = handle
+
+                    override fun dispose() = disposeOnce()
+                }
+            Platform.MacOS ->
+                object : NucleusPlatformView.NsView {
+                    override val nsViewHandle: Long get() = handle
+
+                    override fun dispose() = disposeOnce()
+                }
+            else ->
+                object : NucleusPlatformView.HWnd {
+                    override val hwndHandle: Long get() = handle
+
+                    override fun dispose() = disposeOnce()
+                }
+        }
+
+    private fun disposeOnce() {
+        if (isDisposed) return
+        isDisposed = true
+        disposedCount.incrementAndGet()
+        destroy()
+    }
+
+    companion object {
+        /** Probes created so far in this process. */
+        val createdCount = AtomicInteger()
+
+        /** Probes whose `dispose()` ran so far in this process. */
+        val disposedCount = AtomicInteger()
+
+        /** Why no probe can be made on this host, or null when one can. */
+        fun skipReason(): String? =
+            when (Platform.Current) {
+                Platform.Linux ->
+                    if (!NativeTaoLinuxWidgetBridge.isLoaded) {
+                        "libnucleus_tao_linux_widget is not loaded"
+                    } else if (NativeTaoLinuxWidgetBridge.nativeGtkVersion() == null) {
+                        "GTK 3 is not available"
+                    } else {
+                        null
+                    }
+                Platform.MacOS ->
+                    if (NativeTaoMacOsNativeViewBridge.isLoaded) {
+                        null
+                    } else {
+                        "libnucleus_tao_macos_native_view is not loaded"
+                    }
+                Platform.Windows ->
+                    if (NativeTaoWindowsNativeViewBridge.isLoaded) {
+                        null
+                    } else {
+                        "nucleus_tao_windows_native_view is not loaded"
+                    }
+                else -> "no native view backend on ${Platform.Current}"
+            }
+
+        /**
+         * Makes a probe for [window]. Runs on the loop thread (GTK / AppKit
+         * demand it), typically from a `NativeView` factory. Null when the
+         * platform refused — see [skipReason] for the reasons known upfront.
+         */
+        fun create(window: TaoWindow): NativeProbe? {
+            val probe =
+                when (Platform.Current) {
+                    Platform.Linux -> createGtkEntry(window)
+                    Platform.MacOS -> createNsTextField()
+                    Platform.Windows -> createWin32Edit()
+                    else -> null
+                } ?: return null
+            createdCount.incrementAndGet()
+            return probe.also { probes[window.handle] = it }
+        }
+
+        /** Whether Compose — not an embed — owns the keyboard in [window], as far as the OS can tell. */
+        fun composeOwnsNativeFocus(window: TaoWindow): Boolean? =
+            when (Platform.Current) {
+                Platform.Linux -> {
+                    val gtkWindow = NativeTaoBridge.nativeLinuxGtkWindow(window.handle)
+                    if (gtkWindow == 0L) {
+                        null
+                    } else {
+                        // Tao's own key handler sits on the toplevel: focus on
+                        // nothing, or on one of the suite's input boxes, is what
+                        // "Compose has the keyboard" looks like. Only the embed
+                        // itself steals it.
+                        val focus = NativeTaoLinuxWidgetBridge.nativeDiagFocusWidget(gtkWindow)
+                        probes[window.handle]?.handle != focus
+                    }
+                }
+                Platform.MacOS -> {
+                    val content = NativeTaoBridge.nativeNsViewHandle(window.handle)
+                    if (content == 0L) null else NativeTaoMacOsNativeViewBridge.nativeDiagViewIsFirstResponder(content)
+                }
+                Platform.Windows -> NativeTaoWindowsNativeViewBridge.nativeDiagFocusedHwnd() == window.nativeHandle
+                else -> null
+            }
+
+        /** The last probe created per window, for [composeOwnsNativeFocus]. */
+        private val probes = java.util.concurrent.ConcurrentHashMap<Long, NativeProbe>()
+
+        private fun createGtkEntry(window: TaoWindow): NativeProbe? {
+            val entry = NativeTaoLinuxWidgetBridge.nativeDiagCreateEntry()
+            if (entry == 0L) return null
+            return NativeProbe(
+                handle = entry,
+                focusQuery = { NativeTaoLinuxWidgetBridge.nativeDiagWidgetHasFocus(entry) },
+                textQuery = { NativeTaoLinuxWidgetBridge.nativeDiagEntryText(entry) },
+                frameQuery = {
+                    // GTK lays out in logical px; Compose measures in physical.
+                    val gtkWindow = NativeTaoBridge.nativeLinuxGtkWindow(window.handle)
+                    val scale = window.scaleFactor.takeIf { it > 0f } ?: 1f
+                    NativeTaoLinuxWidgetBridge
+                        .nativeDiagWidgetFrame(gtkWindow, entry)
+                        ?.map { (it * scale).toInt() }
+                        ?.toIntArray()
+                },
+                destroy = { NativeTaoLinuxWidgetBridge.nativeDiagDestroyWidget(entry) },
+            )
+        }
+
+        private fun createNsTextField(): NativeProbe? {
+            val field = NativeTaoMacOsNativeViewBridge.nativeDiagCreateTextField()
+            if (field == 0L) return null
+            return NativeProbe(
+                handle = field,
+                focusQuery = { NativeTaoMacOsNativeViewBridge.nativeDiagViewIsEditing(field) },
+                textQuery = { NativeTaoMacOsNativeViewBridge.nativeDiagTextFieldString(field) },
+                frameQuery = { NativeTaoMacOsNativeViewBridge.nativeDiagViewFrame(field) },
+                destroy = { NativeTaoMacOsNativeViewBridge.nativeDiagReleaseView(field) },
+            )
+        }
+
+        private fun createWin32Edit(): NativeProbe? {
+            val edit = NativeTaoWindowsNativeViewBridge.nativeDiagCreateEdit()
+            if (edit == 0L) return null
+            return NativeProbe(
+                handle = edit,
+                focusQuery = { NativeTaoWindowsNativeViewBridge.nativeDiagFocusedHwnd() == edit },
+                textQuery = { NativeTaoWindowsNativeViewBridge.nativeDiagWindowText(edit) },
+                frameQuery = { NativeTaoWindowsNativeViewBridge.nativeDiagWindowFrame(edit) },
+                destroy = { NativeTaoWindowsNativeViewBridge.nativeDiagDestroyWindow(edit) },
+            )
+        }
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/NativeViewMonkeyHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/NativeViewMonkeyHeadfulCases.kt
@@ -1,0 +1,1100 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
+import dev.nucleusframework.window.tao.LocalTaoWindow
+import dev.nucleusframework.window.tao.NativeView
+import dev.nucleusframework.window.tao.TaoApplication
+import dev.nucleusframework.window.tao.TaoCursorIcon
+import dev.nucleusframework.window.tao.TaoEventCode
+import dev.nucleusframework.window.tao.TaoMouseButton
+import dev.nucleusframework.window.tao.TaoWindow
+import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
+import kotlin.math.roundToInt
+import kotlin.random.Random
+
+/**
+ * Compose and an embedded native widget under one pointer, hit faster than a
+ * human can and in every order a random walk finds.
+ *
+ * The failures this is after are the ones a user reports as "it went dead":
+ * after a few quick clicks between a Compose control and a native view, the
+ * Compose side stops taking clicks, the I-beam never comes back over the text
+ * field, or keystrokes go to whichever side had focus last but the caret
+ * shows on the other. None of those is a crash; each is a state two input
+ * routers — Compose's hit-testing and the platform's own (GtkEventBox capture,
+ * AppKit's responder chain, Win32 focus) — disagree about, reached through an
+ * interleaving nobody wrote a case for.
+ *
+ * The fixture is the smallest desktop that has both routers: a `BasicTextField`
+ * (I-beam, Compose focus), a Compose button, a [NativeView] embedding a real
+ * text widget ([NativeProbe]: it *takes* native focus and *shows* an I-beam of
+ * its own), and a Compose button drawn *over* the native view through the
+ * `content` slot — the blending path.
+ *
+ * What is asserted is not "the right thing happened" but that both routers
+ * still agree and still answer, re-checked after every burst:
+ *
+ *  - **responsiveness** — a click on either Compose button is counted, a
+ *    click on the field focuses it;
+ *  - **one keyboard owner** — Compose focus and native focus are never both
+ *    held, and a typed letter lands on exactly the side that holds it;
+ *  - **the cursor** — a still pointer over the field leaves `TEXT` as the
+ *    last requested cursor and keeps it (no flicker from a stray move);
+ *  - **no leak, no wedge** — every probe an unmount disposed is disposed,
+ *    and the main dispatcher keeps answering ([MainLoopWatchdog]).
+ *
+ * Every case runs twice: with the [SyntheticPointerDriver] (everywhere, native
+ * Wayland included) and with the [RobotPointerDriver] (a real X server or a
+ * real desktop), which is the only one that reaches the platform half.
+ */
+internal object NativeViewMonkeyHeadfulCases {
+    fun all(): List<TaoWindowTestCase> =
+        listOf(
+            alternatingClicksKeepComposeResponsive(synthetic = true),
+            alternatingClicksKeepComposeResponsive(synthetic = false),
+            aRightClickOnTheEmbedDoesNotSwallowLaterClicks(synthetic = true),
+            aRightClickOnTheEmbedDoesNotSwallowLaterClicks(synthetic = false),
+            resizeStormKeepsTheEmbedOnItsSlot(),
+            randomActionsLeaveBothRoutersAgreeing(synthetic = true),
+            randomActionsLeaveBothRoutersAgreeing(synthetic = false),
+        )
+
+    /**
+     * Pinned from the robot monkey's journal: a right click on the embed is
+     * forwarded to the widget, whose own context menu takes a grab and eats
+     * the button *release*. Compose then holds a button that was never let go
+     * of, and every later click on Compose is dead — no down transition. The
+     * plain left click that follows has to be counted.
+     */
+    private fun aRightClickOnTheEmbedDoesNotSwallowLaterClicks(synthetic: Boolean): TaoWindowTestCase {
+        val fixture = NativeViewFixture()
+        return TaoWindowTestCase(
+            name = "native view ${driverName(synthetic)} a right click on the embed does not swallow later clicks",
+            skip = { skipReason(synthetic) },
+            windowState = caseWindowState(),
+            size = DpSize(WINDOW_W_DP.dp, WINDOW_H_DP.dp),
+            paintDefaultBackground = false,
+            content = { fixture.Content() },
+            driver = {
+                fixture.awaitReady(this)
+                val driver = newDriver(synthetic, window, fixture)
+                val probe = ResponsivenessProbe(this, fixture, driver)
+                probe.expectResponsive("before the right click")
+                driver.click(fixture.center(Region.Native), TaoMouseButton.RIGHT)
+                settle()
+                // Whatever menu the embed opened, a click on plain ground
+                // dismisses it — GTK gives that click to the menu, which is the
+                // platform's contract, not the bug. The bug is everything after.
+                driver.click(fixture.backdropPoint())
+                settle()
+                probe.expectResponsive("after a right click on the embed")
+                driver.exit()
+            },
+        )
+    }
+
+    /**
+     * The embed has to *follow* its slot through a resize: sizes asked for one
+     * after another with no pause, then a smooth animated resize. After each
+     * step the platform widget's own frame is compared with the Compose rect
+     * of the slot, the lag between the two is measured, and at the end they
+     * have to agree. Purely programmatic — no pointer, so it runs everywhere.
+     */
+    private fun resizeStormKeepsTheEmbedOnItsSlot(): TaoWindowTestCase {
+        val fixture = NativeViewFixture()
+        return TaoWindowTestCase(
+            name = "native view resize storm keeps the embed on its slot",
+            timeoutMillis = STORM_CASE_TIMEOUT_MILLIS,
+            skip = { NativeProbe.skipReason() },
+            windowState = caseWindowState(),
+            size = DpSize(WINDOW_W_DP.dp, WINDOW_H_DP.dp),
+            paintDefaultBackground = false,
+            content = { fixture.Content() },
+            driver = {
+                fixture.awaitReady(this)
+                val geometry = EmbedGeometryProbe(this, fixture)
+                geometry.expectOnSlot("before the storm")
+
+                // 1. Discrete steps, each awaited: how long does the embed trail the layout?
+                var worstLagMillis = 0L
+                for (round in 0 until RESIZE_ROUNDS) {
+                    // Never the current size: a step that changes nothing has no lag to measure.
+                    val w = WINDOW_W_DP - (round % RESIZE_SPAN + 1) * RESIZE_STEP_DP
+                    val h = WINDOW_H_DP - (round % RESIZE_SPAN + 1) * RESIZE_STEP_DP
+                    worstLagMillis = maxOf(worstLagMillis, geometry.resizeAndMeasureLag(w, h))
+                }
+
+                // 2. A burst with no waiting at all, then a smooth animation.
+                for (round in 0 until RESIZE_BURST) {
+                    window.setInnerSize((WINDOW_W_DP - round * RESIZE_STEP_DP).toDouble(), WINDOW_H_DP.toDouble())
+                }
+                geometry.expectOnSlot("after a burst of resizes")
+                for (step in 0..ANIMATION_STEPS) {
+                    val t = step / ANIMATION_STEPS.toFloat()
+                    window.setInnerSize(
+                        (MIN_INNER_W_DP + (WINDOW_W_DP - MIN_INNER_W_DP) * t),
+                        (MIN_INNER_H_DP + (WINDOW_H_DP - MIN_INNER_H_DP) * t),
+                    )
+                    settle(ANIMATION_FRAME_MILLIS)
+                    geometry.sample()
+                }
+                geometry.expectOnSlot("after an animated resize")
+                System.err.println(
+                    "[native-view-resize] worst lag ${worstLagMillis}ms over $RESIZE_ROUNDS steps; " +
+                        "animated: ${geometry.offSlotSamples} of ${geometry.samples} samples off the slot, " +
+                        "worst ${geometry.worstDistancePx}px behind",
+                )
+
+                // 3. The user's gesture: a real pointer dragging the corner of
+                // the frame, so the sizes flow in from the window manager at
+                // its cadence instead of from setInnerSize. Robot hosts only.
+                if (robotDriverSkipReason() == null) {
+                    val interactive = EmbedGeometryProbe(this, fixture)
+                    val sizeBefore = window.outerBoundsPx()?.drop(2)
+                    dragBottomRightCorner(interactive)
+                    interactive.expectOnSlot("after an interactive edge drag")
+                    val sizeAfter = window.outerBoundsPx()?.drop(2)
+                    System.err.println(
+                        "[native-view-resize] interactive: ${interactive.offSlotSamples} of ${interactive.samples} " +
+                            "samples off the slot, worst ${interactive.worstDistancePx}px behind; frame " +
+                            if (sizeBefore == sizeAfter) {
+                                "$sizeBefore unchanged (the press started no resize on this host)"
+                            } else {
+                                "$sizeBefore -> $sizeAfter"
+                            },
+                    )
+                    check(interactive.worstDistancePx <= ANIMATION_LAG_FRAMES * EDGE_DRAG_STEP_PX) {
+                        "the embed fell ${interactive.worstDistancePx}px behind its slot during an interactive " +
+                            "resize " +
+                            "(${EDGE_DRAG_STEP_PX}px per step, budget $ANIMATION_LAG_FRAMES steps)"
+                    }
+                }
+                check(worstLagMillis <= EMBED_LAG_BUDGET_MILLIS) {
+                    "the embed trailed its slot by ${worstLagMillis}ms after a resize (budget $EMBED_LAG_BUDGET_MILLIS)"
+                }
+                // One frame behind the layout is the pipeline (Compose places,
+                // then the platform allocates); several frames is the embed
+                // visibly peeling away from the window edge as it is dragged.
+                val perFramePx = ((WINDOW_W_DP - MIN_INNER_W_DP) / ANIMATION_STEPS * window.scaleFactor).roundToInt()
+                check(geometry.worstDistancePx <= ANIMATION_LAG_FRAMES * perFramePx) {
+                    "the embed fell ${geometry.worstDistancePx}px behind its slot during an animated resize " +
+                        "(${perFramePx}px per frame, budget $ANIMATION_LAG_FRAMES frames)"
+                }
+            },
+        )
+    }
+
+    /**
+     * The bug report, verbatim: click Compose, click native, click Compose
+     * over native, click the field, again, as fast as possible. Every click
+     * must have been counted at the end, and the desktop must still answer.
+     */
+    private fun alternatingClicksKeepComposeResponsive(synthetic: Boolean): TaoWindowTestCase {
+        val fixture = NativeViewFixture()
+        return TaoWindowTestCase(
+            name = "native view ${driverName(synthetic)} alternating clicks keep compose responsive",
+            timeoutMillis = STORM_CASE_TIMEOUT_MILLIS,
+            skip = { skipReason(synthetic) },
+            windowState = caseWindowState(),
+            size = DpSize(WINDOW_W_DP.dp, WINDOW_H_DP.dp),
+            paintDefaultBackground = false,
+            content = { fixture.Content() },
+            driver = {
+                fixture.awaitReady(this)
+                val driver = newDriver(synthetic, window, fixture)
+                val probe = ResponsivenessProbe(this, fixture, driver)
+                probe.expectResponsive("before the storm")
+
+                val headerBefore = fixture.headerClicks
+                val overlayBefore = fixture.overlayClicks
+                for (round in 0 until STORM_ROUNDS) {
+                    driver.click(fixture.center(Region.HeaderButton))
+                    driver.click(fixture.center(Region.Native))
+                    driver.click(fixture.center(Region.OverlayButton))
+                    driver.click(fixture.center(Region.Field))
+                }
+                settle(SETTLE_AFTER_MAP_MILLIS)
+
+                // Every click must have landed: a lost one is the report.
+                awaitUntil(
+                    "every header click of the storm was counted",
+                    detail = { "counted ${fixture.headerClicks - headerBefore} of $STORM_ROUNDS; ${robotAim()}" },
+                ) { fixture.headerClicks - headerBefore == STORM_ROUNDS }
+                awaitUntil(
+                    "every overlay click of the storm was counted",
+                    detail = { "counted ${fixture.overlayClicks - overlayBefore} of $STORM_ROUNDS; ${robotAim()}" },
+                ) { fixture.overlayClicks - overlayBefore == STORM_ROUNDS }
+                probe.expectResponsive("after the storm")
+                probe.expectKeyboardAgrees("after the storm")
+                driver.exit()
+            },
+        )
+    }
+
+    /** A seeded random walk over every gesture the fixture knows, checked every few steps. */
+    private fun randomActionsLeaveBothRoutersAgreeing(synthetic: Boolean): TaoWindowTestCase {
+        val fixture = NativeViewFixture()
+        return TaoWindowTestCase(
+            name = "native view ${driverName(
+                synthetic,
+            )} monkey $MONKEY_ACTIONS random actions leave both routers agreeing",
+            timeoutMillis = MONKEY_CASE_TIMEOUT_MILLIS,
+            skip = { skipReason(synthetic) },
+            windowState = caseWindowState(),
+            size = DpSize(WINDOW_W_DP.dp, WINDOW_H_DP.dp),
+            paintDefaultBackground = false,
+            content = { fixture.Content() },
+            driver = {
+                fixture.awaitReady(this)
+                val driver = newDriver(synthetic, window, fixture)
+                val monkey = NativeViewMonkey(this, fixture, driver, monkeySeed())
+                monkey.run()
+                monkey.quiesceAndAssert()
+            },
+        )
+    }
+
+    private fun skipReason(synthetic: Boolean): String? =
+        NativeProbe.skipReason() ?: if (synthetic) null else robotDriverSkipReason()
+
+    /**
+     * Presses the resize band at the bottom-right corner of the frame with the
+     * real pointer and drags it inwards, sampling the embed against its slot
+     * after every step. Whether the platform turns the press into a resize is
+     * its business (Tao's own band on X11 and Win32, AppKit's edges on macOS);
+     * a press that resizes nothing simply leaves nothing to trail.
+     */
+    private suspend fun TaoWindowTestScope.dragBottomRightCorner(geometry: EmbedGeometryProbe) {
+        val outer = requireNotNull(window.outerBoundsPx()) { "the case window is not mapped" }
+        val scale = window.scaleFactor.takeIf { it > 0f } ?: 1f
+        val startX = outer[0] + outer[OUTER_W] - EDGE_PRESS_INSET_PX
+        val startY = outer[1] + outer[OUTER_H] - EDGE_PRESS_INSET_PX
+        val moved =
+            HeadfulRobot.inject { robot ->
+                robot.mouseMove((startX / scale).roundToInt(), (startY / scale).roundToInt())
+                HeadfulRobot.noteAim((startX / scale).roundToInt(), (startY / scale).roundToInt())
+                Thread.sleep(ROBOT_PRESS_SETTLE_MILLIS)
+                HeadfulRobot.notePress()
+                robot.mousePress(java.awt.event.InputEvent.BUTTON1_DOWN_MASK)
+                true
+            }
+        checkNotNull(moved) { "the AWT Robot became unavailable: ${HeadfulRobot.unavailableReason}" }
+        for (step in 1..EDGE_DRAG_STEPS) {
+            val x = startX - step * EDGE_DRAG_STEP_PX
+            val y = startY - step * EDGE_DRAG_STEP_PX
+            HeadfulRobot.inject { robot ->
+                robot.mouseMove((x / scale).roundToInt(), (y / scale).roundToInt())
+                true
+            }
+            settle(EDGE_DRAG_STEP_MILLIS)
+            geometry.sample()
+        }
+        HeadfulRobot.inject { robot ->
+            robot.mouseRelease(java.awt.event.InputEvent.BUTTON1_DOWN_MASK)
+            true
+        }
+    }
+
+    private fun driverName(synthetic: Boolean) = if (synthetic) "synthetic" else "robot"
+
+    private fun newDriver(
+        synthetic: Boolean,
+        window: TaoWindow,
+        fixture: NativeViewFixture,
+    ): PointerDriver =
+        if (synthetic) SyntheticPointerDriver(window) else RobotPointerDriver(window) { fixture.sceneSize }
+
+    private fun caseWindowState() =
+        WindowState(
+            position = WindowPosition.Absolute(WINDOW_X_DP.dp, WINDOW_Y_DP.dp),
+            size = DpSize(WINDOW_W_DP.dp, WINDOW_H_DP.dp),
+        )
+}
+
+/** The hit targets the fixture lays out, each with a rect in content px. */
+private enum class Region {
+    /** The `BasicTextField` in the header row. */
+    Field,
+
+    /** The Compose button beside it — plain Compose ground, no embed underneath. */
+    HeaderButton,
+
+    /** The embedded native widget's slot (its centre is clear of the overlay button). */
+    Native,
+
+    /** The Compose button drawn over the native view through `NativeView`'s content slot. */
+    OverlayButton,
+}
+
+/**
+ * The desktop described in [NativeViewMonkeyHeadfulCases], publishing its
+ * rects, its counters and its focus state for the driver to read.
+ */
+private class NativeViewFixture {
+    var fieldText by mutableStateOf("")
+    var fieldFocused by mutableStateOf(false)
+    var headerClicks by mutableIntStateOf(0)
+    var overlayClicks by mutableIntStateOf(0)
+
+    /** Whether the native view is in composition; flipped by the monkey. */
+    var nativeMounted by mutableStateOf(true)
+
+    /** The probe currently embedded, or the last one when unmounted. */
+    var probe: NativeProbe? = null
+        private set
+
+    var sceneSize: IntSize = IntSize.Zero
+        private set
+
+    /** The case window, once composed. */
+    var window: TaoWindow? = null
+        private set
+
+    private val rects = java.util.concurrent.ConcurrentHashMap<Region, Rect>()
+
+    /**
+     * The last presses and releases the Compose scene received, as seen from
+     * the root in the initial pass — so a lost click can be told apart from a
+     * click that arrived at the wrong place, or never arrived at all.
+     */
+    private val recentPointerEvents = java.util.concurrent.ConcurrentLinkedDeque<String>()
+
+    fun recentPointerEvents(): List<String> = recentPointerEvents.toList()
+
+    /** Interleaves a driver-side marker with the scene's events, so intent and reception read together. */
+    fun note(marker: String) {
+        if (recentPointerEvents.size >= POINTER_LOG_DEPTH) recentPointerEvents.pollFirst()
+        recentPointerEvents.addLast(marker)
+    }
+
+    fun rect(region: Region): Rect? = rects[region]
+
+    fun center(region: Region): Offset = requireNotNull(rect(region)) { "$region has no rect yet" }.center
+
+    /**
+     * A point on plain Compose ground: the gap between the header row and the
+     * native slot, well clear of the resize band. Where a context menu the
+     * embed opened gets dismissed — that click is the menu's, not Compose's.
+     */
+    fun backdropPoint(): Offset {
+        val native = requireNotNull(rect(Region.Native)) { "the native slot has no rect yet" }
+        return Offset(native.center.x, native.top - (native.top - requireNotNull(rect(Region.Field)).bottom) / 2f)
+    }
+
+    @Composable
+    fun Content() {
+        val window = LocalTaoWindow.current
+        this.window = window
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(Color(BACKDROP_ARGB))
+                .onGloballyPositioned { sceneSize = it.size }
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event = awaitPointerEvent(PointerEventPass.Initial)
+                            if (event.type == PointerEventType.Press || event.type == PointerEventType.Release) {
+                                val position = event.changes.firstOrNull()?.position
+                                if (recentPointerEvents.size >= POINTER_LOG_DEPTH) recentPointerEvents.pollFirst()
+                                recentPointerEvents.addLast(
+                                    "${event.type}(${event.button})@${position?.x?.toInt()},${position?.y?.toInt()}",
+                                )
+                            }
+                        }
+                    }
+                },
+        ) {
+            Column(Modifier.fillMaxSize()) {
+                Row(Modifier.fillMaxWidth().height(HEADER_H_DP.dp).padding(PAD_DP.dp)) {
+                    Box(
+                        Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .background(Color.White)
+                            .recordRect(Region.Field),
+                    ) {
+                        BasicTextField(
+                            value = fieldText,
+                            onValueChange = { fieldText = it },
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .padding(PAD_DP.dp)
+                                    .onFocusChanged { fieldFocused = it.isFocused }
+                                    .onPreviewKeyEvent { event ->
+                                        // Logged, never consumed: which keys reach the field.
+                                        note("key ${event.type} ${event.key}")
+                                        false
+                                    },
+                            textStyle = TextStyle(color = Color.Black, fontSize = FONT_SP.sp),
+                        )
+                    }
+                    Spacer(Modifier.width(PAD_DP.dp))
+                    Box(
+                        Modifier
+                            .width(BUTTON_W_DP.dp)
+                            .fillMaxHeight()
+                            .background(Color(HEADER_BUTTON_ARGB))
+                            .clickable { headerClicks++ }
+                            .recordRect(Region.HeaderButton),
+                    )
+                }
+                Box(Modifier.fillMaxSize().padding(PAD_DP.dp)) {
+                    if (nativeMounted && window != null) {
+                        NativeView(
+                            factory = {
+                                requireNotNull(NativeProbe.create(window)) { "the platform refused a probe widget" }
+                                    .also { probe = it }
+                                    .platformView
+                            },
+                            modifier = Modifier.fillMaxSize().recordRect(Region.Native),
+                        ) {
+                            Box(Modifier.fillMaxSize()) {
+                                Box(
+                                    Modifier
+                                        .align(Alignment.BottomEnd)
+                                        .size(BUTTON_W_DP.dp, OVERLAY_H_DP.dp)
+                                        .background(Color(OVERLAY_BUTTON_ARGB))
+                                        .clickable { overlayClicks++ }
+                                        .recordRect(Region.OverlayButton),
+                                )
+                            }
+                        }
+                    } else {
+                        // The slot without its embed: the same rect, plain Compose.
+                        Box(Modifier.fillMaxSize().background(Color(EMPTY_SLOT_ARGB)).recordRect(Region.Native))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun Modifier.recordRect(region: Region): Modifier =
+        onGloballyPositioned { coords ->
+            val origin = coords.positionInRoot()
+            rects[region] =
+                Rect(
+                    origin,
+                    androidx.compose.ui.geometry
+                        .Size(coords.size.width.toFloat(), coords.size.height.toFloat()),
+                )
+        }
+
+    suspend fun awaitReady(scope: TaoWindowTestScope) {
+        with(scope) {
+            awaitUntil("the case window is mapped with a real frame") { window.hasRealFramePx() }
+            // On top, please: a window an earlier case leaked may sit where the
+            // real pointer is about to click, and the WM places this one
+            // wherever it finds room. `focus()` is an activation request the WM
+            // may refuse; always-on-top is a stacking order it honours.
+            window.setAlwaysOnTop(true)
+            window.focus()
+            awaitUntil("every region has a rect") { Region.entries.all { rect(it) != null } }
+            awaitUntil("the overlay button sits inside the native slot") {
+                val native = rect(Region.Native) ?: return@awaitUntil false
+                val overlay = rect(Region.OverlayButton) ?: return@awaitUntil false
+                native.contains(overlay.center) && !overlay.contains(native.center)
+            }
+            awaitUntil("a probe widget was created") { probe != null }
+            // The platform must have mapped the widget where Compose put the
+            // slot: this is the "the native view never shows up" check, the
+            // first setFrame routinely beats the attach effect and is what
+            // mounts the widget.
+            awaitUntil("the embed is mapped on its slot", detail = { describeGeometry() }) {
+                val slot = rect(Region.Native) ?: return@awaitUntil false
+                val frame = probe?.framePx() ?: return@awaitUntil false
+                kotlin.math.abs(frame[2] - slot.width.roundToInt()) <= GEOMETRY_TOLERANCE_PX &&
+                    kotlin.math.abs(frame[3] - slot.height.roundToInt()) <= GEOMETRY_TOLERANCE_PX
+            }
+            settle(SETTLE_AFTER_MAP_MILLIS)
+        }
+    }
+}
+
+/**
+ * The checks every case ends on and the monkey repeats at each checkpoint —
+ * each one a gesture followed by a converging assertion, because the point
+ * is not the state the desktop is in but whether it still *answers*.
+ */
+private class ResponsivenessProbe(
+    private val scope: TaoWindowTestScope,
+    private val fixture: NativeViewFixture,
+    private val driver: PointerDriver,
+) {
+    private var typed = 'a'
+
+    /** Compose still takes clicks and focus, and still asks for the I-beam. */
+    suspend fun expectResponsive(moment: String) {
+        val header = fixture.headerClicks
+        driver.click(fixture.center(Region.HeaderButton))
+        converge("$moment: a click on the header button is counted") { fixture.headerClicks == header + 1 }
+
+        if (fixture.nativeMounted) {
+            val overlay = fixture.overlayClicks
+            driver.click(fixture.center(Region.OverlayButton))
+            converge("$moment: a click on the button over the native view is counted") {
+                fixture.overlayClicks == overlay + 1
+            }
+        }
+
+        driver.click(fixture.center(Region.Field))
+        converge("$moment: a click on the text field focuses it") { fixture.fieldFocused }
+
+        expectTextCursor(moment)
+    }
+
+    /**
+     * A still pointer over the field must have left `TEXT` as the last cursor
+     * request and must keep it: a change while nothing moves is the flicker
+     * a stray, mis-positioned move produces.
+     */
+    suspend fun expectTextCursor(moment: String) {
+        driver.moveTo(fixture.center(Region.Field) + Offset(CURSOR_NUDGE_PX, 0f))
+        converge("$moment: the I-beam is requested over the text field") { lastCursor() == TaoCursorIcon.TEXT }
+        // Stability is the robot's to check: it owns the real pointer. With
+        // the synthetic driver the real pointer is wherever the desktop left
+        // it — on a live session, possibly over this very window's edge.
+        if (driver !is RobotPointerDriver) return
+        repeat(CURSOR_STILL_SAMPLES) {
+            scope.settle(CURSOR_STILL_SAMPLE_MILLIS)
+            val now = lastCursor()
+            check(now == TaoCursorIcon.TEXT) {
+                "$moment: the cursor flickered to $now over a text field under a still pointer"
+            }
+        }
+    }
+
+    /**
+     * One keyboard owner, and the right one. Clicking the field gives Compose
+     * the keys and takes them from the embed; clicking the embed does the
+     * reverse; a typed letter lands where the focus says. The embed half only
+     * runs when the driver reaches the widget at all.
+     */
+    suspend fun expectKeyboardAgrees(moment: String) {
+        driver.click(fixture.center(Region.Field))
+        converge("$moment: the field takes Compose focus") { fixture.fieldFocused }
+        converge("$moment: the embed does not hold native focus while the field is focused") {
+            fixture.probe?.hasNativeFocus() != true
+        }
+        val fieldBefore = fixture.fieldText
+        val letter = nextLetter()
+        driver.type(letter)
+        converge("$moment: a letter typed into the focused field arrives there") {
+            fixture.fieldText == fieldBefore + letter
+        }
+        // Caret keys travel as KeyDown, not as typed text — a second path an
+        // embed's focus can cut: the left arrow must move the caret back one.
+        // A frame on either side of the caret move: the legacy text field
+        // lays the new text out and applies the move through recomposition,
+        // and a real keyboard never delivers two keys inside one frame.
+        scope.settle(KEY_SETTLE_MILLIS)
+        driver.arrowLeft()
+        scope.settle(KEY_SETTLE_MILLIS)
+        val inserted = nextLetter()
+        driver.type(inserted)
+        converge("$moment: the left arrow moved the caret so the next letter lands before the last") {
+            fixture.fieldText == fieldBefore + inserted + letter
+        }
+
+        val probe = fixture.probe
+        if (!driver.reachesNative || probe == null || !fixture.nativeMounted) return
+        driver.click(fixture.center(Region.Native))
+        converge("$moment: a click on the embed gives it native focus") { probe.hasNativeFocus() }
+        converge("$moment: the field drops Compose focus once the embed has the keyboard") { !fixture.fieldFocused }
+        val fieldNow = fixture.fieldText
+        val second = nextLetter()
+        driver.type(second)
+        // "Ends with", not "appended": a GtkEntry selects its whole text when
+        // it takes focus (`gtk-entry-select-on-focus`), so the letter may as
+        // well have replaced what an earlier keystroke left there.
+        converge(
+            "$moment: a letter typed into the focused embed arrives there",
+        ) { probe.text().endsWith(second) }
+        check(fixture.fieldText == fieldNow) {
+            "$moment: a letter typed into the embed also reached the Compose field ('${fixture.fieldText}')"
+        }
+    }
+
+    private fun lastCursor(): Int? = NativeTaoBridge.lastCursorIcon[scope.window.handle]
+
+    private fun nextLetter(): Char {
+        val letter = typed
+        typed = if (typed == 'z') 'a' else typed + 1
+        return letter
+    }
+
+    private suspend fun converge(
+        description: String,
+        predicate: () -> Boolean,
+    ) {
+        scope.awaitUntil(
+            description,
+            timeoutMillis = CONVERGE_MILLIS,
+            detail = { fixture.describe(driver) },
+            predicate = predicate,
+        )
+    }
+}
+
+/**
+ * The embed against its slot: the platform's own frame for the widget versus
+ * the Compose rect of the `NativeView`, both in content px. Off by more than
+ * [tolerancePx] is "not on the slot".
+ */
+private class EmbedGeometryProbe(
+    private val scope: TaoWindowTestScope,
+    private val fixture: NativeViewFixture,
+) {
+    var samples = 0
+        private set
+    var offSlotSamples = 0
+        private set
+
+    /** The farthest the embed was seen from its slot across [sample] calls, in px. */
+    var worstDistancePx = 0
+        private set
+
+    private val tolerancePx: Int get() = maxOf(GEOMETRY_TOLERANCE_PX, scope.window.scaleFactor.roundToInt())
+
+    /** How far the embed is from its slot right now, in px, or null when either side is unknown. */
+    fun distancePx(): Int? {
+        val slot = fixture.rect(Region.Native) ?: return null
+        val frame = fixture.probe?.framePx() ?: return null
+        return maxOf(
+            kotlin.math.abs(frame[0] - slot.left.roundToInt()),
+            kotlin.math.abs(frame[1] - slot.top.roundToInt()),
+            kotlin.math.abs(frame[2] - slot.width.roundToInt()),
+            kotlin.math.abs(frame[3] - slot.height.roundToInt()),
+        )
+    }
+
+    fun isOnSlot(): Boolean = distancePx()?.let { it <= tolerancePx } == true
+
+    fun sample() {
+        samples++
+        val distance = distancePx() ?: return
+        if (distance > tolerancePx) offSlotSamples++
+        worstDistancePx = maxOf(worstDistancePx, distance)
+    }
+
+    suspend fun expectOnSlot(moment: String) {
+        scope.awaitUntil(
+            "$moment: the embed sits on its Compose slot",
+            timeoutMillis = CONVERGE_MILLIS,
+            detail = { "distance=${distancePx()} tolerance=$tolerancePx ${fixture.describeGeometry()}" },
+        ) { isOnSlot() }
+    }
+
+    /**
+     * Asks for [wDp]×[hDp], waits until Compose has laid the slot out at the
+     * new size, then measures how long the embed takes to land on it.
+     */
+    suspend fun resizeAndMeasureLag(
+        wDp: Int,
+        hDp: Int,
+    ): Long {
+        val before = fixture.rect(Region.Native)
+        scope.window.setInnerSize(wDp.toDouble(), hDp.toDouble())
+        scope.awaitUntil("Compose laid the slot out for ${wDp}x$hDp", detail = { fixture.describeGeometry() }) {
+            fixture.rect(Region.Native) != before && fixture.sceneSize.width > 0
+        }
+        val start = System.nanoTime()
+        expectOnSlot("after resizing to ${wDp}x$hDp")
+        return (System.nanoTime() - start) / NANOS_PER_MILLI
+    }
+}
+
+private fun NativeViewFixture.describeGeometry(): String =
+    "slot=${rect(Region.Native)} frame=${probe?.framePx()?.toList()} scene=$sceneSize " +
+        "outer=${window?.outerBoundsPx()?.toList()} scale=${window?.scaleFactor}"
+
+private fun NativeViewFixture.describe(driver: PointerDriver): String =
+    "driver=${driver.name} windowFocused=${window?.isFocused} fieldFocused=$fieldFocused field='$fieldText' " +
+        "header=$headerClicks overlay=$overlayClicks mounted=$nativeMounted " +
+        "probe=${probe?.handle?.toString(HEX)}/disposed=${probe?.isDisposed}/nativeFocus=${probe?.hasNativeFocus()}" +
+        "/text='${probe?.text()}' cursor=${NativeTaoBridge.lastCursorIcon} " +
+        "probes=${NativeProbe.createdCount.get()}/${NativeProbe.disposedCount.get()} ${robotAim()} " +
+        "rects=${Region.entries.map {
+            "$it=${rect(
+                it,
+            )}"
+        }} scene=$sceneSize outer=${window?.outerBoundsPx()?.toList()} " +
+        "sceneEvents=${recentPointerEvents()}"
+
+/** One atomic thing the monkey can do; drawn uniformly. */
+private enum class NativeViewAction {
+    ClickField,
+    ClickHeaderButton,
+    ClickOverlayButton,
+    ClickNative,
+    DoubleClickNative,
+    RightClickNative,
+    HoverField,
+    HoverNative,
+    HoverHeaderButton,
+
+    /** A press on one region released on another — the gesture that crosses the boundary. */
+    DragAcross,
+
+    /** Six clicks alternating between two random regions with no settle at all. */
+    Burst,
+    TypeLetter,
+    PointerExit,
+
+    /** Drops the native view from composition, or puts it back. */
+    ToggleNativeMounted,
+    ResizeWindow,
+
+    /** Injects a scale change (synthetic driver only: the robot aims through the real scale). */
+    ChangeDpi,
+
+    /** Asks the OS to focus the window again. */
+    RefocusWindow,
+}
+
+private class NativeViewMonkey(
+    private val scope: TaoWindowTestScope,
+    private val fixture: NativeViewFixture,
+    private val driver: PointerDriver,
+    seed: Long,
+) {
+    private val random = Random(seed)
+    private val journal = MonkeyJournal("native-view-monkey", seed)
+    private val probe = ResponsivenessProbe(scope, fixture, driver)
+    private val geometry = EmbedGeometryProbe(scope, fixture)
+    private var worstStallMillis = 0L
+    private var letter = 'a'
+
+    /** A journal pasted back through the script property, or null for the random walk. */
+    private val script: List<NativeViewAction>? = monkeyScript()?.map { NativeViewAction.valueOf(it) }
+
+    /** Windows alive when the run started: earlier cases may have left some behind, they are not this run's. */
+    private val windowsAtStart = TaoApplication.liveWindowCount()
+
+    suspend fun run() {
+        System.err.println(
+            "[native-view-monkey] seed=${journal.seed} driver=${driver.name} actions=$MONKEY_ACTIONS " +
+                "(replay with -D$MONKEY_SEED_PROPERTY=${journal.seed})",
+        )
+        val watchdog = MainLoopWatchdog("native-view-monkey", journal::report).start()
+        try {
+            while (journal.step < (script?.size ?: MONKEY_ACTIONS)) {
+                val action =
+                    script?.get(journal.step) ?: NativeViewAction.entries[random.nextInt(NativeViewAction.entries.size)]
+                journal.record(action)
+                fixture.note("> ${journal.step} $action")
+                monkeyAction({ journal.failure("$action", fixture.describe(driver)) }) { apply(action) }
+                if ((journal.step + 1) % CHECKPOINT_EVERY == 0) checkpoint()
+                journal.step++
+            }
+        } finally {
+            worstStallMillis = watchdog.stop()
+        }
+    }
+
+    /** Back to the plain desktop, and every probe of [ResponsivenessProbe] strictly. */
+    suspend fun quiesceAndAssert() {
+        // No blind release here: every gesture above released what it
+        // pressed, and a Robot release of a button that was never pressed
+        // segfaults the JVM on macOS.
+        restoreScale()
+        scope.window.setInnerSize(WINDOW_W_DP.toDouble(), WINDOW_H_DP.toDouble())
+        if (!fixture.nativeMounted) {
+            fixture.nativeMounted = true
+            journal.reach("remountedForQuiesce")
+        }
+        scope.window.focus()
+        scope.settle(SETTLE_AFTER_MAP_MILLIS)
+        scope.awaitUntil("the native view is back with a live probe", detail = { fixture.describe(driver) }) {
+            fixture.probe?.isDisposed == false
+        }
+
+        geometry.expectOnSlot("after the monkey")
+        probe.expectResponsive("after the monkey")
+        probe.expectKeyboardAgrees("after the monkey")
+
+        // An unmount must dispose the probe it embedded, and a remount must
+        // bring a fresh one: created − disposed is the number still mounted.
+        fixture.nativeMounted = false
+        scope.awaitUntil("unmounting disposes the embedded probe", detail = { fixture.describe(driver) }) {
+            fixture.probe?.isDisposed == true
+        }
+        fixture.nativeMounted = true
+        scope.awaitUntil("remounting creates a fresh probe", detail = { fixture.describe(driver) }) {
+            fixture.probe?.isDisposed == false
+        }
+        val live = NativeProbe.createdCount.get() - NativeProbe.disposedCount.get()
+        check(live == 1) { "$live probes are alive with one native view mounted — an unmount leaked its widget" }
+
+        check(TaoApplication.liveWindowCount() == windowsAtStart) {
+            "${TaoApplication.liveWindowCount()} native windows are alive, $windowsAtStart when the run started"
+        }
+        // Park the real pointer outside the window: a later case's windows may
+        // map under wherever the last gesture left it.
+        driver.exit()
+        System.err.println(
+            "[native-view-monkey] seed=${journal.seed} driver=${driver.name} survived $MONKEY_ACTIONS actions; " +
+                "worst main-dispatcher round trip ${worstStallMillis}ms; reached ${journal.reachedSummary()}",
+        )
+        check(worstStallMillis <= MONKEY_MAX_STALL_MILLIS) {
+            "the main dispatcher took ${worstStallMillis}ms to answer a heartbeat — the loop stalled"
+        }
+        if (script == null) {
+            check(journal.reachedCount("clickNative") > 0) { "the run never clicked the native view" }
+            check(journal.reachedCount("toggledMount") > 0) { "the run never unmounted the native view" }
+        }
+    }
+
+    private suspend fun apply(action: NativeViewAction) {
+        when (action) {
+            NativeViewAction.ClickField -> driver.click(fixture.center(Region.Field))
+            NativeViewAction.ClickHeaderButton -> driver.click(fixture.center(Region.HeaderButton))
+            NativeViewAction.ClickOverlayButton ->
+                if (fixture.nativeMounted) {
+                    driver.click(
+                        fixture.center(Region.OverlayButton),
+                    )
+                }
+            NativeViewAction.ClickNative -> {
+                driver.click(fixture.center(Region.Native))
+                journal.reach("clickNative")
+            }
+            NativeViewAction.DoubleClickNative -> {
+                val point = fixture.center(Region.Native)
+                driver.click(point)
+                driver.click(point)
+            }
+            NativeViewAction.RightClickNative -> {
+                driver.click(fixture.center(Region.Native), TaoMouseButton.RIGHT)
+                // Dismiss the embed's menu, if it opened one; see the pinned case.
+                scope.settle(STEP_SETTLE_MILLIS)
+                driver.click(fixture.backdropPoint())
+            }
+            NativeViewAction.HoverField -> driver.moveTo(randomPointIn(Region.Field))
+            NativeViewAction.HoverNative -> driver.moveTo(randomPointIn(Region.Native))
+            NativeViewAction.HoverHeaderButton -> driver.moveTo(randomPointIn(Region.HeaderButton))
+            NativeViewAction.DragAcross -> dragAcross()
+            NativeViewAction.Burst -> burst()
+            NativeViewAction.TypeLetter -> driver.type(nextLetter())
+            NativeViewAction.PointerExit -> driver.exit()
+            NativeViewAction.ToggleNativeMounted -> {
+                fixture.nativeMounted = !fixture.nativeMounted
+                journal.reach("toggledMount")
+            }
+            NativeViewAction.ResizeWindow ->
+                scope.window.setInnerSize(
+                    MIN_INNER_W_DP + random.nextDouble(INNER_W_SPAN_DP),
+                    MIN_INNER_H_DP + random.nextDouble(INNER_H_SPAN_DP),
+                )
+            NativeViewAction.ChangeDpi ->
+                if (driver is SyntheticPointerDriver) {
+                    val scale = SCALE_HOPS[random.nextInt(SCALE_HOPS.size)]
+                    scope.window.dispatch(TaoEventCode.SCALE_FACTOR_CHANGED, (scale * SCALE_MILLI).roundToInt(), 0)
+                    journal.reach("dpiChanged")
+                }
+            NativeViewAction.RefocusWindow -> scope.window.focus()
+        }
+        scope.settle(STEP_SETTLE_MILLIS)
+    }
+
+    private suspend fun dragAcross() {
+        val from = randomRegion()
+        val to = randomRegion()
+        fixture.note("> drag $from -> $to")
+        driver.moveTo(fixture.center(from))
+        driver.press()
+        val start = fixture.center(from)
+        val end = fixture.center(to)
+        for (step in 1..DRAG_STEPS) {
+            val t = step / DRAG_STEPS.toFloat()
+            driver.moveTo(start + (end - start) * t)
+        }
+        driver.release()
+        journal.reach("dragged")
+    }
+
+    private suspend fun burst() {
+        val a = randomRegion()
+        val b = randomRegion()
+        fixture.note("> burst $a/$b")
+        repeat(BURST_CLICKS / 2) {
+            driver.click(fixture.center(a))
+            driver.click(fixture.center(b))
+        }
+        journal.reach("burst")
+    }
+
+    /**
+     * The converging checks of a checkpoint: a click on Compose ground is
+     * still counted, and the field still takes focus. The keyboard checks are
+     * kept for the end — they type, which the monkey does on its own.
+     */
+    private suspend fun checkpoint() {
+        // A resize may have shrunk the window past where the layout has a
+        // useful slot; put the size back before aiming. And undo an injected
+        // scale: it moves Compose's density without the platform's, so the
+        // slot and the embed's frame are measured in different pixels.
+        restoreScale()
+        scope.window.setInnerSize(WINDOW_W_DP.toDouble(), WINDOW_H_DP.toDouble())
+        scope.settle(STEP_SETTLE_MILLIS)
+        fixture.note("> checkpoint ${journal.step}")
+        if (fixture.nativeMounted) geometry.expectOnSlot("checkpoint at step ${journal.step}")
+        probe.expectResponsive("checkpoint at step ${journal.step}")
+    }
+
+    /** Puts the platform's real scale back after a [NativeViewAction.ChangeDpi]. */
+    private fun restoreScale() {
+        if (driver !is SyntheticPointerDriver) return
+        scope.window.dispatch(
+            TaoEventCode.SCALE_FACTOR_CHANGED,
+            (scope.window.scaleFactor * SCALE_MILLI).roundToInt(),
+            0,
+        )
+    }
+
+    private fun randomRegion(): Region {
+        val regions = if (fixture.nativeMounted) Region.entries else Region.entries - Region.OverlayButton
+        return regions[random.nextInt(regions.size)]
+    }
+
+    private fun randomPointIn(region: Region): Offset {
+        val rect = fixture.rect(region) ?: return Offset.Zero
+        return Offset(
+            rect.left + INSET_PX + random.nextFloat() * (rect.width - 2 * INSET_PX).coerceAtLeast(1f),
+            rect.top + INSET_PX + random.nextFloat() * (rect.height - 2 * INSET_PX).coerceAtLeast(1f),
+        )
+    }
+
+    private fun nextLetter(): Char {
+        val current = letter
+        letter = if (letter == 'z') 'a' else letter + 1
+        return current
+    }
+}
+
+private const val MONKEY_ACTIONS = 150
+private const val CHECKPOINT_EVERY = 15
+private const val STORM_ROUNDS = 30
+
+/** Resize storm: discrete steps, the burst, and the animated pass. */
+private const val RESIZE_ROUNDS = 12
+private const val RESIZE_SPAN = 4
+private const val RESIZE_STEP_DP = 60
+private const val RESIZE_BURST = 6
+private const val ANIMATION_STEPS = 24
+private const val ANIMATION_FRAME_MILLIS = 16L
+
+/**
+ * How many animation steps the embed may trail the layout by before it is
+ * "peeling away". One step is the pipeline (Compose places, the platform
+ * allocates a frame later) and a software-rendered X server adds a couple
+ * more; a widget visibly detached from the window edge is tens of steps.
+ */
+private const val ANIMATION_LAG_FRAMES = 8
+
+/** The interactive phase drags the bottom-right corner by this much, in steps of this size. */
+private const val EDGE_DRAG_STEPS = 20
+private const val EDGE_DRAG_STEP_PX = 10
+private const val EDGE_DRAG_STEP_MILLIS = 20L
+
+/** Where inside the outer frame the resize band is pressed (`FrameDecoration.DEFAULT_RESIZE_EDGE_THICKNESS = 5`). */
+private const val EDGE_PRESS_INSET_PX = 2
+
+/** Embed frame vs Compose slot: a pixel of rounding each side, more at scale. */
+private const val GEOMETRY_TOLERANCE_PX = 2
+
+/** How long an embed may trail its slot after a resize before it is "struggling to follow". */
+private const val EMBED_LAG_BUDGET_MILLIS = 500L
+private const val NANOS_PER_MILLI = 1_000_000L
+private const val BURST_CLICKS = 6
+private const val DRAG_STEPS = 4
+
+private const val STORM_CASE_TIMEOUT_MILLIS = 120_000L
+private const val MONKEY_CASE_TIMEOUT_MILLIS = 300_000L
+private const val CONVERGE_MILLIS = 5_000L
+
+/** Long enough for the loop to deliver a frame, short enough to stay a storm. */
+private const val STEP_SETTLE_MILLIS = 25L
+
+/** Samples of the cursor under a still pointer, and their spacing. */
+private const val CURSOR_STILL_SAMPLES = 6
+private const val CURSOR_STILL_SAMPLE_MILLIS = 50L
+
+/** A one-pixel move off the centre, so the hover is a real move even after a click there. */
+private const val CURSOR_NUDGE_PX = 1f
+
+/** Random hover points stay this far inside a region: a pixel on the edge is anyone's. */
+private const val INSET_PX = 6f
+
+private const val POINTER_LOG_DEPTH = 48
+private const val KEY_SETTLE_MILLIS = 60L
+
+private const val WINDOW_X_DP = 120
+private const val WINDOW_Y_DP = 80
+private const val WINDOW_W_DP = 760
+private const val WINDOW_H_DP = 520
+private const val HEADER_H_DP = 64
+private const val PAD_DP = 8
+private const val BUTTON_W_DP = 160
+private const val OVERLAY_H_DP = 56
+private const val FONT_SP = 16
+
+private const val MIN_INNER_W_DP = 480.0
+private const val INNER_W_SPAN_DP = 400.0
+private const val MIN_INNER_H_DP = 320.0
+private const val INNER_H_SPAN_DP = 300.0
+
+private val SCALE_HOPS = floatArrayOf(1f, 1.25f, 1.5f, 2f)
+private const val SCALE_MILLI = 1000
+
+private const val BACKDROP_ARGB = 0xFF2B2B2B
+private const val HEADER_BUTTON_ARGB = 0xFF2D6CDF
+private const val OVERLAY_BUTTON_ARGB = 0xFF3AA655
+private const val EMPTY_SLOT_ARGB = 0xFF555555
+
+private const val HEX = 16
+private const val OUTER_W = 2
+private const val OUTER_H = 3

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/NativeViewMonkeyHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/NativeViewMonkeyHeadfulCases.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -373,7 +374,17 @@ private enum class Region {
  * rects, its counters and its focus state for the driver to read.
  */
 private class NativeViewFixture {
-    var fieldText by mutableStateOf("")
+    /**
+     * The field's whole value, caret included: the caret is what a `KeyDown`
+     * for an arrow moves, and a plain `String` would hide it.
+     */
+    var fieldValue by mutableStateOf(TextFieldValue(""))
+
+    val fieldText: String get() = fieldValue.text
+
+    /** Where the caret sits, or the start of the selection. */
+    val caret: Int get() = fieldValue.selection.start
+
     var fieldFocused by mutableStateOf(false)
     var headerClicks by mutableIntStateOf(0)
     var overlayClicks by mutableIntStateOf(0)
@@ -457,8 +468,8 @@ private class NativeViewFixture {
                             .recordRect(Region.Field),
                     ) {
                         BasicTextField(
-                            value = fieldText,
-                            onValueChange = { fieldText = it },
+                            value = fieldValue,
+                            onValueChange = { fieldValue = it },
                             modifier =
                                 Modifier
                                     .fillMaxSize()
@@ -626,18 +637,20 @@ private class ResponsivenessProbe(
             fixture.fieldText == fieldBefore + letter
         }
         // Caret keys travel as KeyDown, not as typed text — a second path an
-        // embed's focus can cut: the left arrow must move the caret back one.
-        // A frame on either side of the caret move: the legacy text field
-        // lays the new text out and applies the move through recomposition,
-        // and a real keyboard never delivers two keys inside one frame.
+        // embed's focus can cut. The caret itself is what moves, so that is
+        // what is asserted: where the next letter lands then depends on the
+        // field's own editing behaviour, not on the key having arrived.
+        // A frame on either side: a real keyboard never delivers two keys
+        // inside one frame, and the field applies the move on recomposition.
         scope.settle(KEY_SETTLE_MILLIS)
+        val caretBefore = fixture.caret
         driver.arrowLeft()
-        scope.settle(KEY_SETTLE_MILLIS)
-        val inserted = nextLetter()
-        driver.type(inserted)
-        converge("$moment: the left arrow moved the caret so the next letter lands before the last") {
-            fixture.fieldText == fieldBefore + inserted + letter
+        // "Back", not "back exactly one": the field clamps a caret the value
+        // left past the end of the text before it moves it.
+        converge("$moment: the left arrow moved the caret back") {
+            if (caretBefore == 0) fixture.caret == 0 else fixture.caret < caretBefore
         }
+        scope.settle(KEY_SETTLE_MILLIS)
 
         val probe = fixture.probe
         if (!driver.reachesNative || probe == null || !fixture.nativeMounted) return
@@ -754,6 +767,7 @@ private fun NativeViewFixture.describeGeometry(): String =
 
 private fun NativeViewFixture.describe(driver: PointerDriver): String =
     "driver=${driver.name} windowFocused=${window?.isFocused} fieldFocused=$fieldFocused field='$fieldText' " +
+        "caret=$caret sel=${fieldValue.selection} " +
         "header=$headerClicks overlay=$overlayClicks mounted=$nativeMounted " +
         "probe=${probe?.handle?.toString(HEX)}/disposed=${probe?.isDisposed}/nativeFocus=${probe?.hasNativeFocus()}" +
         "/text='${probe?.text()}' cursor=${NativeTaoBridge.lastCursorIcon} " +

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/NativeViewMonkeyHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/NativeViewMonkeyHeadfulCases.kt
@@ -644,6 +644,7 @@ private class ResponsivenessProbe(
         driver.click(fixture.center(Region.Native))
         converge("$moment: a click on the embed gives it native focus") { probe.hasNativeFocus() }
         converge("$moment: the field drops Compose focus once the embed has the keyboard") { !fixture.fieldFocused }
+        if (!driver.typesIntoNative) return
         val fieldNow = fixture.fieldText
         val second = nextLetter()
         driver.type(second)

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/PointerDrivers.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/PointerDrivers.kt
@@ -1,0 +1,194 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import dev.nucleusframework.core.runtime.Platform
+import dev.nucleusframework.window.tao.TaoEventCode
+import dev.nucleusframework.window.tao.TaoKeyLocation
+import dev.nucleusframework.window.tao.TaoMouseButton
+import dev.nucleusframework.window.tao.TaoWindow
+import dev.nucleusframework.window.tao.workspace.clientOriginPx
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import kotlin.math.roundToInt
+
+/**
+ * The two ways a headful case can put a pointer and a keyboard on the case
+ * window, behind one interface so a storm or a monkey runs unchanged on both.
+ *
+ * Positions are **content** pixels (physical, top-left of the Compose scene),
+ * the space every fixture measures its rects in.
+ *
+ *  - [SyntheticPointerDriver] posts the very events the native loop posts,
+ *    straight into the window. Deterministic, runs everywhere including
+ *    native Wayland, and reaches everything Compose owns — but it enters
+ *    *after* the platform's own routing, so on Linux a click on an embed
+ *    never becomes a GDK event and the widget never sees it ([reachesNative]).
+ *  - [RobotPointerDriver] moves the real OS pointer and presses the real
+ *    buttons. It is the only way to exercise the platform half of a native
+ *    view — the GtkEventBox capture, AppKit's responder chain, Win32 focus —
+ *    which is where the focus races live. Needs an X server (or a real
+ *    macOS / Windows session); see [HeadfulRobot].
+ */
+internal interface PointerDriver {
+    val name: String
+
+    /** Whether a press on an embedded native widget reaches the widget itself. */
+    val reachesNative: Boolean
+
+    suspend fun moveTo(contentPx: Offset)
+
+    suspend fun press(button: Int = TaoMouseButton.LEFT)
+
+    suspend fun release(button: Int = TaoMouseButton.LEFT)
+
+    /** Takes the pointer out of the window. */
+    suspend fun exit()
+
+    /** Types one lower-case ASCII letter into whatever holds the keyboard. */
+    suspend fun type(letter: Char)
+
+    /** Presses and releases the left arrow — a caret move, which only a `KeyDown` can carry. */
+    suspend fun arrowLeft()
+
+    suspend fun click(
+        contentPx: Offset,
+        button: Int = TaoMouseButton.LEFT,
+    ) {
+        moveTo(contentPx)
+        press(button)
+        release(button)
+    }
+}
+
+/** In-process injection through `TaoWindow.dispatch` — see [PointerDriver]. */
+internal class SyntheticPointerDriver(
+    private val window: TaoWindow,
+) : PointerDriver {
+    override val name: String = "synthetic"
+
+    // GTK only forwards a *live* GDK event onto an embed; a dispatched press
+    // has none. AppKit and Win32 synthesise a real event from the position.
+    override val reachesNative: Boolean = Platform.Current != Platform.Linux
+
+    override suspend fun moveTo(contentPx: Offset) = window.pointerMove(contentPx)
+
+    override suspend fun press(button: Int) = window.pointerPress(button)
+
+    override suspend fun release(button: Int) = window.pointerRelease(button)
+
+    override suspend fun exit() = window.pointerExit()
+
+    override suspend fun type(letter: Char) {
+        window.dispatchKey(TaoEventCode.KEY_TYPED, 0, TaoKeyLocation.STANDARD, 0, letter.code)
+    }
+
+    override suspend fun arrowLeft() {
+        window.dispatchKey(TaoEventCode.KEY_DOWN, KeyEvent.VK_LEFT, TaoKeyLocation.STANDARD, 0, 0)
+        window.dispatchKey(TaoEventCode.KEY_UP, KeyEvent.VK_LEFT, TaoKeyLocation.STANDARD, 0, 0)
+    }
+}
+
+/**
+ * Real OS input through the AWT Robot — see [PointerDriver]. [sceneSize]
+ * reads the scene's current size in physical px, which together with the
+ * window's outer frame locates the content on screen (`clientOriginPx`);
+ * the Robot itself speaks logical screen points.
+ */
+internal class RobotPointerDriver(
+    private val window: TaoWindow,
+    private val sceneSize: () -> IntSize,
+) : PointerDriver {
+    override val name: String = "robot"
+    override val reachesNative: Boolean = true
+
+    override suspend fun moveTo(contentPx: Offset) {
+        val (x, y) = screenPoint(contentPx)
+        inject { robot ->
+            robot.mouseMove(x, y)
+            HeadfulRobot.noteAim(x, y)
+        }
+    }
+
+    override suspend fun press(button: Int) {
+        val mask = mask(button)
+        inject { robot ->
+            HeadfulRobot.notePress()
+            robot.mousePress(mask)
+        }
+    }
+
+    override suspend fun release(button: Int) {
+        val mask = mask(button)
+        inject { robot -> robot.mouseRelease(mask) }
+    }
+
+    override suspend fun exit() {
+        val outer = window.outerBoundsPx() ?: return
+        val scale = window.scaleFactor.takeIf { it > 0f } ?: 1f
+        // Just past the right edge, level with the middle: on screen for any
+        // window the suite places, outside anything the window owns.
+        val x = ((outer[0] + outer[OUTER_W] + EXIT_MARGIN_PX) / scale).roundToInt()
+        val y = ((outer[1] + outer[OUTER_H] / 2) / scale).roundToInt()
+        inject { robot -> robot.mouseMove(x, y) }
+    }
+
+    override suspend fun type(letter: Char) {
+        require(letter in 'a'..'z') { "only lower-case ASCII letters are typed: '$letter'" }
+        val code = KeyEvent.getExtendedKeyCodeForChar(letter.code)
+        inject { robot ->
+            robot.keyPress(code)
+            robot.keyRelease(code)
+        }
+    }
+
+    override suspend fun arrowLeft() {
+        inject { robot ->
+            robot.keyPress(KeyEvent.VK_LEFT)
+            robot.keyRelease(KeyEvent.VK_LEFT)
+        }
+    }
+
+    private fun screenPoint(contentPx: Offset): Pair<Int, Int> {
+        val outer = requireNotNull(window.outerBoundsPx()) { "the case window is not mapped" }
+        val origin = clientOriginPx(outer, sceneSize())
+        val scale = window.scaleFactor.takeIf { it > 0f } ?: 1f
+        return ((origin.x + contentPx.x) / scale).roundToInt() to ((origin.y + contentPx.y) / scale).roundToInt()
+    }
+
+    private suspend fun inject(gesture: (java.awt.Robot) -> Unit) {
+        val ok =
+            HeadfulRobot.inject { robot ->
+                gesture(robot)
+                true
+            }
+        checkNotNull(ok) { "the AWT Robot became unavailable mid-run: ${HeadfulRobot.unavailableReason}" }
+    }
+
+    private fun mask(button: Int): Int =
+        when (button) {
+            TaoMouseButton.RIGHT -> InputEvent.BUTTON3_DOWN_MASK
+            TaoMouseButton.MIDDLE -> InputEvent.BUTTON2_DOWN_MASK
+            else -> InputEvent.BUTTON1_DOWN_MASK
+        }
+
+    private companion object {
+        const val OUTER_W = 2
+        const val OUTER_H = 3
+        const val EXIT_MARGIN_PX = 40
+    }
+}
+
+/**
+ * Why the [RobotPointerDriver] cannot run here, or null when it can: the
+ * Robot's own latched failure, or a Wayland session — the JDK routes
+ * injection through the RemoteDesktop portal there, which blocks until the
+ * suite gives up on it and then silently skips every robot case.
+ */
+internal fun robotDriverSkipReason(): String? {
+    robotSkipReason()?.let { return it }
+    if (Platform.Current == Platform.Linux && System.getenv("WAYLAND_DISPLAY") != null) {
+        return "the AWT Robot cannot inject into a Wayland compositor (WAYLAND_DISPLAY is set)"
+    }
+    return null
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/PointerDrivers.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/PointerDrivers.kt
@@ -36,6 +36,9 @@ internal interface PointerDriver {
     /** Whether a press on an embedded native widget reaches the widget itself. */
     val reachesNative: Boolean
 
+    /** Whether a key typed while the embed holds the keyboard reaches the widget itself. */
+    val typesIntoNative: Boolean
+
     suspend fun moveTo(contentPx: Offset)
 
     suspend fun press(button: Int = TaoMouseButton.LEFT)
@@ -71,6 +74,11 @@ internal class SyntheticPointerDriver(
     // has none. AppKit and Win32 synthesise a real event from the position.
     override val reachesNative: Boolean = Platform.Current != Platform.Linux
 
+    // Win32 delivers keys to the focused HWND itself, so a key dispatched
+    // into the Tao window enters above the child and never reaches it. The
+    // AppKit host forwards to the first responder either way.
+    override val typesIntoNative: Boolean = reachesNative && Platform.Current != Platform.Windows
+
     override suspend fun moveTo(contentPx: Offset) = window.pointerMove(contentPx)
 
     override suspend fun press(button: Int) = window.pointerPress(button)
@@ -101,6 +109,7 @@ internal class RobotPointerDriver(
 ) : PointerDriver {
     override val name: String = "robot"
     override val reachesNative: Boolean = true
+    override val typesIntoNative: Boolean = true
 
     override suspend fun moveTo(contentPx: Offset) {
         val (x, y) = screenPoint(contentPx)

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/SatelliteWorkspaceMonkeyHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/SatelliteWorkspaceMonkeyHeadfulCases.kt
@@ -33,20 +33,10 @@ import dev.nucleusframework.window.tao.SatelliteWorkspace
 import dev.nucleusframework.window.tao.TaoApplication
 import dev.nucleusframework.window.tao.TaoEventCode
 import dev.nucleusframework.window.tao.TaoWindow
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import kotlin.collections.randomOrNull
-import kotlin.concurrent.thread
-import kotlin.math.max
 import kotlin.math.roundToInt
 import kotlin.random.Random
 
@@ -121,9 +111,6 @@ internal object SatelliteWorkspaceMonkeyHeadfulCases {
             },
         )
     }
-
-    /** The seed of the run; overridable so a red run replays exactly. */
-    private fun monkeySeed(): Long = System.getProperty(SEED_PROPERTY)?.toLongOrNull() ?: DEFAULT_SEED
 }
 
 /**
@@ -410,9 +397,9 @@ private class Monkey(
     suspend fun run() {
         System.err.println(
             "[monkey] seed=$seed actions=$MONKEY_ACTIONS " +
-                "(replay with -D$SEED_PROPERTY=$seed)",
+                "(replay with -D$MONKEY_SEED_PROPERTY=$seed)",
         )
-        val watchdog = MainLoopWatchdog(::journalReport).start()
+        val watchdog = MainLoopWatchdog("satellite-monkey", ::journalReport).start()
         try {
             while (step < MONKEY_ACTIONS) {
                 val action = MonkeyAction.entries[random.nextInt(MonkeyAction.entries.size)]
@@ -479,7 +466,7 @@ private class Monkey(
                 "worst main-dispatcher round trip ${worstStallMillis}ms; " +
                 "reached ${reached.toSortedMap()}",
         )
-        if (worstStallMillis > MAX_STALL_MILLIS) {
+        if (worstStallMillis > MONKEY_MAX_STALL_MILLIS) {
             fail("the main dispatcher took ${worstStallMillis}ms to answer a heartbeat — the loop stalled")
         }
         // A degenerate run passes every invariant above without having tested
@@ -767,7 +754,7 @@ private class Monkey(
     private fun report(reason: String): String =
         buildString {
             appendLine("monkey failed at step $step: $reason")
-            appendLine("  seed: $seed (replay with -D$SEED_PROPERTY=$seed)")
+            appendLine("  seed: $seed (replay with -D$MONKEY_SEED_PROPERTY=$seed)")
             appendLine("  workspace: ${describe()}")
             append(journalReport())
         }
@@ -794,85 +781,6 @@ private class Monkey(
                     "/hiddenByOwner=${entry.windowState.isHiddenByParent}" +
                     "/hosts=${fixture.composedHostsOf(entry.id)}"
             }
-}
-
-/**
- * Measures `Dispatchers.Main` from a thread that is not on it.
- *
- * Every workspace mutation, every frame and the driver itself run on the Tao
- * event-loop thread, which is also the main dispatcher. That makes the one
- * failure the monkey is hunting invisible from the inside: if the loop and the
- * dispatcher ever wait on each other, the driver is not running either, so it
- * cannot fail its own case — the suite would just hit its deadline with no
- * clue why.
- *
- * So the heartbeat is posted from outside. A round trip that goes unanswered
- * for [STALL_DUMP_MILLIS] dumps every thread's stack, next to the monkey's
- * journal, which names both halves of the deadlock; one that comes back late
- * is reported as the worst stall and fails the case at the end. If it never
- * comes back the suite's own watchdog halts the process — with the dump
- * already on stderr.
- */
-private class MainLoopWatchdog(
-    private val journal: () -> String,
-) {
-    private val worst = AtomicLong(0)
-    private val stopped = AtomicBoolean(false)
-    private val dumped = AtomicBoolean(false)
-    private val main = CoroutineScope(Dispatchers.Main)
-    private var watcher: Thread? = null
-
-    fun start(): MainLoopWatchdog {
-        watcher = thread(isDaemon = true, name = "satellite-monkey-watchdog") { watch() }
-        return this
-    }
-
-    /** Stops watching and answers the worst round trip it measured, in ms. */
-    fun stop(): Long {
-        stopped.set(true)
-        watcher?.interrupt()
-        main.cancel()
-        return worst.get()
-    }
-
-    private fun watch() {
-        try {
-            while (!stopped.get()) {
-                val posted = System.nanoTime()
-                val beat = CountDownLatch(1)
-                main.launch { beat.countDown() }
-                if (!beat.await(STALL_DUMP_MILLIS, TimeUnit.MILLISECONDS)) {
-                    dumpEveryThread()
-                    // Gone for good: the suite watchdog owns the process from
-                    // here, and the dump above is what it will be diagnosed on.
-                    if (!beat.await(STALL_GIVE_UP_MILLIS, TimeUnit.MILLISECONDS)) return
-                }
-                val roundTrip = (System.nanoTime() - posted) / NANOS_PER_MILLI
-                worst.accumulateAndGet(roundTrip) { a, b -> max(a, b) }
-                Thread.sleep(BEAT_INTERVAL_MILLIS)
-            }
-        } catch (_: InterruptedException) {
-            // stop() interrupted the wait; nothing left to measure.
-        }
-    }
-
-    private fun dumpEveryThread() {
-        if (!dumped.compareAndSet(false, true)) return
-        val dump =
-            buildString {
-                appendLine(
-                    "[monkey] Dispatchers.Main has not answered in ${STALL_DUMP_MILLIS}ms — " +
-                        "the Tao loop and the dispatcher may be deadlocked",
-                )
-                append(journal())
-                for ((thread, frames) in Thread.getAllStackTraces()) {
-                    appendLine("  \"${thread.name}\" ${thread.state}")
-                    for (frame in frames) appendLine("      at $frame")
-                }
-            }
-        System.err.println(dump)
-        System.err.flush()
-    }
 }
 
 /** Enough actions to interleave every pair of them, few enough to stay inside a CI budget. */
@@ -912,11 +820,6 @@ private const val TEARDOWN_SLACK = 3
  */
 private const val MAX_COMPOSED_HOSTS = 2
 
-private const val SEED_PROPERTY = "nucleus.tao.headful.monkeySeed"
-
-/** Fixed so a green run stays green; override the property to explore. */
-private const val DEFAULT_SEED = 20_260_903L
-
 /** Scale factors a display hop can report. */
 private val SCALE_HOPS = floatArrayOf(1f, 1.25f, 1.5f, 2f)
 
@@ -941,18 +844,6 @@ private const val DRAG_POINT_KINDS = 5
 private const val DESKTOP_SPAN_PX = 8_000f
 
 private const val PALETTE_ARGB = 0xFF7A5CD6
-
-private const val BEAT_INTERVAL_MILLIS = 250L
-
-/** A heartbeat unanswered this long is a stall worth every thread's stack. */
-private const val STALL_DUMP_MILLIS = 8_000L
-
-private const val STALL_GIVE_UP_MILLIS = 30_000L
-
-/** Same threshold: a stall that recovered still fails the case, with the dump already printed. */
-private const val MAX_STALL_MILLIS = STALL_DUMP_MILLIS
-
-private const val NANOS_PER_MILLI = 1_000_000L
 
 /** Window handles read better in hex — that is how every other log prints them. */
 private const val HEX = 16

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TaoHeadfulTestSuiteMain.kt
@@ -40,9 +40,17 @@ import kotlin.system.exitProcess
  */
 public object TaoHeadfulTestSuiteMain {
     // Substring match on the case name, e.g.
-    // `-Dnucleus.tao.headful.filter=#418` to run one probe on its own.
+    // `-Dnucleus.tao.headful.filter=#418` to run one probe on its own. Several
+    // substrings separated by `|` run every case matching any of them, in suite
+    // order — the way to replay an interference between two case families.
     private val nameFilter: String? =
         System.getProperty("nucleus.tao.headful.filter")?.takeIf { it.isNotBlank() }
+    private val nameFilters: List<String> =
+        nameFilter
+            ?.split('|')
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            .orEmpty()
 
     private val allCases: List<TaoWindowTestCase> =
         listOf(
@@ -396,10 +404,16 @@ public object TaoHeadfulTestSuiteMain {
             MonitorAndScaleHeadfulCases.all() +
             WorkspaceRaceHeadfulCases.all() +
             ImeHeadfulCases.all() +
-            WindowApiV2HeadfulCases.all()
+            WindowApiV2HeadfulCases.all() +
+            // Last: the monkeys are the longest cases, and the robot ones leave the
+            // real pointer wherever their last gesture ended.
+            NativeViewMonkeyHeadfulCases.all() +
+            TextureViewMonkeyHeadfulCases.all()
 
     private val cases: List<TaoWindowTestCase> =
-        allCases.filter { nameFilter == null || it.name.contains(nameFilter, ignoreCase = true) }
+        allCases.filter { case ->
+            nameFilters.isEmpty() || nameFilters.any { case.name.contains(it, ignoreCase = true) }
+        }
 
     @JvmStatic
     @Suppress("LongMethod") // one flat harness: case hosting, then the driver

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TextureViewMonkeyHeadfulCases.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/headful/TextureViewMonkeyHeadfulCases.kt
@@ -1,0 +1,698 @@
+package dev.nucleusframework.window.tao.headful
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
+import dev.nucleusframework.core.runtime.Platform
+import dev.nucleusframework.window.tao.D3D11TestTextureProducer
+import dev.nucleusframework.window.tao.DmaBufTestTextureProducer
+import dev.nucleusframework.window.tao.MetalTestTextureProducer
+import dev.nucleusframework.window.tao.TaoApplication
+import dev.nucleusframework.window.tao.TaoEventCode
+import dev.nucleusframework.window.tao.TaoGpuRenderContext
+import dev.nucleusframework.window.tao.TaoOpenGlRenderContext
+import dev.nucleusframework.window.tao.TextureView
+import dev.nucleusframework.window.tao.TextureViewController
+import dev.nucleusframework.window.tao.TextureViewSource
+import dev.nucleusframework.window.tao.hasGlTextureImports
+import dev.nucleusframework.window.tao.hasMetalTextureImports
+import dev.nucleusframework.window.tao.hasWindowsTextureImports
+import dev.nucleusframework.window.tao.rememberTaoGpuRenderContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Paint
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.Surface
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.thread
+import kotlin.math.roundToInt
+import kotlin.random.Random
+
+/**
+ * External GPU textures and an in-process renderer on the scene's own GPU
+ * context, under a random walk of everything an app does to them.
+ *
+ * Two GPU paths share the window's Skia context: [TextureView] *imports* a
+ * texture a foreign producer keeps writing from its own thread (a DMA-BUF, an
+ * IOSurface, a D3D11 shared handle), and [rememberTaoGpuRenderContext] lets a
+ * renderer *draw* on the scene's context itself, under `withContextCurrent` /
+ * `runOnGpuThread`. Both live one context rebuild away from a stale handle —
+ * a Wayland hide/show tears the whole EGL stack down, a producer can be closed
+ * while its view is still composing, a burst of frames can land during a
+ * resize — and the failures there are freezes and GL errors, not assertions.
+ *
+ * So the monkey mounts, unmounts, swaps, resizes, hides, shows, minimizes,
+ * closes producers under live views and floods frames from off-thread, and
+ * checks the two things a video app cannot live without: the scene **keeps
+ * rendering** (a frame heartbeat advances after every checkpoint, the shared
+ * renderer keeps producing snapshots), and the loop **keeps answering**
+ * ([MainLoopWatchdog]). At the end nothing may be left: no import alive on the
+ * context once every view is gone, no producer thread that threw, one window.
+ *
+ * The producers are the platform test producers that ship with the module.
+ * Where none can be made (no render node under Xvfb, no D3D11 on a bare
+ * runner) the views run with a null source and the shared-context renderer
+ * carries the GPU half on its own — the case says so in its log.
+ */
+internal object TextureViewMonkeyHeadfulCases {
+    fun all(): List<TaoWindowTestCase> = listOf(randomActionsKeepTheSceneRendering())
+
+    private fun randomActionsKeepTheSceneRendering(): TaoWindowTestCase {
+        val fixture = TextureViewFixture()
+        return TaoWindowTestCase(
+            name =
+                "texture view monkey $MONKEY_ACTIONS random actions keep the scene rendering " +
+                    "on the shared GPU context",
+            timeoutMillis = MONKEY_CASE_TIMEOUT_MILLIS,
+            windowState =
+                WindowState(
+                    position = WindowPosition.Absolute(WINDOW_X_DP.dp, WINDOW_Y_DP.dp),
+                    size = DpSize(WINDOW_W_DP.dp, WINDOW_H_DP.dp),
+                ),
+            size = DpSize(WINDOW_W_DP.dp, WINDOW_H_DP.dp),
+            paintDefaultBackground = false,
+            content = { fixture.Content() },
+            driver = {
+                fixture.awaitReady(this)
+                val monkey = TextureViewMonkey(this, fixture, monkeySeed())
+                try {
+                    monkey.run()
+                    monkey.quiesceAndAssert()
+                } finally {
+                    fixture.shutdown()
+                }
+            },
+        )
+    }
+}
+
+/** A foreign producer behind one interface, whichever platform made it. */
+private class TestProducer(
+    val source: TextureViewSource,
+    val kind: String,
+    private val draw: (tick: Int, backgroundArgb: Int) -> Unit,
+    private val closeProducer: () -> Unit,
+) {
+    private val closed = AtomicBoolean(false)
+
+    val isClosed: Boolean get() = closed.get()
+
+    /** Draws a frame unless closed; producers serialize draw and close themselves. */
+    fun drawFrame(tick: Int) {
+        if (!closed.get()) draw(tick, PRODUCER_BACKGROUND_ARGB)
+    }
+
+    fun close() {
+        if (closed.compareAndSet(false, true)) closeProducer()
+    }
+
+    companion object {
+        /** The first producer this platform can make, or null. */
+        fun create(
+            widthPx: Int,
+            heightPx: Int,
+            variant: Int,
+        ): TestProducer? {
+            D3D11TestTextureProducer.create(widthPx, heightPx, useKeyedMutex = variant % 2 == 0)?.let {
+                return TestProducer(it.source, "D3D11", it::drawTestPattern, it::close)
+            }
+            MetalTestTextureProducer.create(widthPx, heightPx)?.let {
+                return TestProducer(it.source, "IOSurface", it::drawTestPattern, it::close)
+            }
+            val planar = variant % PRODUCER_VARIANTS == PLANAR_VARIANT
+            val dmaBuf =
+                if (planar) {
+                    DmaBufTestTextureProducer.createYuv(widthPx, heightPx)
+                } else {
+                    DmaBufTestTextureProducer.create(widthPx, heightPx)
+                }
+            dmaBuf?.let {
+                return TestProducer(
+                    it.source,
+                    if (planar) "DMA-BUF I420" else "DMA-BUF",
+                    it::drawTestPattern,
+                    it::close,
+                )
+            }
+            return null
+        }
+    }
+}
+
+/**
+ * One [TextureView] slot: what it shows, how, and the producer thread feeding
+ * it. The producer is swapped and closed independently of the view on purpose
+ * — those orderings are the interesting ones.
+ */
+private class Slot(
+    val index: Int,
+) {
+    var mounted by mutableStateOf(true)
+    var producer by mutableStateOf<TestProducer?>(null)
+    var sizeDp by mutableStateOf(DpSize(SLOT_W_DP.dp, SLOT_H_DP.dp))
+    var filterQuality by mutableStateOf(FilterQuality.Low)
+    var contentScale by mutableStateOf<ContentScale>(ContentScale.FillBounds)
+    val controller = TextureViewController()
+
+    /** Frames the producer thread published. */
+    val producedFrames = AtomicLong()
+}
+
+private class TextureViewFixture {
+    val slots = List(SLOT_COUNT) { Slot(it) }
+    var sharedRendererMounted by mutableStateOf(true)
+
+    /** The scene's GPU context as last published; a new instance means a rebuild. */
+    var renderContext: TaoGpuRenderContext? = null
+        private set
+    val contextGenerations = AtomicInteger()
+
+    /** Frames the scene rendered (the heartbeat) and the shared renderer produced. */
+    val renderedFrames = AtomicLong()
+    val sharedFrames = AtomicLong()
+
+    /** Whatever a producer thread or the shared renderer threw. */
+    val errors = CopyOnWriteArrayList<Throwable>()
+
+    private val stopProducers = AtomicBoolean(false)
+    private val producerThreads = mutableListOf<Thread>()
+    private val producersMade = AtomicInteger()
+
+    /** Read in `drawBehind` so every frame tick invalidates the draw and the clock keeps running. */
+    private var heartbeatTick by mutableLongStateOf(0L)
+
+    var producerKind: String? = null
+        private set
+
+    fun newProducer(): TestProducer? {
+        val variant = producersMade.getAndIncrement()
+        val producer = TestProducer.create(PRODUCER_W_PX, PRODUCER_H_PX, variant) ?: return null
+        producerKind = producer.kind
+        return producer
+    }
+
+    fun startProducers() {
+        for (slot in slots) {
+            producerThreads +=
+                thread(isDaemon = true, name = "texture-monkey-producer-${slot.index}") {
+                    val random = Random(slot.index.toLong())
+                    var tick = 0
+                    try {
+                        while (!stopProducers.get()) {
+                            val producer = slot.producer
+                            if (producer != null && !producer.isClosed) {
+                                producer.drawFrame(tick++)
+                                slot.controller.markFrameAvailable()
+                                slot.producedFrames.incrementAndGet()
+                            }
+                            Thread.sleep(MIN_PRODUCER_PERIOD_MILLIS + random.nextLong(PRODUCER_PERIOD_SPAN_MILLIS))
+                        }
+                    } catch (_: InterruptedException) {
+                        // shutdown
+                    } catch (t: Throwable) {
+                        errors += t
+                    }
+                }
+        }
+    }
+
+    fun shutdown() {
+        stopProducers.set(true)
+        for (t in producerThreads) t.interrupt()
+        for (t in producerThreads) t.join(PRODUCER_JOIN_MILLIS)
+        for (slot in slots) slot.producer?.close()
+    }
+
+    @Composable
+    fun Content() {
+        val context = rememberTaoGpuRenderContext()
+        SideEffect {
+            if (context !== renderContext) {
+                renderContext = context
+                if (context != null) contextGenerations.incrementAndGet()
+            }
+        }
+        LaunchedEffect(Unit) {
+            while (isActive) {
+                withFrameNanos { renderedFrames.incrementAndGet() }
+                heartbeatTick++
+            }
+        }
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(Color(BACKDROP_ARGB))
+                .drawBehind {
+                    // The read is the point: it ties the draw to the heartbeat.
+                    if (heartbeatTick < 0L) drawRect(Color.Red)
+                },
+        ) {
+            Column(Modifier.fillMaxSize().padding(PAD_DP.dp)) {
+                for (row in 0 until SLOT_ROWS) {
+                    Row {
+                        for (column in 0 until SLOT_COLUMNS) {
+                            val slot = slots[row * SLOT_COLUMNS + column]
+                            Box(Modifier.padding(PAD_DP.dp)) {
+                                if (slot.mounted) {
+                                    TextureView(
+                                        source = slot.producer?.source,
+                                        modifier = Modifier.size(slot.sizeDp).background(Color(SLOT_ARGB)),
+                                        controller = slot.controller,
+                                        filterQuality = slot.filterQuality,
+                                        contentScale = slot.contentScale,
+                                    )
+                                } else {
+                                    Box(Modifier.size(slot.sizeDp).background(Color(EMPTY_SLOT_ARGB)))
+                                }
+                            }
+                        }
+                    }
+                }
+                if (sharedRendererMounted && context != null) {
+                    SharedContextCanvas(context)
+                }
+            }
+        }
+    }
+
+    /**
+     * The in-process renderer of the GPU-context demo, reduced to what the
+     * monkey needs: a render target on the scene's own Skia context, one
+     * snapshot per frame, freed inside a later frame's GPU scope.
+     */
+    @Composable
+    private fun SharedContextCanvas(context: TaoGpuRenderContext) {
+        val renderer = remember(context) { SceneContextRenderer(context) }
+        var frame by remember(context) { mutableStateOf<Image?>(null) }
+        DisposableEffect(renderer) {
+            onDispose { renderer.close() }
+        }
+        LaunchedEffect(renderer) {
+            var tick = 0
+            while (isActive) {
+                val next =
+                    try {
+                        withFrameNanos { renderer.renderFrame(tick) }
+                    } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                        // The renderer left the composition — not a failure.
+                        throw cancelled
+                    } catch (t: Throwable) {
+                        errors += t
+                        throw t
+                    } ?: continue
+                frame?.let(renderer::retire)
+                frame = next
+                sharedFrames.incrementAndGet()
+                tick++
+            }
+        }
+        Canvas(Modifier.padding(PAD_DP.dp).size(SHARED_W_DP.dp, SHARED_H_DP.dp).background(Color(SLOT_ARGB))) {
+            val image = frame ?: return@Canvas
+            drawIntoCanvas { canvas ->
+                canvas.nativeCanvas.drawImageRect(image, Rect.makeWH(size.width, size.height))
+            }
+        }
+    }
+
+    suspend fun awaitReady(scope: TaoWindowTestScope) {
+        with(scope) {
+            awaitUntil("the case window is mapped with a real frame") { window.hasRealFramePx() }
+            awaitUntil("the scene published its GPU context") { renderContext != null }
+            for (slot in slots) slot.producer = newProducer()
+            startProducers()
+            settle(SETTLE_AFTER_MAP_MILLIS)
+            awaitUntil("the scene renders frames") { renderedFrames.get() > 0L }
+            System.err.println(
+                "[texture-monkey] backend=${renderContext?.backend} producers=" +
+                    (producerKind ?: "none (null sources; the shared-context renderer carries the GPU half)"),
+            )
+        }
+    }
+
+    /** Whether any TextureView import is alive on the current context. */
+    fun hasImports(): Boolean {
+        val context = renderContext?.skiaContext ?: return false
+        return when (Platform.Current) {
+            Platform.Linux -> hasGlTextureImports(context)
+            Platform.Windows -> hasWindowsTextureImports(context)
+            Platform.MacOS -> hasMetalTextureImports(context)
+            else -> false
+        }
+    }
+
+    fun describe(): String =
+        "context=${renderContext?.let { System.identityHashCode(it).toString(HEX) }} " +
+            "generations=${contextGenerations.get()} rendered=${renderedFrames.get()} shared=${sharedFrames.get()} " +
+            "sharedMounted=$sharedRendererMounted producers=$producerKind errors=${errors.size} " +
+            slots.joinToString(prefix = "slots=[", postfix = "]") {
+                "${it.index}:${if (it.mounted) "mounted" else "unmounted"}/" +
+                    "${it.producer?.let { p -> if (p.isClosed) "closed" else "live" } ?: "none"}/" +
+                    "${it.sizeDp.width.value.toInt()}x${it.sizeDp.height.value.toInt()}/frames=${it.producedFrames.get()}"
+            }
+}
+
+/** The GPU-context demo's renderer: see `GpuContextSection` in the tao demo. */
+private class SceneContextRenderer(
+    private val context: TaoGpuRenderContext,
+) : AutoCloseable {
+    private var surface: Surface? = null
+    private val retired = ArrayDeque<Image>()
+    private val paint = Paint()
+
+    private fun <T> withGpuAccess(action: () -> T): T? =
+        when (context) {
+            is TaoOpenGlRenderContext -> context.withContextCurrent(action)
+            else -> context.runOnGpuThread(action)
+        }
+
+    fun renderFrame(tick: Int): Image? =
+        withGpuAccess {
+            val target =
+                surface
+                    ?: Surface
+                        .makeRenderTarget(context.skiaContext, false, ImageInfo.makeN32Premul(RT_W, RT_H))
+                        .also { surface = it }
+            val canvas = target.canvas
+            canvas.clear(HUE_BASE_ARGB + (tick % HUE_SPAN) * HUE_STEP)
+            paint.color = WHITE_ARGB
+            canvas.drawCircle(
+                RT_W / 2f + (RT_W / 3f) * kotlin.math.cos(tick / TICKS_PER_RADIAN).toFloat(),
+                RT_H / 2f + (RT_H / 3f) * kotlin.math.sin(tick / TICKS_PER_RADIAN).toFloat(),
+                DOT_RADIUS,
+                paint,
+            )
+            target.flushAndSubmit()
+            val snapshot = target.makeImageSnapshot()
+            while (retired.size > RETIRED_KEPT) retired.removeFirst().close()
+            snapshot
+        }
+
+    fun retire(image: Image) {
+        retired.addLast(image)
+    }
+
+    override fun close() {
+        withGpuAccess {
+            while (retired.isNotEmpty()) retired.removeFirst().close()
+            surface?.close()
+            surface = null
+        }
+        paint.close()
+    }
+
+    private companion object {
+        const val RT_W = 256
+        const val RT_H = 192
+        const val HUE_BASE_ARGB = 0xFF203040.toInt()
+        const val HUE_SPAN = 64
+        const val HUE_STEP = 0x010203
+        const val WHITE_ARGB = 0xFFFFFFFF.toInt()
+        const val TICKS_PER_RADIAN = 30.0
+        const val DOT_RADIUS = 20f
+        const val RETIRED_KEPT = 2
+    }
+}
+
+private enum class TextureAction {
+    MountSlot,
+    UnmountSlot,
+
+    /** A fresh producer for a slot; the old one is closed after the swap has composed. */
+    SwapProducer,
+
+    /** Closes a slot's producer while its view is still composing it. */
+    CloseProducerUnderView,
+    ResizeSlot,
+    ChangeFilter,
+    ChangeContentScale,
+
+    /** Fifty frame signals from an IO thread with no drawing in between. */
+    BurstFrames,
+    ToggleSharedRenderer,
+    ResizeWindow,
+    ToggleMaximize,
+
+    /** Hides and shows the window; on Wayland this rebuilds the whole EGL stack. */
+    HideShow,
+    MinimizeRestore,
+    ChangeDpi,
+    RedrawStorm,
+}
+
+private class TextureViewMonkey(
+    private val scope: TaoWindowTestScope,
+    private val fixture: TextureViewFixture,
+    seed: Long,
+) {
+    private val random = Random(seed)
+    private val journal = MonkeyJournal("texture-monkey", seed)
+    private var worstStallMillis = 0L
+
+    /** Windows alive when the run started: earlier cases may have left some behind, they are not this run's. */
+    private val windowsAtStart = TaoApplication.liveWindowCount()
+
+    suspend fun run() {
+        System.err.println(
+            "[texture-monkey] seed=${journal.seed} actions=$MONKEY_ACTIONS " +
+                "(replay with -D$MONKEY_SEED_PROPERTY=${journal.seed})",
+        )
+        val watchdog = MainLoopWatchdog("texture-monkey", journal::report).start()
+        try {
+            while (journal.step < MONKEY_ACTIONS) {
+                val action = TextureAction.entries[random.nextInt(TextureAction.entries.size)]
+                journal.record(action)
+                monkeyAction({ journal.failure("$action", fixture.describe()) }) { apply(action) }
+                checkNoErrors()
+                if ((journal.step + 1) % CHECKPOINT_EVERY == 0) checkpoint()
+                journal.step++
+            }
+        } finally {
+            worstStallMillis = watchdog.stop()
+        }
+    }
+
+    suspend fun quiesceAndAssert() {
+        restoreWindow()
+        for (slot in fixture.slots) slot.mounted = true
+        fixture.sharedRendererMounted = true
+        scope.settle(SETTLE_AFTER_MAP_MILLIS)
+        expectRendering("after the monkey")
+
+        // Every view gone: nothing may still be imported on the context.
+        for (slot in fixture.slots) slot.mounted = false
+        converge("no texture import is left once every view is unmounted") { !fixture.hasImports() }
+        for (slot in fixture.slots) {
+            slot.producer?.close()
+            slot.producer = null
+        }
+        scope.settle(SETTLE_AFTER_MAP_MILLIS)
+        expectRendering("with every view gone")
+        checkNoErrors()
+
+        check(TaoApplication.liveWindowCount() == windowsAtStart) {
+            "${TaoApplication.liveWindowCount()} native windows are alive, $windowsAtStart when the run started"
+        }
+        System.err.println(
+            "[texture-monkey] seed=${journal.seed} survived $MONKEY_ACTIONS actions; " +
+                "worst main-dispatcher round trip ${worstStallMillis}ms; context generations " +
+                "${fixture.contextGenerations.get()}; rendered ${fixture.renderedFrames.get()} frames, " +
+                "shared renderer ${fixture.sharedFrames.get()}; reached ${journal.reachedSummary()}",
+        )
+        check(worstStallMillis <= MONKEY_MAX_STALL_MILLIS) {
+            "the main dispatcher took ${worstStallMillis}ms to answer a heartbeat — the loop stalled"
+        }
+        check(journal.reachedCount("hideShow") > 0) { "the run never hid the window" }
+        check(journal.reachedCount("swapped") > 0) { "the run never swapped a producer" }
+        check(fixture.sharedFrames.get() > 0L) { "the shared-context renderer never produced a frame" }
+    }
+
+    private suspend fun apply(action: TextureAction) {
+        val slot = fixture.slots[random.nextInt(fixture.slots.size)]
+        when (action) {
+            TextureAction.MountSlot -> slot.mounted = true
+            TextureAction.UnmountSlot -> slot.mounted = false
+            TextureAction.SwapProducer -> {
+                val old = slot.producer
+                slot.producer = fixture.newProducer()
+                scope.settle(STEP_SETTLE_MILLIS)
+                old?.close()
+                journal.reach("swapped")
+            }
+            TextureAction.CloseProducerUnderView -> {
+                slot.producer?.close()
+                journal.reach("closedUnderView")
+            }
+            TextureAction.ResizeSlot ->
+                slot.sizeDp =
+                    DpSize(
+                        (MIN_SLOT_DP + random.nextInt(SLOT_SPAN_DP)).dp,
+                        (MIN_SLOT_DP + random.nextInt(SLOT_SPAN_DP)).dp,
+                    )
+            TextureAction.ChangeFilter -> slot.filterQuality = FILTERS[random.nextInt(FILTERS.size)]
+            TextureAction.ChangeContentScale -> slot.contentScale = CONTENT_SCALES[random.nextInt(CONTENT_SCALES.size)]
+            TextureAction.BurstFrames ->
+                withContext(Dispatchers.IO) {
+                    repeat(BURST_FRAMES) { slot.controller.markFrameAvailable() }
+                }
+            TextureAction.ToggleSharedRenderer -> fixture.sharedRendererMounted = !fixture.sharedRendererMounted
+            TextureAction.ResizeWindow ->
+                scope.window.setInnerSize(
+                    MIN_INNER_W_DP + random.nextDouble(INNER_W_SPAN_DP),
+                    MIN_INNER_H_DP + random.nextDouble(INNER_H_SPAN_DP),
+                )
+            TextureAction.ToggleMaximize -> scope.window.setMaximized(!scope.window.isMaximized)
+            TextureAction.HideShow -> {
+                scope.window.hide()
+                scope.settle(HIDE_MILLIS)
+                scope.window.show()
+                journal.reach("hideShow")
+            }
+            TextureAction.MinimizeRestore -> {
+                scope.window.setMinimized(true)
+                scope.settle(HIDE_MILLIS)
+                scope.window.setMinimized(false)
+                journal.reach("minimized")
+            }
+            TextureAction.ChangeDpi -> {
+                val scale = SCALE_HOPS[random.nextInt(SCALE_HOPS.size)]
+                scope.window.dispatch(TaoEventCode.SCALE_FACTOR_CHANGED, (scale * SCALE_MILLI).roundToInt(), 0)
+            }
+            TextureAction.RedrawStorm -> repeat(REDRAW_STORM) { scope.window.requestRedraw() }
+        }
+        scope.settle(STEP_SETTLE_MILLIS)
+    }
+
+    /** The scene must still be producing frames once the window is visible again. */
+    private suspend fun checkpoint() {
+        restoreWindow()
+        expectRendering("checkpoint at step ${journal.step}")
+    }
+
+    private suspend fun restoreWindow() {
+        scope.window.dispatch(
+            TaoEventCode.SCALE_FACTOR_CHANGED,
+            (scope.window.scaleFactor * SCALE_MILLI).roundToInt(),
+            0,
+        )
+        scope.window.setMinimized(false)
+        scope.window.setMaximized(false)
+        scope.window.show()
+        scope.window.setInnerSize(WINDOW_W_DP.toDouble(), WINDOW_H_DP.toDouble())
+        scope.settle(STEP_SETTLE_MILLIS)
+    }
+
+    private suspend fun expectRendering(moment: String) {
+        val rendered = fixture.renderedFrames.get()
+        converge("$moment: the scene keeps rendering frames") {
+            fixture.renderedFrames.get() >= rendered + HEARTBEAT_FRAMES
+        }
+        if (fixture.sharedRendererMounted) {
+            val shared = fixture.sharedFrames.get()
+            converge("$moment: the shared-context renderer keeps producing frames") {
+                fixture.sharedFrames.get() >= shared + HEARTBEAT_FRAMES
+            }
+        }
+        converge("$moment: the GPU context is published") { fixture.renderContext != null }
+    }
+
+    private fun checkNoErrors() {
+        val first = fixture.errors.firstOrNull() ?: return
+        throw IllegalStateException(
+            journal.failure("a producer or the shared renderer threw: $first", fixture.describe()),
+            first,
+        )
+    }
+
+    private suspend fun converge(
+        description: String,
+        predicate: () -> Boolean,
+    ) {
+        scope.awaitUntil(
+            description,
+            timeoutMillis = CONVERGE_MILLIS,
+            detail = { fixture.describe() },
+            predicate = predicate,
+        )
+    }
+}
+
+private const val MONKEY_ACTIONS = 200
+private const val CHECKPOINT_EVERY = 20
+private const val MONKEY_CASE_TIMEOUT_MILLIS = 300_000L
+private const val CONVERGE_MILLIS = 6_000L
+private const val STEP_SETTLE_MILLIS = 25L
+private const val HIDE_MILLIS = 120L
+private const val HEARTBEAT_FRAMES = 3L
+private const val BURST_FRAMES = 50
+private const val REDRAW_STORM = 20
+
+private const val SLOT_ROWS = 2
+private const val SLOT_COLUMNS = 2
+private const val SLOT_COUNT = SLOT_ROWS * SLOT_COLUMNS
+private const val SLOT_W_DP = 240
+private const val SLOT_H_DP = 150
+private const val MIN_SLOT_DP = 40
+private const val SLOT_SPAN_DP = 260
+private const val SHARED_W_DP = 240
+private const val SHARED_H_DP = 120
+private const val PAD_DP = 6
+
+private const val PRODUCER_W_PX = 320
+private const val PRODUCER_H_PX = 200
+private const val PRODUCER_VARIANTS = 3
+private const val PLANAR_VARIANT = 2
+private const val PRODUCER_BACKGROUND_ARGB = 0xFF1F2630.toInt()
+private const val MIN_PRODUCER_PERIOD_MILLIS = 4L
+private const val PRODUCER_PERIOD_SPAN_MILLIS = 28L
+private const val PRODUCER_JOIN_MILLIS = 2_000L
+
+private const val WINDOW_X_DP = 120
+private const val WINDOW_Y_DP = 80
+private const val WINDOW_W_DP = 760
+private const val WINDOW_H_DP = 560
+private const val MIN_INNER_W_DP = 300.0
+private const val INNER_W_SPAN_DP = 600.0
+private const val MIN_INNER_H_DP = 200.0
+private const val INNER_H_SPAN_DP = 500.0
+
+private val SCALE_HOPS = floatArrayOf(1f, 1.25f, 1.5f, 2f)
+private const val SCALE_MILLI = 1000
+private val FILTERS = listOf(FilterQuality.None, FilterQuality.Low, FilterQuality.Medium, FilterQuality.High)
+private val CONTENT_SCALES = listOf(ContentScale.FillBounds, ContentScale.Fit, ContentScale.Crop, ContentScale.None)
+
+private const val BACKDROP_ARGB = 0xFF2B2B2B
+private const val SLOT_ARGB = 0xFF101418
+private const val EMPTY_SLOT_ARGB = 0xFF555555
+private const val HEX = 16


### PR DESCRIPTION
## Summary

New stage-2 headful cases (`decorated-window-tao`), run on X11 (Xvfb + openbox, AWT Robot) and on a native Wayland session:

- **NativeView monkey**: a `BasicTextField`, a Compose button, a real native text widget embedded through `NativeView` (`GtkEntry` / `NSTextField` / `EDIT`, handed out by new `nativeDiag*` bridge entry points) and a Compose button drawn over the embed. Alternating click storms, a right click on the embed, a resize storm (discrete, burst, animated, interactive corner drag) and a 150-action random walk, each with an in-process driver and a real-pointer Robot driver. Asserts Compose keeps counting clicks, a single keyboard owner, letters and caret keys landing where the focus says, a stable I-beam over the field, the embed on its Compose slot, no leaked probe, a live main dispatcher.
- **TextureView monkey**: four `TextureView`s fed by the platform test producers from their own threads plus an in-process renderer on the scene's Skia context (`rememberTaoGpuRenderContext`); mount/unmount/swap/close-under-view/hide-show/minimize/DPI/frame bursts.
- Shared `MonkeySupport` (dispatcher watchdog, journal echoed to stderr, seed), `PointerDrivers`, `NativeProbe`; `-Dnucleus.tao.headful.monkeyScript` replays a journal; the suite filter accepts `a|b`.

Bugs the monkeys found, all fixed in this PR:

- `NativeView` disposed the platform view before detaching it (SIGSEGV in `nativeDetach`); `nativeViewHost()` returned a new object per call (detach/attach churn on every recomposition of the window root); a late `setFrame` after detach touched the widget.
- Linux: a right click forwarded to an embed lost its release to the widget's context-menu grab and every later Compose click was dead. The host records buttons forwarded to an embed, heals from GDK's live button mask on the next motion and releases phantoms before a new press.
- Linux: printable keys never reached a focused GTK embed (toplevel IME + `Stop`), and arrows moved GTK focus into the embed (`move-focus` binding). Tao propagates keys to a foreign focus widget and stops the event once Compose consumed it.
- Linux: GTK's map-time default focus landed on the embed (two carets). Focus sink, keyboard reclaim on a Compose-kept press, `clearFocus` on a forwarded press.
- Linux: the embed trailed its slot through a resize; `nativeSetFrame` now relayouts the overlay synchronously (0 px behind measured, was 12–40 px).
- Linux: SIGSEGV in Skia after a Wayland hide/show for `rememberTaoGpuRenderContext` consumers — the old GL host bound the new EGL context for a closed `DirectContext`.
- All platforms: native popup layer windows leaked when an owner window closed during a `Dialog`'s disappearance animation, leaving an invisible click-eating window. Hosts now close surviving layers on detach.

- Linux/Wayland: the embed peeled off the Compose hole by a frame through a resize (a sub-surface position is parent state, applied on GTK's commit, one paint after Compose swapped its desync buffer). During a resize burst with an embed the content sub-surface runs in `set_sync` mode and a toplevel draw is queued after each swap, so hole and embed land in the same commit.
- Linux/Wayland: `nativeSetContentOffset` committed GTK's toplevel surface out of band; that races GDK's end_paint/after_paint buffer bookkeeping and aborts the process in cairo (reproduced by the texture monkey after minimize/restore cycles). It now queues a GTK draw instead.

Windows, once the monkeys were run there (the native probe hands out a plain `EDIT` control):

- A press forwarded to an embedded child HWND is replayed to the owner HWND a moment later — forwarding moves Win32 focus and the queue hands the message to the window that owns the pixels. Dispatched twice, Compose held a press with no release and every later click was dead. The host recognises the replay of the overlay event it just handled and drops it, matched on button, position and recency.
- The child captures the mouse on that press and keeps every later message, so neither the scene nor its blending overlay sees the pointer again. The capture is handed straight back, and a release the child swallowed is healed from Win32's own button state.
- Keys kept going to an embed clicked into earlier while Compose showed a focused text field. A press Compose keeps takes Win32 focus back (the macOS `makeFirstResponder` equivalent), and a press handed to the embed clears the Compose focus.
- A child's handler may run a modal loop — an `EDIT` opens its context menu from `WM_RBUTTONUP` and does not return until dismissed. Everything but the press is now posted rather than sent, and the Tao loop drains the main dispatcher on a wake: Windows derives `MainEventsCleared` from a `WM_PAINT` that a modal loop never generates, so the app's coroutines used to stop for as long as the menu was up.
- The overlay input replay repeated whatever message it saw last regardless of what the caller was forwarding; it only replays the matching one now.
- The scene placed a click where the *last move it saw* left the pointer. Tao reports a button without a position and drops a `WM_MOUSEMOVE` whose coordinate equals the last one it saw, while every move over an embed goes to the blending overlay, which Tao knows nothing about — a pointer that left the embed and came back to a point Tao had seen before got no move at all, so the click landed on the embed the user had just left, and every click after it was dead. When the position came from the overlay the host asks Win32 where the pointer is and walks the scene there first.
- A native modal loop on the loop thread stops Tao producing `MainEventsCleared`, which is where the Windows redraws asked for during a batch were served: the window froze for as long as an embedded `EDIT`'s context menu was up, with no frames, no recomposition, and anything queued behind a frame never running. The wake that drains the dispatcher inside such a loop now serves those redraws too.
- A press handed to an embed cleared the Compose focus through the frame queue, so when that press was the one opening the embed's menu the clear waited for a frame that could not come and the field kept its caret beside the embed's. It goes through the main dispatcher instead.
- Handing an event to a child HWND runs its handler on this thread, and anything it pumps swallows the redraw the window had pending; the coalescing latch then suppressed every later request. Reset after a forwarded dispatch, like the other nested-pump callers.
- Closing a native popup layer is idempotent now: the detach sweep above closes surviving layers itself and Compose then disposes the same layer as the composition unwinds, which released the native panel twice and took the process down.

macOS (real desktop, both drivers):

- `NSTextField.mouseDown:` / `NSTextView.mouseDown:` run `trackMouse:untilMouseUp:` (and a right click may pop an `NSMenu`) on the Tao thread. A synthetic press never returned, and the suite watchdog halted after 900s on the first NativeView case. Tracking and menu selectors are skipped; a press only `makeFirstResponder`s. Compose focus is cleared on a forwarded press, a Compose-kept press takes first-responder back, synthetic keys go to the embed when it holds the keyboard, and a late `setFrame` after detach is refused.
- `nucleusIOSurfaceTextureSource` now retains the `IOSurface`. Closing the producer under a live `TextureView` used to free the surface; remounting then SIGSEGV'd in `IOSurfaceGetPixelFormat`.

## Test plan

- [x] `native view` and `texture view monkey` filters green on X11 (Robot included) and on Wayland
- [x] full X11 headful suite: 235 run / 53 skipped; remaining failures are the `#582` clipboard cases (`wl-copy` on the box) and two known WM-placement flakes that pass 3/3 in isolation
- [x] `ktlintCheck`, `detekt`, `apiCheck`, unit tests green
- [x] Windows (real desktop, both drivers): the `native view` and `texture view monkey` filters green, 13 run / 0 failed, and both monkeys green over four seeds (`7`, `999`, `12345`, `20260903`)
- [x] full Windows headful suite: 234 run / 54 skipped / 3 failed — one tab-drag WM flake that passes in isolation, and the two `dialog appearance` disappearance cases, which fail the same way on this branch before these fixes (`hide gone: in-scene=null native=null`, pre-existing on Windows)
- [x] `ktlintCheck`, `detekt`, `apiCheck`, unit tests green on Windows
- [x] macOS (real desktop, both drivers): 12 `native view` cases green (synthetic + robot storms, right click, resize, both 150-action monkeys) and the 200-action `texture view monkey`

